### PR TITLE
fix(hooks): restore trusted read-only command flow

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12265,
-  "maximum_test_source_lines": 285707,
+  "maximum_collected_cases": 12291,
+  "maximum_test_source_lines": 285938,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 12291,
-  "maximum_test_source_lines": 285938,
+  "maximum_test_source_lines": 285939,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -5479,13 +5479,18 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             )
             guard_home = self._validated_hook_guard_home(self._optional_string(params.get("guard-home", [None])[-1]))
             workspace_query = self._normalized_hook_workspace_string(params.get("workspace", [None])[-1])
+            action_workdir_provided, action_workdir = self._runtime_hook_exec_command_workdir(payload)
+            if action_workdir_provided and action_workdir is None:
+                raise _HookPathValidationError("workspace", "invalid_action_workdir")
             payload_workspace = self._normalized_hook_workspace_string(payload.get("cwd"))
-            workspace_candidate = payload_workspace if payload_workspace is not None else workspace_query
+            workspace_candidate = action_workdir or payload_workspace or workspace_query
             workspace = self._validated_hook_directory_string(
                 "workspace",
                 workspace_candidate,
                 roots=self._hook_safe_roots(),
             )
+            if action_workdir is not None and (workspace is None or not os.path.isdir(workspace)):
+                raise _HookPathValidationError("workspace", "not_directory")
         except _HookPathValidationError as error:
             self._record_hook_path_rejection(parameter=error.parameter, reason=error.reason)
             self._write_json({"error": error.code}, status=400)
@@ -7233,6 +7238,29 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if temporary_root is not None and os.path.realpath(candidate) == os.path.realpath(temporary_root):
             return None
         return candidate
+
+    @staticmethod
+    def _runtime_hook_exec_command_workdir(payload: dict[str, object]) -> tuple[bool, str | None]:
+        tool_name = payload.get("tool_name")
+        if not isinstance(tool_name, str) or tool_name.strip().casefold() != "exec_command":
+            return False, None
+        tool_input = payload.get("tool_input")
+        if not isinstance(tool_input, dict) or "workdir" not in tool_input:
+            return False, None
+        value = tool_input.get("workdir")
+        if not isinstance(value, str):
+            return True, None
+        stripped = value.strip()
+        if not stripped or stripped.casefold() in {"none", "null"}:
+            return True, None
+        candidate = os.path.normpath(os.path.expanduser(stripped))
+        try:
+            temporary_root = trusted_temporary_root_for_path(Path(candidate))
+        except OSError:
+            temporary_root = None
+        if temporary_root is not None and os.path.realpath(candidate) == os.path.realpath(temporary_root):
+            return True, None
+        return True, candidate
 
     def _validate_hook_directory_path(
         self,

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -5488,7 +5488,6 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 "workspace",
                 workspace_candidate,
                 roots=self._hook_safe_roots(),
-                require_directory=action_workdir is not None,
             )
         except _HookPathValidationError as error:
             self._record_hook_path_rejection(parameter=error.parameter, reason=error.reason)
@@ -7210,20 +7209,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         value: str | None,
         *,
         roots: tuple[Path, ...] | None = None,
-        require_directory: bool = False,
     ) -> str | None:
         if value is None:
             return None
-        path = self._validate_hook_directory_path(parameter, value, roots=roots)
-        if require_directory:
-            try:
-                # codeql[py/path-injection] path is canonical and constrained to a trusted root above.
-                path_stat = path.stat()
-            except OSError:
-                raise _HookPathValidationError(parameter, "not_directory") from None
-            if not stat.S_ISDIR(path_stat.st_mode):
-                raise _HookPathValidationError(parameter, "not_directory")
-        return os.fspath(path)
+        return os.fspath(self._validate_hook_directory_path(parameter, value, roots=roots))
 
     @staticmethod
     def _normalized_hook_workspace_string(value: object) -> str | None:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -5488,9 +5488,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 "workspace",
                 workspace_candidate,
                 roots=self._hook_safe_roots(),
