### PR TITLE
feat(guard): observe Rust command decisions in PreToolUse traffic

### DIFF
--- a/.github/workflows/rust-command-shadow.yml
+++ b/.github/workflows/rust-command-shadow.yml
@@ -57,6 +57,7 @@ jobs:
         run: |
           rustfmt --edition 2021 --check rust/crates/guard-runtime/src/main.rs
           cargo clippy --manifest-path rust/Cargo.toml --locked --workspace --all-targets -- -D warnings
+          cargo test --manifest-path rust/Cargo.toml --locked --workspace --all-targets
           uv run --no-sync python -m ruff check \
             src/codex_plugin_scanner/guard/native_command_model.py \
             src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py \

--- a/.github/workflows/rust-command-shadow.yml
+++ b/.github/workflows/rust-command-shadow.yml
@@ -2,14 +2,15 @@ name: Rust command shadow bridge
 
 on:
   pull_request:
-    branches: [release/3.0]
     paths:
       - "rust/crates/guard-command/**"
       - "rust/crates/guard-runtime/**"
       - "src/codex_plugin_scanner/guard/native_command_model.py"
       - "src/codex_plugin_scanner/guard/native_runtime.py"
       - "src/codex_plugin_scanner/guard/native_runtime_resident.py"
+      - "src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py"
       - "ci/native_runtime/test_command_model_resident.py"
+      - "ci/native_runtime/test_command_shadow_activity.py"
       - ".github/workflows/rust-command-shadow.yml"
   push:
     branches: [release/3.0]
@@ -19,7 +20,9 @@ on:
       - "src/codex_plugin_scanner/guard/native_command_model.py"
       - "src/codex_plugin_scanner/guard/native_runtime.py"
       - "src/codex_plugin_scanner/guard/native_runtime_resident.py"
+      - "src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py"
       - "ci/native_runtime/test_command_model_resident.py"
+      - "ci/native_runtime/test_command_shadow_activity.py"
       - ".github/workflows/rust-command-shadow.yml"
   workflow_dispatch:
 
@@ -54,8 +57,16 @@ jobs:
         run: |
           rustfmt --edition 2021 --check rust/crates/guard-runtime/src/main.rs
           cargo clippy --manifest-path rust/Cargo.toml --locked --workspace --all-targets -- -D warnings
-          uv run --no-sync python -m ruff check src/codex_plugin_scanner/guard/native_command_model.py ci/native_runtime/test_command_model_resident.py
-          uv run --no-sync python -m ruff format --check src/codex_plugin_scanner/guard/native_command_model.py ci/native_runtime/test_command_model_resident.py
+          uv run --no-sync python -m ruff check \
+            src/codex_plugin_scanner/guard/native_command_model.py \
+            src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py \
+            ci/native_runtime/test_command_model_resident.py \
+            ci/native_runtime/test_command_shadow_activity.py
+          uv run --no-sync python -m ruff format --check \
+            src/codex_plugin_scanner/guard/native_command_model.py \
+            src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py \
+            ci/native_runtime/test_command_model_resident.py \
+            ci/native_runtime/test_command_shadow_activity.py
       - name: Build version-matched runtime
         env:
           HOL_GUARD_BUILD_SHA: ${{ github.sha }}
@@ -68,4 +79,8 @@ jobs:
         env:
           HOL_GUARD_NATIVE: force
           HOL_GUARD_NATIVE_BINARY: ${{ github.workspace }}/rust/target/release/hol-guard-runtime
-        run: uv run --no-sync pytest ci/native_runtime/test_command_model_resident.py --tb=short
+        run: >-
+          uv run --no-sync pytest
+          ci/native_runtime/test_command_model_resident.py
+          ci/native_runtime/test_command_shadow_activity.py
+          --tb=short

