### PR TITLE
feat(guard): add resident Rust command shadow bridge

### DIFF
--- a/.github/workflows/rust-command-shadow.yml
+++ b/.github/workflows/rust-command-shadow.yml
@@ -1,0 +1,71 @@
+name: Rust command shadow bridge
+
+on:
+  pull_request:
+    branches: [release/3.0]
+    paths:
+      - "rust/crates/guard-command/**"
+      - "rust/crates/guard-runtime/**"
+      - "src/codex_plugin_scanner/guard/native_command_model.py"
+      - "src/codex_plugin_scanner/guard/native_runtime.py"
+      - "src/codex_plugin_scanner/guard/native_runtime_resident.py"
+      - "ci/native_runtime/test_command_model_resident.py"
+      - ".github/workflows/rust-command-shadow.yml"
+  push:
+    branches: [release/3.0]
+    paths:
+      - "rust/crates/guard-command/**"
+      - "rust/crates/guard-runtime/**"
+      - "src/codex_plugin_scanner/guard/native_command_model.py"
+      - "src/codex_plugin_scanner/guard/native_runtime.py"
+      - "src/codex_plugin_scanner/guard/native_runtime_resident.py"
+      - "ci/native_runtime/test_command_model_resident.py"
+      - ".github/workflows/rust-command-shadow.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rust-command-shadow-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  resident-shadow:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+          enable-cache: true
+      - run: uv sync --frozen --extra dev --python 3.12
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup toolchain install 1.88.0 --profile minimal --component rustfmt --component clippy
+          rustup default 1.88.0
+      - name: Check native command bridge
+        run: |
+          rustfmt --edition 2021 --check rust/crates/guard-runtime/src/main.rs
+          cargo clippy --manifest-path rust/Cargo.toml --locked --workspace --all-targets -- -D warnings
+          uv run --no-sync python -m ruff check src/codex_plugin_scanner/guard/native_command_model.py ci/native_runtime/test_command_model_resident.py
+          uv run --no-sync python -m ruff format --check src/codex_plugin_scanner/guard/native_command_model.py ci/native_runtime/test_command_model_resident.py
+      - name: Build version-matched runtime
+        env:
+          HOL_GUARD_BUILD_SHA: ${{ github.sha }}
+        run: |
+          VERSION=$(uv run --no-sync python scripts/sync_repo_version.py --check)
+          export HOL_GUARD_PACKAGE_VERSION="$VERSION"
+          cargo build --manifest-path rust/Cargo.toml --locked --release -p hol-guard-runtime
+          rust/target/release/hol-guard-runtime self-test --json
+      - name: Exercise resident command shadow bridge
+        env:
+          HOL_GUARD_NATIVE: force
+          HOL_GUARD_NATIVE_BINARY: ${{ github.workspace }}/rust/target/release/hol-guard-runtime
+        run: uv run --no-sync pytest ci/native_runtime/test_command_model_resident.py --tb=short