+                require_directory=action_workdir is not None,
             )
-            if action_workdir is not None and (workspace is None or not os.path.isdir(workspace)):
-                raise _HookPathValidationError("workspace", "not_directory")
         except _HookPathValidationError as error:
             self._record_hook_path_rejection(parameter=error.parameter, reason=error.reason)
             self._write_json({"error": error.code}, status=400)
@@ -7211,10 +7210,20 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         value: str | None,
         *,
         roots: tuple[Path, ...] | None = None,
+        require_directory: bool = False,
     ) -> str | None:
         if value is None:
             return None
-        return os.fspath(self._validate_hook_directory_path(parameter, value, roots=roots))
+        path = self._validate_hook_directory_path(parameter, value, roots=roots)
+        if require_directory:
+            try:
+                # codeql[py/path-injection] path is canonical and constrained to a trusted root above.
+                path_stat = path.stat()
+            except OSError:
+                raise _HookPathValidationError(parameter, "not_directory") from None
+            if not stat.S_ISDIR(path_stat.st_mode):
+                raise _HookPathValidationError(parameter, "not_directory")
+        return os.fspath(path)
 
     @staticmethod
     def _normalized_hook_workspace_string(value: object) -> str | None:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/benign_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/benign_requests.py
@@ -50,7 +50,7 @@ from .shell_stdin_sources import (
     _echo_stdout_payload,
     _printf_stdout_payloads,
 )
