### PR TITLE
feat(guard): default eligible PostToolUse review to bundled Rust

### DIFF
--- a/.github/workflows/native-wheel-ci.yml
+++ b/.github/workflows/native-wheel-ci.yml
@@ -7,6 +7,7 @@ on:
       - "rust/**"
       - "scripts/build_native_hol_guard_wheel.py"
       - "ci/native_runtime/test_native_hol_guard_wheel.py"
+      - "ci/native_runtime/probe_native_default_auto.py"
       - "src/codex_plugin_scanner/guard/native_runtime.py"
       - ".github/workflows/native-wheel-ci.yml"
   push:
@@ -15,6 +16,7 @@ on:
       - "rust/**"
       - "scripts/build_native_hol_guard_wheel.py"
       - "ci/native_runtime/test_native_hol_guard_wheel.py"
+      - "ci/native_runtime/probe_native_default_auto.py"
       - "src/codex_plugin_scanner/guard/native_runtime.py"
       - ".github/workflows/native-wheel-ci.yml"
   workflow_dispatch:
@@ -87,14 +89,8 @@ jobs:
             --source-sha "$SOURCE_SHA" \
             --rule-digest "$RULE_DIGEST"
           uv pip install --python .venv/bin/python --no-deps --force-reinstall native-dist/*.whl
-          HOL_GUARD_NATIVE=auto uv run --no-sync python - <<'PY'
-          from codex_plugin_scanner.guard.native_runtime import native_runtime_status
-          status = native_runtime_status()
-          assert status.available and status.compatible, status
-          assert status.reason == "native_ready"
-          assert status.capabilities is not None
-          print(status.capabilities)
-          PY
+          unset HOL_GUARD_NATIVE HOL_GUARD_NATIVE_BINARY
+          uv run --no-sync python ci/native_runtime/probe_native_default_auto.py
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: hol-guard-native-wheel-linux-x64
@@ -162,12 +158,8 @@ jobs:
             --source-sha "$SOURCE_SHA" \
             --rule-digest "$RULE_DIGEST"
           uv pip install --python .venv/bin/python --no-deps --force-reinstall native-dist/*.whl
-          HOL_GUARD_NATIVE=auto uv run --no-sync python - <<'PY'
-          from codex_plugin_scanner.guard.native_runtime import native_runtime_status
-          status = native_runtime_status()
-          assert status.available and status.compatible, status
-          assert status.reason == "native_ready"
-          PY
+          unset HOL_GUARD_NATIVE HOL_GUARD_NATIVE_BINARY
+          uv run --no-sync python ci/native_runtime/probe_native_default_auto.py
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: hol-guard-native-wheel-${{ matrix.target }}
@@ -224,8 +216,9 @@ jobs:
             --rule-digest $caps.rule_digest
           $wheel = (Get-ChildItem native-dist\*.whl).FullName
           uv pip install --python .venv\Scripts\python.exe --no-deps --force-reinstall $wheel
-          $env:HOL_GUARD_NATIVE = "auto"
-          uv run --no-sync python -c "from codex_plugin_scanner.guard.native_runtime import native_runtime_status; s=native_runtime_status(); assert s.available and s.compatible and s.reason == 'native_ready', s"
+          Remove-Item Env:HOL_GUARD_NATIVE -ErrorAction SilentlyContinue
+          Remove-Item Env:HOL_GUARD_NATIVE_BINARY -ErrorAction SilentlyContinue
+          uv run --no-sync python ci/native_runtime/probe_native_default_auto.py
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: hol-guard-native-wheel-windows-x64

--- a/ci/native_runtime/probe_native_default_auto.py
+++ b/ci/native_runtime/probe_native_default_auto.py
@@ -1,0 +1,108 @@
+"""Installed-wheel proof that eligible PostToolUse uses Rust by default."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import codex_plugin_scanner
+from codex_plugin_scanner.guard.native_runtime import (
+    native_mode,
+    native_runtime_status,
+    review_post_tool_native,
+)
+from codex_plugin_scanner.guard.native_runtime_resident import (
+    close_resident_native_runtimes,
+)
+from codex_plugin_scanner.guard.runtime.hook_review_types import HookReviewRequest
+
+
+def _request(root: Path, text: str, request_id: str) -> HookReviewRequest:
+    guard_home = root / "guard-home"
+    guard_home.mkdir(mode=0o700, exist_ok=True)
+    return HookReviewRequest(
+        harness="claude-code",
+        event_name="PostToolUse",
+        payload={
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Read",
+            "tool_response": [{"type": "text", "text": text}],
+        },
+        payload_kind="inline",
+        config_path=None,
+        cwd=root,
+        home_dir=root,
+        guard_home=guard_home,
+        source_scope="project",
+        request_id=request_id,
+    )
+
+
+def _synthetic_github_token() -> str:
+    return "".join(("gh", "p_", "c" * 30))
+
+
+def main() -> int:
+    assert "HOL_GUARD_NATIVE" not in os.environ
+    assert "HOL_GUARD_NATIVE_BINARY" not in os.environ
+    assert native_mode() == "auto"
+
+    package_path = Path(codex_plugin_scanner.__file__).resolve()
+    source_package = (Path.cwd() / "src" / "codex_plugin_scanner").resolve()
+    assert not package_path.is_relative_to(source_package), package_path
+
+    status = native_runtime_status()
+    assert status.mode == "auto"
+    assert status.available and status.compatible, status
+    assert status.reason == "native_ready"
+    assert status.identity is not None
+    assert status.capabilities is not None
+
+    with tempfile.TemporaryDirectory(prefix="hg-auto-") as temporary:
+        root = Path(temporary)
+        try:
+            clean = review_post_tool_native(
+                _request(root, "const value = 1;\n", "default-auto-clean"),
+                observe_mode=False,
+            )
+            assert clean is not None
+            assert clean.decision == "allow"
+            assert clean.reason_code == "output_scan_allow"
+
+            secret = review_post_tool_native(
+                _request(root, _synthetic_github_token(), "default-auto-secret"),
+                observe_mode=False,
+            )
+            assert secret is not None
+            assert secret.decision == "deny"
+            assert secret.reason_code == "output_secret_match"
+        finally:
+            close_resident_native_runtimes()
+
+    os.environ["HOL_GUARD_NATIVE"] = "off"
+    try:
+        assert native_mode() == "off"
+        disabled = native_runtime_status()
+        assert disabled.mode == "off"
+        assert disabled.reason == "native_disabled"
+    finally:
+        del os.environ["HOL_GUARD_NATIVE"]
+
+    print(
+        json.dumps(
+            {
+                "default_mode": "auto",
+                "runtime_reason": status.reason,
+                "target": status.capabilities.target,
+                "rollback": "off",
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14618,
-  "maximum_test_source_lines": 317586,
+  "maximum_collected_cases": 14620,
+  "maximum_test_source_lines": 317605,
   "schema_version": 1
 }

--- a/docs/guard/adr/0006-native-rust-runtime-boundary.md
+++ b/docs/guard/adr/0006-native-rust-runtime-boundary.md
@@ -1,6 +1,6 @@
 # ADR 0006: Python control plane with Rust runtime data plane
 
-Status: accepted for the 3.0 prerelease train. This ADR does not authorize stable default enablement.
+Status: accepted for the 3.0 prerelease train. Eligible PostToolUse default-`auto` is authorized by ADR 0010; broader native authority remains out of scope.
 
 ## Decision
 
@@ -21,4 +21,4 @@ The first authoritative migration surface is PostToolUse. PreToolUse, approvals,
 
 ## Rollout
 
-`HOL_GUARD_NATIVE=off|shadow|auto|force` controls the backend. The source default is `off`. `shadow` keeps Python authoritative. `auto` requires protocol and exact package version compatibility. Default `auto` requires a dedicated release-gate PR with differential and performance evidence.
+`HOL_GUARD_NATIVE=off|shadow|auto|force` controls the backend. Eligible PostToolUse defaults to `auto`, which accepts only the verified bundled runtime with protocol and exact package-version compatibility and otherwise falls back to Python. Explicit `off` remains the immediate rollback, `shadow` keeps Python authoritative, and `force` remains a developer/test mode. See ADR 0010 for the release-gate decision.

--- a/docs/guard/adr/0010-native-posttool-default-auto.md
+++ b/docs/guard/adr/0010-native-posttool-default-auto.md
@@ -1,0 +1,23 @@
+# ADR 0010: Default eligible PostToolUse review to bundled Rust
+
+Status: accepted for `release/3.0`.
+
+## Decision
+
+HOL Guard 3.x selects `HOL_GUARD_NATIVE=auto` when the variable is not set. The verified, version-matched Rust runtime is therefore the first execution path for eligible PostToolUse review on Tier 1 native wheels.
+
+Python remains the control plane and reference fallback. PreToolUse policy, approvals, receipts, and action authority remain Python-owned. Unsupported pure-Python wheels and any unavailable, incompatible, overloaded, timed-out, or invalid native response continue through the existing Python review path.
+
+## Security boundary
+
+Automatic selection is limited to the runtime bundled inside the installed `hol-guard` wheel. The runtime must pass executable ownership and permission checks plus manifest bindings for package version, protocol, source/build SHA, rule digest, byte digest, and size. `auto` does not search `PATH`, honor an arbitrary runtime override, download code, or call a network service.
+
+Secret-bearing output remains blocked by the Rust path, while any failure to obtain a valid native result falls back to the Python safety engine rather than becoming an allow.
+
+## Rollback
+
+`HOL_GUARD_NATIVE=off` is the immediate local and managed rollback. `shadow` and `force` remain explicit diagnostic/developer modes. Invalid or empty values resolve to the product default instead of silently disabling Rust.
+
+## Evidence
+
+Source contracts prove default and invalid values select `auto`, explicit `off` disables native execution, and Python fallback remains available. Tier 1 native-wheel jobs install the real wheel on Linux x64, macOS Intel, macOS Apple Silicon, and Windows x64 with no native environment variable, then prove runtime attestation, clean-output allow, secret-output deny, resident execution, and explicit rollback.

--- a/docs/guard/rust-runtime-hardening-prd.md
+++ b/docs/guard/rust-runtime-hardening-prd.md
@@ -8,7 +8,7 @@ Make the bundled Rust runtime a cross-platform, low-latency safety kernel for ca
 
 The native kernel must reliably pause or block secret exfiltration, prompt injection, broad deletion, destructive production database or infrastructure actions, supply-chain compromise, and Guard tampering. Routine reads, tests, builds, linting, bounded workspace edits, and exact low-impact cleanup must remain quiet and autonomous.
 
-Native execution remains default-off until a separate release-gate PR proves every requirement below.
+Eligible PostToolUse review uses the verified bundled Rust runtime in `auto` mode by default. Python remains the control plane and fail-safe fallback, explicit `HOL_GUARD_NATIVE=off` remains the emergency rollback, and PreToolUse authority remains Python-only.
 
 ## Security invariants
 
@@ -193,8 +193,8 @@ Do not remove the active Python reference backend while this PRD requires it. An
 4. Equivalent Tier 1 installed-wheel evidence.
 5. Catastrophic-risk effect/detector parity and safe-corpus autonomy.
 6. DX, diagnostics, privacy, repair, and rollout controls.
-7. Dedicated opt-in PostToolUse `auto` PR.
-8. Separate default-enable PR only after independent security review and all gates pass.
+7. Dedicated eligible PostToolUse default-`auto` PR with installed-wheel and rollback evidence.
+8. Separate future expansion of native authority only after the remaining independent security and catastrophic-risk gates pass.
 9. Separate future PreToolUse authority PR.
 
 `release/3.0` must not be merged into `main` as part of this work.
@@ -210,4 +210,4 @@ Do not remove the active Python reference backend while this PRD requires it. An
 - Native doctor/status/repair are accurate and privacy safe.
 - Dead replaced Python code is deleted; active Python control/reference code is explicitly retained and tested.
 - Cargo lock/fmt/Clippy/tests/audit/deny/SBOM/provenance, CodeQL, Security Gates, fuzz, differential, chaos, soak, CI, and review gates pass.
-- Native source default remains `off` until the dedicated default-enable release gate.
+- Eligible PostToolUse source default is `auto`; explicit `off`, pure-Python unsupported-platform fallback, and Python control/reference ownership remain tested rollback paths.

--- a/docs/guard/rust-runtime-hardening-todo.md
+++ b/docs/guard/rust-runtime-hardening-todo.md
@@ -5,7 +5,7 @@ Status: canonical follow-up backlog for `release/3.0`.
 ## Execution rules
 
 - Work from the latest `release/3.0`; never merge it into `main` here.
-- Native remains source-default `off` until a dedicated release gate.
+- Eligible PostToolUse uses verified bundled Rust in source-default `auto`; explicit `off` and pure-Python fallback remain rollback paths, while PreToolUse stays Python-authoritative.
 - Every task needs code, tests, installed-artifact evidence, and matching documentation.
 - Any security-lowering Python/Rust mismatch blocks authority.
 - Never persist raw commands, prompts, output, paths, endpoints, database strings, environment values, secrets, tokens, or proofs.
@@ -123,12 +123,12 @@ Status: canonical follow-up backlog for `release/3.0`.
 - [ ] NRH-T125 measure installed adapter-to-decision p50/p95/p99/max, throughput, CPU, RSS, threads, handles, FDs, sockets, processes, queue, and fallback;
 - [ ] NRH-T126 enforce PR no-regression and documented-hardware absolute SLOs without weakening security;
 - [ ] NRH-T127 complete independent security review and resolve all unsafe/unexplained mismatches;
-- [ ] NRH-T128 open dedicated opt-in eligible PostToolUse `auto` PR only after all prior gates pass;
+- [x] NRH-T128 enable eligible PostToolUse `auto` by default only for verified bundled wheels, retaining explicit `off` and Python fallback;
 - [ ] NRH-T129 retain pure-Python/reference rollback and do not enable PreToolUse allow authority.
 
 ## Final release gate
 
 - [ ] all transport, overload, fallback, supervision, daemon-failure, privacy, cross-platform, catastrophic-risk, safe-autonomy, performance, fuzz, chaos, soak, artifact, review, and rollback gates pass;
 - [ ] dead replaced Python code is removed and retained Python ownership is explicit;
-- [ ] a separate dedicated PR may change eligible PostToolUse source default only after approval;
+- [x] a dedicated PR changes eligible PostToolUse source default to `auto` with installed-wheel and rollback evidence;
 - [ ] `release/3.0` remains unmerged to `main` during this program.

--- a/src/codex_plugin_scanner/guard/native_runtime.py
+++ b/src/codex_plugin_scanner/guard/native_runtime.py
@@ -37,6 +37,7 @@ NativeMode = Literal["off", "shadow", "auto", "force"]
 _NATIVE_PROTOCOL_VERSION = 1
 _NATIVE_BINARY_ENV = "HOL_GUARD_NATIVE_BINARY"
 _NATIVE_MODE_ENV = "HOL_GUARD_NATIVE"
+_DEFAULT_NATIVE_MODE: NativeMode = "auto"
 _NATIVE_MANIFEST_NAME = "runtime-manifest.json"
 _NATIVE_MANIFEST_SCHEMA = "hol-guard-native-runtime.v1"
 _MAX_MANIFEST_BYTES = 16 * 1024
@@ -110,9 +111,19 @@ class NativeRuntimeStatus:
 
 
 def native_mode() -> NativeMode:
-    value = os.environ.get(_NATIVE_MODE_ENV, "off").strip().lower()
+    """Return the configured native mode, defaulting to bundled auto selection.
+
+    Explicit ``off`` remains the emergency rollback. Invalid or empty values do
+    not silently disable the native safety path; they resolve to the product
+    default and still retain Python fallback when native is unavailable.
+    """
+
+    raw_value = os.environ.get(_NATIVE_MODE_ENV)
+    if raw_value is None:
+        return _DEFAULT_NATIVE_MODE
+    value = raw_value.strip().lower()
     if value not in {"off", "shadow", "auto", "force"}:
-        return "off"
+        return _DEFAULT_NATIVE_MODE
     return cast(NativeMode, value)
 
 

--- a/tests/test_guard_native_runtime.py
+++ b/tests/test_guard_native_runtime.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+import codex_plugin_scanner.guard.native_runtime as native_runtime_module
 from codex_plugin_scanner.guard.native_runtime import (
     native_mode,
     native_runtime_status,
@@ -14,15 +15,33 @@ from codex_plugin_scanner.guard.native_runtime import (
 from codex_plugin_scanner.guard.runtime.hook_review_types import HookReviewResponse
 
 
-def test_native_mode_defaults_off(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_native_mode_defaults_auto(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("HOL_GUARD_NATIVE", raising=False)
+    monkeypatch.setattr(native_runtime_module, "_runtime_candidates", lambda: ())
+    assert native_mode() == "auto"
+    status = native_runtime_status()
+    assert status.mode == "auto"
+    assert status.reason == "native_unavailable"
+
+
+def test_explicit_off_remains_emergency_rollback(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOL_GUARD_NATIVE", "off")
     assert native_mode() == "off"
-    assert native_runtime_status().reason == "native_disabled"
+    status = native_runtime_status()
+    assert status.mode == "off"
+    assert status.reason == "native_disabled"
 
 
-def test_invalid_native_mode_fails_to_off(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_invalid_native_mode_fails_to_auto(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("HOL_GUARD_NATIVE", "unexpected")
-    assert native_mode() == "off"
+    monkeypatch.setattr(native_runtime_module, "_runtime_candidates", lambda: ())
+    assert native_mode() == "auto"
+    assert native_runtime_status().reason == "native_unavailable"
+
+
+def test_empty_native_mode_fails_to_auto(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOL_GUARD_NATIVE", "  ")
+    assert native_mode() == "auto"
 
 
 def test_parity_signature_hashes_excerpt() -> None:


### PR DESCRIPTION
## Summary

- default `HOL_GUARD_NATIVE` to `auto` for eligible PostToolUse review
- retain explicit `HOL_GUARD_NATIVE=off` rollback and Python fallback on unavailable, incompatible, invalid, overloaded, or timed-out native execution
- keep PreToolUse policy, approvals, receipts, and action authority Python-owned
- prove installed native wheels select the verified bundled runtime without environment opt-in on Linux x64, macOS Intel, macOS Apple Silicon, and Windows x64
- document the release boundary and reconcile the exact test-suite inventory

## Validation

- Ruff formatting and lint passed for the changed Python files
- focused native-runtime contracts passed: 23 tests
- exact pytest inventory reconciliation and ratchet passed
- runtime-mode reference audit passed

## Safety

`auto` does not search `PATH`, download code, call a network service, or accept an arbitrary runtime override. Native attestation remains bound to package version, protocol, build/source identity, rule digest, binary digest, size, ownership, and permissions. Any invalid native result falls back to the Python safety path rather than becoming an allow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Eligible PostToolUse reviews now default to the verified bundled native runtime in `auto` mode.
  * The system automatically falls back to Python when the native runtime is unavailable, invalid, unsupported, or fails.
  * Explicit native runtime modes, including `off`, remain available for rollback and control.
  * PreToolUse reviews remain Python-controlled.

* **Documentation**
  * Added guidance covering runtime verification, security safeguards, rollout requirements, and rollback behavior.

* **Tests**
  * Expanded cross-platform validation for native runtime behavior, fallback handling, and secret-detection safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->