### PR TITLE
fix(guard): make watch-only findings actionable

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12512,
-  "maximum_test_source_lines": 286472,
+  "maximum_collected_cases": 12520,
+  "maximum_test_source_lines": 286908,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12520,
-  "maximum_test_source_lines": 286908,
+  "maximum_collected_cases": 12523,
+  "maximum_test_source_lines": 287085,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 12523,
-  "maximum_test_source_lines": 287085,
+  "maximum_test_source_lines": 287080,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12523,
-  "maximum_test_source_lines": 287080,
+  "maximum_collected_cases": 12524,
+  "maximum_test_source_lines": 287118,
   "schema_version": 1
 }

--- a/dashboard/src/approval-center-layout.test.ts
+++ b/dashboard/src/approval-center-layout.test.ts
@@ -8,6 +8,7 @@ import {
   QUEUE_CONNECTION_ERROR_HEADLINE,
   QUEUE_CONNECTION_ERROR_INSTRUCTION,
   buildRecommendation,
+  buildRetryAfterApprovalCopy,
   buildPauseLine,
   isWatchOnlyObservation,
   requestResolutionBlockReason,
@@ -324,6 +325,18 @@ assert(
 assert(
   buildRecommendation(watchOnlyRequest).includes("Save an exact allow"),
   "Watch-only findings explain how to prevent the same false positive",
+);
+assert(
+  buildRetryAfterApprovalCopy(watchOnlyRequest, "allow").includes("no future rule was saved"),
+  "Watch-only one-time review copy never promises a remembered allow",
+);
+assert(
+  buildRetryAfterApprovalCopy(watchOnlyRequest, "allow", true).includes("allow this exact action next time"),
+  "Watch-only persisted allow copy describes the exact future rule",
+);
+assert(
+  buildRetryAfterApprovalCopy(watchOnlyRequest, "block", true).includes("stop this exact action next time"),
+  "Watch-only persisted block copy describes the exact future rule",
 );
 
 const sandboxRequest: GuardApprovalRequest = { ...BASE_REQUEST, policy_action: "sandbox-required" };

--- a/dashboard/src/approval-center-layout.test.ts
+++ b/dashboard/src/approval-center-layout.test.ts
@@ -8,6 +8,8 @@ import {
   QUEUE_CONNECTION_ERROR_HEADLINE,
   QUEUE_CONNECTION_ERROR_INSTRUCTION,
   buildRecommendation,
+  buildPauseLine,
+  isWatchOnlyObservation,
   requestResolutionBlockReason,
   scopeLabel,
   buildCodexResumeUx,
@@ -301,6 +303,27 @@ assert(
 assert(
   buildRecommendation(BASE_REQUEST).includes("Project approval remembers this same action"),
   "C9: Recommendation explains project approval does not trust new sensitive actions"
+);
+
+const watchOnlyRequest: GuardApprovalRequest = {
+  ...BASE_REQUEST,
+  scanner_evidence: [
+    {
+      source: "observe_mode_inbox",
+      observed_policy_action: "require-reapproval",
+      queued_policy_action: "require-reapproval",
+      authoritative_action: "allow",
+    },
+  ] as unknown as NonNullable<GuardApprovalRequest["scanner_evidence"]>,
+};
+assert(isWatchOnlyObservation(watchOnlyRequest), "Watch-only findings are identified from trusted queue evidence");
+assert(
+  buildPauseLine(watchOnlyRequest).startsWith("Watch only let this action run."),
+  "Watch-only findings never claim the action was paused",
+);
+assert(
+  buildRecommendation(watchOnlyRequest).includes("Save an exact allow"),
+  "Watch-only findings explain how to prevent the same false positive",
 );
 
 const sandboxRequest: GuardApprovalRequest = { ...BASE_REQUEST, policy_action: "sandbox-required" };

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -82,13 +82,18 @@ function resolveDataFlowSinkLabel(signal: RiskSignalV2): string {
   return "External sink";
 }
 
-export function buildRetryAfterApprovalCopy(item: GuardApprovalRequest, action: "allow" | "block"): string {
+export function buildRetryAfterApprovalCopy(
+  item: GuardApprovalRequest,
+  action: "allow" | "block",
+  persistedExactAction = false,
+): string {
   const harness = harnessDisplayName(item.harness);
   if (isWatchOnlyObservation(item)) {
-    if (action === "allow") {
+    if (persistedExactAction && action === "allow") {
       return "Saved. Guard will allow this exact action next time when the remembered option is selected.";
     }
-    return "Saved. Guard will stop matching actions next time.";
+    if (persistedExactAction) return "Saved. Guard will stop this exact action next time.";
+    return "Reviewed. Watch only already allowed this action to run; no future rule was saved.";
   }
   if (action === "allow") {
     return `Approved. Return to ${harness} to resume, or it will continue automatically if still running.`;

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -24,6 +24,16 @@ export type DataFlowEvidenceSummary = {
   count: number;
 };
 
+export function isWatchOnlyObservation(item: GuardApprovalRequest): boolean {
+  return (item.scanner_evidence as unknown[] | undefined ?? []).some(
+    (evidence) =>
+      typeof evidence === "object" &&
+      evidence !== null &&
+      "source" in evidence &&
+      evidence.source === "observe_mode_inbox",
+  );
+}
+
 export function deriveDataFlowEvidence(item: GuardApprovalRequest): DataFlowEvidenceSummary | null {
   const signals = item.decision_v2_json?.signals ?? [];
   const dataFlowSignals = signals.filter(
@@ -74,6 +84,12 @@ function resolveDataFlowSinkLabel(signal: RiskSignalV2): string {
 
 export function buildRetryAfterApprovalCopy(item: GuardApprovalRequest, action: "allow" | "block"): string {
   const harness = harnessDisplayName(item.harness);
+  if (isWatchOnlyObservation(item)) {
+    if (action === "allow") {
+      return "Saved. Guard will allow this exact action next time when the remembered option is selected.";
+    }
+    return "Saved. Guard will stop matching actions next time.";
+  }
   if (action === "allow") {
     return `Approved. Return to ${harness} to resume, or it will continue automatically if still running.`;
   }
@@ -191,6 +207,9 @@ export function buildPauseLine(item: GuardApprovalRequest): string {
   if (resolutionBlockReason !== null) {
     return resolutionBlockReason;
   }
+  if (isWatchOnlyObservation(item)) {
+    return "Watch only let this action run. Guard recorded it because the current policy would have paused it in an enforcing mode.";
+  }
   if (item.policy_action === "block") {
     return `${harnessDisplayName(item.harness)} kept this blocked because you already saved a block decision for it.`;
   }
@@ -204,6 +223,9 @@ export function buildRecommendation(item: GuardApprovalRequest): string {
   const resolutionBlockReason = requestResolutionBlockReason(item);
   if (resolutionBlockReason !== null) {
     return resolutionBlockReason;
+  }
+  if (isWatchOnlyObservation(item)) {
+    return "Save an exact allow only when this action is expected. Changed commands, paths, hosts, or tools will still need review.";
   }
   if (item.changed_fields.length === 1 && item.changed_fields[0] === "first_seen") {
     return "If this is what you expected, approve this retry. Project approval remembers this same action here without trusting new sensitive actions.";

--- a/dashboard/src/approval-scopes.test.ts
+++ b/dashboard/src/approval-scopes.test.ts
@@ -166,6 +166,17 @@ const blockPayload = buildDecisionPayload({
   reason: "blocked in review",
 });
 assert(blockPayload.workspace === "/workspace/project", "T-AS-04: workspace block sends the request workspace");
+const rememberedExactBlockPayload = buildDecisionPayload({
+  item: BASE_REQUEST,
+  action: "block",
+  scope: "artifact",
+  reason: "blocked after Watch-only review",
+  persistExactAction: true,
+});
+assert(
+  rememberedExactBlockPayload.persist_policy === true,
+  "T-AS-04a: exact-action blocks can be persisted explicitly",
+);
 
 const allowScopes = scopeChoicesForRequest(BASE_REQUEST, "allow").map((choice) => choice.value);
 const blockScopes = scopeChoicesForRequest(BASE_REQUEST, "block").map((choice) => choice.value);

--- a/dashboard/src/approval-scopes.test.ts
+++ b/dashboard/src/approval-scopes.test.ts
@@ -9,6 +9,7 @@ import {
   scopeChoicesForRequest,
   standardScopeChoicesForRequest,
   taskCapabilityExplanation,
+  willPersistExactAction,
 } from "./approval-scopes";
 import type { GuardApprovalRequest } from "./guard-types";
 import { ReviewScopeControls } from "./review-scope-controls";
@@ -102,6 +103,14 @@ const unprovenRememberedPayload = buildDecisionPayload({
   persistExactAction: true,
 });
 assert(unprovenRememberedPayload.persist_policy === undefined, "T-AS-03b: unproven actions cannot be remembered");
+assert(
+  willPersistExactAction(BASE_REQUEST, "block", "artifact", true),
+  "T-AS-03c: eligible exact Watch-only blocks can be persisted",
+);
+assert(
+  !willPersistExactAction({ ...BASE_REQUEST, exact_action_persistence_eligible: false }, "block", "artifact", true),
+  "T-AS-03d: ineligible Watch-only blocks cannot promise persistence",
+);
 
 function ignoreScopeChange(): void {}
 

--- a/dashboard/src/approval-scopes.ts
+++ b/dashboard/src/approval-scopes.ts
@@ -246,17 +246,19 @@ export function buildDecisionPayload(input: {
     normalizedScope === "workspace" && typeof input.item.workspace === "string"
       ? input.item.workspace
       : undefined;
+  const persistExactAction = willPersistExactAction(
+    input.item,
+    input.action,
+    normalizedScope,
+    input.persistExactAction === true,
+  );
   return {
     requestId: input.item.request_id,
     action: input.action,
     scope: normalizedScope,
     workspace,
     reason: input.reason,
-    ...(normalizedScope === "artifact" &&
-    input.persistExactAction === true &&
-    input.item.exact_action_persistence_eligible === true
-      ? { persist_policy: true }
-      : {}),
+    ...(persistExactAction ? { persist_policy: true } : {}),
     ...(hasCompleteBinding
       ? {
           scope_contract_version: contractVersion,
@@ -264,4 +266,17 @@ export function buildDecisionPayload(input: {
         }
       : {}),
   };
+}
+
+export function willPersistExactAction(
+  item: GuardApprovalRequest,
+  action: "allow" | "block",
+  scope: DecisionScope,
+  requested: boolean,
+): boolean {
+  return (
+    requested &&
+    normalizeDecisionScope(item, action, scope) === "artifact" &&
+    item.exact_action_persistence_eligible === true
+  );
 }

--- a/dashboard/src/approval-scopes.ts
+++ b/dashboard/src/approval-scopes.ts
@@ -252,8 +252,7 @@ export function buildDecisionPayload(input: {
     scope: normalizedScope,
     workspace,
     reason: input.reason,
-    ...(input.action === "allow" &&
-    normalizedScope === "artifact" &&
+    ...(normalizedScope === "artifact" &&
     input.persistExactAction === true &&
     input.item.exact_action_persistence_eligible === true
       ? { persist_policy: true }

--- a/dashboard/src/home-dashboard.test.ts
+++ b/dashboard/src/home-dashboard.test.ts
@@ -78,14 +78,14 @@ assert(
 
 const singlePending = buildHomePrimaryState(1, 1);
 assert(
-  singlePending.copy.includes("1 action"),
-  "L139: Single pending request uses singular 'action' in copy"
+  singlePending.copy.includes("1 action finding"),
+  "L139: Single pending request uses singular 'finding' in copy"
 );
 
 const multiplePending = buildHomePrimaryState(3, 2);
 assert(
-  multiplePending.copy.includes("3 actions"),
-  "L139: Multiple pending requests uses plural 'actions' in copy"
+  multiplePending.copy.includes("3 action findings"),
+  "L139: Multiple pending requests uses plural 'findings' in copy"
 );
 
 assert(

--- a/dashboard/src/queue-state.test.ts
+++ b/dashboard/src/queue-state.test.ts
@@ -561,8 +561,8 @@ assert(
   "T-QS-43: buildHomePrimaryState returns needs_decision status when pending count is greater than zero"
 );
 assert(
-  needsDecision.copy.includes("3 actions"),
-  "T-QS-44: buildHomePrimaryState includes action count in copy when pending"
+  needsDecision.copy === "3 action findings waiting for review.",
+  "T-QS-44: buildHomePrimaryState uses neutral copy for paused and Watch-only findings"
 );
 assert(
   needsDecision.ctaLabel === "Review waiting action",
@@ -597,8 +597,8 @@ assert(
 
 const singlePending = buildHomePrimaryState(1, 1);
 assert(
-  singlePending.copy.includes("1 action paused"),
-  "T-QS-50: buildHomePrimaryState uses singular 'action' when exactly one pending"
+  singlePending.copy === "1 action finding waiting for review.",
+  "T-QS-50: buildHomePrimaryState uses singular 'finding' when exactly one is pending"
 );
 
 const fileReadEnvelope: GuardActionEnvelope = {

--- a/dashboard/src/queue-state.ts
+++ b/dashboard/src/queue-state.ts
@@ -1230,7 +1230,7 @@ export function buildHomePrimaryState(
   if (pendingCount > 0) {
     return {
       status: "needs_decision",
-      copy: `${pendingCount} action${pendingCount !== 1 ? "s" : ""} paused and waiting for your decision.`,
+      copy: `${pendingCount} action finding${pendingCount !== 1 ? "s" : ""} waiting for review.`,
       ctaLabel: "Review waiting action",
     };
   }

--- a/dashboard/src/review-decision-card.tsx
+++ b/dashboard/src/review-decision-card.tsx
@@ -24,6 +24,7 @@ import {
   scopeChoicesForRequest,
   standardScopeChoicesForRequest,
   taskCapabilityExplanation,
+  willPersistExactAction,
 } from "./approval-scopes";
 import { approvalProofRequiresPassword } from "./approval-proof-inline";
 import { ConsolidatedEvidenceAlert } from "./consolidated-evidence-alert";
@@ -67,8 +68,12 @@ import {
 
 const commonScopeValues = new Set<DecisionScope>(["artifact"]);
 
-function resolvedActionCopy(item: GuardApprovalRequest | null, action: "allow" | "block"): string {
-  if (item !== null) return buildRetryAfterApprovalCopy(item, action);
+function resolvedActionCopy(
+  item: GuardApprovalRequest | null,
+  action: "allow" | "block",
+  persistedExactAction: boolean,
+): string {
+  if (item !== null) return buildRetryAfterApprovalCopy(item, action, persistedExactAction);
   if (action === "allow") return "Approved: action can proceed";
   return "Blocked: action stopped";
 }
@@ -85,7 +90,7 @@ export function ReviewDecisionCard(props: {
   const [allowScope, setAllowScope] = useState<DecisionScope>("artifact");
   const [blockScope, setBlockScope] = useState<DecisionScope>("artifact");
   const [submitting, setSubmitting] = useState<"allow" | "block" | null>(null);
-  const [resolved, setResolved] = useState<"allow" | "block" | null>(null);
+  const [resolved, setResolved] = useState<{ action: "allow" | "block"; persistedExactAction: boolean } | null>(null);
   const [showConsequences, setShowConsequences] = useState(false);
   const [showEvidence, setShowEvidence] = useState(false);
   const [lastAction, setLastAction] = useState<"allow" | "block" | null>(null);
@@ -151,7 +156,7 @@ export function ReviewDecisionCard(props: {
       setUseCooldown(false);
       setPendingAction(null);
       setPendingContractKey(null);
-      setRememberExactAction(item.exact_action_persistence_eligible === true && isWatchOnlyObservation(item));
+      setRememberExactAction(false);
       const nextTemporaryOptions = temporaryMcpApprovalOptions(item);
       if (nextTemporaryOptions !== null) {
         setMcpGrantTarget(defaultTemporaryMcpTarget(nextTemporaryOptions));
@@ -196,6 +201,12 @@ export function ReviewDecisionCard(props: {
       setErrorMessage(null);
       try {
         const requestedScope = action === "allow" ? allowScope : blockScope;
+        const persistExactAction = willPersistExactAction(
+          item,
+          action,
+          requestedScope,
+          action === "allow" ? rememberExactAction : watchOnlyObservation,
+        );
         const gate = props.approvalGate;
         const needsPassword = approvalProofRequiresPassword(gate);
         const includeGateFields =
@@ -208,12 +219,7 @@ export function ReviewDecisionCard(props: {
             action,
             scope: requestedScope,
             reason: action === "allow" ? "approved in review" : "blocked in review",
-            persistExactAction:
-              action === "allow"
-                ? rememberExactAction
-                : watchOnlyObservation &&
-                  requestedScope === "artifact" &&
-                  item.exact_action_persistence_eligible === true,
+            persistExactAction,
           }),
           ...(includeGateFields && needsPassword ? { approval_password: approvalPassword } : {}),
           ...(includeGateFields && !needsPassword ? { approval_totp_code: approvalTotpCode } : {}),
@@ -230,7 +236,7 @@ export function ReviewDecisionCard(props: {
             ? buildLocalToolResolutionFields(localToolOptions, localToolGrantTarget, localToolGrantDuration)
             : {}),
         });
-        setResolved(action);
+        setResolved({ action, persistedExactAction });
         setApprovalPassword("");
         setApprovalTotpCode("");
         setUseCooldown(false);
@@ -395,7 +401,8 @@ export function ReviewDecisionCard(props: {
   const evidenceItems = buildEvidenceItems(item);
   const actionPresentation = guardActionPresentation(item.policy_action);
   let resolvedAllowButtonLabel = allowButtonLabel(allowScope);
-  if (rememberExactAction && allowScope === "artifact") {
+  const persistExactAllow = item !== null && willPersistExactAction(item, "allow", allowScope, rememberExactAction);
+  if (persistExactAllow) {
     resolvedAllowButtonLabel = watchOnlyObservation ? "Allow next time" : "Approve and remember";
   }
   if (temporaryMcpOptions !== null && !rememberExactAction) {
@@ -408,7 +415,7 @@ export function ReviewDecisionCard(props: {
       {resolved && (
         <div
           className={`guard-fade-in flex items-center gap-3 rounded-xl border px-4 py-3 transition-all ${
-            resolved === "allow"
+            resolved.action === "allow"
               ? "border-brand-green/25 bg-brand-green-bg/30"
               : "border-brand-attention/25 bg-brand-attention/[0.04]"
           }`}
@@ -416,11 +423,11 @@ export function ReviewDecisionCard(props: {
           aria-live="polite"
         >
           <HiMiniCheckCircle
-            className={`h-5 w-5 shrink-0 ${resolved === "allow" ? "text-brand-green" : "text-brand-attention"}`}
+            className={`h-5 w-5 shrink-0 ${resolved.action === "allow" ? "text-brand-green" : "text-brand-attention"}`}
             aria-hidden="true"
           />
-          <p className={`text-sm font-medium ${resolved === "allow" ? "text-brand-green-text" : "text-brand-attention"}`}>
-            {resolvedActionCopy(item, resolved)}
+          <p className={`text-sm font-medium ${resolved.action === "allow" ? "text-brand-green-text" : "text-brand-attention"}`}>
+            {resolvedActionCopy(item, resolved.action, resolved.persistedExactAction)}
           </p>
         </div>
       )}

--- a/dashboard/src/review-decision-card.tsx
+++ b/dashboard/src/review-decision-card.tsx
@@ -402,6 +402,7 @@ export function ReviewDecisionCard(props: {
   const actionPresentation = guardActionPresentation(item.policy_action);
   let resolvedAllowButtonLabel = allowButtonLabel(allowScope);
   const persistExactAllow = item !== null && willPersistExactAction(item, "allow", allowScope, rememberExactAction);
+  const persistExactBlock = item !== null && willPersistExactAction(item, "block", blockScope, watchOnlyObservation);
   if (persistExactAllow) {
     resolvedAllowButtonLabel = watchOnlyObservation ? "Allow next time" : "Approve and remember";
   }
@@ -588,7 +589,7 @@ export function ReviewDecisionCard(props: {
             ) : (
               <span className="flex items-center gap-2">
                 <HiMiniNoSymbol className="h-4 w-4" aria-hidden="true" />
-                {watchOnlyObservation && blockScope === "artifact" ? "Block next time" : blockButtonLabel(blockScope)}
+                {persistExactBlock ? "Block next time" : blockButtonLabel(blockScope)}
               </span>
             )}
           </ActionButton>

--- a/dashboard/src/review-decision-card.tsx
+++ b/dashboard/src/review-decision-card.tsx
@@ -13,6 +13,7 @@ import {
   buildRetryAfterApprovalCopy,
   formatRelativeTime,
   harnessDisplayName,
+  isWatchOnlyObservation,
   requestResolutionBlockReason,
 } from "./approval-center-utils";
 import { ApprovalPasswordModal } from "./approval-center-review-cards";
@@ -131,6 +132,7 @@ export function ReviewDecisionCard(props: {
     () => (item ? localToolApprovalOptions(item) : null),
     [item],
   );
+  const watchOnlyObservation = item !== null && isWatchOnlyObservation(item);
   const hasAllowScope = availableScopeChoices.length + advancedScopeOptions.length > 0;
   const decisionContractKey = item
     ? `${item.request_id}:${item.scope_contract_version ?? "legacy"}:${item.scope_contract_digest ?? "legacy"}`
@@ -149,7 +151,7 @@ export function ReviewDecisionCard(props: {
       setUseCooldown(false);
       setPendingAction(null);
       setPendingContractKey(null);
-      setRememberExactAction(false);
+      setRememberExactAction(item.exact_action_persistence_eligible === true && isWatchOnlyObservation(item));
       const nextTemporaryOptions = temporaryMcpApprovalOptions(item);
       if (nextTemporaryOptions !== null) {
         setMcpGrantTarget(defaultTemporaryMcpTarget(nextTemporaryOptions));
@@ -206,7 +208,12 @@ export function ReviewDecisionCard(props: {
             action,
             scope: requestedScope,
             reason: action === "allow" ? "approved in review" : "blocked in review",
-            persistExactAction: action === "allow" ? rememberExactAction : false,
+            persistExactAction:
+              action === "allow"
+                ? rememberExactAction
+                : watchOnlyObservation &&
+                  requestedScope === "artifact" &&
+                  item.exact_action_persistence_eligible === true,
           }),
           ...(includeGateFields && needsPassword ? { approval_password: approvalPassword } : {}),
           ...(includeGateFields && !needsPassword ? { approval_totp_code: approvalTotpCode } : {}),
@@ -240,6 +247,7 @@ export function ReviewDecisionCard(props: {
       item,
       allowScope,
       blockScope,
+      watchOnlyObservation,
       rememberExactAction,
       props.onResolve,
       props.approvalGate,
@@ -374,7 +382,7 @@ export function ReviewDecisionCard(props: {
     return (
       <EmptyState
         title="Select an action"
-        body="Choose a paused action from the queue to review and decide."
+        body="Choose an action or Watch-only finding to review."
         tone="teach"
       />
     );
@@ -388,7 +396,7 @@ export function ReviewDecisionCard(props: {
   const actionPresentation = guardActionPresentation(item.policy_action);
   let resolvedAllowButtonLabel = allowButtonLabel(allowScope);
   if (rememberExactAction && allowScope === "artifact") {
-    resolvedAllowButtonLabel = "Approve and remember";
+    resolvedAllowButtonLabel = watchOnlyObservation ? "Allow next time" : "Approve and remember";
   }
   if (temporaryMcpOptions !== null && !rememberExactAction) {
     resolvedAllowButtonLabel = temporaryMcpAllowButtonLabel(mcpGrantDuration);
@@ -420,14 +428,14 @@ export function ReviewDecisionCard(props: {
       <div className="rounded-xl border border-slate-100 p-4 sm:p-5">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0 flex-1">
-            <SectionLabel>Paused action</SectionLabel>
+            <SectionLabel>{watchOnlyObservation ? "Watch-only finding" : "Paused action"}</SectionLabel>
             <h2 className="mt-2 text-lg font-semibold text-brand-dark">{plainTitle}</h2>
             <p className="mt-1 text-sm text-muted-foreground">
               From {harnessName}
             </p>
           </div>
-          <Badge tone={actionPresentation.tone}>
-            {actionPresentation.label}
+          <Badge tone={watchOnlyObservation ? "info" : actionPresentation.tone}>
+            {watchOnlyObservation ? "Ran in Watch only" : actionPresentation.label}
           </Badge>
         </div>
 
@@ -573,7 +581,7 @@ export function ReviewDecisionCard(props: {
             ) : (
               <span className="flex items-center gap-2">
                 <HiMiniNoSymbol className="h-4 w-4" aria-hidden="true" />
-                {blockButtonLabel(blockScope)}
+                {watchOnlyObservation && blockScope === "artifact" ? "Block next time" : blockButtonLabel(blockScope)}
               </span>
             )}
           </ActionButton>

--- a/dashboard/src/review-queue-item.tsx
+++ b/dashboard/src/review-queue-item.tsx
@@ -21,7 +21,11 @@ import {
   HiMiniShieldCheck,
 } from "react-icons/hi2";
 import { FaDocker, FaGitAlt, FaGithub } from "react-icons/fa";
-import { harnessDisplayName, resolveStoppedCommandText } from "./approval-center-utils";
+import {
+  harnessDisplayName,
+  isWatchOnlyObservation,
+  resolveStoppedCommandText,
+} from "./approval-center-utils";
 import type { GuardApprovalRequest } from "./guard-types";
 import {
   formatQueueRequestDate,
@@ -62,6 +66,7 @@ export function QueueItemRow({ item, active, readState, index, onOpenRequest, se
   const CategoryIcon = iconForQueueCategory(category.id);
   const preview = queueItemPreview(item);
   const isRead = readState.isRead(item.request_id);
+  const watchOnlyObservation = isWatchOnlyObservation(item);
   // Checkboxes render whenever bulk selection is active so the affordance is
   // always discoverable. Non-eligible rows show a disabled checkbox with a
   // tooltip instead of silently hiding the control.
@@ -146,6 +151,7 @@ export function QueueItemRow({ item, active, readState, index, onOpenRequest, se
             </p>
             <p className="truncate text-[11px] text-muted-foreground">
               {harnessDisplayName(item.harness)} · {formatQueueRequestDate(item)}
+              {watchOnlyObservation ? " · Watch only" : ""}
             </p>
           </div>
           <span

--- a/dashboard/src/review-queue-list.tsx
+++ b/dashboard/src/review-queue-list.tsx
@@ -32,7 +32,7 @@ export function ReviewHeader({
       <div>
         <h1 className="text-xl font-semibold tracking-[-0.02em] text-brand-dark sm:text-2xl">Review</h1>
         <p className="mt-1 max-w-xl text-sm leading-relaxed text-muted-foreground">
-          Guard paused these actions before they ran. Review each one and decide what should happen.
+          Review actions Guard paused and findings recorded while Watch only was active.
         </p>
       </div>
       <p className="text-sm text-muted-foreground">

--- a/src/codex_plugin_scanner/guard/approval_scope_support.py
+++ b/src/codex_plugin_scanner/guard/approval_scope_support.py
@@ -235,8 +235,6 @@ def exact_action_allow_persistence_eligible(request: Mapping[str, object]) -> bo
         )
     if artifact_type != "tool_action_request":
         return False
-    if _request_scoped_family_key(request) != "family:tool-action":
-        return False
     action_identity = _string_or_none(request.get("action_identity"))
     raw_command_text = _string_or_none(request.get("raw_command_text"))
     envelope = request.get("action_envelope_json")
@@ -247,7 +245,16 @@ def exact_action_allow_persistence_eligible(request: Mapping[str, object]) -> bo
             or _string_or_none(typed_envelope.get("raw_command_text"))
             or _string_or_none(typed_envelope.get("command"))
         )
-    return bool(artifact_id and artifact_hash and artifact_hash != "unknown" and action_identity and raw_command_text)
+    context_bound = parse_approval_context_token(artifact_hash) is not None
+    trusted_family = _request_scoped_family_key(request) == "family:tool-action"
+    return bool(
+        artifact_id
+        and artifact_hash
+        and artifact_hash != "unknown"
+        and action_identity
+        and raw_command_text
+        and (context_bound or trusted_family)
+    )
 
 
 def resolve_request_scope_selection(

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -1002,7 +1002,11 @@ def _artifact_scope_runtime_exact_match_key(
 ) -> str | None:
     if scope != "artifact" or request.get("artifact_type") != "tool_action_request":
         return None
-    artifact_id = runtime_tool_action_policy_artifact_id(_string_or_none(request.get("artifact_id")))
+    request_artifact_id = _string_or_none(request.get("artifact_id"))
+    artifact_id = runtime_tool_action_policy_artifact_id(request_artifact_id)
+    synthesized_artifact_id = artifact_id != request_artifact_id
+    if synthesized_artifact_id and not include_envelope_command:
+        return None
     raw_command_text = _string_or_none(request.get("raw_command_text"))
     wrapper_chain = request.get("wrapper_chain")
     envelope = request.get("action_envelope_json")
@@ -1017,6 +1021,8 @@ def _artifact_scope_runtime_exact_match_key(
     normalized_wrapper_chain = (
         wrapper_chain if isinstance(wrapper_chain, Sequence) and not isinstance(wrapper_chain, str) else None
     )
+    if synthesized_artifact_id and raw_command_text is None:
+        return None
     context = runtime_tool_action_exact_match_context(
         config_path=_string_or_none(request.get("config_path")),
         source_scope=_string_or_none(request.get("source_scope")),

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -68,6 +68,7 @@ from .runtime.github_workflow_runtime import (
 from .runtime.protection_health_runtime import build_runtime_protection_health
 from .store import (
     GuardStore,
+    _is_runtime_scoped_exact_match_key,
     _runtime_scoped_exact_match_key,
     browser_mcp_exact_match_context,
     runtime_tool_action_exact_match_context,
@@ -844,7 +845,11 @@ def apply_approval_resolution(
         )
 
     resolution_harness = None if scope == "global" else str(request["harness"])
-    resolve_matching_scope_requests = resolve_scope_matches and not (action == "allow" and scope != "artifact")
+    resolve_matching_scope_requests = (
+        resolve_scope_matches
+        and not (action == "allow" and scope != "artifact")
+        and not (scope == "artifact" and _is_runtime_scoped_exact_match_key(scoped_artifact_hash))
+    )
     if return_queue_result:
         result = (
             temporary_mcp_result
@@ -1017,6 +1022,7 @@ def _artifact_scope_runtime_exact_match_key(
         source_scope=_string_or_none(request.get("source_scope")),
         raw_command_text=raw_command_text,
         wrapper_chain=normalized_wrapper_chain,
+        permission_mode=_request_permission_mode(request),
     )
     return _runtime_scoped_exact_match_key(artifact_id, context) if isinstance(artifact_id, str) else None
 
@@ -1047,9 +1053,20 @@ def _broad_runtime_exact_match_key(request: Mapping[str, object], scope: str) ->
             wrapper_chain=(
                 wrapper_chain if isinstance(wrapper_chain, Sequence) and not isinstance(wrapper_chain, str) else None
             ),
+            permission_mode=_request_permission_mode(request),
         )
         return _runtime_scoped_exact_match_key(artifact_id, runtime_tool_action_portable_match_context(context))
     return _runtime_scoped_exact_match_key(artifact_id)
+
+
+def _request_permission_mode(request: Mapping[str, object]) -> str | None:
+    envelope = request.get("action_envelope_json")
+    if not isinstance(envelope, Mapping):
+        return None
+    raw_payload = envelope.get("raw_payload_redacted")
+    if not isinstance(raw_payload, Mapping):
+        return None
+    return _string_or_none(raw_payload.get("permission_mode")) or _string_or_none(raw_payload.get("permissionMode"))
 
 
 def _extract_surface_flags(browser_intent: Mapping[str, object]) -> list[str] | None:

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -71,6 +71,7 @@ from .store import (
     _runtime_scoped_exact_match_key,
     browser_mcp_exact_match_context,
     runtime_tool_action_exact_match_context,
+    runtime_tool_action_policy_artifact_id,
     runtime_tool_action_portable_match_context,
 )
 from .synced_policy import synced_policy_bundle_validation
@@ -681,13 +682,13 @@ def apply_approval_resolution(
     scope = selection.applied_scope
     if selection.warning is not None:
         persist_policy = None
-    elif action == "allow" and scope == "artifact" and persist_policy is True:
+    elif scope == "artifact" and persist_policy is True:
         if scope_contract_version is not None:
             if not exact_action_allow_persistence_eligible(request):
                 raise IneligibleApprovalScopeError(
-                    "saved_allow_scope_ineligible",
+                    "saved_allow_scope_ineligible" if action == "allow" else "saved_block_scope_ineligible",
                     request_scope_contract(request),
-                    action=action,
+                    action="allow" if action == "allow" else "block",
                     requested_scope=scope,
                 )
         else:
@@ -698,7 +699,7 @@ def apply_approval_resolution(
     approval_context_token = (
         request_artifact_hash if parse_approval_context_token(request_artifact_hash) is not None else None
     )
-    exact_context_allow = action == "allow" and approval_context_token is not None
+    exact_context_allow = action == "allow" and approval_context_token is not None and persist_policy is not True
     request_publisher = _string_or_none(request.get("publisher"))
     resolved_workspace = resolve_request_workspace_scope(request, workspace) if scope == "workspace" else None
     portable_package_workspace = package_request_portable_workspace_scope(
@@ -725,6 +726,7 @@ def apply_approval_resolution(
             include_envelope_command=persist_policy is True,
         )
         if artifact_runtime_exact_match_key is not None:
+            scoped_artifact_id = runtime_tool_action_policy_artifact_id(request_artifact_id)
             scoped_artifact_hash = artifact_runtime_exact_match_key
         broad_runtime_exact_match_key = _broad_runtime_exact_match_key(request, scope)
         if broad_runtime_exact_match_key is not None:
@@ -995,7 +997,7 @@ def _artifact_scope_runtime_exact_match_key(
 ) -> str | None:
     if scope != "artifact" or request.get("artifact_type") != "tool_action_request":
         return None
-    artifact_id = request.get("artifact_id")
+    artifact_id = runtime_tool_action_policy_artifact_id(_string_or_none(request.get("artifact_id")))
     raw_command_text = _string_or_none(request.get("raw_command_text"))
     wrapper_chain = request.get("wrapper_chain")
     envelope = request.get("action_envelope_json")

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_copilot.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_copilot.py
@@ -162,14 +162,14 @@ def _run_hook_copilot_pretool(
         }
         decision_scanner_evidence = (*decision_scanner_evidence, observe_mode_evidence)
         policy_action = "allow"
-    if config.mode == "observe":
+    if config.mode == "observe" and observed_policy_action is not None:
         queue_observe_mode_request(
             action_envelope=action_envelope,
             artifact=runtime_artifact,
             artifact_hash=runtime_artifact_hash,
             changed_fields=("runtime_tool_call", *decision.signals),
             executable_action=policy_action,
-            observed_policy_action=observed_policy_action or policy_action,
+            observed_policy_action=observed_policy_action,
             redaction_level=config.receipt_redaction_level,
             risk_summary=decision.summary,
             scanner_evidence=decision_scanner_evidence,
@@ -355,14 +355,14 @@ def _run_hook_copilot_permission_request(
         response_payload["scanner_evidence"] = list(decision_scanner_evidence)
         policy_action = "allow"
         response_payload["policy_action"] = "allow"
-    if config.mode == "observe":
+    if config.mode == "observe" and observed_policy_action is not None:
         queue_observe_mode_request(
             action_envelope=action_envelope,
             artifact=runtime_artifact,
             artifact_hash=runtime_artifact_hash,
             changed_fields=("runtime_tool_call", *decision.signals),
             executable_action=policy_action,
-            observed_policy_action=observed_policy_action or policy_action,
+            observed_policy_action=observed_policy_action,
             redaction_level=config.receipt_redaction_level,
             risk_summary=decision.summary,
             scanner_evidence=decision_scanner_evidence,

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
@@ -519,6 +519,7 @@ def _generic_hook_saved_decision(
             > guard_action_severity(selected_decision.get("action"), unknown_action="block")
         ):
             selected_decision = exact_decision
+            ignored_integrity = exact_lookup.get("ignored_local_integrity")
     if legacy_artifact_hash is not None and legacy_artifact_hash != artifact_hash:
         legacy_lookup = store.resolve_policy_decision_lookup_with_memory_pattern(
             harness,
@@ -541,6 +542,7 @@ def _generic_hook_saved_decision(
             > guard_action_severity(selected_decision.get("action"), unknown_action="block")
         ):
             selected_decision = legacy_decision
+            ignored_integrity = legacy_lookup.get("ignored_local_integrity")
     return selected_decision, ignored_integrity
 
 

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
@@ -479,6 +479,8 @@ def _generic_hook_saved_decision(
         config_path=workspace,
         source_scope=_coalesce_string(payload.get("source_scope"), "project"),
         raw_command_text=memory_command,
+        permission_mode=_optional_string(payload.get("permission_mode"))
+        or _optional_string(payload.get("permissionMode")),
     )
     lookup = store.resolve_policy_decision_lookup_with_memory_pattern(
         harness,

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
@@ -472,19 +472,51 @@ def _generic_hook_saved_decision(
     """Peek saved evidence, retaining legacy blocks without trusting legacy allows."""
 
     workspace = str(runtime_workspace) if runtime_workspace is not None else None
+    from ..store import runtime_tool_action_exact_match_context, runtime_tool_action_policy_artifact_id
+
+    memory_command = _generic_hook_memory_command(payload)
+    runtime_exact_match_context = runtime_tool_action_exact_match_context(
+        config_path=workspace,
+        source_scope=_coalesce_string(payload.get("source_scope"), "project"),
+        raw_command_text=memory_command,
+    )
     lookup = store.resolve_policy_decision_lookup_with_memory_pattern(
         harness,
         artifact_id,
         artifact_hash=artifact_hash,
         workspace=workspace,
         publisher=publisher,
-        memory_command=_generic_hook_memory_command(payload),
+        runtime_exact_match_context=runtime_exact_match_context,
+        memory_command=memory_command,
         memory_artifact_type=_coalesce_string(payload.get("artifact_type"), payload.get("tool_type")),
         memory_artifact_name=artifact_name,
         consume_one_shot=False,
     )
     selected_decision = lookup["decision"]
     ignored_integrity = lookup.get("ignored_local_integrity")
+    policy_artifact_id = runtime_tool_action_policy_artifact_id(artifact_id)
+    if policy_artifact_id is not None and policy_artifact_id != artifact_id:
+        exact_lookup = store.resolve_policy_decision_lookup_with_memory_pattern(
+            harness,
+            policy_artifact_id,
+            artifact_hash=artifact_hash,
+            workspace=workspace,
+            publisher=publisher,
+            runtime_exact_match_context=runtime_exact_match_context,
+            memory_command=memory_command,
+            memory_artifact_type=_coalesce_string(payload.get("artifact_type"), payload.get("tool_type")),
+            memory_artifact_name=artifact_name,
+            consume_one_shot=False,
+        )
+        exact_decision = exact_lookup["decision"]
+        if ignored_integrity is None:
+            ignored_integrity = exact_lookup.get("ignored_local_integrity")
+        if exact_decision is not None and (
+            selected_decision is None
+            or guard_action_severity(exact_decision.get("action"), unknown_action="block")
+            > guard_action_severity(selected_decision.get("action"), unknown_action="block")
+        ):
+            selected_decision = exact_decision
     if legacy_artifact_hash is not None and legacy_artifact_hash != artifact_hash:
         legacy_lookup = store.resolve_policy_decision_lookup_with_memory_pattern(
             harness,
@@ -492,7 +524,8 @@ def _generic_hook_saved_decision(
             artifact_hash=legacy_artifact_hash,
             workspace=workspace,
             publisher=publisher,
-            memory_command=_generic_hook_memory_command(payload),
+            runtime_exact_match_context=runtime_exact_match_context,
+            memory_command=memory_command,
             memory_artifact_type=_coalesce_string(payload.get("artifact_type"), payload.get("tool_type")),
             memory_artifact_name=artifact_name,
             consume_one_shot=False,
@@ -529,10 +562,16 @@ def _generic_hook_approval_reuse(
             saved_action = "require-reapproval"
         validation_reason = "approval_reuse_integrity_failure"
     elif decision is not None and decision.get("action") == "allow":
-        validation_reason = cast(
-            ApprovalReuseValidationFailure | None,
-            approval_context_tokens_validation_reason(decision.get("artifact_hash"), artifact_hash),
-        )
+        from ..store import _is_runtime_scoped_exact_match_key
+
+        saved_artifact_hash = decision.get("artifact_hash")
+        if not _is_runtime_scoped_exact_match_key(
+            saved_artifact_hash if isinstance(saved_artifact_hash, str) else None
+        ):
+            validation_reason = cast(
+                ApprovalReuseValidationFailure | None,
+                approval_context_tokens_validation_reason(saved_artifact_hash, artifact_hash),
+            )
     if not saved_present:
         diagnosed_reason = store.approval_reuse_validation_reason(
             harness,
@@ -1084,8 +1123,7 @@ def _run_hook_generic_payload(
             output_stream=output_stream,
         )
         return 0
-    if config.mode == "observe" and hook_is_pre_event(hook_event_name):
-        inbox_policy_action = observed_policy_action or policy_action
+    if config.mode == "observe" and hook_is_pre_event(hook_event_name) and observed_policy_action is not None:
         observed_artifact = GuardArtifact(
             artifact_id=artifact_id,
             name=artifact_name,
@@ -1109,7 +1147,7 @@ def _run_hook_generic_payload(
             artifact_hash=runtime_artifact_hash,
             changed_fields=changed_capabilities or ["tool_action"],
             executable_action=policy_action,
-            observed_policy_action=inbox_policy_action,
+            observed_policy_action=observed_policy_action,
             redaction_level=config.receipt_redaction_level,
             risk_summary=(
                 "Watch-only mode allowed an action that current policy would stop."
@@ -1164,6 +1202,11 @@ def _run_hook_generic_payload(
                         "changed_fields": changed_capabilities or ["tool_action"],
                         "launch_target": redacted_command_text,
                         "risk_summary": "No command rule matched this tool action.",
+                        "action_envelope_json": (
+                            action_envelope.with_pre_execution_result(None).to_dict()
+                            if action_envelope is not None
+                            else None
+                        ),
                         "scanner_evidence": (
                             [local_tool_eligibility.to_evidence()] if local_tool_eligibility is not None else []
                         ),

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_review.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_review.py
@@ -386,19 +386,6 @@ def _review_runtime_artifact_hook(
                 managed_install=managed_install,
             )
             _localize_pending_approval_copy(response_payload, harness=args.harness)
-    if observe_mode and event_name == "PreToolUse" and not observe_request_queued:
-        queue_observe_mode_request(
-            action_envelope=action_envelope,
-            artifact=runtime_artifact,
-            artifact_hash=runtime_artifact_hash,
-            changed_fields=changed_capabilities,
-            executable_action=policy_action,
-            observed_policy_action=policy_action,
-            redaction_level=config.receipt_redaction_level,
-            risk_summary=risk_summary,
-            scanner_evidence=scanner_evidence_payload,
-            store=store,
-        )
     state.action_envelope = action_envelope
     state.browser_approval_daemon_client = locals().get("browser_approval_daemon_client")
     state.policy_action = policy_action

--- a/src/codex_plugin_scanner/guard/cli/commands_support_observe_queue.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_observe_queue.py
@@ -26,6 +26,8 @@ def queue_observe_mode_request(
 ) -> list[dict[str, object]]:
     """Queue retrospective review without changing the executable decision."""
 
+    if observed_policy_action not in {"review", "require-reapproval", "sandbox-required", "block"}:
+        return []
     review_action: GuardAction = (
         observed_policy_action if observed_policy_action in {"review", "require-reapproval"} else "require-reapproval"
     )

--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
@@ -592,6 +592,7 @@ def _runtime_hook_approval_context_token(
         },
         sandbox={
             "analysis": config.sandbox_analysis,
+            "permission_mode": _runtime_hook_permission_mode(action_envelope),
             "required": current_action == "sandbox-required",
         },
     )
@@ -641,6 +642,13 @@ def _runtime_hook_action_capabilities(action_envelope: GuardActionEnvelope | Non
         "target_paths": list(action_envelope.target_paths),
         "tool_name": action_envelope.tool_name,
     }
+
+
+def _runtime_hook_permission_mode(action_envelope: GuardActionEnvelope | None) -> str | None:
+    if action_envelope is None:
+        return None
+    raw_payload = action_envelope.raw_payload_redacted
+    return _optional_string(raw_payload.get("permission_mode")) or _optional_string(raw_payload.get("permissionMode"))
 
 
 def _runtime_hook_evidence_payload(value: object) -> object:

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13264,18 +13264,27 @@ function buildDecisionPayload(input) {
     throw new Error(`No eligible ${input.action} scope is available for this request.`);
   }
   const workspace = normalizedScope === "workspace" && typeof input.item.workspace === "string" ? input.item.workspace : void 0;
+  const persistExactAction = willPersistExactAction(
+    input.item,
+    input.action,
+    normalizedScope,
+    input.persistExactAction === true
+  );
   return {
     requestId: input.item.request_id,
     action: input.action,
     scope: normalizedScope,
     workspace,
     reason: input.reason,
-    ...normalizedScope === "artifact" && input.persistExactAction === true && input.item.exact_action_persistence_eligible === true ? { persist_policy: true } : {},
+    ...persistExactAction ? { persist_policy: true } : {},
     ...hasCompleteBinding ? {
       scope_contract_version: contractVersion,
       scope_contract_digest: contractDigest
     } : {}
   };
+}
+function willPersistExactAction(item, action, scope, requested) {
+  return requested && normalizeDecisionScope(item, action, scope) === "artifact" && item.exact_action_persistence_eligible === true;
 }
 const REVIEW_SEMANTIC_GROUPS = [
   { id: "all", label: "All", matches: [] },
@@ -14600,13 +14609,14 @@ function resolveDataFlowSinkLabel(signal) {
   }
   return "External sink";
 }
-function buildRetryAfterApprovalCopy(item, action) {
+function buildRetryAfterApprovalCopy(item, action, persistedExactAction2 = false) {
   const harness = harnessDisplayName(item.harness);
   if (isWatchOnlyObservation(item)) {
-    if (action === "allow") {
+    if (persistedExactAction2 && action === "allow") {
       return "Saved. Guard will allow this exact action next time when the remembered option is selected.";
     }
-    return "Saved. Guard will stop matching actions next time.";
+    if (persistedExactAction2) return "Saved. Guard will stop this exact action next time.";
+    return "Reviewed. Watch only already allowed this action to run; no future rule was saved.";
   }
   if (action === "allow") {
     return `Approved. Return to ${harness} to resume, or it will continue automatically if still running.`;
@@ -28791,8 +28801,8 @@ function LocalToolApprovalControls(props) {
   ] });
 }
 const commonScopeValues = /* @__PURE__ */ new Set(["artifact"]);
-function resolvedActionCopy(item, action) {
-  if (item !== null) return buildRetryAfterApprovalCopy(item, action);
+function resolvedActionCopy(item, action, persistedExactAction2) {
+  if (item !== null) return buildRetryAfterApprovalCopy(item, action, persistedExactAction2);
   if (action === "allow") return "Approved: action can proceed";
   return "Blocked: action stopped";
 }
@@ -28866,7 +28876,7 @@ function ReviewDecisionCard(props) {
       setUseCooldown(false);
       setPendingAction(null);
       setPendingContractKey(null);
-      setRememberExactAction(item.exact_action_persistence_eligible === true && isWatchOnlyObservation(item));
+      setRememberExactAction(false);
       const nextTemporaryOptions = temporaryMcpApprovalOptions(item);
       if (nextTemporaryOptions !== null) {
         setMcpGrantTarget(defaultTemporaryMcpTarget(nextTemporaryOptions));
@@ -28907,6 +28917,12 @@ function ReviewDecisionCard(props) {
       setErrorMessage(null);
       try {
         const requestedScope = action === "allow" ? allowScope : blockScope;
+        const persistExactAction = willPersistExactAction(
+          item,
+          action,
+          requestedScope,
+          action === "allow" ? rememberExactAction : watchOnlyObservation
+        );
         const gate = props.approvalGate;
         const needsPassword = approvalProofRequiresPassword(gate);
         const includeGateFields = gate?.enabled === true && gate?.configured === true && requiresApprovalPasswordPrompt(gate.cooldown_active, gate.strict_all_decisions, requestedScope);
@@ -28916,7 +28932,7 @@ function ReviewDecisionCard(props) {
             action,
             scope: requestedScope,
             reason: action === "allow" ? "approved in review" : "blocked in review",
-            persistExactAction: action === "allow" ? rememberExactAction : watchOnlyObservation && requestedScope === "artifact" && item.exact_action_persistence_eligible === true
+            persistExactAction
           }),
           ...includeGateFields && needsPassword ? { approval_password: approvalPassword } : {},
           ...includeGateFields && !needsPassword ? { approval_totp_code: approvalTotpCode } : {},
@@ -28929,7 +28945,7 @@ function ReviewDecisionCard(props) {
           ) : {},
           ...action === "allow" && temporaryMcpOptions === null ? buildLocalToolResolutionFields(localToolOptions, localToolGrantTarget, localToolGrantDuration) : {}
         });
-        setResolved(action);
+        setResolved({ action, persistedExactAction });
         setApprovalPassword("");
         setApprovalTotpCode("");
         setUseCooldown(false);
@@ -29081,7 +29097,8 @@ function ReviewDecisionCard(props) {
   const evidenceItems = buildEvidenceItems(item);
   const actionPresentation = guardActionPresentation(item.policy_action);
   let resolvedAllowButtonLabel = allowButtonLabel(allowScope);
-  if (rememberExactAction && allowScope === "artifact") {
+  const persistExactAllow = item !== null && willPersistExactAction(item, "allow", allowScope, rememberExactAction);
+  if (persistExactAllow) {
     resolvedAllowButtonLabel = watchOnlyObservation ? "Allow next time" : "Approve and remember";
   }
   if (temporaryMcpOptions !== null && !rememberExactAction) {
@@ -29093,18 +29110,18 @@ function ReviewDecisionCard(props) {
     resolved && /* @__PURE__ */ jsxRuntimeExports.jsxs(
       "div",
       {
-        className: `guard-fade-in flex items-center gap-3 rounded-xl border px-4 py-3 transition-all ${resolved === "allow" ? "border-brand-green/25 bg-brand-green-bg/30" : "border-brand-attention/25 bg-brand-attention/[0.04]"}`,
+        className: `guard-fade-in flex items-center gap-3 rounded-xl border px-4 py-3 transition-all ${resolved.action === "allow" ? "border-brand-green/25 bg-brand-green-bg/30" : "border-brand-attention/25 bg-brand-attention/[0.04]"}`,
         role: "status",
         "aria-live": "polite",
         children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx(
             HiMiniCheckCircle,
             {
-              className: `h-5 w-5 shrink-0 ${resolved === "allow" ? "text-brand-green" : "text-brand-attention"}`,
+              className: `h-5 w-5 shrink-0 ${resolved.action === "allow" ? "text-brand-green" : "text-brand-attention"}`,
               "aria-hidden": "true"
             }
           ),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: `text-sm font-medium ${resolved === "allow" ? "text-brand-green-text" : "text-brand-attention"}`, children: resolvedActionCopy(item, resolved) })
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: `text-sm font-medium ${resolved.action === "allow" ? "text-brand-green-text" : "text-brand-attention"}`, children: resolvedActionCopy(item, resolved.action, resolved.persistedExactAction) })
         ]
       }
     ),

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -29098,6 +29098,7 @@ function ReviewDecisionCard(props) {
   const actionPresentation = guardActionPresentation(item.policy_action);
   let resolvedAllowButtonLabel = allowButtonLabel(allowScope);
   const persistExactAllow = item !== null && willPersistExactAction(item, "allow", allowScope, rememberExactAction);
+  const persistExactBlock = item !== null && willPersistExactAction(item, "block", blockScope, watchOnlyObservation);
   if (persistExactAllow) {
     resolvedAllowButtonLabel = watchOnlyObservation ? "Allow next time" : "Approve and remember";
   }
@@ -29255,7 +29256,7 @@ function ReviewDecisionCard(props) {
               "Blocking..."
             ] }) : /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "flex items-center gap-2", children: [
               /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniNoSymbol, { className: "h-4 w-4", "aria-hidden": "true" }),
-              watchOnlyObservation && blockScope === "artifact" ? "Block next time" : blockButtonLabel(blockScope)
+              persistExactBlock ? "Block next time" : blockButtonLabel(blockScope)
             ] })
           }
         )

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13270,7 +13270,7 @@ function buildDecisionPayload(input) {
     scope: normalizedScope,
     workspace,
     reason: input.reason,
-    ...input.action === "allow" && normalizedScope === "artifact" && input.persistExactAction === true && input.item.exact_action_persistence_eligible === true ? { persist_policy: true } : {},
+    ...normalizedScope === "artifact" && input.persistExactAction === true && input.item.exact_action_persistence_eligible === true ? { persist_policy: true } : {},
     ...hasCompleteBinding ? {
       scope_contract_version: contractVersion,
       scope_contract_digest: contractDigest
@@ -14552,6 +14552,11 @@ function whyPaused(request) {
 }
 const QUEUE_CONNECTION_ERROR_HEADLINE = "Guard daemon not reachable: approval links work when Guard is running on this device.";
 const QUEUE_CONNECTION_ERROR_INSTRUCTION = "Start Guard on this machine, then reload to continue approving or blocking.";
+function isWatchOnlyObservation(item) {
+  return (item.scanner_evidence ?? []).some(
+    (evidence) => typeof evidence === "object" && evidence !== null && "source" in evidence && evidence.source === "observe_mode_inbox"
+  );
+}
 function deriveDataFlowEvidence(item) {
   const signals = item.decision_v2_json?.signals ?? [];
   const dataFlowSignals = signals.filter(
@@ -14597,6 +14602,12 @@ function resolveDataFlowSinkLabel(signal) {
 }
 function buildRetryAfterApprovalCopy(item, action) {
   const harness = harnessDisplayName(item.harness);
+  if (isWatchOnlyObservation(item)) {
+    if (action === "allow") {
+      return "Saved. Guard will allow this exact action next time when the remembered option is selected.";
+    }
+    return "Saved. Guard will stop matching actions next time.";
+  }
   if (action === "allow") {
     return `Approved. Return to ${harness} to resume, or it will continue automatically if still running.`;
   }
@@ -28839,6 +28850,7 @@ function ReviewDecisionCard(props) {
     () => item ? localToolApprovalOptions(item) : null,
     [item]
   );
+  const watchOnlyObservation = item !== null && isWatchOnlyObservation(item);
   const hasAllowScope = availableScopeChoices.length + advancedScopeOptions.length > 0;
   const decisionContractKey = item ? `${item.request_id}:${item.scope_contract_version ?? "legacy"}:${item.scope_contract_digest ?? "legacy"}` : null;
   reactExports.useEffect(() => {
@@ -28854,7 +28866,7 @@ function ReviewDecisionCard(props) {
       setUseCooldown(false);
       setPendingAction(null);
       setPendingContractKey(null);
-      setRememberExactAction(false);
+      setRememberExactAction(item.exact_action_persistence_eligible === true && isWatchOnlyObservation(item));
       const nextTemporaryOptions = temporaryMcpApprovalOptions(item);
       if (nextTemporaryOptions !== null) {
         setMcpGrantTarget(defaultTemporaryMcpTarget(nextTemporaryOptions));
@@ -28904,7 +28916,7 @@ function ReviewDecisionCard(props) {
             action,
             scope: requestedScope,
             reason: action === "allow" ? "approved in review" : "blocked in review",
-            persistExactAction: action === "allow" ? rememberExactAction : false
+            persistExactAction: action === "allow" ? rememberExactAction : watchOnlyObservation && requestedScope === "artifact" && item.exact_action_persistence_eligible === true
           }),
           ...includeGateFields && needsPassword ? { approval_password: approvalPassword } : {},
           ...includeGateFields && !needsPassword ? { approval_totp_code: approvalTotpCode } : {},
@@ -28934,6 +28946,7 @@ function ReviewDecisionCard(props) {
       item,
       allowScope,
       blockScope,
+      watchOnlyObservation,
       rememberExactAction,
       props.onResolve,
       props.approvalGate,
@@ -29056,7 +29069,7 @@ function ReviewDecisionCard(props) {
       EmptyState,
       {
         title: "Select an action",
-        body: "Choose a paused action from the queue to review and decide.",
+        body: "Choose an action or Watch-only finding to review.",
         tone: "teach"
       }
     );
@@ -29069,7 +29082,7 @@ function ReviewDecisionCard(props) {
   const actionPresentation = guardActionPresentation(item.policy_action);
   let resolvedAllowButtonLabel = allowButtonLabel(allowScope);
   if (rememberExactAction && allowScope === "artifact") {
-    resolvedAllowButtonLabel = "Approve and remember";
+    resolvedAllowButtonLabel = watchOnlyObservation ? "Allow next time" : "Approve and remember";
   }
   if (temporaryMcpOptions !== null && !rememberExactAction) {
     resolvedAllowButtonLabel = temporaryMcpAllowButtonLabel(mcpGrantDuration);
@@ -29098,14 +29111,14 @@ function ReviewDecisionCard(props) {
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 p-4 sm:p-5", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start justify-between gap-3", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 flex-1", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Paused action" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: watchOnlyObservation ? "Watch-only finding" : "Paused action" }),
           /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { className: "mt-2 text-lg font-semibold text-brand-dark", children: plainTitle }),
           /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-1 text-sm text-muted-foreground", children: [
             "From ",
             harnessName
           ] })
         ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: actionPresentation.tone, children: actionPresentation.label })
+        /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: watchOnlyObservation ? "info" : actionPresentation.tone, children: watchOnlyObservation ? "Ran in Watch only" : actionPresentation.label })
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsx(PrimaryActionCard, { item }),
       resolutionBlockReason !== null && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-5 rounded-xl border border-brand-attention/30 bg-brand-attention/[0.06] p-4", role: "alert", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
@@ -29225,7 +29238,7 @@ function ReviewDecisionCard(props) {
               "Blocking..."
             ] }) : /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "flex items-center gap-2", children: [
               /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniNoSymbol, { className: "h-4 w-4", "aria-hidden": "true" }),
-              blockButtonLabel(blockScope)
+              watchOnlyObservation && blockScope === "artifact" ? "Block next time" : blockButtonLabel(blockScope)
             ] })
           }
         )
@@ -29308,6 +29321,7 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
   const CategoryIcon = iconForQueueCategory(category.id);
   const preview = queueItemPreview(item);
   const isRead = readState.isRead(item.request_id);
+  const watchOnlyObservation = isWatchOnlyObservation(item);
   const showCheckbox = selectionMode;
   const canSelect = selectionMode && selectable;
   const handleClick = reactExports.useCallback(() => {
@@ -29385,7 +29399,8 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
                 /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "truncate text-[11px] text-muted-foreground", children: [
                   harnessDisplayName(item.harness),
                   " · ",
-                  formatQueueRequestDate(item)
+                  formatQueueRequestDate(item),
+                  watchOnlyObservation ? " · Watch only" : ""
                 ] })
               ] }),
               /* @__PURE__ */ jsxRuntimeExports.jsxs(
@@ -29496,7 +29511,7 @@ function ReviewHeader({
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("h1", { className: "text-xl font-semibold tracking-[-0.02em] text-brand-dark sm:text-2xl", children: "Review" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 max-w-xl text-sm leading-relaxed text-muted-foreground", children: "Guard paused these actions before they ran. Review each one and decide what should happen." })
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 max-w-xl text-sm leading-relaxed text-muted-foreground", children: "Review actions Guard paused and findings recorded while Watch only was active." })
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-sm text-muted-foreground", children: [
       progress,

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -6,9 +6,11 @@ from __future__ import annotations
 from .store_base import *
 from .store_base import (
     SystemKeyringSecretStore,
+    _is_runtime_scoped_exact_match_key,
     _runtime_scoped_exact_match_key,
     browser_mcp_exact_match_context,
     runtime_tool_action_exact_match_context,
+    runtime_tool_action_policy_artifact_id,
     runtime_tool_action_portable_match_context,
 )
 from .store_approval_facade import StoreApprovalsMixin

--- a/src/codex_plugin_scanner/guard/store_approvals.py
+++ b/src/codex_plugin_scanner/guard/store_approvals.py
@@ -37,11 +37,15 @@ _VOLATILE_PAYLOAD_KEY_TOKENS = frozenset(
         "callid",
         "conversationid",
         "messageid",
+        "model",
+        "permissionmode",
         "requestid",
         "sessionid",
         "threadid",
         "toolcallid",
+        "tooluseid",
         "traceid",
+        "transcriptpath",
         "turnid",
     }
 )

--- a/src/codex_plugin_scanner/guard/store_approvals.py
+++ b/src/codex_plugin_scanner/guard/store_approvals.py
@@ -38,7 +38,6 @@ _VOLATILE_PAYLOAD_KEY_TOKENS = frozenset(
         "conversationid",
         "messageid",
         "model",
-        "permissionmode",
         "requestid",
         "sessionid",
         "threadid",

--- a/src/codex_plugin_scanner/guard/store_base.py
+++ b/src/codex_plugin_scanner/guard/store_base.py
@@ -1372,6 +1372,18 @@ def _runtime_scoped_exact_match_key(
     return f"{_RUNTIME_SCOPED_EXACT_MATCH_PREFIX}{digest}"
 
 
+def runtime_tool_action_policy_artifact_id(artifact_id: str | None) -> str | None:
+    """Return a scoped family identity for one exact runtime tool action."""
+
+    if artifact_id is None or not artifact_id.strip():
+        return None
+    family_key = _artifact_family_key(artifact_id)
+    if family_key is not None and _family_key_value(family_key) in _SCOPED_RUNTIME_EXACT_FAMILIES:
+        return artifact_id
+    digest = sha256(artifact_id.strip().encode("utf-8")).hexdigest()
+    return f"guard:runtime:tool-action:{digest}"
+
+
 def runtime_tool_action_exact_match_context(
     *,
     config_path: str | None,

--- a/src/codex_plugin_scanner/guard/store_base.py
+++ b/src/codex_plugin_scanner/guard/store_base.py
@@ -1390,14 +1390,16 @@ def runtime_tool_action_exact_match_context(
     source_scope: str | None,
     raw_command_text: str | None = None,
     wrapper_chain: Sequence[object] | None = None,
+    permission_mode: str | None = None,
 ) -> str | None:
-    if not config_path and not source_scope and not raw_command_text and not wrapper_chain:
+    if not config_path and not source_scope and not raw_command_text and not wrapper_chain and not permission_mode:
         return None
     payload: dict[str, object] = {
         "config_path": str(Path(config_path).expanduser()) if config_path else None,
         "source_scope": source_scope,
         "raw_command_text": raw_command_text,
         "wrapper_chain": [item for item in wrapper_chain or () if isinstance(item, str) and item],
+        "permission_mode": permission_mode,
     }
     return json.dumps(payload, sort_keys=True, separators=(",", ":"))
 
@@ -1417,6 +1419,7 @@ def runtime_tool_action_portable_match_context(runtime_exact_match_context: str 
     if not isinstance(raw_command_text, str) or not raw_command_text:
         return None
     wrapper_chain = payload.get("wrapper_chain")
+    permission_mode = payload.get("permission_mode")
     normalized_wrapper_chain = (
         wrapper_chain if isinstance(wrapper_chain, Sequence) and not isinstance(wrapper_chain, str) else None
     )
@@ -1425,6 +1428,7 @@ def runtime_tool_action_portable_match_context(runtime_exact_match_context: str 
         source_scope=None,
         raw_command_text=raw_command_text,
         wrapper_chain=normalized_wrapper_chain,
+        permission_mode=permission_mode if isinstance(permission_mode, str) and permission_mode else None,
     )
 
 

--- a/tests/test_guard_approval_policy_versions.py
+++ b/tests/test_guard_approval_policy_versions.py
@@ -14,6 +14,7 @@ from codex_plugin_scanner.guard.cli import commands_support_runtime_policy as ru
 from codex_plugin_scanner.guard.config import GuardConfig
 from codex_plugin_scanner.guard.models import GuardArtifact
 from codex_plugin_scanner.guard.proxy import stdio as stdio_module
+from codex_plugin_scanner.guard.runtime.actions import GuardActionEnvelope, normalize_harness_payload
 from codex_plugin_scanner.guard.runtime.approval_context import (
     approval_context_tokens_validation_reason,
     parse_approval_context_token,
@@ -64,12 +65,17 @@ def _assert_only_policy_component_changed(saved_token: str, current_token: str) 
     assert approval_context_tokens_validation_reason(saved_token, current_token) == "approval_reuse_policy_changed"
 
 
-def _runtime_hook_token(*, artifact: GuardArtifact, config: GuardConfig) -> str:
+def _runtime_hook_token(
+    *,
+    artifact: GuardArtifact,
+    config: GuardConfig,
+    action_envelope: GuardActionEnvelope | None = None,
+) -> str:
     return runtime_policy_module._runtime_hook_approval_context_token(
         artifact=artifact,
         content_hash="unchanged-runtime-content",
         runtime_workspace=config.workspace,
-        action_envelope=None,
+        action_envelope=action_envelope,
         config=config,
         current_config_action="review",
         trusted_cli_action=None,
@@ -81,6 +87,45 @@ def _runtime_hook_token(*, artifact: GuardArtifact, config: GuardConfig) -> str:
         data_flow_signals=(),
         scanner_evidence=(),
     )
+
+
+def test_runtime_hook_permission_mode_changes_sandbox_identity(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    artifact = GuardArtifact(
+        artifact_id="codex:project:runtime-permission-mode",
+        name="runtime permission mode fixture",
+        harness="codex",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=str(_workspace(config) / ".guard" / "config.toml"),
+        command="npm run guard:acquisition-loop",
+    )
+
+    def envelope(permission_mode: str) -> GuardActionEnvelope:
+        return normalize_harness_payload(
+            "codex",
+            "PreToolUse",
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "npm run guard:acquisition-loop"},
+                "permission_mode": permission_mode,
+            },
+            workspace=_workspace(config),
+            home_dir=tmp_path,
+        )
+
+    ask_token = _runtime_hook_token(artifact=artifact, config=config, action_envelope=envelope("ask"))
+    bypass_token = _runtime_hook_token(
+        artifact=artifact,
+        config=config,
+        action_envelope=envelope("bypassPermissions"),
+    )
+    ask_context = parse_approval_context_token(ask_token)
+    bypass_context = parse_approval_context_token(bypass_token)
+    assert ask_context is not None
+    assert bypass_context is not None
+    assert ask_context.sandbox_hash != bypass_context.sandbox_hash
+    assert approval_context_tokens_validation_reason(ask_token, bypass_token) is not None
 
 
 def test_runtime_hook_evaluator_policy_version_is_the_only_changed_component(

--- a/tests/test_guard_approval_precedence_generic_stdio.py
+++ b/tests/test_guard_approval_precedence_generic_stdio.py
@@ -28,6 +28,7 @@ from codex_plugin_scanner.guard.proxy.stdio import (
     _sensitive_read_current_action,
     build_sensitive_read_approval_hash,
 )
+from codex_plugin_scanner.guard.runtime.actions import GuardActionEnvelope, normalize_harness_payload
 from codex_plugin_scanner.guard.runtime.approval_context import (
     APPROVAL_CONTEXT_TOKEN_PREFIX,
     build_configured_environment_hash,
@@ -115,6 +116,7 @@ def _run_generic_hook(
     store: GuardStore,
     workspace: Path,
     harness: str = _GENERIC_HARNESS,
+    action_envelope: GuardActionEnvelope | None = None,
     post_claim_revalidator: Callable[[str], int | None] | None = None,
 ) -> tuple[int, dict[str, object]]:
     args = argparse.Namespace(
@@ -126,7 +128,7 @@ def _run_generic_hook(
     )
     rc = guard_commands_module._run_hook_generic_payload(
         args,
-        action_envelope=None,
+        action_envelope=action_envelope,
         config=config,
         home_dir=workspace.parent,
         payload=payload,
@@ -506,6 +508,282 @@ def test_codex_pretool_observe_mode_persists_observed_decision_evidence(
         "observed_policy_action": "block",
         "authoritative_action": "allow",
     } in receipt["scanner_evidence"]
+
+
+@pytest.mark.parametrize("default_action", ["allow", "warn"])
+def test_generic_hook_observe_mode_does_not_queue_actions_policy_already_allows(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    default_action: GuardAction,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        default_action=default_action,
+        mode="observe",
+    )
+    payload = {
+        **_generic_payload(),
+        "event": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "git status --short"},
+    }
+
+    rc, output = _run_generic_hook(
+        capsys=capsys,
+        config=config,
+        payload=payload,
+        store=store,
+        workspace=workspace,
+    )
+
+    assert rc == 0
+    assert output["policy_action"] in {"allow", "warn"}
+    assert output["policy_composition"]["observed_policy_action"] is None
+    assert store.list_approval_requests(limit=10) == []
+
+
+def test_codex_review_queue_retains_exact_shell_action_for_remembered_policy(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        default_action="review",
+    )
+    payload = {
+        **_generic_payload(),
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "npm run guard:acquisition-loop"},
+    }
+    action_envelope = normalize_harness_payload(
+        "codex",
+        "PreToolUse",
+        payload,
+        workspace=workspace,
+        home_dir=tmp_path,
+    )
+
+    rc, _output = _run_generic_hook(
+        capsys=capsys,
+        config=config,
+        payload=payload,
+        store=store,
+        workspace=workspace,
+        harness="codex",
+        action_envelope=action_envelope,
+    )
+
+    assert rc == 1
+    pending = store.list_approval_requests(limit=10)
+    assert len(pending) == 1
+    assert pending[0]["action_envelope_json"]["command"] == "npm run guard:acquisition-loop"
+    assert pending[0]["exact_action_persistence_eligible"] is True
+
+
+def test_watch_only_exact_allow_applies_after_enforcement_is_enabled(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    payload = {
+        **_generic_payload(),
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "npm run guard:acquisition-loop"},
+    }
+    action_envelope = normalize_harness_payload(
+        "codex",
+        "PreToolUse",
+        payload,
+        workspace=workspace,
+        home_dir=tmp_path,
+    )
+    observe_config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        default_action="review",
+        mode="observe",
+    )
+    rc, _output = _run_generic_hook(
+        capsys=capsys,
+        config=observe_config,
+        payload=payload,
+        store=store,
+        workspace=workspace,
+        harness="codex",
+        action_envelope=action_envelope,
+    )
+    assert rc == 0
+    observed = store.list_approval_requests(limit=10)[0]
+    approvals_module.apply_approval_resolution(
+        store=store,
+        request_id=str(observed["request_id"]),
+        action="allow",
+        scope="artifact",
+        workspace=None,
+        reason="remember exact action",
+        persist_policy=True,
+        scope_contract_version=str(observed["scope_contract_version"]),
+        scope_contract_digest=str(observed["scope_contract_digest"]),
+    )
+
+    enforce_config = replace(observe_config, mode="prompt")
+    rc, output = _run_generic_hook(
+        capsys=capsys,
+        config=enforce_config,
+        payload=payload,
+        store=store,
+        workspace=workspace,
+        harness="codex",
+        action_envelope=action_envelope,
+    )
+
+    assert rc == 0, json.dumps(output, sort_keys=True)
+    assert output["policy_action"] == "allow"
+
+    changed_payload = {
+        **payload,
+        "tool_input": {"command": "npm run guard:other"},
+    }
+    changed_envelope = normalize_harness_payload(
+        "codex",
+        "PreToolUse",
+        changed_payload,
+        workspace=workspace,
+        home_dir=tmp_path,
+    )
+    changed_rc, changed_output = _run_generic_hook(
+        capsys=capsys,
+        config=enforce_config,
+        payload=changed_payload,
+        store=store,
+        workspace=workspace,
+        harness="codex",
+        action_envelope=changed_envelope,
+    )
+
+    assert changed_rc == 1
+    assert changed_output["policy_action"] == "review"
+
+    other_workspace = tmp_path / "other-workspace"
+    other_workspace.mkdir()
+    other_envelope = normalize_harness_payload(
+        "codex",
+        "PreToolUse",
+        payload,
+        workspace=other_workspace,
+        home_dir=tmp_path,
+    )
+    other_rc, other_output = _run_generic_hook(
+        capsys=capsys,
+        config=replace(enforce_config, workspace=other_workspace),
+        payload=payload,
+        store=store,
+        workspace=other_workspace,
+        harness="codex",
+        action_envelope=other_envelope,
+    )
+
+    assert other_rc == 1
+    assert other_output["policy_action"] == "review"
+
+
+def test_watch_only_exact_block_applies_after_enforcement_is_enabled(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    payload = {
+        **_generic_payload(),
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "npm run guard:acquisition-loop"},
+    }
+    action_envelope = normalize_harness_payload(
+        "codex",
+        "PreToolUse",
+        payload,
+        workspace=workspace,
+        home_dir=tmp_path,
+    )
+    observe_config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=workspace,
+        default_action="review",
+        mode="observe",
+    )
+    rc, _output = _run_generic_hook(
+        capsys=capsys,
+        config=observe_config,
+        payload=payload,
+        store=store,
+        workspace=workspace,
+        harness="codex",
+        action_envelope=action_envelope,
+    )
+    assert rc == 0
+    observed = store.list_approval_requests(limit=10)[0]
+    approvals_module.apply_approval_resolution(
+        store=store,
+        request_id=str(observed["request_id"]),
+        action="block",
+        scope="artifact",
+        workspace=None,
+        reason="block exact action",
+        persist_policy=True,
+        scope_contract_version=str(observed["scope_contract_version"]),
+        scope_contract_digest=str(observed["scope_contract_digest"]),
+    )
+    assert any(decision["action"] == "block" for decision in store.list_policy_decisions())
+
+    enforce_config = replace(observe_config, mode="prompt")
+    blocked_rc, blocked_output = _run_generic_hook(
+        capsys=capsys,
+        config=enforce_config,
+        payload=payload,
+        store=store,
+        workspace=workspace,
+        harness="codex",
+        action_envelope=action_envelope,
+    )
+    assert blocked_rc == 1
+    assert blocked_output["policy_action"] == "block"
+
+    changed_payload = {
+        **payload,
+        "tool_input": {"command": "npm run guard:other"},
+    }
+    changed_envelope = normalize_harness_payload(
+        "codex",
+        "PreToolUse",
+        changed_payload,
+        workspace=workspace,
+        home_dir=tmp_path,
+    )
+    changed_rc, changed_output = _run_generic_hook(
+        capsys=capsys,
+        config=enforce_config,
+        payload=changed_payload,
+        store=store,
+        workspace=workspace,
+        harness="codex",
+        action_envelope=changed_envelope,
+    )
+    assert changed_rc == 1
+    assert changed_output["policy_action"] == "review"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_guard_approval_precedence_generic_stdio.py
+++ b/tests/test_guard_approval_precedence_generic_stdio.py
@@ -18,6 +18,7 @@ from codex_plugin_scanner.guard.cli.commands_hook_generic import (
     _generic_hook_approval_reuse,
     _generic_hook_memory_command,
     _generic_hook_payload_digest,
+    _generic_hook_saved_decision,
 )
 from codex_plugin_scanner.guard.config import GuardConfig
 from codex_plugin_scanner.guard.consumer import artifact_hash
@@ -61,6 +62,43 @@ def test_generic_hook_integrity_warning_does_not_hide_separate_valid_saved_block
     assert reuse.action == "block"
     assert reuse.saved_action == "block"
     assert reuse.reason_code == "approval_reuse_integrity_failure"
+
+
+def test_generic_hook_exact_decision_uses_its_own_integrity_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    responses: list[dict[str, object]] = [
+        {
+            "decision": {"action": "allow"},
+            "ignored_local_integrity": {"integrity_status": "tampered"},
+        },
+        {
+            "decision": {"action": "block"},
+            "ignored_local_integrity": None,
+        },
+    ]
+
+    def lookup(*_args: object, **_kwargs: object) -> dict[str, object]:
+        return responses.pop(0)
+
+    monkeypatch.setattr(store, "resolve_policy_decision_lookup_with_memory_pattern", lookup)
+
+    decision, ignored_integrity = _generic_hook_saved_decision(
+        artifact_hash="guard-approval-context:v1:current",
+        artifact_id=_GENERIC_ARTIFACT_ID,
+        artifact_name="opaque request",
+        harness=_GENERIC_HARNESS,
+        legacy_artifact_hash=None,
+        payload=_generic_payload(),
+        publisher=None,
+        runtime_workspace=tmp_path,
+        store=store,
+    )
+
+    assert decision == {"action": "block"}
+    assert ignored_integrity is None
 
 
 def _generic_payload() -> dict[str, object]:

--- a/tests/test_guard_approval_precedence_generic_stdio.py
+++ b/tests/test_guard_approval_precedence_generic_stdio.py
@@ -561,6 +561,7 @@ def test_codex_review_queue_retains_exact_shell_action_for_remembered_policy(
     payload = {
         **_generic_payload(),
         "hook_event_name": "PreToolUse",
+        "permission_mode": "ask",
         "tool_name": "Bash",
         "tool_input": {"command": "npm run guard:acquisition-loop"},
     }
@@ -599,6 +600,7 @@ def test_watch_only_exact_allow_applies_after_enforcement_is_enabled(
     payload = {
         **_generic_payload(),
         "hook_event_name": "PreToolUse",
+        "permission_mode": "ask",
         "tool_name": "Bash",
         "tool_input": {"command": "npm run guard:acquisition-loop"},
     }
@@ -651,6 +653,26 @@ def test_watch_only_exact_allow_applies_after_enforcement_is_enabled(
 
     assert rc == 0, json.dumps(output, sort_keys=True)
     assert output["policy_action"] == "allow"
+
+    changed_mode_payload = {**payload, "permission_mode": "bypassPermissions"}
+    changed_mode_envelope = normalize_harness_payload(
+        "codex",
+        "PreToolUse",
+        changed_mode_payload,
+        workspace=workspace,
+        home_dir=tmp_path,
+    )
+    changed_mode_rc, changed_mode_output = _run_generic_hook(
+        capsys=capsys,
+        config=enforce_config,
+        payload=changed_mode_payload,
+        store=store,
+        workspace=workspace,
+        harness="codex",
+        action_envelope=changed_mode_envelope,
+    )
+    assert changed_mode_rc == 1
+    assert changed_mode_output["policy_action"] == "review"
 
     changed_payload = {
         **payload,
@@ -748,7 +770,6 @@ def test_watch_only_exact_block_applies_after_enforcement_is_enabled(
         scope_contract_digest=str(observed["scope_contract_digest"]),
     )
     assert any(decision["action"] == "block" for decision in store.list_policy_decisions())
-
     enforce_config = replace(observe_config, mode="prompt")
     blocked_rc, blocked_output = _run_generic_hook(
         capsys=capsys,

--- a/tests/test_guard_approval_scope_contract.py
+++ b/tests/test_guard_approval_scope_contract.py
@@ -482,6 +482,49 @@ def test_context_bound_saved_allow_survives_context_token_changes_but_not_comman
     )
 
 
+def test_persisted_exact_action_does_not_resolve_sibling_command_request(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    artifact_id = "codex:project:Bash"
+
+    def exact_request(request_id: str, command: str) -> GuardApprovalRequest:
+        context_token = build_approval_context_token(
+            identity={"harness": "codex", "tool": "Bash"},
+            content={"command": command},
+            capabilities={"action_type": "shell_command"},
+            policy={"action": "require-reapproval"},
+            sandbox={"permission_mode": "ask"},
+        )
+        return replace(
+            _request(request_id, artifact_id=artifact_id, artifact_hash=context_token),
+            launch_target=command,
+            raw_command_text=command,
+            action_envelope_json={
+                "action_type": "shell_command",
+                "tool_name": "Bash",
+                "command": command,
+                "raw_payload_redacted": {"permission_mode": "ask"},
+            },
+        )
+
+    selected = _store_request(store, exact_request("selected-command", "npm run guard:acquisition-loop"))
+    _store_request(store, exact_request("sibling-command", "npm run guard:other"))
+
+    apply_approval_resolution(
+        store=store,
+        request_id="selected-command",
+        action="allow",
+        scope="artifact",
+        workspace=None,
+        reason="remember exact action",
+        persist_policy=True,
+        scope_contract_version=str(selected["scope_contract_version"]),
+        scope_contract_digest=str(selected["scope_contract_digest"]),
+    )
+
+    assert store.get_approval_request("selected-command")["status"] == "resolved"
+    assert store.get_approval_request("sibling-command")["status"] == "pending"
+
+
 def test_v2_saved_artifact_allow_requires_exact_action_proof(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     request = replace(
@@ -667,7 +710,15 @@ def test_legacy_unknown_broad_deny_is_not_silently_narrowed(tmp_path: Path) -> N
 
 def test_legacy_global_allow_persists_an_action_bound_rule(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
-    _store_request(store, _request("legacy"))
+    request = replace(
+        _request("legacy"),
+        action_envelope_json={
+            "action_type": "shell_command",
+            "command": "echo test",
+            "raw_payload_redacted": {"permission_mode": "ask"},
+        },
+    )
+    _store_request(store, request)
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
     try:
@@ -696,11 +747,19 @@ def test_legacy_global_allow_persists_an_action_bound_rule(tmp_path: Path) -> No
         config_path="/workspace/other/.guard/config.toml",
         source_scope="project",
         raw_command_text="echo test",
+        permission_mode="ask",
     )
     changed_action_context = runtime_tool_action_exact_match_context(
         config_path="/workspace/other/.guard/config.toml",
         source_scope="project",
         raw_command_text="echo changed",
+        permission_mode="ask",
+    )
+    changed_mode_context = runtime_tool_action_exact_match_context(
+        config_path="/workspace/other/.guard/config.toml",
+        source_scope="project",
+        raw_command_text="echo test",
+        permission_mode="bypassPermissions",
     )
     same_action = store.resolve_policy_decision(
         "pi",
@@ -710,6 +769,16 @@ def test_legacy_global_allow_persists_an_action_bound_rule(tmp_path: Path) -> No
         consume_one_shot=False,
     )
     assert same_action is not None and same_action["action"] == "allow"
+    assert (
+        store.resolve_policy_decision(
+            "pi",
+            "codex:project:tool-action:legacy",
+            "hash-retry",
+            runtime_exact_match_context=changed_mode_context,
+            consume_one_shot=False,
+        )
+        is None
+    )
     assert (
         store.resolve_policy_decision(
             "pi",

--- a/tests/test_guard_approval_scope_contract.py
+++ b/tests/test_guard_approval_scope_contract.py
@@ -22,7 +22,11 @@ from codex_plugin_scanner.guard.approvals import apply_approval_resolution
 from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
 from codex_plugin_scanner.guard.models import GuardAction, GuardApprovalRequest
 from codex_plugin_scanner.guard.runtime.approval_context import build_approval_context_token
-from codex_plugin_scanner.guard.store import GuardStore, runtime_tool_action_exact_match_context
+from codex_plugin_scanner.guard.store import (
+    GuardStore,
+    runtime_tool_action_exact_match_context,
+    runtime_tool_action_policy_artifact_id,
+)
 
 
 def _request(
@@ -408,6 +412,76 @@ def test_v2_saved_artifact_allow_persists_only_the_exact_action(tmp_path: Path) 
     )
 
 
+def test_context_bound_saved_allow_survives_context_token_changes_but_not_command_changes(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    context_token = build_approval_context_token(
+        identity={"harness": "codex", "tool": "Bash"},
+        content={"command": "npm run guard:acquisition-loop"},
+        capabilities={"action_type": "shell_command"},
+        policy={"mode": "observe", "action": "require-reapproval"},
+        sandbox={"mode": "workspace-write"},
+    )
+    request = replace(
+        _request(
+            "saved-context-action",
+            artifact_id="codex:project:Bash",
+            artifact_hash=context_token,
+        ),
+        launch_target="npm run guard:acquisition-loop",
+        raw_command_text="npm run guard:acquisition-loop",
+        action_envelope_json={
+            "action_type": "shell_command",
+            "tool_name": "Bash",
+            "command": "npm run guard:acquisition-loop",
+        },
+    )
+    row = _store_request(store, request)
+    apply_approval_resolution(
+        store=store,
+        request_id="saved-context-action",
+        action="allow",
+        scope="artifact",
+        workspace=None,
+        reason="remember exact action",
+        persist_policy=True,
+        scope_contract_version=str(row["scope_contract_version"]),
+        scope_contract_digest=str(row["scope_contract_digest"]),
+    )
+    same_action_context = runtime_tool_action_exact_match_context(
+        config_path="/workspace/repo/.guard/config.toml",
+        source_scope="project",
+        raw_command_text="npm run guard:acquisition-loop",
+    )
+    changed_action_context = runtime_tool_action_exact_match_context(
+        config_path="/workspace/repo/.guard/config.toml",
+        source_scope="project",
+        raw_command_text="npm run guard:other",
+    )
+    policy_artifact_id = runtime_tool_action_policy_artifact_id("codex:project:Bash")
+    assert policy_artifact_id is not None
+
+    assert (
+        store.resolve_policy_decision(
+            "codex",
+            policy_artifact_id,
+            artifact_hash="guard-approval-context:v1:different-mode-token",
+            runtime_exact_match_context=same_action_context,
+            consume_one_shot=False,
+        )
+        is not None
+    )
+    assert (
+        store.resolve_policy_decision(
+            "codex",
+            policy_artifact_id,
+            artifact_hash="guard-approval-context:v1:different-mode-token",
+            runtime_exact_match_context=changed_action_context,
+            consume_one_shot=False,
+        )
+        is None
+    )
+
+
 def test_v2_saved_artifact_allow_requires_exact_action_proof(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     request = replace(
@@ -432,6 +506,32 @@ def test_exact_action_persistence_accepts_envelope_raw_command_text(tmp_path: Pa
     request = replace(
         _request("envelope-raw-command"),
         action_envelope_json={"action_type": "shell_command", "raw_command_text": "echo test"},
+    )
+    row = _store_request(store, request)
+
+    assert request_scope_contract(row).exact_action_persistence_eligible is True
+
+
+def test_exact_action_persistence_accepts_context_bound_generic_tool_action(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    context_token = build_approval_context_token(
+        identity={"harness": "codex", "tool": "Bash"},
+        content={"command": "npm run guard:acquisition-loop"},
+        capabilities={"action_type": "shell_command"},
+        policy={"action": "require-reapproval"},
+        sandbox={"mode": "workspace-write"},
+    )
+    request = replace(
+        _request(
+            "generic-tool-action",
+            artifact_id="codex:project:Bash",
+            artifact_hash=context_token,
+        ),
+        action_envelope_json={
+            "action_type": "shell_command",
+            "tool_name": "Bash",
+            "command": "npm run guard:acquisition-loop",
+        },
     )
     row = _store_request(store, request)
 

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -8,6 +8,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -98,6 +99,63 @@ def _disable_real_desktop_notification_setup(monkeypatch: pytest.MonkeyPatch) ->
 
 
 class TestGuardApprovals:
+    def test_guard_queue_dedupes_harness_delivery_metadata(self, tmp_path):
+        store = GuardStore(tmp_path / "guard-home")
+        workspace = str(tmp_path / "workspace")
+        base = GuardApprovalRequest(
+            request_id="req-first",
+            harness="codex",
+            artifact_id="codex:project:tool-action:script",
+            artifact_name="Bash unmatched tool action",
+            artifact_type="tool_action_request",
+            artifact_hash="hash-script",
+            policy_action="require-reapproval",
+            recommended_scope="artifact",
+            changed_fields=("tool_action",),
+            source_scope="project",
+            config_path=workspace,
+            workspace=workspace,
+            launch_target="npm run guard:acquisition-loop",
+            action_envelope_json={
+                "action_type": "shell_command",
+                "tool_name": "Bash",
+                "command": "npm run guard:acquisition-loop",
+                "raw_payload_redacted": {
+                    "tool_name": "Bash",
+                    "tool_input": {"command": "npm run guard:acquisition-loop"},
+                    "tool_use_id": "tool-first",
+                    "transcript_path": "sessions/first.jsonl",
+                    "model": "model-first",
+                    "permission_mode": "ask",
+                },
+            },
+            review_command="hol-guard approvals approve req-first",
+            approval_url="http://127.0.0.1:5474/requests/req-first",
+        )
+        store.add_approval_request(base, "2026-08-11T00:00:00+00:00")
+        second = replace(
+            base,
+            request_id="req-second",
+            action_envelope_json={
+                **(base.action_envelope_json or {}),
+                "raw_payload_redacted": {
+                    "tool_name": "Bash",
+                    "tool_input": {"command": "npm run guard:acquisition-loop"},
+                    "tool_use_id": "tool-second",
+                    "transcript_path": "sessions/second.jsonl",
+                    "model": "model-second",
+                    "permission_mode": "bypassPermissions",
+                },
+            },
+        )
+
+        persisted = store.add_approval_request(second, "2026-08-11T00:01:00+00:00")
+
+        assert persisted == "req-first"
+        pending = store.list_approval_requests(limit=10)
+        assert len(pending) == 1
+        assert pending[0]["dedupe_count"] == 2
+
     def test_guard_store_persists_and_resolves_approval_requests(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")
         workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -144,7 +144,7 @@ class TestGuardApprovals:
                     "tool_use_id": "tool-second",
                     "transcript_path": "sessions/second.jsonl",
                     "model": "model-second",
-                    "permission_mode": "bypassPermissions",
+                    "permission_mode": "ask",
                 },
             },
         )
@@ -155,6 +155,48 @@ class TestGuardApprovals:
         pending = store.list_approval_requests(limit=10)
         assert len(pending) == 1
         assert pending[0]["dedupe_count"] == 2
+
+    def test_guard_queue_keeps_permission_modes_separate(self, tmp_path):
+        store = GuardStore(tmp_path / "guard-home")
+        workspace = str(tmp_path / "workspace")
+
+        def request(request_id: str, permission_mode: str) -> GuardApprovalRequest:
+            return GuardApprovalRequest(
+                request_id=request_id,
+                harness="codex",
+                artifact_id="codex:project:tool-action:script",
+                artifact_name="Bash unmatched tool action",
+                artifact_type="tool_action_request",
+                artifact_hash=f"hash-{permission_mode}",
+                policy_action="require-reapproval",
+                recommended_scope="artifact",
+                changed_fields=("tool_action",),
+                source_scope="project",
+                config_path=workspace,
+                workspace=workspace,
+                launch_target="npm run guard:acquisition-loop",
+                action_envelope_json={
+                    "action_type": "shell_command",
+                    "tool_name": "Bash",
+                    "command": "npm run guard:acquisition-loop",
+                    "raw_payload_redacted": {
+                        "tool_name": "Bash",
+                        "tool_input": {"command": "npm run guard:acquisition-loop"},
+                        "permission_mode": permission_mode,
+                    },
+                },
+                review_command=f"hol-guard approvals approve {request_id}",
+                approval_url=f"http://127.0.0.1:5474/requests/{request_id}",
+            )
+
+        store.add_approval_request(request("req-ask", "ask"), "2026-08-11T00:00:00+00:00")
+        store.add_approval_request(
+            request("req-bypass", "bypassPermissions"),
+            "2026-08-11T00:01:00+00:00",
+        )
+
+        pending = store.list_approval_requests(limit=10)
+        assert len(pending) == 2
 
     def test_guard_store_persists_and_resolves_approval_requests(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")

--- a/tests/test_guard_codex_apply_patch_policy.py
+++ b/tests/test_guard_codex_apply_patch_policy.py
@@ -100,7 +100,7 @@ def test_verified_workspace_apply_patch_does_not_queue_approval(
 
 
 @pytest.mark.parametrize(("default_action", "expected_action"), (("review", "warn"), ("allow", "allow")))
-def test_watch_only_workspace_apply_patch_is_visible_without_blocking(
+def test_watch_only_workspace_apply_patch_nonblocking_actions_do_not_fill_inbox(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
     default_action: str,
@@ -153,12 +153,7 @@ def test_watch_only_workspace_apply_patch_is_visible_without_blocking(
     assert rc == 0
     assert output["policy_action"] == expected_action
     assert "approval_requests" not in output
-    pending = store.list_approval_requests(limit=10)
-    assert len(pending) == 1
-    assert pending[0]["policy_action"] == "require-reapproval"
-    assert pending[0]["launch_target"] == ("apply_patch ~.../plugin.json ~.../.mcp.json")
-    assert pending[0]["scanner_evidence"][-1]["authoritative_action"] == expected_action
-    assert pending[0]["action_envelope_json"]["pre_execution_result"] is None
+    assert store.list_approval_requests(limit=10) == []
 
 
 def test_watch_only_inbox_failure_never_changes_execution(
@@ -228,7 +223,7 @@ def test_watch_only_inbox_accepts_stamped_runtime_envelope(
         artifact_hash=f"stamped-{executable_action}-hash",
         changed_fields=("tool_action",),
         executable_action=executable_action,
-        observed_policy_action=executable_action,
+        observed_policy_action="review",
         redaction_level="full",
         risk_summary="Routine action",
         scanner_evidence=(),


### PR DESCRIPTION
## Summary
- keep Watch only non-blocking while recording only actions that enforcing policy would stop
- coalesce repeated findings and present them as completed Watch-only activity instead of paused actions
- let users save exact future allow or block rules that remain bound to the command, harness, and workspace

## Testing
- `uv run --no-sync pytest -q tests/test_guard_approval_precedence_generic_stdio.py tests/test_guard_approval_scope_contract.py tests/test_guard_approvals.py tests/test_guard_hook_saved_block_terminal.py tests/test_guard_codex_apply_patch_policy.py --tb=short`
- `uv run --no-sync ruff format --check <changed Python files>`
- `uv run --no-sync ruff check <changed Python files>`
- `uv run --no-sync basedpyright`
- `bun run src/approval-center-layout.test.ts && bun run src/approval-scopes.test.ts && bun run src/queue-state.test.ts && bun run src/approval-center-mobile.test.ts`
- `bun run test`
- `bun run build`
- `uv run --no-sync python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory <generated-inventory>`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clear Watch-only labels, badges, queue metadata, and review guidance for non-action findings.
  - Added “Allow next time” and “Block next time” options for eligible watch-only reviews.
  - Expanded exact-action decisions to support both allowing and blocking artifact actions.

- **Bug Fixes**
  - Prevented unnecessary observe-mode items from entering the review queue.
  - Improved reuse of saved decisions only when the exact action and workspace match.
  - Improved request deduplication and neutralized pending-item messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->