-from .shell_tokenization import _shell_segment_primary_command, _split_shell_parts
+from .shell_tokenization import _iter_shell_command_segments, _shell_segment_primary_command, _split_shell_parts
 
 
 def is_explicitly_benign_tool_action_request(
@@ -65,6 +65,7 @@ def is_explicitly_benign_tool_action_request(
         return False
     found_benign_candidate = False
     for command_text in _candidate_command_texts(arguments):
+        raw_command_text = command_text
         interpreter_evidence = _python_interpreter_executable_identities(
             command_text,
             cwd=cwd,
@@ -73,9 +74,16 @@ def is_explicitly_benign_tool_action_request(
         if any(evidence.get("trust") not in {"trusted_guard", "trusted_system"} for evidence in interpreter_evidence):
             return False
         if normalized_tool_name in _SHELL_TOOL_NAMES:
-            command_text = normalize_transparent_shell_command(
-                command_text, cwd=cwd, home_dir=home_dir
-            ).normalized_command
+            normalization = normalize_transparent_shell_command(command_text, cwd=cwd, home_dir=home_dir)
+            command_text = normalization.normalized_command
+            if normalization.wrapper_chain:
+                normalized_parts = _split_shell_parts(command_text)
+                normalized_segments = _iter_shell_command_segments(normalized_parts)
+                invokes_guard = any(
+                    _shell_segment_primary_command(segment)[0] == "hol-guard" for segment in normalized_segments
+                )
+                if invokes_guard and command_text != raw_command_text:
+                    return False
         stripped_command = command_text.strip()
         if not stripped_command:
             continue

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/developer_inspection.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/developer_inspection.py
@@ -194,7 +194,13 @@ def _compound_developer_effect_graph(
         if command_name == "gh" and github_is_low_risk:
             effects.append(DeveloperShellSegmentEffect(index, command_name, DeveloperShellEffect.REMOTE_READ))
             continue
-        if _safe_cli_metadata_segment_is_safe(command_name, args, cwd=segment_root):
+        if _safe_cli_metadata_segment_is_safe(
+            command_name,
+            args,
+            cwd=segment_root,
+            command_token=segment.tokens[command_index],
+            command_index=command_index,
+        ):
             effects.append(DeveloperShellSegmentEffect(index, command_name, DeveloperShellEffect.LOCAL_READ))
             continue
         if (

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/developer_routines.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/developer_routines.py
@@ -96,6 +96,8 @@ def _looks_like_safe_compound_developer_inspection(
             command_name or "",
             args,
             cwd=segment.effective_cwd or home_dir,
+            command_token=segment.tokens[command_index],
+            command_index=command_index,
         ):
             continue
         if command_name != "git":
@@ -161,7 +163,13 @@ def _looks_like_safe_cli_metadata_command(command_text: str, parts: list[str], *
     executable = segments[0][0]
     if "/" in executable or "\\" in executable:
         return False
-    return _safe_cli_metadata_segment_is_safe(command_name, segments[0][1:], cwd=cwd or Path.cwd())
+    return _safe_cli_metadata_segment_is_safe(
+        command_name,
+        segments[0][1:],
+        cwd=cwd or Path.cwd(),
+        command_token=segments[0][0],
+        command_index=command_index,
+    )
 
 
 def _safe_dependency_symlink_execution_context(

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/shell_static_safety.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/shell_static_safety.py
@@ -18,7 +18,16 @@ from .request_artifacts import _normalized_shell_command_name
 from .shell_tokenization import _iter_shell_command_segments, _shell_segment_primary_command
 
 
-def _safe_cli_metadata_segment_is_safe(command_name: str, args: list[str], *, cwd: Path) -> bool:
+def _safe_cli_metadata_segment_is_safe(
+    command_name: str,
+    args: list[str],
+    *,
+    cwd: Path,
+    command_token: str,
+    command_index: int,
+) -> bool:
+    if command_index != 0 or command_token != command_name:
+        return False
     if command_name == "git" and args in (["--version"], ["version"]):
         git_path = _which_for_execution_cwd("git", cwd=cwd)
         if git_path is None:
@@ -27,7 +36,14 @@ def _safe_cli_metadata_segment_is_safe(command_name: str, args: list[str], *, cw
             return git_binary_path_is_trusted(Path(git_path).resolve(), cwd=cwd.resolve())
         except (OSError, RuntimeError):
             return False
-    if command_name != "hol-guard" or args not in (["--version"], ["status"], ["daemon", "status"]):
+    if command_name != "hol-guard" or args not in (
+        ["--version"],
+        ["status"],
+        ["status", "--json"],
+        ["daemon", "status"],
+        ["settings"],
+        ["settings", "--json"],
+    ):
         return False
     executable = _which_for_execution_cwd("hol-guard", cwd=cwd)
     if executable is None:

--- a/tests/test_codex_daemon_hook_bridge.py
+++ b/tests/test_codex_daemon_hook_bridge.py
@@ -16,8 +16,10 @@ import pytest
 
 from codex_plugin_scanner.guard.adapters import codex_daemon_hook_auth as hook_auth
 from codex_plugin_scanner.guard.adapters import codex_daemon_hook_bridge as bridge
+from codex_plugin_scanner.guard.config import load_guard_config
 from codex_plugin_scanner.guard.daemon import manager as daemon_manager
 from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
+from codex_plugin_scanner.guard.runtime.local_temp_paths import trusted_temporary_root_for_path
 from codex_plugin_scanner.guard.store import GuardStore
 from tests.codex_daemon_hook_bridge_fixtures import (
     _bridge_config,
@@ -489,6 +491,168 @@ def test_bridge_real_daemon_prefers_payload_cwd_for_verified_git_fetch(
                     "tool_name": "Bash",
                     "tool_input": {"command": "git fetch origin main"},
                     "cwd": str(repository),
+                }
+            )
+        ),
+    )
+
+    try:
+        exit_code = bridge.main(**config)
+    finally:
+        daemon.stop()
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out) == {}
+
+
+def test_bridge_real_daemon_uses_exec_command_workdir_for_verified_git_fetch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    session_workspace = tmp_path / "projects"
+    repository = session_workspace / "example"
+    repository.mkdir(parents=True)
+    _ = subprocess.run(["git", "init", "--quiet", str(repository)], check=True)
+    _ = subprocess.run(
+        ["git", "-C", str(repository), "remote", "add", "origin", "https://github.com/example/project.git"],
+        check=True,
+    )
+    guard_config = load_guard_config(guard_home)
+    assert guard_config.mode == "prompt"
+    assert guard_config.security_level == "balanced"
+    daemon = GuardDaemonServer(GuardStore(guard_home), host="127.0.0.1", port=0)
+    daemon.start()
+    config = _bridge_config(guard_home, daemon.port)
+    config["query"] = urlencode({"guard-home": str(guard_home), "home": str(tmp_path)})
+    config["fallback_command"] = [sys.executable, "-c", "raise SystemExit(1)"]
+    monkeypatch.setattr(
+        "sys.stdin",
+        io.StringIO(
+            json.dumps(
+                {
+                    "hook_event_name": "PreToolUse",
+                    "tool_name": "exec_command",
+                    "tool_input": {"cmd": "git fetch origin main", "workdir": str(repository)},
+                    "cwd": str(session_workspace),
+                }
+            )
+        ),
+    )
+
+    try:
+        exit_code = bridge.main(**config)
+    finally:
+        daemon.stop()
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out) == {}
+
+
+@pytest.mark.parametrize("workdir", ("relative/repository", "/"))
+def test_bridge_real_daemon_rejects_untrusted_exec_command_workdir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    workdir: str,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    daemon = GuardDaemonServer(GuardStore(guard_home), host="127.0.0.1", port=0)
+    daemon.start()
+    config = _bridge_config(guard_home, daemon.port)
+    config["query"] = urlencode({"guard-home": str(guard_home), "home": str(tmp_path)})
+    config["fallback_command"] = [sys.executable, "-c", "raise SystemExit(1)"]
+    monkeypatch.setattr(
+        "sys.stdin",
+        io.StringIO(
+            json.dumps(
+                {
+                    "hook_event_name": "PreToolUse",
+                    "tool_name": "exec_command",
+                    "tool_input": {"cmd": "git status --short", "workdir": workdir},
+                    "cwd": str(workspace),
+                }
+            )
+        ),
+    )
+
+    try:
+        exit_code = bridge.main(**config)
+    finally:
+        daemon.stop()
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out) != {}
+
+
+def test_bridge_real_daemon_rejects_temp_root_workdir_without_falling_back_to_repository(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    _ = subprocess.run(["git", "init", "--quiet", str(repository)], check=True)
+    _ = subprocess.run(
+        ["git", "-C", str(repository), "remote", "add", "origin", "https://github.com/example/project.git"],
+        check=True,
+    )
+    temporary_root = trusted_temporary_root_for_path(tmp_path)
+    assert temporary_root is not None
+    daemon = GuardDaemonServer(GuardStore(guard_home), host="127.0.0.1", port=0)
+    daemon.start()
+    config = _bridge_config(guard_home, daemon.port)
+    config["query"] = urlencode({"guard-home": str(guard_home), "home": str(tmp_path)})
+    config["fallback_command"] = [sys.executable, "-c", "raise SystemExit(1)"]
+    monkeypatch.setattr(
+        "sys.stdin",
+        io.StringIO(
+            json.dumps(
+                {
+                    "hook_event_name": "PreToolUse",
+                    "tool_name": "exec_command",
+                    "tool_input": {"cmd": "git fetch origin main", "workdir": str(temporary_root)},
+                    "cwd": str(repository),
+                }
+            )
+        ),
+    )
+
+    try:
+        exit_code = bridge.main(**config)
+    finally:
+        daemon.stop()
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out) != {}
+
+
+def test_bridge_real_daemon_ignores_workdir_for_opaque_tool(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    daemon = GuardDaemonServer(GuardStore(guard_home), host="127.0.0.1", port=0)
+    daemon.start()
+    config = _bridge_config(guard_home, daemon.port)
+    config["query"] = urlencode({"guard-home": str(guard_home), "home": str(tmp_path)})
+    config["fallback_command"] = [sys.executable, "-c", "raise SystemExit(1)"]
+    monkeypatch.setattr(
+        "sys.stdin",
+        io.StringIO(
+            json.dumps(
+                {
+                    "hook_event_name": "PreToolUse",
+                    "tool_name": "opaque_tool",
+                    "tool_input": {"command": "git status --short", "workdir": "/"},
+                    "cwd": str(workspace),
                 }
             )
         ),

--- a/tests/test_guard_benign_operations.py
+++ b/tests/test_guard_benign_operations.py
@@ -15,7 +15,7 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import (
 
 
 def _git(repository: Path, *args: str) -> None:
-    subprocess.run(["git", *args], cwd=repository, check=True, capture_output=True, text=True)
+    _ = subprocess.run(["git", *args], cwd=repository, check=True, capture_output=True, text=True)
 
 
 @pytest.fixture
@@ -23,7 +23,7 @@ def repository(tmp_path: Path) -> Path:
     path = tmp_path / "repository"
     path.mkdir()
     _git(path, "init", "-q")
-    (path / "app.ts").write_text("export const value = 1;\n", encoding="utf-8")
+    _ = (path / "app.ts").write_text("export const value = 1;\n", encoding="utf-8")
     _git(path, "remote", "add", "origin", "https://github.com/example/project.git")
     return path
 
@@ -34,6 +34,23 @@ def _benign(command: str, *, repository: Path, home: Path) -> bool:
         {"command": command},
         cwd=repository,
         home_dir=home,
+    )
+
+
+def _trust_guard_executable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    executable = tmp_path / "bin" / "hol-guard"
+    executable.parent.mkdir()
+    _ = executable.write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.setattr(sys, "prefix", str(tmp_path))
+
+    def trusted_guard_path(_command: str, *, cwd: Path) -> str:
+        _ = cwd
+        return str(executable)
+
+    monkeypatch.setattr(
+        shell_static_safety,
+        "_which_for_execution_cwd",
+        trusted_guard_path,
     )
 
 
@@ -66,10 +83,21 @@ def test_non_shell_tool_text_is_not_interpreted_as_a_command() -> None:
     assert extract_sensitive_tool_action_request("todo", {"command": "rm -rf build"}) is not None
 
 
-def test_guard_status_native_name_is_unverified_but_cli_is_benign(
+@pytest.mark.parametrize(
+    "command",
+    (
+        "hol-guard status",
+        "hol-guard status --json",
+        "hol-guard daemon status",
+        "hol-guard settings",
+        "hol-guard settings --json",
+    ),
+)
+def test_guard_read_only_cli_commands_are_benign(
     repository: Path,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    command: str,
 ) -> None:
     assert not is_explicitly_benign_tool_action_request(
         "mcp__codex_apps__hol_guard__get_guard_status",
@@ -77,25 +105,64 @@ def test_guard_status_native_name_is_unverified_but_cli_is_benign(
         cwd=repository,
         home_dir=tmp_path,
     )
-    executable = tmp_path / "bin" / "hol-guard"
-    executable.parent.mkdir()
-    executable.write_text("#!/bin/sh\n", encoding="utf-8")
-    monkeypatch.setattr(sys, "prefix", str(tmp_path))
-    monkeypatch.setattr(
-        shell_static_safety,
-        "_which_for_execution_cwd",
-        lambda *_args, **_kwargs: str(executable),
-    )
+    _trust_guard_executable(tmp_path, monkeypatch)
 
-    assert _benign("hol-guard status", repository=repository, home=tmp_path)
-    assert _benign("hol-guard daemon status", repository=repository, home=tmp_path)
-    assert not _benign("hol-guard daemon repair", repository=repository, home=tmp_path)
+    assert _benign(command, repository=repository, home=tmp_path)
 
 
 @pytest.mark.parametrize(
     "command",
     (
+        "hol-guard status --verbose",
+        "hol-guard daemon repair",
+        "hol-guard settings set enforcement.mode strict",
+        "hol-guard settings --json --verbose",
+        "/tmp/evil/hol-guard status",
+        "./hol-guard status",
+        "PATH=/tmp/evil hol-guard status",
+        "env PATH=/tmp/evil hol-guard status",
+        "command -p hol-guard status",
+        "sudo hol-guard status",
+        "hol-guard status > report.json",
+        "hol-guard status && touch marker",
+    ),
+)
+def test_guard_cli_commands_reject_mutation_and_unmodeled_options(
+    repository: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+) -> None:
+    _trust_guard_executable(tmp_path, monkeypatch)
+
+    assert not _benign(command, repository=repository, home=tmp_path)
+
+
+@pytest.mark.parametrize(
+    "template",
+    (
+        "/bin/zsh -lc 'cd {repository} && hol-guard status'",
+        "/bin/zsh -lc 'cd {repository}; hol-guard settings --json'",
+        "/bin/zsh -lc \"sh -c 'cd {repository} && hol-guard status --json'\"",
+    ),
+)
+def test_guard_cli_commands_reject_wrapped_compound_launches(
+    repository: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    template: str,
+) -> None:
+    _trust_guard_executable(tmp_path, monkeypatch)
+
+    assert not _benign(template.format(repository=repository), repository=repository, home=tmp_path)
+
+
+@pytest.mark.parametrize(
+    "command",
+    (
+        "git fetch origin main",
         "git fetch origin --quiet",
+        "git rev-parse origin/main",
         "git log -1 --format='%H %cI %s' origin/main",
         "git blame -L 1,1 -- app.ts",
         "git show HEAD~1:app.ts | sed -n '1,55p'",
@@ -145,6 +212,6 @@ def test_git_blame_rejects_executable_repository_config(
 def test_guard_safety_doc_is_a_read_only_source(tmp_path: Path, repository: Path) -> None:
     support = tmp_path / ".hol-support"
     support.mkdir()
-    (support / "SAFETY.md").write_text("# Safety\n", encoding="utf-8")
+    _ = (support / "SAFETY.md").write_text("# Safety\n", encoding="utf-8")
 
     assert _benign("sed -n '1,220p' ~/.hol-support/SAFETY.md", repository=repository, home=tmp_path)

--- a/tests/test_guard_benign_operations.py
+++ b/tests/test_guard_benign_operations.py
@@ -38,7 +38,8 @@ def _benign(command: str, *, repository: Path, home: Path) -> bool:
 
 
 def _trust_guard_executable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    executable = tmp_path / "bin" / "hol-guard"
+    executable_directory = "Scripts" if sys.platform == "win32" else "bin"
+    executable = tmp_path / executable_directory / "hol-guard"
     executable.parent.mkdir()
     _ = executable.write_text("#!/bin/sh\n", encoding="utf-8")
     monkeypatch.setattr(sys, "prefix", str(tmp_path))


### PR DESCRIPTION
## Summary

- honor validated per-action working directories when classifying shell commands
- allow exact read-only Guard status and settings commands from the trusted executable
- reject executable shadowing, shell wrappers, invalid working directories, and mutating variants

## Verification

- focused daemon bridge and command-classification tests
- adversarial wrapper, Git configuration, secret, exfiltration, and destructive-command tests
- Ruff lint and format checks
- BasedPyright
- test-suite inventory ratchet


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for safely using explicitly provided working directories when verifying repository operations.
  * Expanded support for read-only guard commands, including status and settings views.

* **Bug Fixes**
  * Improved validation of invalid, temporary, or untrusted working directories.
  * Strengthened protection against wrapped, altered, chained, or mutating commands being treated as benign.

* **Tests**
  * Added coverage for working-directory handling and expanded read-only and unsafe command scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->