### PR TITLE
test(guard): add deterministic Rust runtime mutation parity

### DIFF
--- a/.github/workflows/rust-runtime-mutation-differential.yml
+++ b/.github/workflows/rust-runtime-mutation-differential.yml
@@ -1,0 +1,67 @@
+name: Rust runtime mutation differential
+
+on:
+  pull_request:
+    paths:
+      - "rust/**"
+      - "src/codex_plugin_scanner/guard/native_runtime.py"
+      - "src/codex_plugin_scanner/guard/native_runtime_resident.py"
+      - "src/codex_plugin_scanner/guard/runtime/hook_*.py"
+      - "ci/native_runtime/test_guard_native_runtime_mutation_differential.py"
+      - ".github/workflows/rust-runtime-mutation-differential.yml"
+  push:
+    branches: [release/3.0]
+    paths:
+      - "rust/**"
+      - "src/codex_plugin_scanner/guard/native_runtime.py"
+      - "src/codex_plugin_scanner/guard/native_runtime_resident.py"
+      - "src/codex_plugin_scanner/guard/runtime/hook_*.py"
+      - "ci/native_runtime/test_guard_native_runtime_mutation_differential.py"
+      - ".github/workflows/rust-runtime-mutation-differential.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rust-runtime-mutation-differential-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mutation-parity:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+          enable-cache: true
+      - run: uv sync --frozen --extra dev --python 3.12
+      - name: Check deterministic mutation harness
+        run: |
+          uv run --no-sync python -m ruff format ci/native_runtime/test_guard_native_runtime_mutation_differential.py
+          uv run --no-sync python -m ruff check ci/native_runtime/test_guard_native_runtime_mutation_differential.py
+          git diff --check -- ci/native_runtime/test_guard_native_runtime_mutation_differential.py
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup toolchain install 1.88.0 --profile minimal
+          rustup default 1.88.0
+      - name: Build version-matched native runtime
+        env:
+          HOL_GUARD_BUILD_SHA: ${{ github.sha }}
+        run: |
+          VERSION=$(uv run --no-sync python scripts/sync_repo_version.py --check)
+          export HOL_GUARD_PACKAGE_VERSION="$VERSION"
+          cargo build --manifest-path rust/Cargo.toml --locked --release -p hol-guard-runtime
+          rust/target/release/hol-guard-runtime self-test --json
+      - name: Run deterministic mutation parity corpus
+        env:
+          HOL_GUARD_NATIVE: force
+          HOL_GUARD_NATIVE_BINARY: ${{ github.workspace }}/rust/target/release/hol-guard-runtime
+        run: uv run --no-sync pytest ci/native_runtime/test_guard_native_runtime_mutation_differential.py --tb=short

