### PR TITLE
fix(guard): handle stale approval contracts in CLI

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 12526,
-  "maximum_test_source_lines": 287249,
+  "maximum_test_source_lines": 287250,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 12526,
-  "maximum_test_source_lines": 287185,
+  "maximum_test_source_lines": 287227,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/cli/approval_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/approval_commands.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from ..approval_gate import ApprovalGateError, require_high_risk, revoke_cooldown, unlock_cooldown
 from ..approval_gate import public_config as approval_gate_public_config
+from ..approval_scope_support import IneligibleApprovalScopeError, StaleApprovalScopeContractError
 from ..approvals import apply_approval_resolution, build_runtime_snapshot
 from ..browser_opener import open_browser_url
 from ..codex_resume import retry_request_resume
@@ -275,10 +276,12 @@ def run_approval_command(
         scope_contract_version = None
         scope_contract_digest = None
         if exact_action_remember and request is not None:
-            if request.get("scope_contract_version") is not None:
-                scope_contract_version = str(request["scope_contract_version"])
-            if request.get("scope_contract_digest") is not None:
-                scope_contract_digest = str(request["scope_contract_digest"])
+            version = request.get("scope_contract_version")
+            digest = request.get("scope_contract_digest")
+            if version is None or digest is None:
+                raise ValueError("incomplete_scope_contract")
+            scope_contract_version = str(version)
+            scope_contract_digest = str(digest)
         item = apply_approval_resolution(
             store=store,
             request_id=args.request_id,
@@ -296,6 +299,28 @@ def run_approval_command(
         )
     except ApprovalGateError as error:
         return approval_gate_cli_payload(error)
+    except StaleApprovalScopeContractError as error:
+        return {
+            "resolved": False,
+            "error": str(error),
+            **error.contract.to_dict(),
+            "exit_code": 4,
+        }
+    except IneligibleApprovalScopeError as error:
+        return {
+            "resolved": False,
+            "error": str(error),
+            "action": error.action,
+            "requested_scope": error.requested_scope,
+            **error.contract.to_dict(),
+            "exit_code": 2,
+        }
+    except ValueError as error:
+        return {
+            "resolved": False,
+            "error": str(error),
+            "exit_code": 2,
+        }
     return {"resolved": True, "item": item}
 
 

--- a/src/codex_plugin_scanner/guard/cli/approval_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/approval_commands.py
@@ -11,7 +11,12 @@ from pathlib import Path
 from ..approval_gate import ApprovalGateError, require_high_risk, revoke_cooldown, unlock_cooldown
 from ..approval_gate import public_config as approval_gate_public_config
 from ..approval_scope_support import IneligibleApprovalScopeError, StaleApprovalScopeContractError
-from ..approvals import apply_approval_resolution, build_runtime_snapshot
+from ..approvals import (
+    ApprovalRequestAlreadyResolvedError,
+    ApprovalRequestNotFoundError,
+    apply_approval_resolution,
+    build_runtime_snapshot,
+)
 from ..browser_opener import open_browser_url
 from ..codex_resume import retry_request_resume
 from ..config import load_guard_config
@@ -318,6 +323,18 @@ def run_approval_command(
             "requested_scope": error.requested_scope,
             **error.contract.to_dict(),
             "exit_code": 2,
+        }
+    except ApprovalRequestNotFoundError:
+        return {
+            "resolved": False,
+            "error": "request_unknown",
+            "exit_code": 4,
+        }
+    except ApprovalRequestAlreadyResolvedError:
+        return {
+            "resolved": False,
+            "error": "already_resolved",
+            "exit_code": 4,
         }
     return {"resolved": True, "item": item}
 

--- a/src/codex_plugin_scanner/guard/cli/approval_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/approval_commands.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from ..approval_gate import ApprovalGateError, require_high_risk, revoke_cooldown, unlock_cooldown
 from ..approval_gate import public_config as approval_gate_public_config
+from ..approval_resolution import TERMINAL_POLICY_ACTION_NOT_RESOLVABLE
 from ..approval_scope_support import IneligibleApprovalScopeError, StaleApprovalScopeContractError
 from ..approvals import (
     ApprovalRequestAlreadyResolvedError,
@@ -21,6 +22,7 @@ from ..browser_opener import open_browser_url
 from ..codex_resume import retry_request_resume
 from ..config import load_guard_config
 from ..daemon import load_guard_daemon_url
+from ..runtime.decisions import AUTHORITATIVE_DECISION_INCONSISTENT
 from ..runtime.self_approval import SELF_APPROVAL_REASON, approval_resolution_invoked_from_agent
 from ..runtime.surface_server import GuardSurfaceRuntime
 from ..store import GuardStore
@@ -334,6 +336,19 @@ def run_approval_command(
         return {
             "resolved": False,
             "error": "already_resolved",
+            "exit_code": 4,
+        }
+    except ValueError as error:
+        message = str(error)
+        known_resolution_error = message in {
+            AUTHORITATIVE_DECISION_INCONSISTENT,
+            TERMINAL_POLICY_ACTION_NOT_RESOLVABLE,
+        } or message.startswith("Approval request disappeared: ")
+        if not known_resolution_error:
+            raise
+        return {
+            "resolved": False,
+            "error": message,
             "exit_code": 4,
         }
     return {"resolved": True, "item": item}

--- a/src/codex_plugin_scanner/guard/cli/approval_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/approval_commands.py
@@ -279,7 +279,11 @@ def run_approval_command(
             version = request.get("scope_contract_version")
             digest = request.get("scope_contract_digest")
             if version is None or digest is None:
-                raise ValueError("incomplete_scope_contract")
+                return {
+                    "resolved": False,
+                    "error": "incomplete_scope_contract",
+                    "exit_code": 2,
+                }
             scope_contract_version = str(version)
             scope_contract_digest = str(digest)
         item = apply_approval_resolution(
@@ -313,12 +317,6 @@ def run_approval_command(
             "action": error.action,
             "requested_scope": error.requested_scope,
             **error.contract.to_dict(),
-            "exit_code": 2,
-        }
-    except ValueError as error:
-        return {
-            "resolved": False,
-            "error": str(error),
             "exit_code": 2,
         }
     return {"resolved": True, "item": item}

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -16,13 +16,18 @@ import pytest
 
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard import bridge as guard_bridge_module
-from codex_plugin_scanner.guard.approval_scope_support import package_request_portable_workspace_scope
+from codex_plugin_scanner.guard.approval_scope_support import (
+    StaleApprovalScopeContractError,
+    package_request_portable_workspace_scope,
+    request_scope_contract,
+)
 from codex_plugin_scanner.guard.approvals import (
     apply_approval_resolution,
     build_runtime_snapshot,
     queue_blocked_approvals,
 )
 from codex_plugin_scanner.guard.bridge import BridgeConfig, GuardBridge
+from codex_plugin_scanner.guard.cli import approval_commands as approval_commands_module
 from codex_plugin_scanner.guard.config import GuardConfig
 from codex_plugin_scanner.guard.consumer import artifact_hash, evaluate_detection
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
@@ -3261,38 +3266,39 @@ class TestGuardApprovals:
         assert remember_output["item"]["applied_scope"] == "artifact"
         assert store.list_policy_decisions("codex") == []
 
-    def test_guard_approvals_cli_remembers_eligible_exact_action(self, tmp_path, capsys):
+    def test_guard_approvals_cli_remembers_eligible_exact_action(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         workspace = str(tmp_path / "workspace")
         store = GuardStore(home_dir)
-        store.add_approval_request(
-            GuardApprovalRequest(
-                request_id="req-exact-remember",
-                harness="codex",
-                artifact_id="codex:project:tool-action:script",
-                artifact_name="Bash unmatched tool action",
-                artifact_type="tool_action_request",
-                artifact_hash="hash-exact-remember",
-                policy_action="require-reapproval",
-                recommended_scope="artifact",
-                changed_fields=("tool_action",),
-                source_scope="project",
-                config_path=workspace,
-                workspace=workspace,
-                launch_target="npm run guard:acquisition-loop",
-                action_envelope_json={
-                    "action_type": "shell_command",
+        exact_request = GuardApprovalRequest(
+            request_id="req-exact-remember",
+            harness="codex",
+            artifact_id="codex:project:tool-action:script",
+            artifact_name="Bash unmatched tool action",
+            artifact_type="tool_action_request",
+            artifact_hash="hash-exact-remember",
+            policy_action="require-reapproval",
+            recommended_scope="artifact",
+            changed_fields=("tool_action",),
+            source_scope="project",
+            config_path=workspace,
+            workspace=workspace,
+            launch_target="npm run guard:acquisition-loop",
+            action_envelope_json={
+                "action_type": "shell_command",
+                "tool_name": "Bash",
+                "command": "npm run guard:acquisition-loop",
+                "raw_payload_redacted": {
                     "tool_name": "Bash",
-                    "command": "npm run guard:acquisition-loop",
-                    "raw_payload_redacted": {
-                        "tool_name": "Bash",
-                        "tool_input": {"command": "npm run guard:acquisition-loop"},
-                        "permission_mode": "ask",
-                    },
+                    "tool_input": {"command": "npm run guard:acquisition-loop"},
+                    "permission_mode": "ask",
                 },
-                review_command="hol-guard approvals approve req-exact-remember",
-                approval_url="http://127.0.0.1/pending",
-            ),
+            },
+            review_command="hol-guard approvals approve req-exact-remember",
+            approval_url="http://127.0.0.1/pending",
+        )
+        store.add_approval_request(
+            exact_request,
             "2026-08-11T00:02:00+00:00",
         )
 
@@ -3315,10 +3321,46 @@ class TestGuardApprovals:
         assert remember_rc == 0
         assert remember_output["resolved"] is True
         assert remember_output["item"]["exact_action_persistence_eligible"] is True
+        assert remember_output["item"]["scope_contract_version"].startswith("guard.approval-scopes.v")
+        assert len(remember_output["item"]["scope_contract_digest"]) == 64
         decisions = store.list_policy_decisions("codex")
         assert len(decisions) == 1
         assert decisions[0]["action"] == "allow"
         assert decisions[0]["scope"] == "artifact"
+
+        stale_request = replace(
+            exact_request,
+            request_id="req-stale-remember",
+            artifact_hash="hash-stale-remember",
+            review_command="hol-guard approvals approve req-stale-remember",
+        )
+        store.add_approval_request(stale_request, "2026-08-11T00:03:00+00:00")
+        stale_contract = request_scope_contract(store.get_approval_request("req-stale-remember") or {})
+
+        def raise_stale_contract(**_kwargs):
+            raise StaleApprovalScopeContractError(stale_contract)
+
+        monkeypatch.setattr(approval_commands_module, "apply_approval_resolution", raise_stale_contract)
+        stale_rc = main(
+            [
+                "guard",
+                "approvals",
+                "approve",
+                "req-stale-remember",
+                "--home",
+                str(home_dir),
+                "--scope",
+                "artifact",
+                "--remember",
+                "--json",
+            ]
+        )
+        stale_output = json.loads(capsys.readouterr().out)
+
+        assert stale_rc == 4
+        assert stale_output["resolved"] is False
+        assert stale_output["error"] == "stale_scope_contract"
+        assert stale_output["scope_contract_digest"] == stale_contract.digest
 
     def test_guard_policies_cli_clears_local_decisions_for_harness(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -3267,6 +3267,7 @@ class TestGuardApprovals:
         assert store.list_policy_decisions("codex") == []
 
     def test_guard_approvals_cli_remembers_eligible_exact_action(self, tmp_path, capsys, monkeypatch):
+        _clear_agent_context(monkeypatch)
         home_dir = tmp_path / "home"
         workspace = str(tmp_path / "workspace")
         store = GuardStore(home_dir)


### PR DESCRIPTION
## Summary

- return structured CLI errors for stale, ineligible, or incomplete approval scope contracts
- validate remembered exact-action contracts as a complete version and digest pair
- extend the CLI regression to cover contract fields and stale-contract recovery

## Verification

- focused approval CLI regression tests
- Ruff lint and formatting
- BasedPyright on the changed source
- test-suite ratchet regenerated and verified


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remembered approval handling by requiring valid scope information before approvals can be reused.
  * Added clearer responses and dedicated exit codes for outdated, ineligible, or invalid approval scopes.
  * Preserved relevant approval policy and scope details for validated approval requests.

* **Tests**
  * Expanded coverage for approval validation, saved approval policies, and outdated scope-contract scenarios.
  * Updated test baselines to reflect the latest test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->