### PR TITLE
fix(daemon): backport hook recovery stability

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -488,11 +488,10 @@ def recover_guard_daemon_after_hook_failure(
     """Recover daemon service after a classified hook endpoint failure.
 
     Recovery is single-flight across threads and processes for one Guard home.
-    Capacity rejection preserves an authenticated current process even when
-    its health endpoint is saturated. Transport and authenticated control-plane
-    failures replace a process only when health cannot prove it responsive,
-    while the cooldown preserves a replacement long enough for concurrent and
-    immediately repeated callers to converge.
+    A hook authentication failure is client evidence, not daemon-health evidence.
+    Recovery therefore preserves every authenticated live generation. A daemon
+    is replaced only when neither the health probe nor signed process identity
+    can prove that generation is still running.
     """
 
     if failure_kind not in {
@@ -526,15 +525,9 @@ def recover_guard_daemon_after_hook_failure(
             current_url = load_guard_daemon_url(guard_home)
             live_process_url = _authenticated_live_current_daemon_url(guard_home, state)
             if current_url is not None:
-                if failure_kind != "authenticated-control-plane-failure" or _daemon_generation_is_recent(state):
-                    return current_url
-            elif live_process_url is not None and (failure_kind == "overload" or _daemon_generation_is_recent(state)):
+                return current_url
+            if live_process_url is not None:
                 return live_process_url
-            live_generation_url = current_url or live_process_url
-            if live_generation_url is not None:
-                retire_all_guard_daemons_for_home(guard_home)
-                if not guard_daemon_retirement_is_complete(guard_home):
-                    raise RuntimeError("Unresponsive Guard daemon could not be retired safely.")
         if os.name == "nt":
             return ensure_guard_daemon(
                 guard_home,

--- a/tests/fixtures/guard-daemon-acceptance/workloads.json
+++ b/tests/fixtures/guard-daemon-acceptance/workloads.json
@@ -43,7 +43,7 @@
     "tests/test_guard_daemon_acceptance.py::test_sqlite_lock_is_bounded_and_recovers",
     "tests/test_guard_daemon_adversarial_transport.py::test_malformed_request_framing_returns_bounded_error_without_handler_exception",
     "tests/test_guard_daemon_adversarial_transport.py::test_slow_request_body_expires_and_releases_handler_capacity",
-    "tests/test_guard_daemon_recovery_resilience.py::test_transport_recovery_replaces_old_process_when_health_probe_misses",
+    "tests/test_guard_daemon_recovery_resilience.py::test_transport_recovery_preserves_verified_old_process_when_health_probe_misses",
     "tests/test_guard_update_artifact.py::test_revalidate_rejects_staged_byte_mutation"
   ],
   "soak": {

--- a/tests/test_guard_daemon_manager.py
+++ b/tests/test_guard_daemon_manager.py
@@ -185,6 +185,7 @@ def test_frozen_daemon_launch_rejects_unreleased_windows_gate(tmp_path, monkeypa
             gate_on_stdin=True,
         )
 
+
 def test_schedule_guard_daemon_ensure_is_reserved_and_nonblocking(
     tmp_path,
     monkeypatch,
@@ -444,7 +445,7 @@ def test_maintenance_thread_start_failure_clears_single_flight_state(
         assert daemon_manager_module._LAST_EPHEMERAL_REAP_AT == 0.0
 
 
-def test_hook_failure_restarts_an_older_unresponsive_daemon(tmp_path, monkeypatch) -> None:
+def test_hook_failure_preserves_an_older_authenticated_daemon(tmp_path, monkeypatch) -> None:
     guard_home = tmp_path / "guard-home"
     old_state = {"started_at": "2020-01-01T00:00:00+00:00"}
     retired: list[Path] = []
@@ -454,7 +455,7 @@ def test_hook_failure_restarts_an_older_unresponsive_daemon(tmp_path, monkeypatc
     monkeypatch.setattr(
         daemon_manager_module,
         "retire_all_guard_daemons_for_home",
-        lambda home: retired.append(home) or [],
+        lambda home: retired.append(home) or pytest.fail("hook traffic must not retire an authenticated daemon"),
     )
     monkeypatch.setattr(daemon_manager_module, "guard_daemon_retirement_is_complete", lambda _home: True)
     monkeypatch.setattr(
@@ -465,8 +466,8 @@ def test_hook_failure_restarts_an_older_unresponsive_daemon(tmp_path, monkeypatc
 
     recovered = daemon_manager_module.recover_guard_daemon_after_hook_failure(guard_home)
 
-    assert recovered == "http://127.0.0.1:5475"
-    assert retired == [guard_home]
+    assert recovered == "http://127.0.0.1:5474"
+    assert retired == []
 
 
 def test_hook_failure_preserves_a_concurrently_started_replacement(tmp_path, monkeypatch) -> None:

--- a/tests/test_guard_daemon_recovery_resilience.py
+++ b/tests/test_guard_daemon_recovery_resilience.py
@@ -195,7 +195,7 @@ def test_transport_recovery_preserves_authenticated_process_when_health_probe_mi
     assert recovered == "http://127.0.0.1:4781"
 
 
-def test_transport_recovery_replaces_old_process_when_health_probe_misses(
+def test_transport_recovery_preserves_verified_old_process_when_health_probe_misses(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -234,8 +234,8 @@ def test_transport_recovery_replaces_old_process_when_health_probe_misses(
         failure_kind="transport-failure",
     )
 
-    assert recovered == "http://127.0.0.1:4782"
-    assert retired == [guard_home]
+    assert recovered == "http://127.0.0.1:4781"
+    assert retired == []
 
 
 def test_recovery_does_not_reuse_recent_stale_runtime_generation(
@@ -276,7 +276,7 @@ def test_recovery_does_not_reuse_recent_stale_runtime_generation(
     assert start_count == 1
 
 
-def test_recovery_retires_one_old_generation_for_concurrent_control_failures(
+def test_recovery_preserves_old_live_generation_for_concurrent_control_failures(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -284,8 +284,6 @@ def test_recovery_retires_one_old_generation_for_concurrent_control_failures(
     generation_lock = threading.Lock()
     generation_state = _old_generation()
     generation_url: str | None = "http://127.0.0.1:4781"
-    retirement_started = threading.Event()
-    allow_retirement = threading.Event()
     retire_count = 0
     start_count = 0
 
@@ -298,12 +296,8 @@ def test_recovery_retires_one_old_generation_for_concurrent_control_failures(
             return generation_url
 
     def retire(_home: Path) -> list[int]:
-        nonlocal generation_url, retire_count
+        nonlocal retire_count
         retire_count += 1
-        retirement_started.set()
-        assert allow_retirement.wait(timeout=2)
-        with generation_lock:
-            generation_url = None
         return []
 
     def ensure(_home: Path, *, home_dir: Path | None = None) -> str:
@@ -323,26 +317,28 @@ def test_recovery_retires_one_old_generation_for_concurrent_control_failures(
     monkeypatch.setattr(daemon_manager_module, "ensure_guard_daemon", ensure)
     results: list[str] = []
 
-    first = threading.Thread(
-        target=lambda: results.append(daemon_manager_module.recover_guard_daemon_after_hook_failure(guard_home))
-    )
-    second = threading.Thread(
-        target=lambda: results.append(daemon_manager_module.recover_guard_daemon_after_hook_failure(guard_home))
-    )
-    first.start()
-    assert retirement_started.wait(timeout=1)
-    second.start()
-    time.sleep(0.05)
-    assert second.is_alive()
-    allow_retirement.set()
-    first.join(timeout=2)
-    second.join(timeout=2)
+    start_gate = threading.Barrier(32, timeout=10)
+    barrier_errors: list[threading.BrokenBarrierError] = []
 
-    assert not first.is_alive()
-    assert not second.is_alive()
-    assert retire_count == 1
-    assert start_count == 1
-    assert results == ["http://127.0.0.1:4782"] * 2
+    def recover() -> None:
+        try:
+            start_gate.wait()
+        except threading.BrokenBarrierError as error:
+            barrier_errors.append(error)
+            return
+        results.append(daemon_manager_module.recover_guard_daemon_after_hook_failure(guard_home))
+
+    workers = [threading.Thread(target=recover) for _ in range(32)]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=2)
+
+    assert all(not worker.is_alive() for worker in workers)
+    assert barrier_errors == []
+    assert retire_count == 0
+    assert start_count == 0
+    assert results == ["http://127.0.0.1:4781"] * 32
 
 
 def test_recovery_lock_serializes_separate_processes(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- backport the reviewed daemon recovery invariant from #2280
- prevent hook authentication, overload, and transport failures from retiring a verified live daemon
- retain concurrent 32-request recovery coverage and aligned acceptance fixtures

## Validation

- `uv run --no-sync pytest -q tests/test_guard_daemon_acceptance.py::test_adversarial_workload_nodeids_resolve tests/test_guard_daemon_manager.py::test_hook_failure_preserves_an_older_authenticated_daemon tests/test_guard_daemon_recovery_resilience.py`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/daemon/manager.py tests/test_guard_daemon_recovery_resilience.py tests/test_guard_daemon_manager.py`
- `git diff --check origin/release/3.0...HEAD`

Main PR: #2280
