### PR TITLE
fix(guard): describe Watch-only findings accurately

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 14558,
-  "maximum_test_source_lines": 316248,
+  "maximum_test_source_lines": 316251,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/cli/commands_support_observe_queue.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_observe_queue.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sqlite3
 from collections.abc import Mapping, Sequence
+from dataclasses import replace
 
 from ..approvals import queue_blocked_approvals
 from ..daemon.manager import guard_daemon_url_for_home
@@ -42,15 +43,23 @@ def queue_observe_mode_request(
             "authoritative_action": executable_action,
         }
     )
+    observed_artifact = replace(
+        artifact,
+        metadata={
+            **artifact.metadata,
+            "watch_only_observation": True,
+            "watch_only_authoritative_action": executable_action,
+        },
+    )
     try:
         approval_center_url = guard_daemon_url_for_home(store.guard_home)
         return queue_blocked_approvals(
             detection=HarnessDetection(
-                harness=artifact.harness,
+                harness=observed_artifact.harness,
                 installed=True,
                 command_available=True,
-                config_paths=(artifact.config_path,),
-                artifacts=(artifact,),
+                config_paths=(observed_artifact.config_path,),
+                artifacts=(observed_artifact,),
             ),
             evaluation={
                 "artifacts": [

--- a/src/codex_plugin_scanner/guard/incident.py
+++ b/src/codex_plugin_scanner/guard/incident.py
@@ -47,7 +47,8 @@ def build_incident_context(
     harness_label = _HARNESS_LABELS.get(harness, harness.title())
     artifact_label = _ARTIFACT_LABELS.get(artifact_type or "artifact", "Artifact")
     normalized_scope = source_scope or "project"
-    action_verb = _trigger_verb(policy_action=policy_action, changed_fields=changed_fields)
+    presentation_action = _presentation_action(artifact=artifact, policy_action=policy_action)
+    action_verb = _trigger_verb(policy_action=presentation_action, changed_fields=changed_fields)
     if artifact_type == "prompt_request":
         source_label = f"{harness_label} session prompt"
         trigger_summary = (
@@ -79,7 +80,7 @@ def build_incident_context(
             f"HOL Guard {action_verb} the {artifact_label} `{artifact_name or artifact_id}` from "
             f"`{short_config_path}` for {harness_label}."
         )
-    why_now = _why_now_text(changed_fields, policy_action, harness_label, artifact_type)
+    why_now = _why_now_text(changed_fields, presentation_action, harness_label, artifact_type)
     launch_summary = _launch_summary(artifact=artifact, launch_target=launch_target)
     risk_headline = risk_summary or _fallback_risk_headline(policy_action)
     return {
@@ -90,6 +91,17 @@ def build_incident_context(
         "launch_summary": launch_summary,
         "risk_headline": risk_headline,
     }
+
+
+def _presentation_action(*, artifact: GuardArtifact | None, policy_action: GuardAction) -> GuardAction:
+    if artifact is None or artifact.metadata.get("watch_only_observation") is not True:
+        return policy_action
+    authoritative_action = artifact.metadata.get("watch_only_authoritative_action")
+    if authoritative_action == "allow":
+        return "allow"
+    if authoritative_action == "warn":
+        return "warn"
+    return policy_action
 
 
 def _fallback_risk_headline(policy_action: GuardAction) -> str:

--- a/tests/test_guard_approval_precedence_generic_stdio.py
+++ b/tests/test_guard_approval_precedence_generic_stdio.py
@@ -666,6 +666,9 @@ def test_watch_only_exact_allow_applies_after_enforcement_is_enabled(
     )
     assert rc == 0
     observed = store.list_approval_requests(limit=10)[0]
+    assert "paused" not in str(observed["trigger_summary"]).lower()
+    assert "paused" not in str(observed["why_now"]).lower()
+    assert "continue" in str(observed["why_now"]).lower()
     approvals_module.apply_approval_resolution(
         store=store,
         request_id=str(observed["request_id"]),


### PR DESCRIPTION
## Summary

- describe Watch-only findings as observed actions that continued running
- preserve the enforcement decision separately from presentation copy
- add regression coverage for the request summary and explanation

## Verification

- `uv run pytest -q tests/test_guard_approval_precedence_generic_stdio.py`
- `uv run ruff check src/codex_plugin_scanner/guard/cli/commands_support_observe_queue.py src/codex_plugin_scanner/guard/incident.py tests/test_guard_approval_precedence_generic_stdio.py`
- `uv run ruff format --check src/codex_plugin_scanner/guard/cli/commands_support_observe_queue.py src/codex_plugin_scanner/guard/incident.py tests/test_guard_approval_precedence_generic_stdio.py`
- `uv run basedpyright --level error src/codex_plugin_scanner/guard/cli/commands_support_observe_queue.py src/codex_plugin_scanner/guard/incident.py`
- test-suite ratchet regenerated and verified
