### PR TITLE
fix(guard): bind native rule digest to exact implementation bytes

### DIFF
--- a/.github/workflows/rust-runtime-rule-contract.yml
+++ b/.github/workflows/rust-runtime-rule-contract.yml
@@ -1,0 +1,67 @@
+name: Rust runtime rule contract
+
+on:
+  pull_request:
+    paths:
+      - "rust/**"
+      - "ci/native_runtime/test_native_rule_contract.py"
+      - ".github/workflows/rust-runtime-rule-contract.yml"
+  push:
+    branches: [release/3.0]
+    paths:
+      - "rust/**"
+      - "ci/native_runtime/test_native_rule_contract.py"
+      - ".github/workflows/rust-runtime-rule-contract.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rust-runtime-rule-contract-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rule-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+          enable-cache: true
+      - run: uv sync --frozen --extra dev --python 3.12
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup toolchain install 1.88.0 --profile minimal --component rustfmt --component clippy
+          rustup default 1.88.0
+      - name: Validate locked Rust workspace
+        run: |
+          cargo metadata --manifest-path rust/Cargo.toml --locked --format-version 1 --no-deps > /dev/null
+          rustfmt --edition 2021 --check rust/crates/guard-rule-contract/src/lib.rs rust/crates/guard-runtime/src/main.rs
+          cargo clippy --manifest-path rust/Cargo.toml --locked --workspace --all-targets -- -D warnings
+          cargo test --manifest-path rust/Cargo.toml --locked --workspace --all-targets
+      - name: Check Python rule-contract verifier
+        run: |
+          uv run --no-sync python -m ruff format ci/native_runtime/test_native_rule_contract.py
+          uv run --no-sync python -m ruff check ci/native_runtime/test_native_rule_contract.py
+          git diff --check -- ci/native_runtime/test_native_rule_contract.py
+      - name: Build version-matched runtime
+        env:
+          HOL_GUARD_BUILD_SHA: ${{ github.sha }}
+        run: |
+          VERSION=$(uv run --no-sync python scripts/sync_repo_version.py --check)
+          export HOL_GUARD_PACKAGE_VERSION="$VERSION"
+          cargo build --manifest-path rust/Cargo.toml --locked --release -p hol-guard-runtime
+          rust/target/release/hol-guard-runtime self-test --json
+          rust/target/release/hol-guard-runtime rule-contract --json
+      - name: Prove runtime digest binds exact component source bytes
+        env:
+          HOL_GUARD_NATIVE_BINARY: ${{ github.workspace }}/rust/target/release/hol-guard-runtime
+        run: uv run --no-sync pytest ci/native_runtime/test_native_rule_contract.py --tb=short

