### PR TITLE
feat(guard): add authenticated Windows resident Rust runtime

### DIFF
--- a/.github/workflows/rust-command-shadow.yml
+++ b/.github/workflows/rust-command-shadow.yml
@@ -1,0 +1,71 @@
+name: Rust command shadow bridge
+
+on:
+  pull_request:
+    branches: [release/3.0]
+    paths:
+      - "rust/crates/guard-command/**"
+      - "rust/crates/guard-runtime/**"
+      - "src/codex_plugin_scanner/guard/native_command_model.py"
+      - "src/codex_plugin_scanner/guard/native_runtime.py"
+      - "src/codex_plugin_scanner/guard/native_runtime_resident.py"
+      - "ci/native_runtime/test_command_model_resident.py"
+      - ".github/workflows/rust-command-shadow.yml"
+  push:
+    branches: [release/3.0]
+    paths:
+      - "rust/crates/guard-command/**"
+      - "rust/crates/guard-runtime/**"
+      - "src/codex_plugin_scanner/guard/native_command_model.py"
+      - "src/codex_plugin_scanner/guard/native_runtime.py"
+      - "src/codex_plugin_scanner/guard/native_runtime_resident.py"
+      - "ci/native_runtime/test_command_model_resident.py"
+      - ".github/workflows/rust-command-shadow.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rust-command-shadow-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  resident-shadow:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+          enable-cache: true
+      - run: uv sync --frozen --extra dev --python 3.12
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup toolchain install 1.88.0 --profile minimal --component rustfmt --component clippy
+          rustup default 1.88.0
+      - name: Check native command bridge
+        run: |
+          rustfmt --edition 2021 --check rust/crates/guard-runtime/src/main.rs
+          cargo clippy --manifest-path rust/Cargo.toml --locked --workspace --all-targets -- -D warnings
+          uv run --no-sync python -m ruff check src/codex_plugin_scanner/guard/native_command_model.py ci/native_runtime/test_command_model_resident.py
+          uv run --no-sync python -m ruff format --check src/codex_plugin_scanner/guard/native_command_model.py ci/native_runtime/test_command_model_resident.py
+      - name: Build version-matched runtime
+        env:
+          HOL_GUARD_BUILD_SHA: ${{ github.sha }}
+        run: |
+          VERSION=$(uv run --no-sync python scripts/sync_repo_version.py --check)
+          export HOL_GUARD_PACKAGE_VERSION="$VERSION"
+          cargo build --manifest-path rust/Cargo.toml --locked --release -p hol-guard-runtime
+          rust/target/release/hol-guard-runtime self-test --json
+      - name: Exercise resident command shadow bridge
+        env:
+          HOL_GUARD_NATIVE: force
+          HOL_GUARD_NATIVE_BINARY: ${{ github.workspace }}/rust/target/release/hol-guard-runtime
+        run: uv run --no-sync pytest ci/native_runtime/test_command_model_resident.py --tb=short

--- a/.github/workflows/rust-command-shadow.yml
+++ b/.github/workflows/rust-command-shadow.yml
@@ -2,14 +2,15 @@ name: Rust command shadow bridge
 
 on:
   pull_request:
-    branches: [release/3.0]
     paths:
       - "rust/crates/guard-command/**"
       - "rust/crates/guard-runtime/**"
       - "src/codex_plugin_scanner/guard/native_command_model.py"
       - "src/codex_plugin_scanner/guard/native_runtime.py"
       - "src/codex_plugin_scanner/guard/native_runtime_resident.py"
+      - "src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py"
       - "ci/native_runtime/test_command_model_resident.py"
+      - "ci/native_runtime/test_command_shadow_activity.py"
       - ".github/workflows/rust-command-shadow.yml"
   push:
     branches: [release/3.0]
@@ -19,7 +20,9 @@ on:
       - "src/codex_plugin_scanner/guard/native_command_model.py"
       - "src/codex_plugin_scanner/guard/native_runtime.py"
       - "src/codex_plugin_scanner/guard/native_runtime_resident.py"
+      - "src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py"
       - "ci/native_runtime/test_command_model_resident.py"
+      - "ci/native_runtime/test_command_shadow_activity.py"
       - ".github/workflows/rust-command-shadow.yml"
   workflow_dispatch:
 
@@ -54,8 +57,16 @@ jobs:
         run: |
           rustfmt --edition 2021 --check rust/crates/guard-runtime/src/main.rs
           cargo clippy --manifest-path rust/Cargo.toml --locked --workspace --all-targets -- -D warnings
-          uv run --no-sync python -m ruff check src/codex_plugin_scanner/guard/native_command_model.py ci/native_runtime/test_command_model_resident.py
-          uv run --no-sync python -m ruff format --check src/codex_plugin_scanner/guard/native_command_model.py ci/native_runtime/test_command_model_resident.py
+          uv run --no-sync python -m ruff check \
+            src/codex_plugin_scanner/guard/native_command_model.py \
+            src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py \
+            ci/native_runtime/test_command_model_resident.py \
+            ci/native_runtime/test_command_shadow_activity.py
+          uv run --no-sync python -m ruff format --check \
+            src/codex_plugin_scanner/guard/native_command_model.py \
+            src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py \
+            ci/native_runtime/test_command_model_resident.py \
+            ci/native_runtime/test_command_shadow_activity.py
       - name: Build version-matched runtime
         env:
           HOL_GUARD_BUILD_SHA: ${{ github.sha }}
@@ -68,4 +79,8 @@ jobs:
         env:
           HOL_GUARD_NATIVE: force
           HOL_GUARD_NATIVE_BINARY: ${{ github.workspace }}/rust/target/release/hol-guard-runtime
-        run: uv run --no-sync pytest ci/native_runtime/test_command_model_resident.py --tb=short
+        run: >-
+          uv run --no-sync pytest
+          ci/native_runtime/test_command_model_resident.py
+          ci/native_runtime/test_command_shadow_activity.py
+          --tb=short

--- a/.github/workflows/rust-runtime-windows-resident.yml
+++ b/.github/workflows/rust-runtime-windows-resident.yml
@@ -1,0 +1,129 @@
+name: Rust runtime Windows resident
+
+on:
+  pull_request:
+    paths:
+      - "rust/**"
+      - "src/codex_plugin_scanner/guard/native_runtime.py"
+      - "src/codex_plugin_scanner/guard/native_runtime_resident.py"
+      - "src/codex_plugin_scanner/guard/native_command_model.py"
+      - "ci/native_runtime/test_guard_native_runtime_windows_resident.py"
+      - "ci/native_runtime/test_guard_native_runtime_resident.py"
+      - ".github/workflows/rust-runtime-windows-resident.yml"
+  push:
+    branches: [release/3.0]
+    paths:
+      - "rust/**"
+      - "src/codex_plugin_scanner/guard/native_runtime.py"
+      - "src/codex_plugin_scanner/guard/native_runtime_resident.py"
+      - "src/codex_plugin_scanner/guard/native_command_model.py"
+      - "ci/native_runtime/test_guard_native_runtime_windows_resident.py"
+      - "ci/native_runtime/test_guard_native_runtime_resident.py"
+      - ".github/workflows/rust-runtime-windows-resident.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rust-runtime-windows-resident-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  windows-resident:
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+          enable-cache: true
+      - run: uv sync --frozen --extra dev --python 3.12
+      - name: Install pinned Rust toolchain
+        shell: pwsh
+        run: |
+          rustup toolchain install 1.88.0 --profile minimal --component rustfmt --component clippy
+          rustup default 1.88.0
+      - name: Check locked Rust workspace
+        shell: pwsh
+        run: |
+          cargo metadata --manifest-path rust/Cargo.toml --locked --format-version 1 --no-deps | Out-Null
+          rustfmt --edition 2021 rust/crates/guard-runtime/src/main.rs
+          git diff --check -- rust/crates/guard-runtime/src/main.rs
+          cargo clippy --manifest-path rust/Cargo.toml --locked --workspace --all-targets -- -D warnings
+          cargo test --manifest-path rust/Cargo.toml --locked --workspace --all-targets
+      - name: Check Python transport boundary
+        shell: pwsh
+        run: |
+          uv run --no-sync python -m ruff format src/codex_plugin_scanner/guard/native_runtime_resident.py ci/native_runtime/test_guard_native_runtime_windows_resident.py
+          uv run --no-sync python -m ruff check src/codex_plugin_scanner/guard/native_runtime_resident.py ci/native_runtime/test_guard_native_runtime_windows_resident.py
+          git diff --check -- src/codex_plugin_scanner/guard/native_runtime_resident.py ci/native_runtime/test_guard_native_runtime_windows_resident.py
+      - name: Build version-matched Windows runtime
+        shell: pwsh
+        run: |
+          $version = (uv run --no-sync python scripts/sync_repo_version.py --check).Trim()
+          $env:HOL_GUARD_BUILD_SHA = "${{ github.sha }}"
+          $env:HOL_GUARD_PACKAGE_VERSION = $version
+          cargo build --manifest-path rust/Cargo.toml --locked --release -p hol-guard-runtime
+          rust/target/release/hol-guard-runtime.exe self-test --json
+      - name: Exercise authenticated Windows resident runtime
+        shell: pwsh
+        env:
+          HOL_GUARD_NATIVE: force
+          HOL_GUARD_NATIVE_BINARY: ${{ github.workspace }}\rust\target\release\hol-guard-runtime.exe
+        run: uv run --no-sync pytest ci/native_runtime/test_guard_native_runtime_windows_resident.py --tb=short
+
+  unix-regression:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+          enable-cache: true
+      - run: uv sync --frozen --extra dev --python 3.12
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup toolchain install 1.88.0 --profile minimal --component rustfmt --component clippy
+          rustup default 1.88.0
+      - name: Check locked Rust workspace
+        run: |
+          cargo metadata --manifest-path rust/Cargo.toml --locked --format-version 1 --no-deps > /dev/null
+          rustfmt --edition 2021 rust/crates/guard-runtime/src/main.rs
+          git diff --check -- rust/crates/guard-runtime/src/main.rs
+          cargo clippy --manifest-path rust/Cargo.toml --locked --workspace --all-targets -- -D warnings
+          cargo test --manifest-path rust/Cargo.toml --locked --workspace --all-targets
+      - name: Check Python transport boundary
+        run: |
+          uv run --no-sync python -m ruff format src/codex_plugin_scanner/guard/native_runtime_resident.py ci/native_runtime/test_guard_native_runtime_windows_resident.py
+          uv run --no-sync python -m ruff check src/codex_plugin_scanner/guard/native_runtime_resident.py ci/native_runtime/test_guard_native_runtime_windows_resident.py
+          git diff --check -- src/codex_plugin_scanner/guard/native_runtime_resident.py ci/native_runtime/test_guard_native_runtime_windows_resident.py
+      - name: Build version-matched Unix runtime
+        env:
+          HOL_GUARD_BUILD_SHA: ${{ github.sha }}
+        run: |
+          VERSION=$(uv run --no-sync python scripts/sync_repo_version.py --check)
+          export HOL_GUARD_PACKAGE_VERSION="$VERSION"
+          cargo build --manifest-path rust/Cargo.toml --locked --release -p hol-guard-runtime
+          rust/target/release/hol-guard-runtime self-test --json
+      - name: Preserve owner-only Unix resident behavior
+        env:
+          HOL_GUARD_NATIVE: force
+          HOL_GUARD_NATIVE_BINARY: ${{ github.workspace }}/rust/target/release/hol-guard-runtime
+        run: >-
+          uv run --no-sync pytest
+          ci/native_runtime/test_guard_native_runtime_windows_resident.py
+          ci/native_runtime/test_guard_native_runtime_resident.py
+          --tb=short

