### PR TITLE
fix(guard): preserve Linux approval trust

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12527,
-  "maximum_test_source_lines": 287306,
+  "maximum_collected_cases": 12529,
+  "maximum_test_source_lines": 287425,
   "schema_version": 1
 }

--- a/dashboard/src/supply-chain-firewall-panel.tsx
+++ b/dashboard/src/supply-chain-firewall-panel.tsx
@@ -294,7 +294,7 @@ export const PackageFirewallPanel = forwardRef(function PackageFirewallPanel(
       setPendingOp({ op: "audit", manager: null });
       setLastFailed(null);
       setConnectError(null);
-      setActivationAssistError(null);
+      setActivationAssist(null);
       onAuditErrorChange?.(null);
       onAuditStarted?.();
       onAuditRunningChange?.(true);
@@ -696,7 +696,7 @@ export const PackageFirewallPanel = forwardRef(function PackageFirewallPanel(
       setPendingOp({ op, manager });
       setLastFailed(null);
       setConnectError(null);
-      setActivationAssistError(null);
+      setActivationAssist(null);
       try {
         const response = await runPackageFirewallAction(op, manager, credentials);
         setLastCompleted({ op, manager, response });
@@ -741,7 +741,7 @@ export const PackageFirewallPanel = forwardRef(function PackageFirewallPanel(
       setPendingOp({ op, manager: null });
       setLastFailed(null);
       setConnectError(null);
-      setActivationAssistError(null);
+      setActivationAssist(null);
       try {
         const response = await runPackageSync();
         setLastCompleted({ op, manager: null, response });
@@ -826,7 +826,7 @@ export const PackageFirewallPanel = forwardRef(function PackageFirewallPanel(
   const handleRetry = useCallback(() => void load(), [load]);
   const handleActivateRuntime = useCallback(async () => {
     setActivatingRuntime(true);
-    setActivationAssistError(null);
+    setActivationAssist(null);
     try {
       const message = await activatePackageFirewallRuntime();
       setActivationAssist({ message, isError: false });

--- a/dashboard/src/user-reported-regressions.test.ts
+++ b/dashboard/src/user-reported-regressions.test.ts
@@ -14,6 +14,7 @@ const feedHealthSource = readFileSync(join(__dirname, "feed-health-workspace.tsx
 const policyTabSource = readFileSync(join(__dirname, "policy-strict-config-tab.tsx"), "utf8");
 const strictModeSource = readFileSync(join(__dirname, "policy-strict-config-strict-mode-card.tsx"), "utf8");
 const sparklineSource = readFileSync(join(__dirname, "evidence/sparkline.tsx"), "utf8");
+const supplyChainFirewallPanelSource = readFileSync(join(__dirname, "supply-chain-firewall-panel.tsx"), "utf8");
 
 assert(
   !feedHealthSource.includes("onClick={onOpenSettings}"),
@@ -38,6 +39,10 @@ assert(
 assert(
   sparklineSource.includes("aria-label={`Guard activity over the last ${days} days`}"),
   "evidence activity chart has an accessible label",
+);
+assert(
+  !supplyChainFirewallPanelSource.includes("setActivationAssistError"),
+  "supply-chain actions must only use the current activation-assist state setter",
 );
 
 console.log("user-reported-regressions.test.ts: all tests passed");

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-hub-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-hub-workspace.js
@@ -1707,7 +1707,7 @@ const PackageFirewallPanel = reactExports.forwardRef(function PackageFirewallPan
       setPendingOp({ op: "audit", manager: null });
       setLastFailed(null);
       setConnectError(null);
-      setActivationAssistError(null);
+      setActivationAssist(null);
       onAuditErrorChange?.(null);
       onAuditStarted?.();
       onAuditRunningChange?.(true);
@@ -2075,7 +2075,7 @@ const PackageFirewallPanel = reactExports.forwardRef(function PackageFirewallPan
       setPendingOp({ op, manager });
       setLastFailed(null);
       setConnectError(null);
-      setActivationAssistError(null);
+      setActivationAssist(null);
       try {
         const response = await runPackageFirewallAction(op, manager, credentials);
         setLastCompleted({ op, manager, response });
@@ -2115,7 +2115,7 @@ const PackageFirewallPanel = reactExports.forwardRef(function PackageFirewallPan
       setPendingOp({ op, manager: null });
       setLastFailed(null);
       setConnectError(null);
-      setActivationAssistError(null);
+      setActivationAssist(null);
       try {
         const response = await runPackageSync();
         setLastCompleted({ op, manager: null, response });
@@ -2198,7 +2198,7 @@ const PackageFirewallPanel = reactExports.forwardRef(function PackageFirewallPan
   const handleRetry = reactExports.useCallback(() => void load(), [load]);
   const handleActivateRuntime = reactExports.useCallback(async () => {
     setActivatingRuntime(true);
-    setActivationAssistError(null);
+    setActivationAssist(null);
     try {
       const message = await activatePackageFirewallRuntime();
       setActivationAssist({ message, isError: false });

--- a/src/codex_plugin_scanner/guard/store_policy_integrity_backend.py
+++ b/src/codex_plugin_scanner/guard/store_policy_integrity_backend.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from .store_base import (
     _POLICY_INTEGRITY_SERVICE_NAME,
     EncryptedFileSecretStore,
+    MigratingFallbackSecretStore,
     SecretStore,
     SystemKeyringSecretStore,
 )
@@ -36,7 +37,10 @@ def build_policy_integrity_secret_store(
         )
 
     if SystemKeyringSecretStore._backend_is_available():
-        return SystemKeyringSecretStore(service_name=_POLICY_INTEGRITY_SERVICE_NAME)
+        return MigratingFallbackSecretStore(
+            SystemKeyringSecretStore(service_name=_POLICY_INTEGRITY_SERVICE_NAME),
+            EncryptedFileSecretStore(guard_home),
+        )
     return EncryptedFileSecretStore(guard_home)
 
 

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -58,6 +58,7 @@ from codex_plugin_scanner.guard.policy_bundle_parser import policy_bundle_accept
 from codex_plugin_scanner.guard.store import (
     EncryptedFileSecretStore,
     GuardStore,
+    MigratingFallbackSecretStore,
     SystemKeyringSecretStore,
 )
 from tests.policy_bundle_signing_helpers import policy_bundle_test_keyring, sign_policy_bundle
@@ -770,7 +771,7 @@ def test_policy_integrity_status_includes_trust_status(tmp_path: Path) -> None:
 def test_guard_store_init_does_not_create_policy_integrity_keyring_material(tmp_path: Path) -> None:
     store = _store(tmp_path)
     secret_store = store._policy_integrity_secret_store
-    assert isinstance(secret_store, SystemKeyringSecretStore)
+    assert isinstance(secret_store, MigratingFallbackSecretStore)
 
     assert secret_store.get_secret(store._policy_integrity_key_ref) is None
     assert secret_store.get_secret(store._policy_integrity_control_ref) is None
@@ -1046,7 +1047,7 @@ def test_upsert_policy_uses_single_integrity_key_lookup_per_write(
     assert state["key_id"] is None
 
 
-def test_policy_integrity_status_uses_timed_keychain_reads_once_per_secret(
+def test_policy_integrity_status_uses_mirrored_vault_without_keychain_reads(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1056,7 +1057,7 @@ def test_policy_integrity_status_uses_timed_keychain_reads_once_per_secret(
         "2026-06-14T00:00:00Z",
     )
     secret_store = store._policy_integrity_secret_store
-    assert isinstance(secret_store, SystemKeyringSecretStore)
+    assert isinstance(secret_store, MigratingFallbackSecretStore)
     key_value = secret_store.get_secret(store._policy_integrity_key_ref)
     control_value = secret_store.get_secret(store._policy_integrity_control_ref)
     assert isinstance(key_value, str) and key_value
@@ -1073,14 +1074,7 @@ def test_policy_integrity_status_uses_timed_keychain_reads_once_per_secret(
             return control_value
         raise AssertionError(f"unexpected policy-integrity secret lookup: {secret_id}")
 
-    monkeypatch.setattr(
-        store,
-        "_get_secret_from_store",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            AssertionError("plain keyring reads should not run for policy integrity")
-        ),
-    )
-    monkeypatch.setattr(secret_store, "get_secret_with_timeout", _count_timed_reads)
+    monkeypatch.setattr(secret_store.primary, "get_secret_with_timeout", _count_timed_reads)
     store._clear_policy_integrity_cache()
 
     first_status = store.get_policy_integrity_status()
@@ -1088,16 +1082,13 @@ def test_policy_integrity_status_uses_timed_keychain_reads_once_per_secret(
 
     assert first_status["mode"] == "protected"
     assert second_status["mode"] == "protected"
-    assert timed_reads == [
-        store._policy_integrity_control_ref,
-        store._policy_integrity_key_ref,
-    ]
+    assert timed_reads == []
 
 
 def test_policy_integrity_status_and_verify_do_not_create_keyring_material_on_fresh_store(tmp_path: Path) -> None:
     store = _store(tmp_path)
     secret_store = store._policy_integrity_secret_store
-    assert isinstance(secret_store, SystemKeyringSecretStore)
+    assert isinstance(secret_store, MigratingFallbackSecretStore)
     _delete_policy_integrity_key(store)
     _delete_policy_integrity_control_state(store)
     assert secret_store.get_secret(store._policy_integrity_key_ref) is None

--- a/tests/test_guard_policy_integrity_local_vault.py
+++ b/tests/test_guard_policy_integrity_local_vault.py
@@ -14,6 +14,7 @@ from codex_plugin_scanner.guard.models import PolicyDecision
 from codex_plugin_scanner.guard.store import (
     EncryptedFileSecretStore,
     GuardStore,
+    MigratingFallbackSecretStore,
     SystemKeyringSecretStore,
 )
 
@@ -47,28 +48,36 @@ def test_linux_policy_integrity_uses_local_vault_without_system_keyring(
 
     artifact_id = "codex:project:tampered-local-vault"
     store.upsert_policy(
-        PolicyDecision(harness="codex", scope="artifact", action="allow", artifact_id=artifact_id, artifact_hash="hash"),
+        PolicyDecision(
+            harness="codex", scope="artifact", action="allow", artifact_id=artifact_id, artifact_hash="hash"
+        ),
         "2026-08-07T20:01:00Z",
     )
     with sqlite3.connect(store.guard_home / "guard.db") as connection:
-        connection.execute("update policy_decisions set payload_mac = ? where artifact_id = ?", ("deadbeef", artifact_id))
-        before_row = connection.execute("select * from policy_decisions where artifact_id = ?", (artifact_id,)).fetchone()
+        connection.execute(
+            "update policy_decisions set payload_mac = ? where artifact_id = ?", ("deadbeef", artifact_id)
+        )
+        before_row = connection.execute(
+            "select * from policy_decisions where artifact_id = ?", (artifact_id,)
+        ).fetchone()
     assert store.verify_policy_integrity()["counts"]["tampered"] == 1
 
     rerun = store.setup_policy_integrity(now="2026-08-07T20:02:00Z", include_items=False)
     with sqlite3.connect(store.guard_home / "guard.db") as connection:
-        after_row = connection.execute("select * from policy_decisions where artifact_id = ?", (artifact_id,)).fetchone()
+        after_row = connection.execute(
+            "select * from policy_decisions where artifact_id = ?", (artifact_id,)
+        ).fetchone()
 
     assert rerun["mode"] == "protected"
     assert after_row == before_row
     assert store.verify_policy_integrity()["counts"]["tampered"] == 1
 
 
-def test_linux_system_keyring_remains_authoritative_for_policy_integrity(
+def test_linux_system_keyring_mirrors_policy_integrity_into_local_vault(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # Once available, the OS keyring remains the single authoritative integrity store.
+    # Keep the OS keyring while adding a prompt-free mirror for daemon and headless reads.
     monkeypatch.setattr(policy_integrity_backend_module.sys, "platform", "linux", raising=False)
     monkeypatch.setattr(
         SystemKeyringSecretStore,
@@ -78,7 +87,126 @@ def test_linux_system_keyring_remains_authoritative_for_policy_integrity(
 
     store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
 
-    assert isinstance(store._policy_integrity_secret_store, SystemKeyringSecretStore)
+    secret_store = store._policy_integrity_secret_store
+    assert isinstance(secret_store, MigratingFallbackSecretStore)
+    assert isinstance(secret_store.primary, SystemKeyringSecretStore)
+    assert isinstance(secret_store.fallback, EncryptedFileSecretStore)
+
+
+def test_linux_local_vault_keeps_policy_valid_when_system_keyring_becomes_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(policy_integrity_backend_module.sys, "platform", "linux", raising=False)
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "_backend_is_available",
+        classmethod(lambda cls: True),
+    )
+    primary_values: dict[str, str] = {}
+    monkeypatch.setattr(
+        SystemKeyringSecretStore, "set_secret", lambda self, key, value: primary_values.__setitem__(key, value)
+    )
+    monkeypatch.setattr(SystemKeyringSecretStore, "get_secret", lambda self, key: primary_values.get(key))
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "get_secret_with_timeout",
+        lambda self, key, *, timeout_seconds: primary_values.get(key),
+    )
+
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home, prime_policy_integrity=False)
+    store.setup_policy_integrity(now="2026-08-11T20:00:00Z", include_items=False)
+    store.upsert_policy(
+        PolicyDecision(
+            harness="guard-cli",
+            scope="artifact",
+            action="allow",
+            artifact_id="guard-cli:project:package-request",
+            artifact_hash="approval-context",
+        ),
+        "2026-08-11T20:01:00Z",
+    )
+
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "get_secret",
+        lambda self, key: (_ for _ in ()).throw(RuntimeError("keyring unavailable")),
+    )
+    restarted = GuardStore(guard_home, prime_policy_integrity=False)
+    status = restarted.get_policy_integrity_status()
+
+    assert status["mode"] == "protected"
+    assert status["trust_status"]["remembered_rules"] == "enforced"
+    assert (
+        restarted.resolve_policy(
+            "guard-cli",
+            "guard-cli:project:package-request",
+            "approval-context",
+            now="2026-08-11T20:02:00Z",
+        )
+        == "allow"
+    )
+
+
+def test_linux_migrates_existing_system_keyring_policy_before_headless_restart(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(policy_integrity_backend_module.sys, "platform", "linux", raising=False)
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "_backend_is_available",
+        classmethod(lambda cls: True),
+    )
+    primary_values: dict[str, str] = {}
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "set_secret",
+        lambda self, key, value: primary_values.__setitem__(key, value),
+    )
+    monkeypatch.setattr(SystemKeyringSecretStore, "get_secret", lambda self, key: primary_values.get(key))
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "get_secret_with_timeout",
+        lambda self, key, *, timeout_seconds: primary_values.get(key),
+    )
+
+    guard_home = tmp_path / "guard-home"
+    legacy = GuardStore(guard_home, prime_policy_integrity=False)
+    legacy._policy_integrity_secret_store = SystemKeyringSecretStore(service_name="hol-guard.policy-integrity")
+    legacy.setup_policy_integrity(now="2026-08-11T20:00:00Z", include_items=False)
+    legacy.upsert_policy(
+        PolicyDecision(
+            harness="guard-cli",
+            scope="artifact",
+            action="allow",
+            artifact_id="guard-cli:project:legacy-package-request",
+            artifact_hash="legacy-approval-context",
+        ),
+        "2026-08-11T20:01:00Z",
+    )
+
+    migrated = GuardStore(guard_home, prime_policy_integrity=False)
+    assert migrated.get_policy_integrity_status()["mode"] == "protected"
+
+    def _keyring_unavailable(*args: object, **kwargs: object) -> str | None:
+        raise RuntimeError("keyring unavailable")
+
+    monkeypatch.setattr(SystemKeyringSecretStore, "get_secret", _keyring_unavailable)
+    monkeypatch.setattr(SystemKeyringSecretStore, "get_secret_with_timeout", _keyring_unavailable)
+    restarted = GuardStore(guard_home, prime_policy_integrity=False)
+
+    assert restarted.get_policy_integrity_status()["mode"] == "protected"
+    assert (
+        restarted.resolve_policy(
+            "guard-cli",
+            "guard-cli:project:legacy-package-request",
+            "legacy-approval-context",
+            now="2026-08-11T20:02:00Z",
+        )
+        == "allow"
+    )
 
 
 def test_doctor_can_report_protected_after_linux_local_vault_repair(


### PR DESCRIPTION
## Summary
- remove stale dashboard state-setter calls that crash package firewall actions
- mirror Linux policy-integrity keys into the prompt-free local vault so remembered approvals survive keyring availability changes
- cover existing-key migration, headless restart, and generated dashboard regressions

## Testing
- `bun run test`
- `bun run build`
- `uv run --no-sync pytest tests/test_guard_policy_integrity.py tests/test_guard_policy_integrity_local_vault.py tests/test_guard_trust_cli_passive_backend.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/store_policy_integrity_backend.py tests/test_guard_policy_integrity.py tests/test_guard_policy_integrity_local_vault.py`
- `uv run --no-sync basedpyright --level error src/codex_plugin_scanner/guard/store_policy_integrity_backend.py`
- `uv build`