--- a/ci/native_runtime/test_command_model_resident.py
+++ b/ci/native_runtime/test_command_model_resident.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import copy
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.native_command_model import (
+    _decode_command_model,
+    review_command_model_native,
+)
+from codex_plugin_scanner.guard.native_runtime import native_runtime_status
+from codex_plugin_scanner.guard.native_runtime_resident import (
+    close_resident_native_runtimes,
+    resident_service_starts,
+)
+
+pytestmark = pytest.mark.skipif(os.name == "nt", reason="resident native service is POSIX-only in this wave")
+
+_EXACT_COMMAND = "PATH=/tmp git status --short"
+_DECODER_ARGUMENTS = {
+    "command": _EXACT_COMMAND,
+    "dialect": "posix",
+    "transport": "shell_string",
+    "extraction_provenance": "guard-shell",
+}
+
+
+def _runtime_from_environment() -> Path:
+    value = os.environ.get("HOL_GUARD_NATIVE_BINARY")
+    assert value, "HOL_GUARD_NATIVE_BINARY is required for resident integration"
+    return Path(value).resolve(strict=True)
+
+
+def _exact_payload() -> dict[str, object]:
+    return {
+        "normalized_text": _EXACT_COMMAND,
+        "dialect": "posix",
+        "transport": "shell_string",
+        "extraction_provenance": "guard-shell",
+        "wrapper_chain": [],
+        "segments": [
+            {
+                "text": _EXACT_COMMAND,
+                "tokens": ["PATH=/tmp", "git", "status", "--short"],
+                "executable": "git",
+                "arguments": ["status", "--short"],
+                "environment_names": ["PATH"],
+                "wrapper_chain": [],
+                "path_overridden": True,
+                "execution_context": "top:0",
+                "pipeline_index": 0,
+                "span": {"source": "normalized", "start": 0, "end": len(_EXACT_COMMAND)},
+            }
+        ],
+        "confidence": "exact",
+        "uncertainty_reason": None,
+        "path_overridden": True,
+        "parser_profile": "posix-simple-v1",
+    }
+
+
+def test_command_model_decoder_accepts_bound_exact_response() -> None:
+    payload = _exact_payload()
+    assert _decode_command_model(payload, **_DECODER_ARGUMENTS) == payload
+
+
+def test_command_model_decoder_binds_response_to_request() -> None:
+    for field, value in (
+        ("normalized_text", "git status"),
+        ("dialect", "cmd"),
+        ("transport", "argv"),
+        ("extraction_provenance", "untrusted"),
+        ("parser_profile", "future-profile"),
+    ):
+        payload = _exact_payload()
+        payload[field] = value
+        assert _decode_command_model(payload, **_DECODER_ARGUMENTS) is None, field
+
+
+def test_command_model_decoder_enforces_confidence_contract() -> None:
+    exact_with_reason = _exact_payload()
+    exact_with_reason["uncertainty_reason"] = "unexpected"
+    assert _decode_command_model(exact_with_reason, **_DECODER_ARGUMENTS) is None
+
+    uncertain_with_segments = _exact_payload()
+    uncertain_with_segments["confidence"] = "uncertain"
+    uncertain_with_segments["uncertainty_reason"] = "unsupported"
+    assert _decode_command_model(uncertain_with_segments, **_DECODER_ARGUMENTS) is None
+
+    valid_uncertain = {
+        "normalized_text": "echo $(uname)",
+        "dialect": "posix",
+        "transport": "shell_string",
+        "extraction_provenance": "guard-shell",
+        "wrapper_chain": [],
+        "segments": [],
+        "confidence": "uncertain",
+        "uncertainty_reason": "command_substitution_not_yet_supported",
+        "path_overridden": False,
+        "parser_profile": "posix-simple-v1",
+    }
+    assert (
+        _decode_command_model(
+            valid_uncertain,
+            command="echo $(uname)",
+            dialect="posix",
+            transport="shell_string",
+            extraction_provenance="guard-shell",
+        )
+        == valid_uncertain
+    )
+
+
+def test_command_model_decoder_rejects_inconsistent_segments() -> None:
+    mutations: tuple[tuple[str, object], ...] = (
+        ("span", {"source": "normalized", "start": 0, "end": len(_EXACT_COMMAND) + 1}),
+        ("text", "git status"),
+        ("tokens", ["PATH=/tmp", "git", "status"]),
+        ("executable", "status"),
+        ("arguments", ["--short"]),
+        ("environment_names", []),
+        ("path_overridden", False),
+        ("execution_context", "top:1"),
+        ("pipeline_index", True),
+    )
+    for field, value in mutations:
+        payload = copy.deepcopy(_exact_payload())
+        segments = payload["segments"]
+        assert isinstance(segments, list)
+        segment = segments[0]
+        assert isinstance(segment, dict)
+        segment[field] = value
+        assert _decode_command_model(payload, **_DECODER_ARGUMENTS) is None, field
+
+    aggregate_mismatch = _exact_payload()
+    aggregate_mismatch["path_overridden"] = False
+    assert _decode_command_model(aggregate_mismatch, **_DECODER_ARGUMENTS) is None
+
+
+def test_command_model_reuses_version_matched_resident_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime = _runtime_from_environment()
+    monkeypatch.setenv("HOL_GUARD_NATIVE", "force")
+    close_resident_native_runtimes()
+    with tempfile.TemporaryDirectory(prefix="hgr-", dir="/tmp") as short_tmp:
+        guard_home = Path(short_tmp) / "guard-home"
+        guard_home.mkdir(mode=0o700)
+        try:
+            first = review_command_model_native("git status --short", guard_home=guard_home)
+            second = review_command_model_native("printf 'a|b' | grep b", guard_home=guard_home)
+            assert first is not None
+            assert first["confidence"] == "exact"
+            assert first["segments"][0]["executable"] == "git"
+            assert second is not None
+            assert second["confidence"] == "exact"
+            assert [segment["pipeline_index"] for segment in second["segments"]] == [0, 1]
+
+            status = native_runtime_status()
+            assert status.identity is not None
+            assert status.capabilities is not None
+            assert "resident-command-model-shadow-v1" in status.capabilities.features
+            assert (
+                resident_service_starts(
+                    executable=runtime,
+                    identity_sha256=status.identity.sha256,
+                    guard_home=guard_home,
+                )
+                == 1
+            )
+        finally:
+            close_resident_native_runtimes()
+
+
+def test_complex_command_remains_non_authoritative(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir(mode=0o700)
+    monkeypatch.setenv("HOL_GUARD_NATIVE", "force")
+    close_resident_native_runtimes()
+    try:
+        model = review_command_model_native("echo $(uname) > out.txt", guard_home=guard_home)
+        assert model is not None
+        assert model["confidence"] == "uncertain"
+        assert model["segments"] == []
+        assert model["uncertainty_reason"]
+    finally:
+        close_resident_native_runtimes()
+
+
+def test_command_model_bridge_is_disabled_by_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir(mode=0o700)
+    monkeypatch.delenv("HOL_GUARD_NATIVE", raising=False)
+    assert review_command_model_native("git status", guard_home=guard_home) is None

--- a/rust/crates/guard-runtime/src/main.rs
+++ b/rust/crates/guard-runtime/src/main.rs
@@ -6,6 +6,7 @@ use guard_contracts::{
     MAX_NATIVE_RESPONSE_BYTES, NATIVE_PROTOCOL_VERSION,
 };
 use guard_hook_core::review_post_tool;
+use serde::Deserialize;
 use std::env;
 use std::io::{self, Read, Write};
 
@@ -18,6 +19,19 @@ const PACKAGE_VERSION: &str = match option_env!("HOL_GUARD_PACKAGE_VERSION") {
     None => env!("CARGO_PKG_VERSION"),
 };
 const MAX_RESIDENT_CONCURRENCY: usize = 16;
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "operation", content = "request", rename_all = "snake_case")]
+enum ResidentOperationV1 {
+    CommandModel(CommandModelRequestV1),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum ResidentRequestV1 {
+    Operation(ResidentOperationV1),
+    Hook(NativeHookRequestV1),
+}
 
 fn capabilities() -> RuntimeCapabilitiesV1 {
     RuntimeCapabilitiesV1 {
@@ -34,6 +48,7 @@ fn capabilities() -> RuntimeCapabilitiesV1 {
             "bounded-concurrency-v1".into(),
             "rule-contract-v2".into(),
             "pre-tool-command-model-shadow-v1".into(),
+            "resident-command-model-shadow-v1".into(),
         ],
     }
 }
@@ -53,13 +68,30 @@ fn read_stdin_bounded() -> Result<Vec<u8>, String> {
 fn evaluate_hook_bytes(bytes: &[u8]) -> Result<Vec<u8>, String> {
     let request: NativeHookRequestV1 =
         serde_json::from_slice(bytes).map_err(|_| "native_request_invalid_json".to_owned())?;
-    encode_response(&review_post_tool(&request))
+    let response = review_post_tool(&request);
+    encode_response(&response)
+}
+
+fn evaluate_command_model_request(request: &CommandModelRequestV1) -> Result<Vec<u8>, String> {
+    let response = parse_command(request)?;
+    encode_response(&response)
 }
 
 fn evaluate_command_model_bytes(bytes: &[u8]) -> Result<Vec<u8>, String> {
     let request: CommandModelRequestV1 = serde_json::from_slice(bytes)
         .map_err(|_| "native_command_model_invalid_json".to_owned())?;
-    encode_response(&parse_command(&request)?)
+    evaluate_command_model_request(&request)
+}
+
+fn evaluate_resident_bytes(bytes: &[u8]) -> Result<Vec<u8>, String> {
+    let request: ResidentRequestV1 = serde_json::from_slice(bytes)
+        .map_err(|_| "native_resident_request_invalid_json".to_owned())?;
+    match request {
+        ResidentRequestV1::Operation(ResidentOperationV1::CommandModel(request)) => {
+            evaluate_command_model_request(&request)
+        }
+        ResidentRequestV1::Hook(request) => encode_response(&review_post_tool(&request)),
+    }
 }
 
 fn encode_response<T: serde::Serialize>(value: &T) -> Result<Vec<u8>, String> {
@@ -75,16 +107,6 @@ fn write_json<T: serde::Serialize>(value: &T) -> Result<(), String> {
     serde_json::to_writer(io::stdout().lock(), value)
         .map_err(|_| "native_response_encode_failed".to_owned())?;
     println!();
-    Ok(())
-}
-
-fn write_bytes_response(response: &[u8]) -> Result<(), String> {
-    io::stdout()
-        .write_all(response)
-        .map_err(|_| "native_response_write_failed".to_owned())?;
-    io::stdout()
-        .write_all(b"\n")
-        .map_err(|_| "native_response_write_failed".to_owned())?;
     Ok(())
 }
 
@@ -110,7 +132,7 @@ fn serve(socket_path: &str) -> Result<(), String> {
         stream
             .read_exact(&mut request)
             .map_err(|_| "native_frame_read_failed".to_owned())?;
-        let response = evaluate_hook_bytes(&request)?;
+        let response = evaluate_resident_bytes(&request)?;
         stream
             .write_all(&(response.len() as u32).to_be_bytes())
             .map_err(|_| "native_frame_write_failed".to_owned())?;
@@ -166,6 +188,16 @@ fn serve(_socket_path: &str) -> Result<(), String> {
     Err("native_named_pipe_not_available".into())
 }
 
+fn write_bytes_response(response: &[u8]) -> Result<(), String> {
+    io::stdout()
+        .write_all(response)
+        .map_err(|_| "native_response_write_failed".to_owned())?;
+    io::stdout()
+        .write_all(b"\n")
+        .map_err(|_| "native_response_write_failed".to_owned())?;
+    Ok(())
+}
+
 fn run() -> Result<(), String> {
     let args: Vec<String> = env::args().skip(1).collect();
     match args.as_slice() {
@@ -185,11 +217,13 @@ fn run() -> Result<(), String> {
         }
         [command, flag] if command == "hook" && flag == "--stdin" => {
             let bytes = read_stdin_bounded()?;
-            write_bytes_response(&evaluate_hook_bytes(&bytes)?)
+            let response = evaluate_hook_bytes(&bytes)?;
+            write_bytes_response(&response)
         }
         [command, flag] if command == "command-model" && flag == "--stdin" => {
             let bytes = read_stdin_bounded()?;
-            write_bytes_response(&evaluate_command_model_bytes(&bytes)?)
+            let response = evaluate_command_model_bytes(&bytes)?;
+            write_bytes_response(&response)
         }
         [command, flag, path] if command == "serve" && flag == "--socket" => serve(path),
         _ => Err(

--- a/src/codex_plugin_scanner/guard/native_command_model.py
+++ b/src/codex_plugin_scanner/guard/native_command_model.py
@@ -1,0 +1,278 @@
+"""Shadow-only Python bridge to the native command model.
+
+This module never makes a PreToolUse decision. It exists to exercise and compare
+the native parser through the same version-matched resident runtime used by the
+PostToolUse path. Python remains authoritative until later rollout gates land.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .codex_hook_launch_runtime import run_isolated_hook_process
+from .native_runtime import _isolated_environment, native_runtime_status
+from .native_runtime_resident import resident_native_request
+
+_MAX_REQUEST_BYTES = 64 * 1024
+_MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+_MAX_SEGMENTS = 128
+_MAX_TOKENS = 2_048
+_PARSER_PROFILE = "posix-simple-v1"
+_REQUIRED_FEATURE = "pre-tool-command-model-shadow-v1"
+_RESIDENT_FEATURE = "resident-command-model-shadow-v1"
+
+
+def _plain_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _assignment_name(token: str) -> str | None:
+    name, separator, _value = token.partition("=")
+    if not separator or not name:
+        return None
+    first = name[0]
+    if first != "_" and not (first.isascii() and first.isalpha()):
+        return None
+    if not all(character == "_" or (character.isascii() and character.isalnum()) for character in name[1:]):
+        return None
+    return name
+
+
+def _decode_command_model(
+    payload: object,
+    *,
+    command: str,
+    dialect: str,
+    transport: str,
+    extraction_provenance: str,
+) -> dict[str, Any] | None:
+    """Validate and bind one native response to the request that produced it."""
+    if not isinstance(payload, dict):
+        return None
+    normalized_text = payload.get("normalized_text")
+    wrapper_chain = payload.get("wrapper_chain")
+    segments = payload.get("segments")
+    confidence = payload.get("confidence")
+    uncertainty_reason = payload.get("uncertainty_reason")
+    path_overridden = payload.get("path_overridden")
+    if (
+        not isinstance(normalized_text, str)
+        or not normalized_text
+        or normalized_text != command.strip()
+        or payload.get("dialect") != dialect
+        or payload.get("transport") != transport
+        or payload.get("extraction_provenance") != extraction_provenance
+        or wrapper_chain != []
+        or not isinstance(segments, list)
+        or len(segments) > _MAX_SEGMENTS
+        or confidence not in {"exact", "uncertain"}
+        or not isinstance(path_overridden, bool)
+        or payload.get("parser_profile") != _PARSER_PROFILE
+    ):
+        return None
+
+    if confidence == "uncertain":
+        if segments or not isinstance(uncertainty_reason, str) or not uncertainty_reason.strip() or path_overridden:
+            return None
+        return payload
+    if uncertainty_reason is not None or not segments:
+        return None
+
+    total_tokens = 0
+    aggregate_path_override = False
+    previous_end = 0
+    previous_group = -1
+    previous_pipeline = -1
+    for index, segment in enumerate(segments):
+        if not isinstance(segment, dict):
+            return None
+        text = segment.get("text")
+        tokens = segment.get("tokens")
+        arguments = segment.get("arguments")
+        environment_names = segment.get("environment_names")
+        segment_wrappers = segment.get("wrapper_chain")
+        executable = segment.get("executable")
+        segment_path_overridden = segment.get("path_overridden")
+        execution_context = segment.get("execution_context")
+        pipeline_index = segment.get("pipeline_index")
+        span = segment.get("span")
+        if (
+            not isinstance(text, str)
+            or not text
+            or text.strip() != text
+            or not isinstance(tokens, list)
+            or not tokens
+            or not all(isinstance(value, str) for value in tokens)
+            or not isinstance(arguments, list)
+            or not all(isinstance(value, str) for value in arguments)
+            or not isinstance(environment_names, list)
+            or not all(isinstance(value, str) for value in environment_names)
+            or segment_wrappers != []
+            or (executable is not None and not isinstance(executable, str))
+            or not isinstance(segment_path_overridden, bool)
+            or not isinstance(execution_context, str)
+            or not execution_context.startswith("top:")
+            or not execution_context.removeprefix("top:").isdigit()
+            or not _plain_int(pipeline_index)
+            or pipeline_index < 0
+            or not isinstance(span, dict)
+            or span.get("source") != "normalized"
+            or not _plain_int(span.get("start"))
+            or not _plain_int(span.get("end"))
+        ):
+            return None
+
+        start = span["start"]
+        end = span["end"]
+        group_index = int(execution_context.removeprefix("top:"))
+        if (
+            start < previous_end
+            or start < 0
+            or end <= start
+            or end > len(normalized_text)
+            or normalized_text[start:end] != text
+        ):
+            return None
+        if index == 0:
+            if group_index != 0 or pipeline_index != 0:
+                return None
+        elif group_index == previous_group:
+            if pipeline_index != previous_pipeline + 1:
+                return None
+        elif group_index == previous_group + 1:
+            if pipeline_index != 0:
+                return None
+        else:
+            return None
+
+        executable_index = 0
+        expected_environment_names: list[str] = []
+        while executable_index < len(tokens):
+            name = _assignment_name(tokens[executable_index])
+            if name is None:
+                break
+            expected_environment_names.append(name)
+            executable_index += 1
+        expected_executable = tokens[executable_index] if executable_index < len(tokens) else None
+        expected_arguments = tokens[executable_index + 1 :] if expected_executable is not None else []
+        expected_path_override = "PATH" in expected_environment_names
+        if (
+            environment_names != expected_environment_names
+            or executable != expected_executable
+            or arguments != expected_arguments
+            or segment_path_overridden != expected_path_override
+        ):
+            return None
+
+        total_tokens += len(tokens)
+        if total_tokens > _MAX_TOKENS:
+            return None
+        aggregate_path_override = aggregate_path_override or segment_path_overridden
+        previous_end = end
+        previous_group = group_index
+        previous_pipeline = pipeline_index
+
+    if path_overridden != aggregate_path_override:
+        return None
+    return payload
+
+
+def _request_payload(
+    command: str,
+    *,
+    dialect: str,
+    transport: str,
+    extraction_provenance: str,
+) -> tuple[dict[str, str], bytes] | None:
+    request = {
+        "command": command,
+        "dialect": dialect,
+        "transport": transport,
+        "extraction_provenance": extraction_provenance,
+    }
+    encoded = json.dumps(request, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    if len(encoded) > _MAX_REQUEST_BYTES:
+        return None
+    return request, encoded
+
+
+def review_command_model_native(
+    command: str,
+    *,
+    guard_home: Path,
+    dialect: str = "posix",
+    transport: str = "shell_string",
+    extraction_provenance: str = "guard-shell",
+    timeout_seconds: float = 0.25,
+) -> dict[str, Any] | None:
+    """Return native command-model evidence in explicit shadow/force modes only."""
+    status = native_runtime_status()
+    if (
+        status.mode not in {"shadow", "force"}
+        or not status.available
+        or not status.compatible
+        or status.identity is None
+        or status.capabilities is None
+        or _REQUIRED_FEATURE not in status.capabilities.features
+        or timeout_seconds <= 0
+    ):
+        return None
+    prepared = _request_payload(
+        command,
+        dialect=dialect,
+        transport=transport,
+        extraction_provenance=extraction_provenance,
+    )
+    if prepared is None:
+        return None
+    request, request_bytes = prepared
+    timeout_seconds = min(timeout_seconds, 1.0)
+    environment = _isolated_environment()
+    decoder_arguments = {
+        "command": command,
+        "dialect": dialect,
+        "transport": transport,
+        "extraction_provenance": extraction_provenance,
+    }
+
+    if _RESIDENT_FEATURE in status.capabilities.features:
+        resident_envelope = json.dumps(
+            {"operation": "command_model", "request": request},
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+        resident_output = resident_native_request(
+            executable=status.identity.path,
+            identity_sha256=status.identity.sha256,
+            guard_home=guard_home,
+            environment=environment,
+            payload=resident_envelope,
+            timeout_seconds=timeout_seconds,
+        )
+        if resident_output is not None:
+            try:
+                decoded = _decode_command_model(json.loads(resident_output), **decoder_arguments)
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                decoded = None
+            if decoded is not None:
+                return decoded
+
+    result = run_isolated_hook_process(
+        (str(status.identity.path), "command-model", "--stdin"),
+        input_text=request_bytes.decode("utf-8"),
+        cwd=status.identity.path.parent,
+        environment=environment,
+        timeout_seconds=timeout_seconds,
+        output_limit=_MAX_RESPONSE_BYTES,
+    )
+    if result.returncode != 0 or result.timed_out or result.output_limit_exceeded or result.containment_failed:
+        return None
+    try:
+        return _decode_command_model(json.loads(result.stdout), **decoder_arguments)
+    except json.JSONDecodeError:
+        return None
+
+
+__all__ = ["review_command_model_native"]

--- a/src/codex_plugin_scanner/guard/native_command_model.py
+++ b/src/codex_plugin_scanner/guard/native_command_model.py
@@ -24,10 +24,6 @@ _REQUIRED_FEATURE = "pre-tool-command-model-shadow-v1"
 _RESIDENT_FEATURE = "resident-command-model-shadow-v1"
 
 
-def _plain_int(value: object) -> bool:
-    return isinstance(value, int) and not isinstance(value, bool)
-
-
 def _assignment_name(token: str) -> str | None:
     name, separator, _value = token.partition("=")
     if not separator or not name:
@@ -96,7 +92,7 @@ def _decode_command_model(
         executable = segment.get("executable")
         segment_path_overridden = segment.get("path_overridden")
         execution_context = segment.get("execution_context")
-        pipeline_index = segment.get("pipeline_index")
+        raw_pipeline_index = segment.get("pipeline_index")
         span = segment.get("span")
         if (
             not isinstance(text, str)
@@ -115,17 +111,26 @@ def _decode_command_model(
             or not isinstance(execution_context, str)
             or not execution_context.startswith("top:")
             or not execution_context.removeprefix("top:").isdigit()
-            or not _plain_int(pipeline_index)
-            or pipeline_index < 0
+            or not isinstance(raw_pipeline_index, int)
+            or isinstance(raw_pipeline_index, bool)
+            or raw_pipeline_index < 0
             or not isinstance(span, dict)
             or span.get("source") != "normalized"
-            or not _plain_int(span.get("start"))
-            or not _plain_int(span.get("end"))
         ):
             return None
 
-        start = span["start"]
-        end = span["end"]
+        raw_start = span.get("start")
+        raw_end = span.get("end")
+        if (
+            not isinstance(raw_start, int)
+            or isinstance(raw_start, bool)
+            or not isinstance(raw_end, int)
+            or isinstance(raw_end, bool)
+        ):
+            return None
+        pipeline_index = raw_pipeline_index
+        start = raw_start
+        end = raw_end
         group_index = int(execution_context.removeprefix("top:"))
         if (
             start < previous_end


### PR DESCRIPTION
## Summary

Adds a resident Rust transport for the shadow-only PreToolUse command model after the parser landed in `release/3.0`.

- extends the version-matched `hol-guard-runtime` resident server with an operation-tagged command-model request while preserving raw PostToolUse frames
- adds a strict request-bound Python decoder/client that rejects malformed, inconsistent, or unbound native evidence
- uses the resident runtime first and a bounded one-shot Rust fallback only for explicit shadow/force use
- preserves Python as the authoritative PreToolUse evaluator
- carries exact rule-contract provenance and bundled runtime identity checks forward
- adds live resident reuse and adversarial decoder contracts

## Rollout

Shadow/evidence only. This PR does not change action selection, approvals, policy authority, receipts, or the default `HOL_GUARD_NATIVE=off` behavior.