### PR TITLE
fix(daemon): ignore mutable trust metadata during auth

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14559,
-  "maximum_test_source_lines": 316362,
+  "maximum_collected_cases": 14560,
+  "maximum_test_source_lines": 316427,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_transport.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_transport.py
@@ -110,13 +110,19 @@ def _daemon_response_once(
             hook_event=hook_event,
         )
         current_state, current_key = _authenticated_state(state_path)
-        if current_state != state or not secrets.compare_digest(current_key, discovery_key):
+        if (
+            _daemon_generation_identity(current_state) != _daemon_generation_identity(state)
+            or not secrets.compare_digest(current_key, discovery_key)
+        ):
             raise _DaemonGenerationChangedError("daemon state changed during identity verification")
         try:
             auth_token = _daemon_auth_token(state_path, state)
         except ValueError as error:
             current_state, current_key = _authenticated_state(state_path)
-            if current_state != state or not secrets.compare_digest(current_key, discovery_key):
+            if (
+                _daemon_generation_identity(current_state) != _daemon_generation_identity(state)
+                or not secrets.compare_digest(current_key, discovery_key)
+            ):
                 raise _DaemonGenerationChangedError("daemon state changed before token authentication") from error
             raise
         remaining = _remaining_seconds(deadline)

--- a/src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_transport.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_transport.py
@@ -110,19 +110,17 @@ def _daemon_response_once(
             hook_event=hook_event,
         )
         current_state, current_key = _authenticated_state(state_path)
-        if (
-            _daemon_generation_identity(current_state) != _daemon_generation_identity(state)
-            or not secrets.compare_digest(current_key, discovery_key)
-        ):
+        if _daemon_generation_identity(current_state) != _daemon_generation_identity(
+            state
+        ) or not secrets.compare_digest(current_key, discovery_key):
             raise _DaemonGenerationChangedError("daemon state changed during identity verification")
         try:
             auth_token = _daemon_auth_token(state_path, state)
         except ValueError as error:
             current_state, current_key = _authenticated_state(state_path)
-            if (
-                _daemon_generation_identity(current_state) != _daemon_generation_identity(state)
-                or not secrets.compare_digest(current_key, discovery_key)
-            ):
+            if _daemon_generation_identity(current_state) != _daemon_generation_identity(
+                state
+            ) or not secrets.compare_digest(current_key, discovery_key):
                 raise _DaemonGenerationChangedError("daemon state changed before token authentication") from error
             raise
         remaining = _remaining_seconds(deadline)

--- a/tests/codex_daemon_hook_bridge_fixtures.py
+++ b/tests/codex_daemon_hook_bridge_fixtures.py
@@ -71,6 +71,21 @@ class _DaemonHandler(BaseHTTPRequestHandler):
             )
             if type(self).challenge_mode == "wrong-proof":
                 response["proof"] = "0" * 64
+            if type(self).challenge_mode == "refresh-trust-status":
+                current_state_id = state.get("state_id")
+                current_started_at = state.get("started_at")
+                assert isinstance(current_state_id, str)
+                assert isinstance(current_started_at, str)
+                daemon_manager.write_guard_daemon_state(
+                    guard_home,
+                    self.server.server_address[1],
+                    type(self).auth_token,
+                    pid=os.getpid(),
+                    state_id=current_state_id,
+                    started_at=current_started_at,
+                    trust_status={"status": "verified"},
+                )
+                type(self).challenge_mode = "valid"
             if type(self).challenge_mode == "replace-state":
                 daemon_manager.write_guard_daemon_state(
                     guard_home,

--- a/tests/test_codex_daemon_generation_refresh.py
+++ b/tests/test_codex_daemon_generation_refresh.py
@@ -1,0 +1,50 @@
+"""Regression coverage for authenticated daemon generation refreshes."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import threading
+from http.server import HTTPServer
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters import codex_daemon_hook_bridge as bridge
+from tests.codex_daemon_hook_bridge_fixtures import (
+    _bridge_config,
+    _DaemonHandler,
+    _write_authenticated_daemon_files,
+)
+
+
+def test_authenticated_trust_metadata_refresh_keeps_same_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    daemon = HTTPServer(("127.0.0.1", 0), _DaemonHandler)
+    daemon_thread = threading.Thread(target=daemon.serve_forever, daemon=True)
+    daemon_thread.start()
+    _write_authenticated_daemon_files(guard_home, daemon.server_address[1])
+    _DaemonHandler.challenge_mode = "refresh-trust-status"
+    monkeypatch.setattr(
+        "sys.stdin",
+        io.StringIO(json.dumps({"hook_event_name": "UserPromptSubmit"})),
+    )
+    config = _bridge_config(guard_home, daemon.server_address[1])
+    config["fallback_command"] = [sys.executable, "-c", "raise SystemExit(1)"]
+
+    try:
+        exit_code = bridge.main(**config)
+    finally:
+        daemon.shutdown()
+        daemon_thread.join(timeout=5)
+
+    assert exit_code == 0
+    assert _DaemonHandler.challenge_count == 1
+    assert _DaemonHandler.captured_guard_token == "fixture-token"
+    assert json.loads(str(_DaemonHandler.captured_hook_body))["hook_event_name"] == "UserPromptSubmit"
+    assert json.loads(capsys.readouterr().out) == {}


### PR DESCRIPTION
## Summary

- compare daemon generations using immutable identity fields rather than the full mutable state document
- retain discovery-key rotation checks and fail closed on real daemon replacement
- add deterministic regression coverage for trust-status refreshes during the identity challenge

## Validation

- targeted daemon-generation regression
- existing replacement-state and authenticated bridge coverage
- full CI and security gates