--- a/ci/native_runtime/test_command_model_resident.py
+++ b/ci/native_runtime/test_command_model_resident.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.native_command_model import review_command_model_native
+from codex_plugin_scanner.guard.native_runtime import native_runtime_status
+from codex_plugin_scanner.guard.native_runtime_resident import (
+    close_resident_native_runtimes,
+    resident_service_starts,
+)
+
+pytestmark = pytest.mark.skipif(os.name == "nt", reason="resident native service is POSIX-only in this wave")
+
+
+def _runtime_from_environment() -> Path:
+    value = os.environ.get("HOL_GUARD_NATIVE_BINARY")
+    assert value, "HOL_GUARD_NATIVE_BINARY is required for resident integration"
+    return Path(value).resolve(strict=True)
+
+
+def test_command_model_reuses_version_matched_resident_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime = _runtime_from_environment()
+    monkeypatch.setenv("HOL_GUARD_NATIVE", "force")
+    close_resident_native_runtimes()
+    with tempfile.TemporaryDirectory(prefix="hgr-", dir="/tmp") as short_tmp:
+        guard_home = Path(short_tmp) / "guard-home"
+        guard_home.mkdir(mode=0o700)
+        try:
+            first = review_command_model_native("git status --short", guard_home=guard_home)
+            second = review_command_model_native("printf 'a|b' | grep b", guard_home=guard_home)
+            assert first is not None
+            assert first["confidence"] == "exact"
+            assert first["segments"][0]["executable"] == "git"
+            assert second is not None
+            assert second["confidence"] == "exact"
+            assert [segment["pipeline_index"] for segment in second["segments"]] == [0, 1]
+
+            status = native_runtime_status()
+            assert status.identity is not None
+            assert status.capabilities is not None
+            assert "resident-command-model-shadow-v1" in status.capabilities.features
+            assert (
+                resident_service_starts(
+                    executable=runtime,
+                    identity_sha256=status.identity.sha256,
+                    guard_home=guard_home,
+                )
+                == 1
+            )
+        finally:
+            close_resident_native_runtimes()
+
+
+def test_complex_command_remains_non_authoritative(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir(mode=0o700)
+    monkeypatch.setenv("HOL_GUARD_NATIVE", "force")
+    close_resident_native_runtimes()
+    try:
+        model = review_command_model_native("echo $(uname) > out.txt", guard_home=guard_home)
+        assert model is not None
+        assert model["confidence"] == "uncertain"
+        assert model["segments"] == []
+        assert model["uncertainty_reason"]
+    finally:
+        close_resident_native_runtimes()
+
+
+def test_command_model_bridge_is_disabled_by_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir(mode=0o700)
+    monkeypatch.delenv("HOL_GUARD_NATIVE", raising=False)
+    assert review_command_model_native("git status", guard_home=guard_home) is None

--- a/ci/native_runtime/test_command_shadow_activity.py
+++ b/ci/native_runtime/test_command_shadow_activity.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+import codex_plugin_scanner.guard.cli.commands_support_command_activity as command_activity
+import codex_plugin_scanner.guard.native_command_model as native_command_model
+from codex_plugin_scanner.guard.runtime.command_evaluation import evaluate_command
+from codex_plugin_scanner.guard.runtime.command_model import parse_shell_command
+from codex_plugin_scanner.guard.runtime.command_shadow_evaluation import (
+    COMMAND_SHADOW_BASELINE_PROPOSAL_VERSION,
+    CommandShadowCohort,
+    CommandShadowProposal,
+)
+
+_OCCURRED_AT = datetime(2026, 8, 10, 12, 0, tzinfo=timezone.utc)
+_NATIVE_PROPOSAL_VERSION = "guard.command-shadow-proposal.rust-parser.v1"
+
+
+def _native_payload(command: str) -> dict[str, object]:
+    payload = parse_shell_command(command).to_dict()
+    payload["parser_profile"] = "guard-command-posix-v1"
+    return payload
+
+
+def test_exact_native_parse_builds_python_rule_shadow_proposal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    command = "git push origin main --force"
+    expected = evaluate_command(command)
+    monkeypatch.setattr(
+        native_command_model,
+        "review_command_model_native",
+        lambda *_args, **_kwargs: _native_payload(command),
+    )
+
+    proposal = native_command_model.native_command_shadow_proposal(
+        command,
+        guard_home=tmp_path,
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+
+    assert proposal is not None
+    assert proposal.version == _NATIVE_PROPOSAL_VERSION
+    assert proposal.cohorts == frozenset({CommandShadowCohort.BASELINE})
+    assert proposal.decision == expected.decision_plane
+
+
+def test_uncertain_native_parse_does_not_create_shadow_proposal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    command = "echo $(uname)"
+    payload = _native_payload(command)
+    payload.update(
+        {
+            "segments": [],
+            "confidence": "uncertain",
+            "uncertainty_reason": "command_substitution_unsupported",
+            "path_overridden": False,
+        }
+    )
+    monkeypatch.setattr(
+        native_command_model,
+        "review_command_model_native",
+        lambda *_args, **_kwargs: payload,
+    )
+
+    assert (
+        native_command_model.native_command_shadow_proposal(
+            command,
+            guard_home=tmp_path,
+            cwd=tmp_path,
+            home_dir=tmp_path,
+        )
+        is None
+    )
+
+
+def test_activity_shadow_prefers_native_proposal_without_changing_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    command = "git push origin main --force"
+    evaluation = evaluate_command(command)
+    native_proposal = CommandShadowProposal(
+        decision=evaluation.decision_plane,
+        cohorts=frozenset({CommandShadowCohort.BASELINE}),
+        version=_NATIVE_PROPOSAL_VERSION,
+    )
+    monkeypatch.setattr(
+        command_activity,
+        "native_command_shadow_proposal",
+        lambda *_args, **_kwargs: native_proposal,
+    )
+
+    observation, failed = command_activity._build_shadow_best_effort(
+        evaluation=evaluation,
+        command_text=command,
+        guard_home=tmp_path,
+        cwd=tmp_path,
+        home_dir=tmp_path,
+        policy_action="review",
+        activity_id="activity:native-shadow-test",
+        occurred_at=_OCCURRED_AT,
+    )
+
+    assert failed is False
+    assert observation is not None
+    assert observation.authoritative_action == "review"
+    assert observation.proposal_version == _NATIVE_PROPOSAL_VERSION
+    assert command not in repr(asdict(observation))
+
+
+def test_native_shadow_exception_falls_back_to_existing_python_baseline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    command = "git push origin main --force"
+    evaluation = evaluate_command(command)
+
+    def fail_native(*_args: object, **_kwargs: object) -> CommandShadowProposal | None:
+        raise RuntimeError("synthetic native failure")
+
+    monkeypatch.setattr(command_activity, "native_command_shadow_proposal", fail_native)
+
+    observation, failed = command_activity._build_shadow_best_effort(
+        evaluation=evaluation,
+        command_text=command,
+        guard_home=tmp_path,
+        cwd=tmp_path,
+        home_dir=tmp_path,
+        policy_action="review",
+        activity_id="activity:native-shadow-fallback",
+        occurred_at=_OCCURRED_AT,
+    )
+
+    assert failed is False
+    assert observation is not None
+    assert observation.authoritative_action == "review"
+    assert observation.proposal_version == COMMAND_SHADOW_BASELINE_PROPOSAL_VERSION

--- a/ci/native_runtime/test_guard_native_runtime_windows_resident.py
+++ b/ci/native_runtime/test_guard_native_runtime_windows_resident.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import hmac
+import os
+import socket
+import threading
+from pathlib import Path
+
+import pytest
+
+import codex_plugin_scanner.guard.native_runtime_resident as resident
+from codex_plugin_scanner.guard.native_runtime import native_runtime_status, review_post_tool_native
+from codex_plugin_scanner.guard.runtime.hook_review_types import HookReviewRequest
+
+_NATIVE_BINARY = os.environ.get("HOL_GUARD_NATIVE_BINARY")
+
+
+def _request(tmp_path: Path, request_id: str) -> HookReviewRequest:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir(mode=0o700, exist_ok=True)
+    return HookReviewRequest(
+        harness="claude-code",
+        event_name="PostToolUse",
+        payload={
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Read",
+            "tool_response": [{"type": "text", "text": "const value = 1;\n"}],
+        },
+        payload_kind="inline",
+        config_path=None,
+        cwd=tmp_path,
+        home_dir=tmp_path,
+        guard_home=guard_home,
+        source_scope="project",
+        request_id=request_id,
+    )
+
+
+def test_invalid_loopback_server_proof_receives_no_authenticated_payload() -> None:
+    token = b"t" * resident._AUTH_TOKEN_BYTES
+    received_after_invalid_proof: list[bytes] = []
+    ready = threading.Event()
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(1)
+        host, port = listener.getsockname()[:2]
+
+        def malicious_server() -> None:
+            ready.set()
+            connection, _ = listener.accept()
+            with connection:
+                connection.settimeout(1.0)
+                nonce = resident._read_exact(connection, resident._AUTH_NONCE_BYTES)
+                assert nonce is not None
+                connection.sendall(b"\x00" * resident._AUTH_PROOF_BYTES)
+                try:
+                    extra = connection.recv(4096)
+                except OSError:
+                    extra = b""
+                received_after_invalid_proof.append(extra)
+
+        thread = threading.Thread(target=malicious_server, daemon=True)
+        thread.start()
+        assert ready.wait(timeout=1.0)
+        client = resident._authenticated_loopback_client(
+            (str(host), int(port)),
+            token,
+            timeout_seconds=1.0,
+        )
+        assert client is None
+        thread.join(timeout=2.0)
+
+    assert received_after_invalid_proof == [b""]
+
+
+def test_loopback_proof_is_role_bound() -> None:
+    token = b"k" * resident._AUTH_TOKEN_BYTES
+    nonce = b"n" * resident._AUTH_NONCE_BYTES
+    server = resident._proof(token, resident._SERVER_PROOF_LABEL, nonce)
+    client = resident._proof(token, resident._CLIENT_PROOF_LABEL, nonce)
+    assert len(server) == resident._AUTH_PROOF_BYTES
+    assert not hmac.compare_digest(server, client)
+
+
+@pytest.mark.skipif(
+    os.name != "nt" or not _NATIVE_BINARY,
+    reason="compiled Windows native runtime is required",
+)
+def test_windows_native_runtime_reuses_authenticated_resident_service(tmp_path: Path) -> None:
+    status = native_runtime_status()
+    assert status.available and status.compatible, status
+    assert status.identity is not None
+    assert status.capabilities is not None
+    assert "authenticated-loopback-resident-v1" in status.capabilities.features
+
+    first_request = _request(tmp_path, "windows-resident-first")
+    second_request = _request(tmp_path, "windows-resident-second")
+    try:
+        first = review_post_tool_native(first_request, observe_mode=False)
+        second = review_post_tool_native(second_request, observe_mode=False)
+        assert first is not None and first.decision == "allow"
+        assert second is not None and second.decision == "allow"
+        assert (
+            resident.resident_service_starts(
+                executable=status.identity.path,
+                identity_sha256=status.identity.sha256,
+                guard_home=first_request.guard_home,
+            )
+            == 1
+        )
+    finally:
+        resident.close_resident_native_runtimes()

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -155,6 +155,7 @@ dependencies = [
  "guard-rule-contract",
  "serde",
  "serde_json",
+ "sha2",
 ]
 
 [[package]]

--- a/rust/crates/guard-runtime/Cargo.toml
+++ b/rust/crates/guard-runtime/Cargo.toml
@@ -16,6 +16,7 @@ guard-hook-core = { path = "../guard-hook-core" }
 guard-rule-contract = { path = "../guard-rule-contract" }
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 
 [lints]
 workspace = true

--- a/rust/crates/guard-runtime/src/main.rs
+++ b/rust/crates/guard-runtime/src/main.rs
@@ -6,6 +6,7 @@ use guard_contracts::{
     MAX_NATIVE_RESPONSE_BYTES, NATIVE_PROTOCOL_VERSION,
 };
 use guard_hook_core::review_post_tool;
+use serde::Deserialize;
 use std::env;
 use std::io::{self, Read, Write};
 
@@ -18,6 +19,19 @@ const PACKAGE_VERSION: &str = match option_env!("HOL_GUARD_PACKAGE_VERSION") {
     None => env!("CARGO_PKG_VERSION"),
 };
 const MAX_RESIDENT_CONCURRENCY: usize = 16;
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "operation", content = "request", rename_all = "snake_case")]
+enum ResidentOperationV1 {
+    CommandModel(CommandModelRequestV1),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum ResidentRequestV1 {
+    Operation(ResidentOperationV1),
+    Hook(NativeHookRequestV1),
+}
 
 fn capabilities() -> RuntimeCapabilitiesV1 {
     RuntimeCapabilitiesV1 {
@@ -34,6 +48,7 @@ fn capabilities() -> RuntimeCapabilitiesV1 {
             "bounded-concurrency-v1".into(),
             "rule-contract-v2".into(),
             "pre-tool-command-model-shadow-v1".into(),
+            "resident-command-model-shadow-v1".into(),
         ],
     }
 }
@@ -53,13 +68,30 @@ fn read_stdin_bounded() -> Result<Vec<u8>, String> {
 fn evaluate_hook_bytes(bytes: &[u8]) -> Result<Vec<u8>, String> {
     let request: NativeHookRequestV1 =
         serde_json::from_slice(bytes).map_err(|_| "native_request_invalid_json".to_owned())?;
-    encode_response(&review_post_tool(&request))
+    let response = review_post_tool(&request);
+    encode_response(&response)
+}
+
+fn evaluate_command_model_request(request: &CommandModelRequestV1) -> Result<Vec<u8>, String> {
+    let response = parse_command(request)?;
+    encode_response(&response)
 }
 
 fn evaluate_command_model_bytes(bytes: &[u8]) -> Result<Vec<u8>, String> {
     let request: CommandModelRequestV1 = serde_json::from_slice(bytes)
         .map_err(|_| "native_command_model_invalid_json".to_owned())?;
-    encode_response(&parse_command(&request)?)
+    evaluate_command_model_request(&request)
+}
+
+fn evaluate_resident_bytes(bytes: &[u8]) -> Result<Vec<u8>, String> {
+    let request: ResidentRequestV1 = serde_json::from_slice(bytes)
+        .map_err(|_| "native_resident_request_invalid_json".to_owned())?;
+    match request {
+        ResidentRequestV1::Operation(ResidentOperationV1::CommandModel(request)) => {
+            evaluate_command_model_request(&request)
+        }
+        ResidentRequestV1::Hook(request) => encode_response(&review_post_tool(&request)),
+    }
 }
 
 fn encode_response<T: serde::Serialize>(value: &T) -> Result<Vec<u8>, String> {
@@ -75,16 +107,6 @@ fn write_json<T: serde::Serialize>(value: &T) -> Result<(), String> {
     serde_json::to_writer(io::stdout().lock(), value)
         .map_err(|_| "native_response_encode_failed".to_owned())?;
     println!();
-    Ok(())
-}
-
-fn write_bytes_response(response: &[u8]) -> Result<(), String> {
-    io::stdout()
-        .write_all(response)
-        .map_err(|_| "native_response_write_failed".to_owned())?;
-    io::stdout()
-        .write_all(b"\n")
-        .map_err(|_| "native_response_write_failed".to_owned())?;
     Ok(())
 }
 
@@ -110,7 +132,7 @@ fn serve(socket_path: &str) -> Result<(), String> {
         stream
             .read_exact(&mut request)
             .map_err(|_| "native_frame_read_failed".to_owned())?;
-        let response = evaluate_hook_bytes(&request)?;
+        let response = evaluate_resident_bytes(&request)?;
         stream
             .write_all(&(response.len() as u32).to_be_bytes())
             .map_err(|_| "native_frame_write_failed".to_owned())?;
@@ -166,6 +188,16 @@ fn serve(_socket_path: &str) -> Result<(), String> {
     Err("native_named_pipe_not_available".into())
 }
 
+fn write_bytes_response(response: &[u8]) -> Result<(), String> {
+    io::stdout()
+        .write_all(response)
+        .map_err(|_| "native_response_write_failed".to_owned())?;
+    io::stdout()
+        .write_all(b"\n")
+        .map_err(|_| "native_response_write_failed".to_owned())?;
+    Ok(())
+}
+
 fn run() -> Result<(), String> {
     let args: Vec<String> = env::args().skip(1).collect();
     match args.as_slice() {
@@ -185,11 +217,13 @@ fn run() -> Result<(), String> {
         }
         [command, flag] if command == "hook" && flag == "--stdin" => {
             let bytes = read_stdin_bounded()?;
-            write_bytes_response(&evaluate_hook_bytes(&bytes)?)
+            let response = evaluate_hook_bytes(&bytes)?;
+            write_bytes_response(&response)
         }
         [command, flag] if command == "command-model" && flag == "--stdin" => {
             let bytes = read_stdin_bounded()?;
-            write_bytes_response(&evaluate_command_model_bytes(&bytes)?)
+            let response = evaluate_command_model_bytes(&bytes)?;
+            write_bytes_response(&response)
         }
         [command, flag, path] if command == "serve" && flag == "--socket" => serve(path),
         _ => Err(

--- a/rust/crates/guard-runtime/src/main.rs
+++ b/rust/crates/guard-runtime/src/main.rs
@@ -7,8 +7,13 @@ use guard_contracts::{
 };
 use guard_hook_core::review_post_tool;
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
 use std::env;
 use std::io::{self, Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread;
+use std::time::Duration;
 
 const BUILD_SHA: &str = match option_env!("HOL_GUARD_BUILD_SHA") {
     Some(value) => value,
@@ -19,6 +24,12 @@ const PACKAGE_VERSION: &str = match option_env!("HOL_GUARD_PACKAGE_VERSION") {
     None => env!("CARGO_PKG_VERSION"),
 };
 const MAX_RESIDENT_CONCURRENCY: usize = 16;
+const AUTH_TOKEN_BYTES: usize = 32;
+const AUTH_NONCE_BYTES: usize = 32;
+const AUTH_PROOF_BYTES: usize = 32;
+const AUTH_TIMEOUT: Duration = Duration::from_secs(1);
+const SERVER_PROOF_LABEL: &[u8] = b"hol-guard-resident-server-v1\0";
+const CLIENT_PROOF_LABEL: &[u8] = b"hol-guard-resident-client-v1\0";
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "operation", content = "request", rename_all = "snake_case")]
@@ -34,22 +45,26 @@ enum ResidentRequestV1 {
 }
 
 fn capabilities() -> RuntimeCapabilitiesV1 {
+    let mut features = vec![
+        "post-tool-inline-v1".into(),
+        "post-tool-source-read-v1".into(),
+        "oneshot-v1".into(),
+        "framed-serve-v1".into(),
+        "bounded-concurrency-v1".into(),
+        "rule-contract-v2".into(),
+        "pre-tool-command-model-shadow-v1".into(),
+        "resident-command-model-shadow-v1".into(),
+    ];
+    if cfg!(windows) {
+        features.push("authenticated-loopback-resident-v1".into());
+    }
     RuntimeCapabilitiesV1 {
         protocol_version: NATIVE_PROTOCOL_VERSION,
         runtime_version: PACKAGE_VERSION.to_owned(),
         rule_digest: guard_rule_contract::rule_digest(),
         build_sha: BUILD_SHA.to_owned(),
         target: format!("{}-{}", env::consts::ARCH, env::consts::OS),
-        features: vec![
-            "post-tool-inline-v1".into(),
-            "post-tool-source-read-v1".into(),
-            "oneshot-v1".into(),
-            "framed-serve-v1".into(),
-            "bounded-concurrency-v1".into(),
-            "rule-contract-v2".into(),
-            "pre-tool-command-model-shadow-v1".into(),
-            "resident-command-model-shadow-v1".into(),
-        ],
+        features,
     }
 }
 
@@ -110,37 +125,57 @@ fn write_json<T: serde::Serialize>(value: &T) -> Result<(), String> {
     Ok(())
 }
 
+fn handle_framed_stream<S: Read + Write>(stream: &mut S) -> Result<(), String> {
+    let mut header = [0u8; 4];
+    stream
+        .read_exact(&mut header)
+        .map_err(|_| "native_frame_read_failed".to_owned())?;
+    let length = u32::from_be_bytes(header) as usize;
+    if length > MAX_NATIVE_REQUEST_BYTES {
+        return Err("native_request_too_large".into());
+    }
+    let mut request = vec![0u8; length];
+    stream
+        .read_exact(&mut request)
+        .map_err(|_| "native_frame_read_failed".to_owned())?;
+    let response = evaluate_resident_bytes(&request)?;
+    stream
+        .write_all(&(response.len() as u32).to_be_bytes())
+        .map_err(|_| "native_frame_write_failed".to_owned())?;
+    stream
+        .write_all(&response)
+        .map_err(|_| "native_frame_write_failed".to_owned())?;
+    Ok(())
+}
+
+fn take_resident_permit(permits: &Arc<(Mutex<usize>, Condvar)>) -> Result<(), String> {
+    let (lock, available) = &**permits;
+    let mut remaining = lock
+        .lock()
+        .map_err(|_| "native_runtime_concurrency_poisoned".to_owned())?;
+    while *remaining == 0 {
+        remaining = available
+            .wait(remaining)
+            .map_err(|_| "native_runtime_concurrency_poisoned".to_owned())?;
+    }
+    *remaining -= 1;
+    Ok(())
+}
+
+fn release_resident_permit(permits: &Arc<(Mutex<usize>, Condvar)>) {
+    let (lock, available) = &**permits;
+    if let Ok(mut remaining) = lock.lock() {
+        *remaining = (*remaining + 1).min(MAX_RESIDENT_CONCURRENCY);
+        available.notify_one();
+    }
+}
+
 #[cfg(unix)]
 fn serve(socket_path: &str) -> Result<(), String> {
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
-    use std::os::unix::net::{UnixListener, UnixStream};
+    use std::os::unix::net::UnixListener;
     use std::path::Path;
-    use std::sync::{Arc, Condvar, Mutex};
-    use std::thread;
-
-    fn handle(mut stream: UnixStream) -> Result<(), String> {
-        let mut header = [0u8; 4];
-        stream
-            .read_exact(&mut header)
-            .map_err(|_| "native_frame_read_failed".to_owned())?;
-        let length = u32::from_be_bytes(header) as usize;
-        if length > MAX_NATIVE_REQUEST_BYTES {
-            return Err("native_request_too_large".into());
-        }
-        let mut request = vec![0u8; length];
-        stream
-            .read_exact(&mut request)
-            .map_err(|_| "native_frame_read_failed".to_owned())?;
-        let response = evaluate_resident_bytes(&request)?;
-        stream
-            .write_all(&(response.len() as u32).to_be_bytes())
-            .map_err(|_| "native_frame_write_failed".to_owned())?;
-        stream
-            .write_all(&response)
-            .map_err(|_| "native_frame_write_failed".to_owned())?;
-        Ok(())
-    }
 
     let path = Path::new(socket_path);
     if path.exists() {
@@ -157,27 +192,12 @@ fn serve(socket_path: &str) -> Result<(), String> {
 
     let permits = Arc::new((Mutex::new(MAX_RESIDENT_CONCURRENCY), Condvar::new()));
     for stream in listener.incoming() {
-        let stream = stream.map_err(|_| "native_socket_accept_failed".to_owned())?;
+        let mut stream = stream.map_err(|_| "native_socket_accept_failed".to_owned())?;
+        take_resident_permit(&permits)?;
         let thread_permits = Arc::clone(&permits);
-        {
-            let (lock, available) = &*thread_permits;
-            let mut remaining = lock
-                .lock()
-                .map_err(|_| "native_runtime_concurrency_poisoned".to_owned())?;
-            while *remaining == 0 {
-                remaining = available
-                    .wait(remaining)
-                    .map_err(|_| "native_runtime_concurrency_poisoned".to_owned())?;
-            }
-            *remaining -= 1;
-        }
         thread::spawn(move || {
-            let _ = handle(stream);
-            let (lock, available) = &*thread_permits;
-            if let Ok(mut remaining) = lock.lock() {
-                *remaining = (*remaining + 1).min(MAX_RESIDENT_CONCURRENCY);
-                available.notify_one();
-            }
+            let _ = handle_framed_stream(&mut stream);
+            release_resident_permit(&thread_permits);
         });
     }
     Ok(())
@@ -185,7 +205,143 @@ fn serve(socket_path: &str) -> Result<(), String> {
 
 #[cfg(not(unix))]
 fn serve(_socket_path: &str) -> Result<(), String> {
-    Err("native_named_pipe_not_available".into())
+    Err("native_unix_socket_not_available".into())
+}
+
+fn hex_nibble(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        b'A'..=b'F' => Some(value - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn read_resident_auth_token() -> Result<[u8; AUTH_TOKEN_BYTES], String> {
+    let mut encoded = String::new();
+    io::stdin()
+        .take((AUTH_TOKEN_BYTES * 2 + 2) as u64)
+        .read_to_string(&mut encoded)
+        .map_err(|_| "native_resident_auth_read_failed".to_owned())?;
+    let encoded = encoded.trim();
+    if encoded.len() != AUTH_TOKEN_BYTES * 2 {
+        return Err("native_resident_auth_invalid".into());
+    }
+    let mut token = [0u8; AUTH_TOKEN_BYTES];
+    for (index, pair) in encoded.as_bytes().chunks_exact(2).enumerate() {
+        let high = hex_nibble(pair[0]).ok_or_else(|| "native_resident_auth_invalid".to_owned())?;
+        let low = hex_nibble(pair[1]).ok_or_else(|| "native_resident_auth_invalid".to_owned())?;
+        token[index] = (high << 4) | low;
+    }
+    Ok(token)
+}
+
+fn hmac_sha256(key: &[u8], label: &[u8], nonce: &[u8]) -> [u8; AUTH_PROOF_BYTES] {
+    const BLOCK_BYTES: usize = 64;
+    let mut key_block = [0u8; BLOCK_BYTES];
+    if key.len() > BLOCK_BYTES {
+        let digest = Sha256::digest(key);
+        key_block[..digest.len()].copy_from_slice(&digest);
+    } else {
+        key_block[..key.len()].copy_from_slice(key);
+    }
+
+    let mut inner_pad = [0x36u8; BLOCK_BYTES];
+    let mut outer_pad = [0x5cu8; BLOCK_BYTES];
+    for index in 0..BLOCK_BYTES {
+        inner_pad[index] ^= key_block[index];
+        outer_pad[index] ^= key_block[index];
+    }
+
+    let mut inner = Sha256::new();
+    inner.update(inner_pad);
+    inner.update(label);
+    inner.update(nonce);
+    let inner_digest = inner.finalize();
+
+    let mut outer = Sha256::new();
+    outer.update(outer_pad);
+    outer.update(inner_digest);
+    let digest = outer.finalize();
+    let mut proof = [0u8; AUTH_PROOF_BYTES];
+    proof.copy_from_slice(&digest);
+    proof
+}
+
+fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    let mut difference = 0u8;
+    for (left_byte, right_byte) in left.iter().zip(right) {
+        difference |= left_byte ^ right_byte;
+    }
+    difference == 0
+}
+
+fn authenticate_loopback_stream(
+    stream: &mut TcpStream,
+    token: &[u8; AUTH_TOKEN_BYTES],
+) -> Result<(), String> {
+    stream
+        .set_read_timeout(Some(AUTH_TIMEOUT))
+        .map_err(|_| "native_resident_auth_timeout_failed".to_owned())?;
+    stream
+        .set_write_timeout(Some(AUTH_TIMEOUT))
+        .map_err(|_| "native_resident_auth_timeout_failed".to_owned())?;
+    let _ = stream.set_nodelay(true);
+
+    let mut nonce = [0u8; AUTH_NONCE_BYTES];
+    stream
+        .read_exact(&mut nonce)
+        .map_err(|_| "native_resident_auth_nonce_failed".to_owned())?;
+    let server_proof = hmac_sha256(token, SERVER_PROOF_LABEL, &nonce);
+    stream
+        .write_all(&server_proof)
+        .map_err(|_| "native_resident_auth_proof_failed".to_owned())?;
+
+    let mut client_proof = [0u8; AUTH_PROOF_BYTES];
+    stream
+        .read_exact(&mut client_proof)
+        .map_err(|_| "native_resident_auth_client_failed".to_owned())?;
+    let expected = hmac_sha256(token, CLIENT_PROOF_LABEL, &nonce);
+    if !constant_time_eq(&client_proof, &expected) {
+        return Err("native_resident_auth_rejected".into());
+    }
+    Ok(())
+}
+
+fn serve_loopback(address: &str) -> Result<(), String> {
+    let requested: SocketAddr = address
+        .parse()
+        .map_err(|_| "native_resident_address_invalid".to_owned())?;
+    if !requested.ip().is_loopback() || requested.port() == 0 {
+        return Err("native_resident_address_not_loopback".into());
+    }
+    let token = Arc::new(read_resident_auth_token()?);
+    let listener = TcpListener::bind(requested)
+        .map_err(|_| "native_resident_loopback_bind_failed".to_owned())?;
+    let local = listener
+        .local_addr()
+        .map_err(|_| "native_resident_loopback_addr_failed".to_owned())?;
+    if local != requested {
+        return Err("native_resident_loopback_addr_changed".into());
+    }
+
+    let permits = Arc::new((Mutex::new(MAX_RESIDENT_CONCURRENCY), Condvar::new()));
+    for stream in listener.incoming() {
+        let mut stream = stream.map_err(|_| "native_resident_loopback_accept_failed".to_owned())?;
+        take_resident_permit(&permits)?;
+        let thread_permits = Arc::clone(&permits);
+        let thread_token = Arc::clone(&token);
+        thread::spawn(move || {
+            if authenticate_loopback_stream(&mut stream, &thread_token).is_ok() {
+                let _ = handle_framed_stream(&mut stream);
+            }
+            release_resident_permit(&thread_permits);
+        });
+    }
+    Ok(())
 }
 
 fn write_bytes_response(response: &[u8]) -> Result<(), String> {
@@ -226,8 +382,11 @@ fn run() -> Result<(), String> {
             write_bytes_response(&response)
         }
         [command, flag, path] if command == "serve" && flag == "--socket" => serve(path),
+        [command, flag, address] if command == "serve" && flag == "--tcp-loopback" => {
+            serve_loopback(address)
+        }
         _ => Err(
-            "usage: hol-guard-runtime capabilities --json | rule-contract --json | self-test --json | hook --stdin | command-model --stdin | serve --socket PATH"
+            "usage: hol-guard-runtime capabilities --json | rule-contract --json | self-test --json | hook --stdin | command-model --stdin | serve --socket PATH | serve --tcp-loopback 127.0.0.1:PORT"
                 .into(),
         ),
     }
@@ -237,5 +396,34 @@ fn main() {
     if let Err(code) = run() {
         eprintln!("{code}");
         std::process::exit(2);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resident_hmac_is_role_bound_and_deterministic() {
+        let token = [7u8; AUTH_TOKEN_BYTES];
+        let nonce = [9u8; AUTH_NONCE_BYTES];
+        let server = hmac_sha256(&token, SERVER_PROOF_LABEL, &nonce);
+        let client = hmac_sha256(&token, CLIENT_PROOF_LABEL, &nonce);
+        assert_eq!(server, hmac_sha256(&token, SERVER_PROOF_LABEL, &nonce));
+        assert_ne!(server, client);
+        assert!(constant_time_eq(&server, &server));
+        assert!(!constant_time_eq(&server, &client));
+    }
+
+    #[test]
+    fn resident_hmac_changes_with_nonce() {
+        let token = [3u8; AUTH_TOKEN_BYTES];
+        let mut first_nonce = [1u8; AUTH_NONCE_BYTES];
+        let second_nonce = [2u8; AUTH_NONCE_BYTES];
+        let first = hmac_sha256(&token, SERVER_PROOF_LABEL, &first_nonce);
+        let second = hmac_sha256(&token, SERVER_PROOF_LABEL, &second_nonce);
+        assert_ne!(first, second);
+        first_nonce[0] ^= 1;
+        assert_ne!(first, hmac_sha256(&token, SERVER_PROOF_LABEL, &first_nonce));
     }
 }

--- a/src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py
@@ -11,6 +11,7 @@ from typing import cast
 
 from ..action_lattice import guard_action_severity
 from ..models import GuardAction
+from ..native_command_model import native_command_shadow_proposal
 from ..runtime.command_activity_contract import (
     ActivityApprovalReuseStatus,
     ActivityDecisionReason,
@@ -108,6 +109,10 @@ def record_pre_hook_command_activity_best_effort(
             return False
         shadow, shadow_failed = _build_shadow_best_effort(
             evaluation=evaluation,
+            command_text=_payload_command_text(payload),
+            guard_home=guard_home,
+            cwd=cwd,
+            home_dir=home_dir,
             policy_action=policy_action,
             activity_id=activity_id,
             occurred_at=occurred_at,
@@ -260,15 +265,43 @@ def record_command_activity_failure_best_effort(store: GuardStore, error_code: s
     _record_persistence_failure(store, error_code)
 
 
+def _compatibility_context(
+    evaluation: CompositeCommandEvaluation,
+) -> tuple[str | None, str | None]:
+    """Return only an explicit compatibility fallback already used by Python."""
+
+    for owned in evaluation.matches:
+        if owned.match.rule.compatibility_fallback and not owned.match.matcher_evidence:
+            return evaluation.controlling_action_class, evaluation.controlling_reason
+    return None, None
+
+
 def _build_shadow_best_effort(
     *,
     evaluation: CompositeCommandEvaluation,
+    command_text: str | None,
+    guard_home: Path,
+    cwd: Path | None,
+    home_dir: Path | None,
     policy_action: GuardAction,
     activity_id: str,
     occurred_at: datetime,
 ) -> tuple[CommandShadowObservation | None, bool]:
     try:
         proposal = baseline_command_shadow_proposal(evaluation)
+        if command_text is not None:
+            compatibility_action_class, compatibility_reason = _compatibility_context(evaluation)
+            with suppress(Exception):
+                native_proposal = native_command_shadow_proposal(
+                    command_text,
+                    guard_home=guard_home,
+                    cwd=cwd,
+                    home_dir=home_dir,
+                    compatibility_action_class=compatibility_action_class,
+                    compatibility_reason=compatibility_reason,
+                )
+                if native_proposal is not None:
+                    proposal = native_proposal
         return (
             build_command_shadow_observation(
                 evaluation,

--- a/src/codex_plugin_scanner/guard/native_command_model.py
+++ b/src/codex_plugin_scanner/guard/native_command_model.py
@@ -14,6 +14,9 @@ from typing import Any
 from .codex_hook_launch_runtime import run_isolated_hook_process
 from .native_runtime import _isolated_environment, native_runtime_status
 from .native_runtime_resident import resident_native_request
+from .runtime.command_evaluation import evaluate_command
+from .runtime.command_model import CanonicalCommand, CommandSegment
+from .runtime.command_shadow_evaluation import CommandShadowCohort, CommandShadowProposal
 
 _MAX_REQUEST_BYTES = 64 * 1024
 _MAX_RESPONSE_BYTES = 2 * 1024 * 1024
@@ -21,6 +24,7 @@ _MAX_SEGMENTS = 128
 _MAX_TOKENS = 2_048
 _REQUIRED_FEATURE = "pre-tool-command-model-shadow-v1"
 _RESIDENT_FEATURE = "resident-command-model-shadow-v1"
+_NATIVE_SHADOW_PROPOSAL_VERSION = "guard.command-shadow-proposal.rust-parser.v1"
 
 
 def _decode_command_model(payload: object) -> dict[str, Any] | None:
@@ -46,8 +50,7 @@ def _decode_command_model(payload: object) -> dict[str, Any] | None:
         or not isinstance(segments, list)
         or len(segments) > _MAX_SEGMENTS
         or confidence not in {"exact", "uncertain"}
-        or uncertainty_reason is not None
-        and not isinstance(uncertainty_reason, str)
+        or (uncertainty_reason is not None and not isinstance(uncertainty_reason, str))
         or not isinstance(path_overridden, bool)
         or not isinstance(parser_profile, str)
     ):
@@ -74,8 +77,7 @@ def _decode_command_model(payload: object) -> dict[str, Any] | None:
             or not all(isinstance(value, str) for value in environment_names)
             or not isinstance(segment_wrappers, list)
             or not all(isinstance(value, str) for value in segment_wrappers)
-            or executable is not None
-            and not isinstance(executable, str)
+            or (executable is not None and not isinstance(executable, str))
             or not isinstance(segment.get("path_overridden"), bool)
             or not isinstance(segment.get("execution_context"), str)
             or not isinstance(pipeline_index, int)
@@ -184,4 +186,137 @@ def review_command_model_native(
         return None
 
 
-__all__ = ["review_command_model_native"]
+def _canonical_command_from_native(
+    command: str,
+    payload: dict[str, Any],
+) -> CanonicalCommand | None:
+    """Convert only a fully exact native parse into the Python canonical type."""
+    raw_text = command.strip()
+    if (
+        not raw_text
+        or payload.get("confidence") != "exact"
+        or payload.get("uncertainty_reason") is not None
+        or payload.get("dialect") != "posix"
+        or payload.get("transport") != "shell_string"
+    ):
+        return None
+    normalized_text = payload.get("normalized_text")
+    provenance = payload.get("extraction_provenance")
+    wrapper_chain = payload.get("wrapper_chain")
+    raw_segments = payload.get("segments")
+    if (
+        not isinstance(normalized_text, str)
+        or not isinstance(provenance, str)
+        or not isinstance(wrapper_chain, list)
+        or not all(isinstance(value, str) for value in wrapper_chain)
+        or not isinstance(raw_segments, list)
+    ):
+        return None
+
+    segments: list[CommandSegment] = []
+    for raw_segment in raw_segments:
+        if not isinstance(raw_segment, dict):
+            return None
+        text = raw_segment.get("text")
+        tokens = raw_segment.get("tokens")
+        executable = raw_segment.get("executable")
+        arguments = raw_segment.get("arguments")
+        environment_names = raw_segment.get("environment_names")
+        segment_wrappers = raw_segment.get("wrapper_chain")
+        path_overridden = raw_segment.get("path_overridden")
+        execution_context = raw_segment.get("execution_context")
+        pipeline_index = raw_segment.get("pipeline_index")
+        span = raw_segment.get("span")
+        if (
+            not isinstance(text, str)
+            or not isinstance(tokens, list)
+            or not all(isinstance(value, str) for value in tokens)
+            or (executable is not None and not isinstance(executable, str))
+            or not isinstance(arguments, list)
+            or not all(isinstance(value, str) for value in arguments)
+            or not isinstance(environment_names, list)
+            or not all(isinstance(value, str) for value in environment_names)
+            or not isinstance(segment_wrappers, list)
+            or not all(isinstance(value, str) for value in segment_wrappers)
+            or not isinstance(path_overridden, bool)
+            or not isinstance(execution_context, str)
+            or not isinstance(pipeline_index, int)
+            or not isinstance(span, dict)
+            or span.get("source") != "normalized"
+            or not isinstance(span.get("start"), int)
+            or not isinstance(span.get("end"), int)
+        ):
+            return None
+        start = span["start"]
+        end = span["end"]
+        if start < 0 or end < start or end > len(normalized_text):
+            return None
+        segments.append(
+            CommandSegment(
+                text=text,
+                tokens=tuple(tokens),
+                executable=executable,
+                arguments=tuple(arguments),
+                environment_names=tuple(environment_names),
+                wrapper_chain=tuple(segment_wrappers),
+                path_overridden=path_overridden,
+                execution_context=execution_context,
+                pipeline_index=pipeline_index,
+                start=start,
+                end=end,
+            )
+        )
+
+    canonical = CanonicalCommand(
+        raw_text=raw_text,
+        normalized_text=normalized_text,
+        dialect="posix",
+        transport="shell_string",
+        extraction_provenance=provenance,
+        wrapper_chain=tuple(wrapper_chain),
+        segments=tuple(segments),
+        redirects=(),
+        embedded_commands=(),
+        confidence="exact",
+        uncertainty_reason=None,
+    )
+    if payload.get("path_overridden") is not canonical.path_overridden:
+        return None
+    return canonical
+
+
+def native_command_shadow_proposal(
+    command: str,
+    *,
+    guard_home: Path,
+    cwd: Path | None,
+    home_dir: Path | None,
+    compatibility_action_class: str | None = None,
+    compatibility_reason: str | None = None,
+) -> CommandShadowProposal | None:
+    """Build a privacy-safe shadow proposal from a Rust parse and Python rules."""
+    payload = review_command_model_native(command, guard_home=guard_home)
+    if payload is None:
+        return None
+    canonical = _canonical_command_from_native(command, payload)
+    if canonical is None:
+        return None
+    evaluation = evaluate_command(
+        command,
+        canonical_command=canonical,
+        compatibility_action_class=compatibility_action_class,
+        compatibility_reason=compatibility_reason,
+        cwd=cwd,
+        home_dir=home_dir,
+    )
+    return CommandShadowProposal(
+        decision=evaluation.decision_plane,
+        cohorts=frozenset({CommandShadowCohort.BASELINE}),
+        version=_NATIVE_SHADOW_PROPOSAL_VERSION,
+    )
+
+
+__all__ = [
+    "native_command_shadow_proposal",
+    "review_command_model_native",
+]

--- a/src/codex_plugin_scanner/guard/native_command_model.py
+++ b/src/codex_plugin_scanner/guard/native_command_model.py
@@ -1,0 +1,187 @@
+"""Shadow-only Python bridge to the native command model.
+
+This module never makes a PreToolUse decision. It exists to exercise and compare
+the native parser through the same version-matched resident runtime used by the
+PostToolUse path. Python remains authoritative until later rollout gates land.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .codex_hook_launch_runtime import run_isolated_hook_process
+from .native_runtime import _isolated_environment, native_runtime_status
+from .native_runtime_resident import resident_native_request
+
+_MAX_REQUEST_BYTES = 64 * 1024
+_MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+_MAX_SEGMENTS = 128
+_MAX_TOKENS = 2_048
+_REQUIRED_FEATURE = "pre-tool-command-model-shadow-v1"
+_RESIDENT_FEATURE = "resident-command-model-shadow-v1"
+
+
+def _decode_command_model(payload: object) -> dict[str, Any] | None:
+    if not isinstance(payload, dict):
+        return None
+    normalized_text = payload.get("normalized_text")
+    dialect = payload.get("dialect")
+    transport = payload.get("transport")
+    provenance = payload.get("extraction_provenance")
+    wrapper_chain = payload.get("wrapper_chain")
+    segments = payload.get("segments")
+    confidence = payload.get("confidence")
+    uncertainty_reason = payload.get("uncertainty_reason")
+    path_overridden = payload.get("path_overridden")
+    parser_profile = payload.get("parser_profile")
+    if (
+        not isinstance(normalized_text, str)
+        or not isinstance(dialect, str)
+        or not isinstance(transport, str)
+        or not isinstance(provenance, str)
+        or not isinstance(wrapper_chain, list)
+        or not all(isinstance(value, str) for value in wrapper_chain)
+        or not isinstance(segments, list)
+        or len(segments) > _MAX_SEGMENTS
+        or confidence not in {"exact", "uncertain"}
+        or uncertainty_reason is not None
+        and not isinstance(uncertainty_reason, str)
+        or not isinstance(path_overridden, bool)
+        or not isinstance(parser_profile, str)
+    ):
+        return None
+
+    total_tokens = 0
+    for segment in segments:
+        if not isinstance(segment, dict):
+            return None
+        tokens = segment.get("tokens")
+        arguments = segment.get("arguments")
+        environment_names = segment.get("environment_names")
+        segment_wrappers = segment.get("wrapper_chain")
+        executable = segment.get("executable")
+        span = segment.get("span")
+        pipeline_index = segment.get("pipeline_index")
+        if (
+            not isinstance(segment.get("text"), str)
+            or not isinstance(tokens, list)
+            or not all(isinstance(value, str) for value in tokens)
+            or not isinstance(arguments, list)
+            or not all(isinstance(value, str) for value in arguments)
+            or not isinstance(environment_names, list)
+            or not all(isinstance(value, str) for value in environment_names)
+            or not isinstance(segment_wrappers, list)
+            or not all(isinstance(value, str) for value in segment_wrappers)
+            or executable is not None
+            and not isinstance(executable, str)
+            or not isinstance(segment.get("path_overridden"), bool)
+            or not isinstance(segment.get("execution_context"), str)
+            or not isinstance(pipeline_index, int)
+            or pipeline_index < 0
+            or not isinstance(span, dict)
+            or span.get("source") != "normalized"
+            or not isinstance(span.get("start"), int)
+            or not isinstance(span.get("end"), int)
+            or span["start"] < 0
+            or span["end"] < span["start"]
+        ):
+            return None
+        total_tokens += len(tokens)
+        if total_tokens > _MAX_TOKENS:
+            return None
+    return payload
+
+
+def _request_payload(
+    command: str,
+    *,
+    dialect: str,
+    transport: str,
+    extraction_provenance: str,
+) -> tuple[dict[str, str], bytes] | None:
+    request = {
+        "command": command,
+        "dialect": dialect,
+        "transport": transport,
+        "extraction_provenance": extraction_provenance,
+    }
+    encoded = json.dumps(request, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    if len(encoded) > _MAX_REQUEST_BYTES:
+        return None
+    return request, encoded
+
+
+def review_command_model_native(
+    command: str,
+    *,
+    guard_home: Path,
+    dialect: str = "posix",
+    transport: str = "shell_string",
+    extraction_provenance: str = "guard-shell",
+    timeout_seconds: float = 0.25,
+) -> dict[str, Any] | None:
+    """Return native command-model evidence in explicit shadow/force modes only."""
+    status = native_runtime_status()
+    if (
+        status.mode not in {"shadow", "force"}
+        or not status.available
+        or not status.compatible
+        or status.identity is None
+        or status.capabilities is None
+        or _REQUIRED_FEATURE not in status.capabilities.features
+        or timeout_seconds <= 0
+    ):
+        return None
+    prepared = _request_payload(
+        command,
+        dialect=dialect,
+        transport=transport,
+        extraction_provenance=extraction_provenance,
+    )
+    if prepared is None:
+        return None
+    request, request_bytes = prepared
+    timeout_seconds = min(timeout_seconds, 1.0)
+    environment = _isolated_environment()
+
+    if _RESIDENT_FEATURE in status.capabilities.features:
+        resident_envelope = json.dumps(
+            {"operation": "command_model", "request": request},
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+        resident_output = resident_native_request(
+            executable=status.identity.path,
+            identity_sha256=status.identity.sha256,
+            guard_home=guard_home,
+            environment=environment,
+            payload=resident_envelope,
+            timeout_seconds=timeout_seconds,
+        )
+        if resident_output is not None:
+            try:
+                decoded = _decode_command_model(json.loads(resident_output))
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                decoded = None
+            if decoded is not None:
+                return decoded
+
+    result = run_isolated_hook_process(
+        (str(status.identity.path), "command-model", "--stdin"),
+        input_text=request_bytes.decode("utf-8"),
+        cwd=status.identity.path.parent,
+        environment=environment,
+        timeout_seconds=timeout_seconds,
+        output_limit=_MAX_RESPONSE_BYTES,
+    )
+    if result.returncode != 0 or result.timed_out or result.output_limit_exceeded or result.containment_failed:
+        return None
+    try:
+        return _decode_command_model(json.loads(result.stdout))
+    except json.JSONDecodeError:
+        return None
+
+
+__all__ = ["review_command_model_native"]

--- a/src/codex_plugin_scanner/guard/native_runtime_resident.py
+++ b/src/codex_plugin_scanner/guard/native_runtime_resident.py
@@ -1,15 +1,19 @@
-"""Resident local transport for the Rust PostToolUse runtime.
+"""Resident local transport for the Rust Guard runtime.
 
-The resident service is POSIX-only in this wave. It runs through Guard's
-existing contained process launcher, speaks a length-prefixed protocol over an
-owner-only Unix socket, and falls back to the one-shot native path on any
-startup, transport, or lifecycle failure.
+POSIX uses an owner-only Unix socket. Windows uses an authenticated loopback
+transport because default named-pipe ACLs are not acceptable for Guard hook
+material. The per-process authentication secret is generated in Python and is
+sent to the contained Rust child only through inherited stdin. It is never
+placed in argv, environment variables, files, logs, or request payloads.
 """
 
 from __future__ import annotations
 
 import atexit
+import hashlib
+import hmac
 import os
+import secrets
 import socket
 import stat
 import threading
@@ -22,9 +26,14 @@ from .codex_hook_launch_runtime import run_isolated_hook_process
 _MAX_REQUEST_BYTES = 6 * 1024 * 1024
 _MAX_RESPONSE_BYTES = 2 * 1024 * 1024
 _MAX_SOCKET_PATH_BYTES = 100
-_START_TIMEOUT_SECONDS = 0.4
+_START_TIMEOUT_SECONDS = 0.6
 _SERVICE_LIFETIME_SECONDS = 7 * 24 * 60 * 60
 _SERVICE_OUTPUT_LIMIT = 64 * 1024
+_AUTH_TOKEN_BYTES = 32
+_AUTH_NONCE_BYTES = 32
+_AUTH_PROOF_BYTES = 32
+_SERVER_PROOF_LABEL = b"hol-guard-resident-server-v1\x00"
+_CLIENT_PROOF_LABEL = b"hol-guard-resident-client-v1\x00"
 
 
 class _ResidentService:
@@ -41,6 +50,8 @@ class _ResidentService:
         self.guard_home = guard_home
         self.environment = dict(environment)
         self.socket_path = _resident_socket_path(guard_home, identity_sha256)
+        self.loopback_address = _select_loopback_address() if os.name == "nt" else None
+        self._auth_token = secrets.token_bytes(_AUTH_TOKEN_BYTES) if self.loopback_address is not None else None
         self._lock = threading.Lock()
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
@@ -52,17 +63,36 @@ class _ResidentService:
             return self._starts
 
     def request(self, payload: bytes, *, timeout_seconds: float) -> bytes | None:
-        if self.socket_path is None or len(payload) > _MAX_REQUEST_BYTES or timeout_seconds <= 0:
+        if len(payload) > _MAX_REQUEST_BYTES or timeout_seconds <= 0 or not self._transport_configured():
             return None
-        response = _send_request(self.socket_path, payload, timeout_seconds=min(timeout_seconds, 0.05))
+        response = self._send(payload, timeout_seconds=min(timeout_seconds, 0.05))
         if response is not None:
             return response
         if not self._ensure_started(timeout_seconds=min(timeout_seconds, _START_TIMEOUT_SECONDS)):
             return None
-        return _send_request(self.socket_path, payload, timeout_seconds=timeout_seconds)
+        return self._send(payload, timeout_seconds=timeout_seconds)
+
+    def _transport_configured(self) -> bool:
+        if os.name == "nt":
+            return self.loopback_address is not None and self._auth_token is not None
+        return self.socket_path is not None
+
+    def _send(self, payload: bytes, *, timeout_seconds: float) -> bytes | None:
+        if os.name == "nt":
+            if self.loopback_address is None or self._auth_token is None:
+                return None
+            return _send_authenticated_loopback_request(
+                self.loopback_address,
+                self._auth_token,
+                payload,
+                timeout_seconds=timeout_seconds,
+            )
+        if self.socket_path is None:
+            return None
+        return _send_unix_request(self.socket_path, payload, timeout_seconds=timeout_seconds)
 
     def _ensure_started(self, *, timeout_seconds: float) -> bool:
-        if self.socket_path is None or timeout_seconds <= 0:
+        if not self._transport_configured() or timeout_seconds <= 0:
             return False
         with self._lock:
             thread = self._thread
@@ -78,15 +108,27 @@ class _ResidentService:
                 thread.start()
         deadline = time.monotonic() + timeout_seconds
         while time.monotonic() < deadline:
-            if self._socket_accepts_connections():
+            if self._transport_accepts_authenticated_connections():
                 return True
             with self._lock:
                 if self._thread is None or not self._thread.is_alive():
                     return False
             time.sleep(0.01)
-        return self._socket_accepts_connections()
+        return self._transport_accepts_authenticated_connections()
 
-    def _socket_accepts_connections(self) -> bool:
+    def _transport_accepts_authenticated_connections(self) -> bool:
+        if os.name == "nt":
+            if self.loopback_address is None or self._auth_token is None:
+                return False
+            client = _authenticated_loopback_client(
+                self.loopback_address,
+                self._auth_token,
+                timeout_seconds=0.05,
+            )
+            if client is None:
+                return False
+            client.close()
+            return True
         if self.socket_path is None:
             return False
         try:
@@ -98,12 +140,25 @@ class _ResidentService:
             return False
 
     def _run(self) -> None:
-        socket_path = self.socket_path
-        if socket_path is None:
-            return
+        if os.name == "nt":
+            if self.loopback_address is None or self._auth_token is None:
+                return
+            host, port = self.loopback_address
+            command = (
+                str(self.executable),
+                "serve",
+                "--tcp-loopback",
+                f"{host}:{port}",
+            )
+            input_text = self._auth_token.hex() + "\n"
+        else:
+            if self.socket_path is None:
+                return
+            command = (str(self.executable), "serve", "--socket", str(self.socket_path))
+            input_text = ""
         _ = run_isolated_hook_process(
-            (str(self.executable), "serve", "--socket", str(socket_path)),
-            input_text="",
+            command,
+            input_text=input_text,
             cwd=self.executable.parent,
             environment=self.environment,
             timeout_seconds=_SERVICE_LIFETIME_SECONDS,
@@ -118,6 +173,7 @@ class _ResidentService:
         if thread is not None and thread.is_alive():
             thread.join(timeout=1.5)
         _unlink_owned_socket(self.socket_path)
+        self._auth_token = None
 
 
 _SERVICES_LOCK = threading.Lock()
@@ -161,6 +217,22 @@ def _resident_socket_path(guard_home: Path, identity_sha256: str) -> Path | None
     return socket_path
 
 
+def _select_loopback_address() -> tuple[str, int] | None:
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.bind(("127.0.0.1", 0))
+            host, port = probe.getsockname()[:2]
+            if host != "127.0.0.1" or not isinstance(port, int) or port <= 0:
+                return None
+            return host, port
+    except OSError:
+        return None
+
+
+def _proof(token: bytes, label: bytes, nonce: bytes) -> bytes:
+    return hmac.new(token, label + nonce, hashlib.sha256).digest()
+
+
 def _read_exact(client: socket.socket, length: int) -> bytes | None:
     if length < 0:
         return None
@@ -175,7 +247,60 @@ def _read_exact(client: socket.socket, length: int) -> bytes | None:
     return b"".join(chunks)
 
 
-def _send_request(socket_path: Path, payload: bytes, *, timeout_seconds: float) -> bytes | None:
+def _authenticated_loopback_client(
+    address: tuple[str, int],
+    token: bytes,
+    *,
+    timeout_seconds: float,
+) -> socket.socket | None:
+    if len(token) != _AUTH_TOKEN_BYTES or timeout_seconds <= 0:
+        return None
+    client: socket.socket | None = None
+    try:
+        client = socket.create_connection(address, timeout=timeout_seconds)
+        client.settimeout(timeout_seconds)
+        nonce = secrets.token_bytes(_AUTH_NONCE_BYTES)
+        client.sendall(nonce)
+        server_proof = _read_exact(client, _AUTH_PROOF_BYTES)
+        expected_server = _proof(token, _SERVER_PROOF_LABEL, nonce)
+        if server_proof is None or not hmac.compare_digest(server_proof, expected_server):
+            client.close()
+            return None
+        client.sendall(_proof(token, _CLIENT_PROOF_LABEL, nonce))
+        return client
+    except (OSError, OverflowError):
+        if client is not None:
+            client.close()
+        return None
+
+
+def _send_authenticated_loopback_request(
+    address: tuple[str, int],
+    token: bytes,
+    payload: bytes,
+    *,
+    timeout_seconds: float,
+) -> bytes | None:
+    if len(payload) > _MAX_REQUEST_BYTES or timeout_seconds <= 0:
+        return None
+    client = _authenticated_loopback_client(address, token, timeout_seconds=timeout_seconds)
+    if client is None:
+        return None
+    try:
+        with client:
+            client.sendall(len(payload).to_bytes(4, "big") + payload)
+            header = _read_exact(client, 4)
+            if header is None:
+                return None
+            response_length = int.from_bytes(header, "big")
+            if response_length > _MAX_RESPONSE_BYTES:
+                return None
+            return _read_exact(client, response_length)
+    except (OSError, OverflowError):
+        return None
+
+
+def _send_unix_request(socket_path: Path, payload: bytes, *, timeout_seconds: float) -> bytes | None:
     if len(payload) > _MAX_REQUEST_BYTES or timeout_seconds <= 0:
         return None
     try:
@@ -204,7 +329,7 @@ def resident_native_request(
     timeout_seconds: float,
 ) -> bytes | None:
     """Send one request to a resident native runtime, starting it lazily."""
-    if os.name == "nt" or not hasattr(socket, "AF_UNIX"):
+    if os.name != "nt" and not hasattr(socket, "AF_UNIX"):
         return None
     try:
         resolved_executable = executable.resolve(strict=True)


### PR DESCRIPTION
## Summary

Closes the Windows residency gap without relying on default named-pipe ACLs.

- preserves the existing owner-only Unix-domain-socket resident transport on POSIX
- adds Windows residency over IPv4 loopback only
- generates a fresh 256-bit per-process authentication secret in Python
- delivers that secret to the contained Rust child only through inherited stdin, never argv, environment variables, files, logs, or hook payloads
- performs mutual HMAC-SHA256 challenge-response before any framed Guard request is sent
- requires the client to verify the Rust server proof before sending hook bytes
- requires the Rust server to verify the client proof before reading a framed request
- keeps the existing 16-request resident concurrency bound and one-shot fallback on any bind, authentication, timeout, transport, or lifecycle failure
- advertises `authenticated-loopback-resident-v1` on Windows
- preserves the exact `rule-contract-v2` digest and `rule-contract --json` provenance surface
- keeps `unsafe` forbidden in the Rust runtime

## Security model

A process racing the selected loopback port does not receive the authentication secret or Guard payload. It can observe only a random client nonce and can at most cause authentication failure and fallback. A client connected to an unauthenticated or spoofed listener sends no framed hook data until the expected server HMAC is proven.

## Verification

Adds a Windows/Linux CI workflow that runs locked Rust metadata, scoped rustfmt, clippy, workspace tests, Python boundary checks and a real version-matched runtime build. Windows proves two native reviews reuse one authenticated resident process. A malicious-listener regression proves invalid server proof receives no framed payload. Linux reruns owner-only Unix resident regressions.

## Rollout

This does not enable native execution by default. This PR is intentionally stacked after the live PreToolUse observation slice and consists of one clean four-file commit.