--- a/ci/native_runtime/test_native_rule_contract.py
+++ b/ci/native_runtime/test_native_rule_contract.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_RUNTIME = os.environ.get("HOL_GUARD_NATIVE_BINARY")
+pytestmark = pytest.mark.skipif(not _RUNTIME, reason="compiled native runtime is required")
+
+_SCHEMA = "hol-guard-native-rule-contract.v2"
+_DOMAIN = b"hol-guard-native-rule-contract.v2\x00"
+_COMPONENTS = (
+    ("guard-rules", Path("rust/crates/guard-rules/src/lib.rs")),
+    ("guard-scanner", Path("rust/crates/guard-scanner/src/lib.rs")),
+    ("guard-secure-fs", Path("rust/crates/guard-secure-fs/src/lib.rs")),
+    ("guard-hook-core", Path("rust/crates/guard-hook-core/src/lib.rs")),
+)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _expected_contract() -> dict[str, object]:
+    root = _repo_root()
+    components: list[dict[str, str]] = []
+    combined = hashlib.sha256()
+    combined.update(_DOMAIN)
+    for name, relative_path in _COMPONENTS:
+        digest = hashlib.sha256((root / relative_path).read_bytes()).hexdigest()
+        components.append({"name": name, "sha256": digest})
+        combined.update(name.encode("utf-8"))
+        combined.update(b"\x00")
+        combined.update(digest.encode("ascii"))
+        combined.update(b"\x00")
+    return {
+        "schema": _SCHEMA,
+        "components": components,
+        "rule_digest": combined.hexdigest(),
+    }
+
+
+def _runtime_json(*args: str) -> dict[str, object]:
+    assert _RUNTIME is not None
+    completed = subprocess.run(
+        (_RUNTIME, *args),
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        check=True,
+        timeout=5.0,
+    )
+    payload = json.loads(completed.stdout)
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_runtime_rule_contract_matches_exact_checkout_source_bytes() -> None:
+    assert _runtime_json("rule-contract", "--json") == _expected_contract()
+
+
+def test_capabilities_rule_digest_is_the_exact_rule_contract_digest() -> None:
+    contract = _runtime_json("rule-contract", "--json")
+    capabilities = _runtime_json("capabilities", "--json")
+    assert capabilities["rule_digest"] == contract["rule_digest"]
+    features = capabilities.get("features")
+    assert isinstance(features, list)
+    assert "rule-contract-v2" in features
+
+
+def test_rule_contract_changes_when_any_component_bytes_change() -> None:
+    expected = _expected_contract()
+    components = expected["components"]
+    assert isinstance(components, list)
+    original = str(expected["rule_digest"])
+    for index, component in enumerate(components):
+        assert isinstance(component, dict)
+        mutated_components = [dict(value) for value in components]
+        digest = str(mutated_components[index]["sha256"])
+        mutated_components[index]["sha256"] = (
+            ("0" if digest[0] != "0" else "1") + digest[1:]
+        )
+        combined = hashlib.sha256()
+        combined.update(_DOMAIN)
+        for value in mutated_components:
+            combined.update(str(value["name"]).encode("utf-8"))
+            combined.update(b"\x00")
+            combined.update(str(value["sha256"]).encode("ascii"))
+            combined.update(b"\x00")
+        assert combined.hexdigest() != original

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -97,6 +97,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "guard-rule-contract"
+version = "0.1.0"
+dependencies = [
+ "hex",
+ "serde",
+ "sha2",
+]
+
+[[package]]
 name = "guard-rules"
 version = "0.1.0"
 dependencies = [
@@ -135,7 +144,7 @@ version = "0.1.0"
 dependencies = [
  "guard-contracts",
  "guard-hook-core",
- "guard-rules",
+ "guard-rule-contract",
  "serde",
  "serde_json",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/guard-secure-fs",
     "crates/guard-hook-core",
     "crates/guard-policy-snapshot",
+    "crates/guard-rule-contract",
     "crates/guard-runtime",
 ]
 resolver = "2"

--- a/rust/crates/guard-rule-contract/Cargo.toml
+++ b/rust/crates/guard-rule-contract/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "guard-rule-contract"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+hex.workspace = true
+serde.workspace = true
+sha2.workspace = true
+
+[lints]
+workspace = true

--- a/rust/crates/guard-rule-contract/src/lib.rs
+++ b/rust/crates/guard-rule-contract/src/lib.rs
@@ -1,0 +1,103 @@
+#![forbid(unsafe_code)]
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+pub const RULE_CONTRACT_SCHEMA: &str = "hol-guard-native-rule-contract.v2";
+const RULE_CONTRACT_DOMAIN: &[u8] = b"hol-guard-native-rule-contract.v2\0";
+
+const COMPONENTS: [(&str, &[u8]); 4] = [
+    (
+        "guard-rules",
+        include_bytes!("../../guard-rules/src/lib.rs"),
+    ),
+    (
+        "guard-scanner",
+        include_bytes!("../../guard-scanner/src/lib.rs"),
+    ),
+    (
+        "guard-secure-fs",
+        include_bytes!("../../guard-secure-fs/src/lib.rs"),
+    ),
+    (
+        "guard-hook-core",
+        include_bytes!("../../guard-hook-core/src/lib.rs"),
+    ),
+];
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RuleComponentDigest {
+    pub name: &'static str,
+    pub sha256: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RuleContract {
+    pub schema: &'static str,
+    pub components: Vec<RuleComponentDigest>,
+    pub rule_digest: String,
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    hex::encode(Sha256::digest(bytes))
+}
+
+pub fn rule_contract() -> RuleContract {
+    let components: Vec<RuleComponentDigest> = COMPONENTS
+        .iter()
+        .map(|(name, bytes)| RuleComponentDigest {
+            name,
+            sha256: sha256_hex(bytes),
+        })
+        .collect();
+
+    let mut combined = Sha256::new();
+    combined.update(RULE_CONTRACT_DOMAIN);
+    for component in &components {
+        combined.update(component.name.as_bytes());
+        combined.update([0]);
+        combined.update(component.sha256.as_bytes());
+        combined.update([0]);
+    }
+
+    RuleContract {
+        schema: RULE_CONTRACT_SCHEMA,
+        components,
+        rule_digest: hex::encode(combined.finalize()),
+    }
+}
+
+pub fn rule_digest() -> String {
+    rule_contract().rule_digest
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contract_is_stable_and_complete() {
+        let first = rule_contract();
+        let second = rule_contract();
+        assert_eq!(first, second);
+        assert_eq!(first.schema, RULE_CONTRACT_SCHEMA);
+        assert_eq!(
+            first
+                .components
+                .iter()
+                .map(|component| component.name)
+                .collect::<Vec<_>>(),
+            vec![
+                "guard-rules",
+                "guard-scanner",
+                "guard-secure-fs",
+                "guard-hook-core",
+            ]
+        );
+        assert!(first
+            .components
+            .iter()
+            .all(|component| component.sha256.len() == 64));
+        assert_eq!(first.rule_digest.len(), 64);
+    }
+}

--- a/rust/crates/guard-runtime/Cargo.toml
+++ b/rust/crates/guard-runtime/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 [dependencies]
 guard-contracts = { path = "../guard-contracts" }
 guard-hook-core = { path = "../guard-hook-core" }
-guard-rules = { path = "../guard-rules" }
+guard-rule-contract = { path = "../guard-rule-contract" }
 serde.workspace = true
 serde_json.workspace = true
 

--- a/rust/crates/guard-runtime/src/main.rs
+++ b/rust/crates/guard-runtime/src/main.rs
@@ -1,8 +1,8 @@
 #![forbid(unsafe_code)]
 
 use guard_contracts::{
-    NativeHookRequestV1, RuntimeCapabilitiesV1, MAX_NATIVE_REQUEST_BYTES, MAX_NATIVE_RESPONSE_BYTES,
-    NATIVE_PROTOCOL_VERSION,
+    NativeHookRequestV1, RuntimeCapabilitiesV1, MAX_NATIVE_REQUEST_BYTES,
+    MAX_NATIVE_RESPONSE_BYTES, NATIVE_PROTOCOL_VERSION,
 };
 use guard_hook_core::review_post_tool;
 use std::env;
@@ -22,7 +22,7 @@ fn capabilities() -> RuntimeCapabilitiesV1 {
     RuntimeCapabilitiesV1 {
         protocol_version: NATIVE_PROTOCOL_VERSION,
         runtime_version: PACKAGE_VERSION.to_owned(),
-        rule_digest: guard_rules::rule_digest(),
+        rule_digest: guard_rule_contract::rule_digest(),
         build_sha: BUILD_SHA.to_owned(),
         target: format!("{}-{}", env::consts::ARCH, env::consts::OS),
         features: vec![
@@ -31,6 +31,7 @@ fn capabilities() -> RuntimeCapabilitiesV1 {
             "oneshot-v1".into(),
             "framed-serve-v1".into(),
             "bounded-concurrency-v1".into(),
+            "rule-contract-v2".into(),
         ],
     }
 }
@@ -51,7 +52,8 @@ fn evaluate_bytes(bytes: &[u8]) -> Result<Vec<u8>, String> {
     let request: NativeHookRequestV1 =
         serde_json::from_slice(bytes).map_err(|_| "native_request_invalid_json".to_owned())?;
     let response = review_post_tool(&request);
-    let encoded = serde_json::to_vec(&response).map_err(|_| "native_response_encode_failed".to_owned())?;
+    let encoded =
+        serde_json::to_vec(&response).map_err(|_| "native_response_encode_failed".to_owned())?;
     if encoded.len() > MAX_NATIVE_RESPONSE_BYTES {
         return Err("native_response_too_large".into());
     }
@@ -99,7 +101,8 @@ fn serve(socket_path: &str) -> Result<(), String> {
 
     let path = Path::new(socket_path);
     if path.exists() {
-        let metadata = fs::symlink_metadata(path).map_err(|_| "native_socket_stat_failed".to_owned())?;
+        let metadata =
+            fs::symlink_metadata(path).map_err(|_| "native_socket_stat_failed".to_owned())?;
         if metadata.file_type().is_symlink() {
             return Err("native_socket_symlink_rejected".into());
         }
@@ -146,7 +149,13 @@ fn run() -> Result<(), String> {
     let args: Vec<String> = env::args().skip(1).collect();
     match args.as_slice() {
         [command] if command == "capabilities" => write_json(&capabilities()),
-        [command, flag] if command == "capabilities" && flag == "--json" => write_json(&capabilities()),
+        [command, flag] if command == "capabilities" && flag == "--json" => {
+            write_json(&capabilities())
+        }
+        [command] if command == "rule-contract" => write_json(&guard_rule_contract::rule_contract()),
+        [command, flag] if command == "rule-contract" && flag == "--json" => {
+            write_json(&guard_rule_contract::rule_contract())
+        }
         [command] if command == "self-test" => {
             write_json(&serde_json::json!({"ok": true, "capabilities": capabilities()}))
         }
@@ -166,7 +175,7 @@ fn run() -> Result<(), String> {
         }
         [command, flag, path] if command == "serve" && flag == "--socket" => serve(path),
         _ => Err(
-            "usage: hol-guard-runtime capabilities --json | self-test --json | hook --stdin | serve --socket PATH"
+            "usage: hol-guard-runtime capabilities --json | rule-contract --json | self-test --json | hook --stdin | serve --socket PATH"
                 .into(),
         ),
     }


### PR DESCRIPTION
## Summary

Replaces the native runtime's handwritten rule-summary digest with a cryptographic contract over the exact Rust implementation files that determine PostToolUse behavior.

- adds an `unsafe`-forbidden `guard-rule-contract` crate
- hashes the exact source bytes for `guard-rules`, `guard-scanner`, `guard-secure-fs`, and `guard-hook-core`
- combines those component hashes with a domain-separated `hol-guard-native-rule-contract.v2` digest
- makes runtime capabilities advertise that exact combined digest
- adds `hol-guard-runtime rule-contract --json` for deterministic, non-secret provenance inspection
- advertises `rule-contract-v2`
- preserves the existing build/source SHA binding separately

## Verification

Dedicated CI independently reads the four repository source files in Python, recomputes each SHA-256 and the domain-separated combined digest, and requires byte-for-byte equality with the compiled Rust runtime's rule contract. It also requires `capabilities.rule_digest` to equal the contract digest and proves mutating any component digest changes the combined value. The stacked version already passed locked Rust metadata, rustfmt, clippy, full workspace tests, exact source-byte proof, Python/Rust differential parity, security gates, and CodeQL before this final release rebase.

## Rollout

This does not enable native execution by default. It strengthens artifact/runtime provenance and complements the behavioral differential and mutation parity gates.