### PR TITLE
feat(mcp): declare canonical registry ownership

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1
 
+LABEL io.modelcontextprotocol.server.name="io.github.hashgraph-online/hol-guard"
+
 WORKDIR /app
 
 COPY docker-requirements.txt LICENSE README.md /app/


### PR DESCRIPTION
## Summary
- declare the canonical MCP Registry server name on the existing HOL Guard OCI image
- use the registry-standard `io.modelcontextprotocol.server.name` label
- preserve the existing image build, entrypoint, and release flow unchanged

## Scope
This is packaging metadata only. It enables ownership verification for the existing stdio MCP server and existing GHCR image; it does not add a new runtime or publishing workflow.

Target: `release/3.0`.