### PR TITLE
fix(guard): describe Watch-only findings accurately

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 12525,
-  "maximum_test_source_lines": 287123,
+  "maximum_test_source_lines": 287126,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/cli/commands_support_observe_queue.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_observe_queue.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from dataclasses import replace
 
 from ..approvals import queue_blocked_approvals
 from ..daemon.manager import guard_daemon_url_for_home
@@ -41,15 +42,23 @@ def queue_observe_mode_request(
             "authoritative_action": executable_action,
         }
     )
+    observed_artifact = replace(
+        artifact,
+        metadata={
+            **artifact.metadata,
+            "watch_only_observation": True,
+            "watch_only_authoritative_action": executable_action,
+        },
+    )
     try:
         approval_center_url = guard_daemon_url_for_home(store.guard_home)
         return queue_blocked_approvals(
             detection=HarnessDetection(
-                harness=artifact.harness,
+                harness=observed_artifact.harness,
                 installed=True,
                 command_available=True,
-                config_paths=(artifact.config_path,),
-                artifacts=(artifact,),
+                config_paths=(observed_artifact.config_path,),
+                artifacts=(observed_artifact,),
             ),
             evaluation={
                 "artifacts": [

--- a/src/codex_plugin_scanner/guard/incident.py
+++ b/src/codex_plugin_scanner/guard/incident.py
@@ -47,7 +47,8 @@ def build_incident_context(
     harness_label = _HARNESS_LABELS.get(harness, harness.title())
     artifact_label = _ARTIFACT_LABELS.get(artifact_type or "artifact", "Artifact")
     normalized_scope = source_scope or "project"
-    action_verb = _trigger_verb(policy_action=policy_action, changed_fields=changed_fields)
+    presentation_action = _presentation_action(artifact=artifact, policy_action=policy_action)
+    action_verb = _trigger_verb(policy_action=presentation_action, changed_fields=changed_fields)
     if artifact_type == "prompt_request":
         source_label = f"{harness_label} session prompt"
         trigger_summary = (
@@ -79,7 +80,7 @@ def build_incident_context(
             f"HOL Guard {action_verb} the {artifact_label} `{artifact_name or artifact_id}` from "
             f"`{short_config_path}` for {harness_label}."
         )
-    why_now = _why_now_text(changed_fields, policy_action, harness_label, artifact_type)
+    why_now = _why_now_text(changed_fields, presentation_action, harness_label, artifact_type)
     launch_summary = _launch_summary(artifact=artifact, launch_target=launch_target)
     risk_headline = risk_summary or _fallback_risk_headline(policy_action)
     return {
@@ -90,6 +91,17 @@ def build_incident_context(
         "launch_summary": launch_summary,
         "risk_headline": risk_headline,
     }
+
+
+def _presentation_action(*, artifact: GuardArtifact | None, policy_action: GuardAction) -> GuardAction:
+    if artifact is None or artifact.metadata.get("watch_only_observation") is not True:
+        return policy_action
+    authoritative_action = artifact.metadata.get("watch_only_authoritative_action")
+    if authoritative_action == "allow":
+        return "allow"
+    if authoritative_action == "warn":
+        return "warn"
+    return policy_action
 
 
 def _fallback_risk_headline(policy_action: GuardAction) -> str:

--- a/tests/test_guard_approval_precedence_generic_stdio.py
+++ b/tests/test_guard_approval_precedence_generic_stdio.py
@@ -666,6 +666,9 @@ def test_watch_only_exact_allow_applies_after_enforcement_is_enabled(
     )
     assert rc == 0
     observed = store.list_approval_requests(limit=10)[0]
+    assert "paused" not in str(observed["trigger_summary"]).lower()
+    assert "paused" not in str(observed["why_now"]).lower()
+    assert "continue" in str(observed["why_now"]).lower()
     approvals_module.apply_approval_resolution(
         store=store,
         request_id=str(observed["request_id"]),


### PR DESCRIPTION
## Summary
- preserve the authoritative nonblocking outcome when Watch only records a would-stop finding
- describe recorded actions as reviewed or flagged instead of paused
- keep enforcing-mode incident copy unchanged

## Testing
- `uv run pytest -q tests/test_guard_approval_precedence_generic_stdio.py tests/test_guard_codex_apply_patch_policy.py tests/test_guard_risk.py -k 'watch_only or incident_context'`
- `uv run ruff format --check src/codex_plugin_scanner/guard/incident.py src/codex_plugin_scanner/guard/cli/commands_support_observe_queue.py tests/test_guard_approval_precedence_generic_stdio.py`
- `uv run ruff check src/codex_plugin_scanner/guard/incident.py src/codex_plugin_scanner/guard/cli/commands_support_observe_queue.py tests/test_guard_approval_precedence_generic_stdio.py`
- `uv run basedpyright src/codex_plugin_scanner/guard/incident.py src/codex_plugin_scanner/guard/cli/commands_support_observe_queue.py`
- `uv run python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory <generated-inventory>`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved watch-only approval handling so displayed actions accurately reflect authoritative allow or warn decisions.
  * Updated incident explanations and trigger messages to provide clearer, more relevant context.
  * Removed misleading “paused” wording from watch-only approval requests and clarified that processing can continue.
* **Tests**
  * Added coverage to verify correct watch-only approval messaging and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->