### PR TITLE
fix(guard): persist exact approvals from CLI

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12525,
-  "maximum_test_source_lines": 287126,
+  "maximum_collected_cases": 12526,
+  "maximum_test_source_lines": 287185,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/cli/approval_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/approval_commands.py
@@ -269,6 +269,16 @@ def run_approval_command(
             )
             else None
         )
+        remember = bool(getattr(args, "remember", False))
+        request = store.get_approval_request(args.request_id) if remember else None
+        exact_action_remember = request is not None and request.get("exact_action_persistence_eligible") is True
+        scope_contract_version = None
+        scope_contract_digest = None
+        if exact_action_remember and request is not None:
+            if request.get("scope_contract_version") is not None:
+                scope_contract_version = str(request["scope_contract_version"])
+            if request.get("scope_contract_digest") is not None:
+                scope_contract_digest = str(request["scope_contract_digest"])
         item = apply_approval_resolution(
             store=store,
             request_id=args.request_id,
@@ -278,7 +288,9 @@ def run_approval_command(
             reason=args.reason,
             now=_now(),
             approval_gate_input=gate_input,
-            persist_policy=True if bool(getattr(args, "remember", False)) else None,
+            persist_policy=True if remember else None,
+            scope_contract_version=scope_contract_version,
+            scope_contract_digest=scope_contract_digest,
             local_tool_grant_target=(getattr(args, "trust_target", None) if trust_local_tool else None),
             local_tool_grant_duration=(getattr(args, "trust_duration", None) if trust_local_tool else None),
         )

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -3261,6 +3261,65 @@ class TestGuardApprovals:
         assert remember_output["item"]["applied_scope"] == "artifact"
         assert store.list_policy_decisions("codex") == []
 
+    def test_guard_approvals_cli_remembers_eligible_exact_action(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace = str(tmp_path / "workspace")
+        store = GuardStore(home_dir)
+        store.add_approval_request(
+            GuardApprovalRequest(
+                request_id="req-exact-remember",
+                harness="codex",
+                artifact_id="codex:project:tool-action:script",
+                artifact_name="Bash unmatched tool action",
+                artifact_type="tool_action_request",
+                artifact_hash="hash-exact-remember",
+                policy_action="require-reapproval",
+                recommended_scope="artifact",
+                changed_fields=("tool_action",),
+                source_scope="project",
+                config_path=workspace,
+                workspace=workspace,
+                launch_target="npm run guard:acquisition-loop",
+                action_envelope_json={
+                    "action_type": "shell_command",
+                    "tool_name": "Bash",
+                    "command": "npm run guard:acquisition-loop",
+                    "raw_payload_redacted": {
+                        "tool_name": "Bash",
+                        "tool_input": {"command": "npm run guard:acquisition-loop"},
+                        "permission_mode": "ask",
+                    },
+                },
+                review_command="hol-guard approvals approve req-exact-remember",
+                approval_url="http://127.0.0.1/pending",
+            ),
+            "2026-08-11T00:02:00+00:00",
+        )
+
+        remember_rc = main(
+            [
+                "guard",
+                "approvals",
+                "approve",
+                "req-exact-remember",
+                "--home",
+                str(home_dir),
+                "--scope",
+                "artifact",
+                "--remember",
+                "--json",
+            ]
+        )
+        remember_output = json.loads(capsys.readouterr().out)
+
+        assert remember_rc == 0
+        assert remember_output["resolved"] is True
+        assert remember_output["item"]["exact_action_persistence_eligible"] is True
+        decisions = store.list_policy_decisions("codex")
+        assert len(decisions) == 1
+        assert decisions[0]["action"] == "allow"
+        assert decisions[0]["scope"] == "artifact"
+
     def test_guard_policies_cli_clears_local_decisions_for_harness(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)


### PR DESCRIPTION
## Summary

- forward the current scope contract when the CLI remembers an eligible exact action
- preserve existing one-time behavior for requests that are not eligible for exact persistence
- prove the documented `--remember` flow writes an artifact-scoped allow rule

## Verification

- focused approval CLI regression tests
- Ruff lint and format checks
- BasedPyright on the changed source
- test-suite ratchet regenerated and verified


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Approving eligible exact shell actions with **Remember** now saves an artifact-scoped allow policy.
  - Approval results now indicate when an action qualifies for exact-action policy persistence.

- **Bug Fixes**
  - Improved approval handling so remembered decisions are consistently applied when saving eligible policies.

- **Tests**
  - Added coverage for remembering eligible exact shell actions through the command-line approval flow.
  - Updated test capacity thresholds to reflect the expanded test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->