### PR TITLE
fix(update): converge daemon restart after upgrade

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14574,
-  "maximum_test_source_lines": 316675,
+  "maximum_collected_cases": 14575,
+  "maximum_test_source_lines": 316721,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -146,6 +146,7 @@ from __future__ import annotations
 import inspect
 import json
 import sys
+import time
 from pathlib import Path
 
 from codex_plugin_scanner.guard.daemon.manager import (
@@ -173,7 +174,17 @@ try:
 except (OSError, json.JSONDecodeError):
     state = {}
 preferred_port = state.get("port") if isinstance(state.get("port"), int) else None
-retired = retire_all_guard_daemons_for_home(guard_home)
+retired = []
+retirement_deadline = time.monotonic() + 5.0
+while True:
+    for pid in retire_all_guard_daemons_for_home(guard_home):
+        if pid not in retired:
+            retired.append(pid)
+    if guard_daemon_retirement_is_complete(guard_home):
+        break
+    if time.monotonic() >= retirement_deadline:
+        break
+    time.sleep(0.1)
 if not guard_daemon_retirement_is_complete(guard_home):
     print(json.dumps({"status": "retirement_failed", "retired": retired}))
     raise SystemExit(1)

--- a/tests/test_guard_update_daemon_handoff.py
+++ b/tests/test_guard_update_daemon_handoff.py
@@ -81,6 +81,54 @@ def test_refresh_script_adapts_to_new_manager_signature(
     }
 
 
+def test_refresh_script_converges_when_supervisor_respawns_daemon(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    home_dir = tmp_path / "home"
+    guard_home = home_dir / ".hol-guard"
+    _ = guard_home.mkdir(parents=True)
+    _ = (guard_home / "daemon-state.json").write_text('{"port":8125}', encoding="utf-8")
+    retirement_checks = 0
+    retirement_calls = 0
+
+    def retire(_guard_home: Path) -> list[int]:
+        nonlocal retirement_calls
+        retirement_calls += 1
+        return [20 + retirement_calls]
+
+    def retirement_complete(_guard_home: Path) -> bool:
+        nonlocal retirement_checks
+        retirement_checks += 1
+        return retirement_checks >= 3
+
+    monkeypatch.setattr(manager, "retire_all_guard_daemons_for_home", retire)
+    monkeypatch.setattr(manager, "guard_daemon_retirement_is_complete", retirement_complete)
+    monkeypatch.setattr(manager, "clear_guard_daemon_state", lambda _guard_home: None)
+    monkeypatch.setattr(manager, "repair_approval_center_locator", lambda _guard_home: None)
+    monkeypatch.setattr(
+        manager,
+        "ensure_guard_daemon_after_update",
+        lambda _guard_home, **_kwargs: "http://127.0.0.1:8125",
+    )
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(json.dumps({"guard_home": str(guard_home), "home_dir": str(home_dir)})),
+    )
+
+    refresh_script = cast(str, update_commands.__dict__["_DAEMON_REFRESH_SCRIPT"])
+    exec(refresh_script, {})
+
+    assert retirement_calls == 3
+    assert json.loads(capsys.readouterr().out) == {
+        "status": "restarted",
+        "retired": [21, 22, 23],
+        "daemon_url": "http://127.0.0.1:8125",
+    }
+
+
 def test_refresh_script_preserves_legacy_manager_signature(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- retry authenticated daemon retirement during package updates until short-lived supervised respawns settle
- retain every retired process identifier and start the updated runtime only after retirement is proven complete

## Testing
- `uv run pytest -q tests/test_guard_update_daemon_handoff.py`
- `uv run ruff check src/codex_plugin_scanner/guard/cli/update_commands.py tests/test_guard_update_daemon_handoff.py`
- `uv run ruff format --check src/codex_plugin_scanner/guard/cli/update_commands.py tests/test_guard_update_daemon_handoff.py`