--- a/ci/native_runtime/test_guard_native_runtime_mutation_differential.py
+++ b/ci/native_runtime/test_guard_native_runtime_mutation_differential.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import os
+import random
+import string
+import time
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.config import load_guard_config
+from codex_plugin_scanner.guard.native_runtime import parity_signature, review_post_tool_native
+from codex_plugin_scanner.guard.native_runtime_resident import close_resident_native_runtimes
+from codex_plugin_scanner.guard.runtime.hook_content_scanner import ContentScanner
+from codex_plugin_scanner.guard.runtime.hook_decision_cache import HookDecisionCache
+from codex_plugin_scanner.guard.runtime.hook_review_engine import HookReviewEngine
+from codex_plugin_scanner.guard.runtime.hook_review_types import HookReviewRequest
+from codex_plugin_scanner.guard.store import GuardStore
+
+_NATIVE_BINARY = os.environ.get("HOL_GUARD_NATIVE_BINARY")
+pytestmark = pytest.mark.skipif(not _NATIVE_BINARY, reason="compiled native runtime is required")
+_SEEDS = (7, 29, 113)
+_CASES_PER_SEED = 64
+_OUTPUT_KEYS = ("tool_response", "stdout", "stderr", "result")
+_TEXT_KEYS = ("text", "output", "content", "message", "stdout", "stderr")
+
+
+def _engine(store: GuardStore) -> HookReviewEngine:
+    return HookReviewEngine(
+        store=store,
+        scanner=ContentScanner(),
+        cache=HookDecisionCache(store),
+        config_loader=lambda guard_home, workspace: load_guard_config(guard_home, workspace=workspace),
+    )
+
+
+def _clean_text(rng: random.Random) -> str:
+    alphabet = string.ascii_letters + string.digits + " _-/:.\n"
+    length = rng.randint(0, 5000)
+    return "".join(rng.choice(alphabet) for _ in range(length))
+
+
+def _risk_text(rng: random.Random) -> str:
+    family = rng.randrange(4)
+    if family == 0:
+        return "".join(("gh", "p_")) + "z" * 30
+    if family == 1:
+        return "".join(("AK", "IA")) + "A" * 16
+    if family == 2:
+        return "Bearer " + "sk-" + "x" * 32
+    return "token = " + "xoxb-" + "1" * 20 + "-" + "a" * 24
+
+
+def _leaf(rng: random.Random) -> object:
+    selector = rng.randrange(8)
+    if selector <= 2:
+        return _clean_text(rng)
+    if selector == 3:
+        return _risk_text(rng)
+    if selector == 4:
+        return rng.randint(-1000, 1000)
+    if selector == 5:
+        return rng.choice((True, False, None))
+    if selector == 6:
+        return {"type": "text", "text": _clean_text(rng)}
+    return {"type": "text", "text": _risk_text(rng)}
+
+
+def _nested_value(rng: random.Random, depth: int) -> object:
+    if depth >= 4 or rng.random() < 0.45:
+        return _leaf(rng)
+    if rng.random() < 0.5:
+        return [_nested_value(rng, depth + 1) for _ in range(rng.randint(0, 8))]
+    record: dict[str, object] = {}
+    keys = list(_TEXT_KEYS)
+    rng.shuffle(keys)
+    for key in keys[: rng.randint(0, min(5, len(keys)))]:
+        record[key] = _nested_value(rng, depth + 1)
+    if rng.random() < 0.25:
+        record["ignored_metadata"] = {"value": rng.randint(0, 50)}
+    return record
+
+
+def _payload(rng: random.Random, case_index: int) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Read" if case_index % 3 == 0 else "Bash",
+    }
+    keys = list(_OUTPUT_KEYS)
+    rng.shuffle(keys)
+    for key in keys[: rng.randint(0, len(keys))]:
+        payload[key] = _nested_value(rng, 0)
+    if case_index % 5 == 0:
+        payload["tool_input"] = {"file_path": "docs/example.md"}
+    elif case_index % 7 == 0:
+        payload["tool_input"] = {"file_path": "src/example.ts"}
+    if case_index % 11 == 0:
+        payload["unknown"] = {"nested": ["ignored", {"textual": "not-output"}]}
+    return payload
+
+
+def _request(tmp_path: Path, *, payload: dict[str, object], request_id: str) -> HookReviewRequest:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir(mode=0o700, exist_ok=True)
+    return HookReviewRequest(
+        harness="claude-code",
+        event_name="PostToolUse",
+        payload=payload,
+        payload_kind="inline",
+        config_path=None,
+        cwd=tmp_path,
+        home_dir=tmp_path,
+        guard_home=guard_home,
+        source_scope="project",
+        request_id=request_id,
+        deadline_monotonic=time.monotonic() + 5.0,
+    )
+
+
+@pytest.mark.parametrize("seed", _SEEDS)
+def test_mutated_inline_corpus_keeps_exact_python_rust_parity(tmp_path: Path, seed: int) -> None:
+    rng = random.Random(seed)
+    store = GuardStore(tmp_path / "guard-home")
+    engine = _engine(store)
+    try:
+        for case_index in range(_CASES_PER_SEED):
+            request = _request(
+                tmp_path,
+                payload=_payload(rng, case_index),
+                request_id=f"mutation-{seed}-{case_index}",
+            )
+            python_response = engine.review(request)
+            native_response = review_post_tool_native(request, observe_mode=False)
+            assert native_response is not None
+            assert parity_signature(native_response) == parity_signature(python_response), (
+                seed,
+                case_index,
+                request.payload,
+                native_response,
+                python_response,
+            )
+    finally:
+        close_resident_native_runtimes()
+
+
+def test_mutation_corpus_is_deterministic() -> None:
+    first = random.Random(_SEEDS[0])
+    second = random.Random(_SEEDS[0])
+    assert [_payload(first, index) for index in range(12)] == [
+        _payload(second, index) for index in range(12)
+    ]


### PR DESCRIPTION
## Summary

Adds a broader deterministic differential gate for the Rust PostToolUse runtime without changing product authority.

- generates 192 synthetic inline PostToolUse requests from three fixed seeds
- mutates output-key placement across `tool_response`, `stdout`, `stderr`, and `result`
- covers nested lists/maps, text-block objects, empty/null/bool/numeric values, documentation/source context, ignored metadata, and generated secret-shaped content
- executes every case through the authoritative Python `HookReviewEngine` and the compiled version-matched Rust runtime
- requires exact parity for decision, model-output action, public reason code, notice, policy action, observed action, reviewed-output hash, and reviewed-excerpt hash
- keeps the corpus deterministic and reproducible for CI triage
- runs outside the global pytest ratchet in dedicated native-runtime CI

## Security / rollout

All inputs are synthetic. No user commands, files, paths, or secrets are persisted. `HOL_GUARD_NATIVE` remains default-off. This is evidence only and is a prerequisite for later rollout decisions, not an authority change.