### PR TITLE
fix(guard): refresh approval locator after update

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 12526,
-  "maximum_test_source_lines": 287185,
+  "maximum_test_source_lines": 287192,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 12526,
-  "maximum_test_source_lines": 287192,
+  "maximum_test_source_lines": 287207,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -149,6 +149,7 @@ from pathlib import Path
 
 from codex_plugin_scanner.guard.daemon.manager import (
     clear_guard_daemon_state,
+    ensure_approval_center,
     ensure_guard_daemon_after_update,
     guard_daemon_retirement_is_complete,
     repair_approval_center_locator,
@@ -185,6 +186,7 @@ if "home_dir" in refresh_parameters:
 if "allow_windows_job_breakaway" in refresh_parameters:
     refresh_kwargs["allow_windows_job_breakaway"] = True
 daemon_url = ensure_guard_daemon_after_update(guard_home, **refresh_kwargs)
+ensure_approval_center(guard_home)
 print(json.dumps({"status": "restarted", "retired": retired, "daemon_url": daemon_url}))
 """.strip()
 _DAEMON_REFRESH_CLEANUP_SCRIPT = """

--- a/tests/test_guard_update_daemon_handoff.py
+++ b/tests/test_guard_update_daemon_handoff.py
@@ -24,6 +24,7 @@ def test_refresh_script_adapts_to_new_manager_signature(
     _ = guard_home.mkdir(parents=True)
     _ = (guard_home / "daemon-state.json").write_text('{"port":8123}', encoding="utf-8")
     observed: dict[str, object] = {}
+    events: list[str] = []
 
     def retire(_guard_home: Path) -> list[int]:
         return [17]
@@ -38,7 +39,12 @@ def test_refresh_script_adapts_to_new_manager_signature(
     monkeypatch.setattr(manager, "guard_daemon_retirement_is_complete", retirement_complete)
     monkeypatch.setattr(manager, "clear_guard_daemon_state", no_op)
     monkeypatch.setattr(manager, "repair_approval_center_locator", no_op)
-    monkeypatch.setattr(manager, "ensure_approval_center", lambda _guard_home: observed.update(locator_refreshed=True))
+
+    def refresh_approval_center(received_guard_home: Path) -> None:
+        events.append("approval_center")
+        observed["approval_center_home"] = received_guard_home
+
+    monkeypatch.setattr(manager, "ensure_approval_center", refresh_approval_center)
 
     def require_new_parameters(
         received_guard_home: Path,
@@ -47,6 +53,7 @@ def test_refresh_script_adapts_to_new_manager_signature(
         preferred_port: int | None = None,
         allow_windows_job_breakaway: bool = False,
     ) -> str:
+        events.append("restart")
         observed.update(
             guard_home=received_guard_home,
             home_dir=home_dir,
@@ -74,8 +81,9 @@ def test_refresh_script_adapts_to_new_manager_signature(
         "home_dir": home_dir.resolve(),
         "preferred_port": 8123,
         "allow_windows_job_breakaway": True,
-        "locator_refreshed": True,
+        "approval_center_home": guard_home.resolve(),
     }
+    assert events == ["restart", "approval_center"]
     assert json.loads(capsys.readouterr().out) == {
         "status": "restarted",
         "retired": [17],
@@ -93,6 +101,7 @@ def test_refresh_script_preserves_legacy_manager_signature(
     _ = guard_home.mkdir(parents=True)
     _ = (guard_home / "daemon-state.json").write_text('{"port":8124}', encoding="utf-8")
     observed: dict[str, object] = {}
+    events: list[str] = []
 
     def retire(_guard_home: Path) -> list[int]:
         return [18]
@@ -104,14 +113,19 @@ def test_refresh_script_preserves_legacy_manager_signature(
         return True
 
     def legacy_parameters(received_guard_home: Path, *, preferred_port: int | None = None) -> str:
+        events.append("restart")
         observed.update(guard_home=received_guard_home, preferred_port=preferred_port)
         return "http://127.0.0.1:8124"
+
+    def refresh_approval_center(received_guard_home: Path) -> None:
+        events.append("approval_center")
+        observed["approval_center_home"] = received_guard_home
 
     monkeypatch.setattr(manager, "retire_all_guard_daemons_for_home", retire)
     monkeypatch.setattr(manager, "guard_daemon_retirement_is_complete", retirement_complete)
     monkeypatch.setattr(manager, "clear_guard_daemon_state", no_op)
     monkeypatch.setattr(manager, "repair_approval_center_locator", no_op)
-    monkeypatch.setattr(manager, "ensure_approval_center", lambda _guard_home: observed.update(locator_refreshed=True))
+    monkeypatch.setattr(manager, "ensure_approval_center", refresh_approval_center)
     monkeypatch.setattr(manager, "ensure_guard_daemon_after_update", legacy_parameters)
     monkeypatch.setattr(
         sys,
@@ -125,8 +139,9 @@ def test_refresh_script_preserves_legacy_manager_signature(
     assert observed == {
         "guard_home": guard_home.resolve(),
         "preferred_port": 8124,
-        "locator_refreshed": True,
+        "approval_center_home": guard_home.resolve(),
     }
+    assert events == ["restart", "approval_center"]
     assert json.loads(capsys.readouterr().out) == {
         "status": "restarted",
         "retired": [18],

--- a/tests/test_guard_update_daemon_handoff.py
+++ b/tests/test_guard_update_daemon_handoff.py
@@ -38,6 +38,7 @@ def test_refresh_script_adapts_to_new_manager_signature(
     monkeypatch.setattr(manager, "guard_daemon_retirement_is_complete", retirement_complete)
     monkeypatch.setattr(manager, "clear_guard_daemon_state", no_op)
     monkeypatch.setattr(manager, "repair_approval_center_locator", no_op)
+    monkeypatch.setattr(manager, "ensure_approval_center", lambda _guard_home: observed.update(locator_refreshed=True))
 
     def require_new_parameters(
         received_guard_home: Path,
@@ -73,6 +74,7 @@ def test_refresh_script_adapts_to_new_manager_signature(
         "home_dir": home_dir.resolve(),
         "preferred_port": 8123,
         "allow_windows_job_breakaway": True,
+        "locator_refreshed": True,
     }
     assert json.loads(capsys.readouterr().out) == {
         "status": "restarted",
@@ -109,6 +111,7 @@ def test_refresh_script_preserves_legacy_manager_signature(
     monkeypatch.setattr(manager, "guard_daemon_retirement_is_complete", retirement_complete)
     monkeypatch.setattr(manager, "clear_guard_daemon_state", no_op)
     monkeypatch.setattr(manager, "repair_approval_center_locator", no_op)
+    monkeypatch.setattr(manager, "ensure_approval_center", lambda _guard_home: observed.update(locator_refreshed=True))
     monkeypatch.setattr(manager, "ensure_guard_daemon_after_update", legacy_parameters)
     monkeypatch.setattr(
         sys,
@@ -119,7 +122,11 @@ def test_refresh_script_preserves_legacy_manager_signature(
     refresh_script = cast(str, update_commands.__dict__["_DAEMON_REFRESH_SCRIPT"])
     exec(refresh_script, {})
 
-    assert observed == {"guard_home": guard_home.resolve(), "preferred_port": 8124}
+    assert observed == {
+        "guard_home": guard_home.resolve(),
+        "preferred_port": 8124,
+        "locator_refreshed": True,
+    }
     assert json.loads(capsys.readouterr().out) == {
         "status": "restarted",
         "retired": [18],


### PR DESCRIPTION
## Summary
- recreate the browser approval locator after an in-place daemon restart
- keep updater completion aligned with a usable approval center
- cover both current and legacy daemon restart signatures

## Validation
- `uv run pytest -q tests/test_guard_update_daemon_handoff.py tests/test_guard_phase03_local_install.py -x`
- `uv run pytest -q tests/test_guard_policy_integrity.py -k build_trust_doctor_payload`
- `uv run ruff check src/codex_plugin_scanner/guard/cli/update_commands.py tests/test_guard_update_daemon_handoff.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Approval Center locator information now refreshes automatically after the Guard daemon restarts.
  * Improved compatibility with both current and legacy manager configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->