--- a/ci/native_runtime/test_command_shadow_activity.py
+++ b/ci/native_runtime/test_command_shadow_activity.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+import codex_plugin_scanner.guard.cli.commands_support_command_activity as command_activity
+import codex_plugin_scanner.guard.native_command_model as native_command_model
+from codex_plugin_scanner.guard.runtime.command_evaluation import evaluate_command
+from codex_plugin_scanner.guard.runtime.command_model import parse_shell_command
+from codex_plugin_scanner.guard.runtime.command_shadow_evaluation import (
+    COMMAND_SHADOW_BASELINE_PROPOSAL_VERSION,
+    CommandShadowCohort,
+    CommandShadowProposal,
+)
+
+_OCCURRED_AT = datetime(2026, 8, 10, 12, 0, tzinfo=timezone.utc)
+_NATIVE_PROPOSAL_VERSION = "guard.command-shadow-proposal.rust-parser.v1"
+
+
+def _native_payload(command: str) -> dict[str, object]:
+    payload = parse_shell_command(command).to_dict()
+    payload["parser_profile"] = "posix-simple-v1"
+    return payload
+
+
+def test_exact_native_parse_builds_python_rule_shadow_proposal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    command = "git push origin main --force"
+    expected = evaluate_command(command)
+    monkeypatch.setattr(
+        native_command_model,
+        "review_command_model_native",
+        lambda *_args, **_kwargs: _native_payload(command),
+    )
+
+    proposal = native_command_model.native_command_shadow_proposal(
+        command,
+        guard_home=tmp_path,
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+
+    assert proposal is not None
+    assert proposal.version == _NATIVE_PROPOSAL_VERSION
+    assert proposal.cohorts == frozenset({CommandShadowCohort.BASELINE})
+    assert proposal.decision == expected.decision_plane
+
+
+def test_unbound_or_inconsistent_native_parse_cannot_create_proposal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    command = "git push origin main --force"
+    payload = _native_payload(command)
+    segments = payload["segments"]
+    assert isinstance(segments, list)
+    segment = segments[0]
+    assert isinstance(segment, dict)
+    span = segment["span"]
+    assert isinstance(span, dict)
+    span["end"] = len(command) + 1
+    monkeypatch.setattr(
+        native_command_model,
+        "review_command_model_native",
+        lambda *_args, **_kwargs: payload,
+    )
+
+    assert (
+        native_command_model.native_command_shadow_proposal(
+            command,
+            guard_home=tmp_path,
+            cwd=tmp_path,
+            home_dir=tmp_path,
+        )
+        is None
+    )
+
+    mismatched = _native_payload(command)
+    mismatched["normalized_text"] = "git status --short"
+    monkeypatch.setattr(
+        native_command_model,
+        "review_command_model_native",
+        lambda *_args, **_kwargs: mismatched,
+    )
+    assert (
+        native_command_model.native_command_shadow_proposal(
+            command,
+            guard_home=tmp_path,
+            cwd=tmp_path,
+            home_dir=tmp_path,
+        )
+        is None
+    )
+
+
+def test_uncertain_native_parse_does_not_create_shadow_proposal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    command = "echo $(uname)"
+    payload = _native_payload(command)
+    payload.update(
+        {
+            "segments": [],
+            "confidence": "uncertain",
+            "uncertainty_reason": "command_substitution_unsupported",
+            "path_overridden": False,
+        }
+    )
+    monkeypatch.setattr(
+        native_command_model,
+        "review_command_model_native",
+        lambda *_args, **_kwargs: payload,
+    )
+
+    assert (
+        native_command_model.native_command_shadow_proposal(
+            command,
+            guard_home=tmp_path,
+            cwd=tmp_path,
+            home_dir=tmp_path,
+        )
+        is None
+    )
+
+
+def test_activity_shadow_prefers_native_proposal_without_changing_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    command = "git push origin main --force"
+    evaluation = evaluate_command(command)
+    native_proposal = CommandShadowProposal(
+        decision=evaluation.decision_plane,
+        cohorts=frozenset({CommandShadowCohort.BASELINE}),
+        version=_NATIVE_PROPOSAL_VERSION,
+    )
+    monkeypatch.setattr(
+        command_activity,
+        "native_command_shadow_proposal",
+        lambda *_args, **_kwargs: native_proposal,
+    )
+
+    observation, failed = command_activity._build_shadow_best_effort(
+        evaluation=evaluation,
+        command_text=command,
+        guard_home=tmp_path,
+        cwd=tmp_path,
+        home_dir=tmp_path,
+        policy_action="review",
+        activity_id="activity:native-shadow-test",
+        occurred_at=_OCCURRED_AT,
+    )
+
+    assert failed is False
+    assert observation is not None
+    assert observation.authoritative_action == "review"
+    assert observation.proposal_version == _NATIVE_PROPOSAL_VERSION
+    assert command not in repr(asdict(observation))
+
+
+def test_native_shadow_exception_falls_back_to_existing_python_baseline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    command = "git push origin main --force"
+    evaluation = evaluate_command(command)
+
+    def fail_native(*_args: object, **_kwargs: object) -> CommandShadowProposal | None:
+        raise RuntimeError("synthetic native failure")
+
+    monkeypatch.setattr(command_activity, "native_command_shadow_proposal", fail_native)
+
+    observation, failed = command_activity._build_shadow_best_effort(
+        evaluation=evaluation,
+        command_text=command,
+        guard_home=tmp_path,
+        cwd=tmp_path,
+        home_dir=tmp_path,
+        policy_action="review",
+        activity_id="activity:native-shadow-fallback",
+        occurred_at=_OCCURRED_AT,
+    )
+
+    assert failed is False
+    assert observation is not None
+    assert observation.authoritative_action == "review"
+    assert observation.proposal_version == COMMAND_SHADOW_BASELINE_PROPOSAL_VERSION

--- a/src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_command_activity.py
@@ -11,6 +11,7 @@ from typing import cast
 
 from ..action_lattice import guard_action_severity
 from ..models import GuardAction
+from ..native_command_model import native_command_shadow_proposal
 from ..runtime.command_activity_contract import (
     ActivityApprovalReuseStatus,
     ActivityDecisionReason,
@@ -108,6 +109,10 @@ def record_pre_hook_command_activity_best_effort(
             return False
         shadow, shadow_failed = _build_shadow_best_effort(
             evaluation=evaluation,
+            command_text=_payload_command_text(payload),
+            guard_home=guard_home,
+            cwd=cwd,
+            home_dir=home_dir,
             policy_action=policy_action,
             activity_id=activity_id,
             occurred_at=occurred_at,
@@ -260,15 +265,43 @@ def record_command_activity_failure_best_effort(store: GuardStore, error_code: s
     _record_persistence_failure(store, error_code)
 
 
+def _compatibility_context(
+    evaluation: CompositeCommandEvaluation,
+) -> tuple[str | None, str | None]:
+    """Return only an explicit compatibility fallback already used by Python."""
+
+    for owned in evaluation.matches:
+        if owned.match.rule.compatibility_fallback and not owned.match.matcher_evidence:
+            return evaluation.controlling_action_class, evaluation.controlling_reason
+    return None, None
+
+
 def _build_shadow_best_effort(
     *,
     evaluation: CompositeCommandEvaluation,
+    command_text: str | None,
+    guard_home: Path,
+    cwd: Path | None,
+    home_dir: Path | None,
     policy_action: GuardAction,
     activity_id: str,
     occurred_at: datetime,
 ) -> tuple[CommandShadowObservation | None, bool]:
     try:
         proposal = baseline_command_shadow_proposal(evaluation)
+        if command_text is not None:
+            compatibility_action_class, compatibility_reason = _compatibility_context(evaluation)
+            with suppress(Exception):
+                native_proposal = native_command_shadow_proposal(
+                    command_text,
+                    guard_home=guard_home,
+                    cwd=cwd,
+                    home_dir=home_dir,
+                    compatibility_action_class=compatibility_action_class,
+                    compatibility_reason=compatibility_reason,
+                )
+                if native_proposal is not None:
+                    proposal = native_proposal
         return (
             build_command_shadow_observation(
                 evaluation,

--- a/src/codex_plugin_scanner/guard/native_command_model.py
+++ b/src/codex_plugin_scanner/guard/native_command_model.py
@@ -14,6 +14,9 @@ from typing import Any
 from .codex_hook_launch_runtime import run_isolated_hook_process
 from .native_runtime import _isolated_environment, native_runtime_status
 from .native_runtime_resident import resident_native_request
+from .runtime.command_evaluation import evaluate_command
+from .runtime.command_model import CanonicalCommand, CommandSegment
+from .runtime.command_shadow_evaluation import CommandShadowCohort, CommandShadowProposal
 
 _MAX_REQUEST_BYTES = 64 * 1024
 _MAX_RESPONSE_BYTES = 2 * 1024 * 1024
@@ -22,6 +25,11 @@ _MAX_TOKENS = 2_048
 _PARSER_PROFILE = "posix-simple-v1"
 _REQUIRED_FEATURE = "pre-tool-command-model-shadow-v1"
 _RESIDENT_FEATURE = "resident-command-model-shadow-v1"
+_NATIVE_SHADOW_PROPOSAL_VERSION = "guard.command-shadow-proposal.rust-parser.v1"
+
+
+def _plain_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
 
 
 def _assignment_name(token: str) -> str | None:
@@ -280,4 +288,132 @@ def review_command_model_native(
         return None
 
 
-__all__ = ["review_command_model_native"]
+def _canonical_command_from_native(
+    command: str,
+    payload: dict[str, Any],
+) -> CanonicalCommand | None:
+    """Convert only request-bound exact native evidence into the Python type."""
+    validated = _decode_command_model(
+        payload,
+        command=command,
+        dialect="posix",
+        transport="shell_string",
+        extraction_provenance="guard-shell",
+    )
+    if validated is None or validated.get("confidence") != "exact":
+        return None
+
+    normalized_text = validated.get("normalized_text")
+    raw_segments = validated.get("segments")
+    if not isinstance(normalized_text, str) or not isinstance(raw_segments, list):
+        return None
+
+    segments: list[CommandSegment] = []
+    for raw_segment in raw_segments:
+        if not isinstance(raw_segment, dict):
+            return None
+        text = raw_segment.get("text")
+        tokens = raw_segment.get("tokens")
+        executable = raw_segment.get("executable")
+        arguments = raw_segment.get("arguments")
+        environment_names = raw_segment.get("environment_names")
+        path_overridden = raw_segment.get("path_overridden")
+        execution_context = raw_segment.get("execution_context")
+        raw_pipeline_index = raw_segment.get("pipeline_index")
+        span = raw_segment.get("span")
+        if (
+            not isinstance(text, str)
+            or not isinstance(tokens, list)
+            or not all(isinstance(value, str) for value in tokens)
+            or (executable is not None and not isinstance(executable, str))
+            or not isinstance(arguments, list)
+            or not all(isinstance(value, str) for value in arguments)
+            or not isinstance(environment_names, list)
+            or not all(isinstance(value, str) for value in environment_names)
+            or not isinstance(path_overridden, bool)
+            or not isinstance(execution_context, str)
+            or not isinstance(raw_pipeline_index, int)
+            or isinstance(raw_pipeline_index, bool)
+            or raw_pipeline_index < 0
+            or not isinstance(span, dict)
+        ):
+            return None
+        raw_start = span.get("start")
+        raw_end = span.get("end")
+        if (
+            not isinstance(raw_start, int)
+            or isinstance(raw_start, bool)
+            or not isinstance(raw_end, int)
+            or isinstance(raw_end, bool)
+        ):
+            return None
+        pipeline_index = raw_pipeline_index
+        segments.append(
+            CommandSegment(
+                text=text,
+                tokens=tuple(tokens),
+                executable=executable,
+                arguments=tuple(arguments),
+                environment_names=tuple(environment_names),
+                wrapper_chain=(),
+                path_overridden=path_overridden,
+                execution_context=execution_context,
+                pipeline_index=pipeline_index,
+                start=raw_start,
+                end=raw_end,
+            )
+        )
+
+    canonical = CanonicalCommand(
+        raw_text=command.strip(),
+        normalized_text=normalized_text,
+        dialect="posix",
+        transport="shell_string",
+        extraction_provenance="guard-shell",
+        wrapper_chain=(),
+        segments=tuple(segments),
+        redirects=(),
+        embedded_commands=(),
+        confidence="exact",
+        uncertainty_reason=None,
+    )
+    if validated.get("path_overridden") is not canonical.path_overridden:
+        return None
+    return canonical
+
+
+def native_command_shadow_proposal(
+    command: str,
+    *,
+    guard_home: Path,
+    cwd: Path | None,
+    home_dir: Path | None,
+    compatibility_action_class: str | None = None,
+    compatibility_reason: str | None = None,
+) -> CommandShadowProposal | None:
+    """Build a privacy-safe shadow proposal from a Rust parse and Python rules."""
+    payload = review_command_model_native(command, guard_home=guard_home)
+    if payload is None:
+        return None
+    canonical = _canonical_command_from_native(command, payload)
+    if canonical is None:
+        return None
+    evaluation = evaluate_command(
+        command,
+        canonical_command=canonical,
+        compatibility_action_class=compatibility_action_class,
+        compatibility_reason=compatibility_reason,
+        cwd=cwd,
+        home_dir=home_dir,
+    )
+    return CommandShadowProposal(
+        decision=evaluation.decision_plane,
+        cohorts=frozenset({CommandShadowCohort.BASELINE}),
+        version=_NATIVE_SHADOW_PROPOSAL_VERSION,
+    )
+
+
+__all__ = [
+    "native_command_shadow_proposal",
+    "review_command_model_native",
+]


### PR DESCRIPTION
## Summary

Adds privacy-safe, telemetry-only observation of Rust command parsing at the existing best-effort command activity boundary.

- requests native command evidence only in explicit shadow/force modes
- converts only request-bound, structurally valid exact Rust parses into the existing Python canonical command type
- applies the existing Python command evaluator to measure parse-induced decision drift
- persists only action/disposition/comparison/proposal-version telemetry, never raw command text, tokens, paths, or native payloads
- rejects malformed, inconsistent, unbound, and uncertain native evidence
- falls back to the existing Python shadow baseline on native failure

## Rollout

Python remains authoritative. This PR cannot change PreToolUse actions, approval floors, policy authority, receipts, or the default `HOL_GUARD_NATIVE=off` behavior.