### PR TITLE
fix(update): repair legacy Cursor surface records

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -2426,7 +2426,9 @@ def _repair_cursor_install(
     if not isinstance(manifest, dict):
         return None, "Could not inspect Cursor protection during update: managed manifest is invalid"
     surface_value = manifest.get("surface")
-    surface = surface_value if surface_value in {"editor", "all"} else None
+    surface: str | None = (
+        surface_value if isinstance(surface_value, str) and surface_value in {"editor", "all"} else None
+    )
     if surface is None:
         return None, None
     try:
@@ -2437,6 +2439,7 @@ def _repair_cursor_install(
     if hook_state["protection_active"] is True:
         return None, None
     try:
+        repair_surface = None if surface == "all" else surface
         payload = apply_managed_install(
             "install",
             "cursor",
@@ -2445,9 +2448,9 @@ def _repair_cursor_install(
             store,
             repair_workspace or workspace,
             now,
-            surface=surface,
+            surface=repair_surface,
         )
-    except (OSError, RuntimeError, json.JSONDecodeError, sqlite3.Error) as error:
+    except (OSError, RuntimeError, ValueError, json.JSONDecodeError, sqlite3.Error) as error:
         return None, f"Could not repair Cursor protection during update: {error}"
     repaired = payload.get("managed_install")
     if not isinstance(repaired, dict):

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -801,6 +801,36 @@ def test_cursor_update_repairs_stale_attested_cli_identity(tmp_path: Path) -> No
     assert cursor_native_hook_state(context)["protection_active"] is True
 
 
+def test_cursor_update_repairs_legacy_all_surface(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    context = HarnessContext(home_dir=home, guard_home=tmp_path / "guard", workspace_dir=workspace)
+    hooks_manifest = install_cursor_hooks(context)
+    store = GuardStore(context.guard_home)
+    store.set_managed_install(
+        "cursor",
+        True,
+        str(workspace),
+        {"surface": "all", **hooks_manifest},
+        "2026-07-20T00:00:00+00:00",
+    )
+    script_path = Path(str(hooks_manifest["managed_hook_script_path"]))
+    script_path.write_text("tampered", encoding="utf-8")
+
+    repaired, warning = guard_update_commands_module._repair_cursor_install(
+        context=context,
+        store=store,
+        workspace=str(workspace),
+        now="2026-07-20T00:01:00+00:00",
+    )
+
+    assert warning is None
+    assert repaired is not None
+    assert repaired["manifest"]["surface"] == "all"
+    assert cursor_native_hook_state(context)["protection_active"] is True
+
+
 def test_cursor_update_reports_context_resolution_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -833,6 +863,41 @@ def test_cursor_update_reports_context_resolution_failure(
 
     assert repaired is None
     assert warning == "Could not inspect Cursor protection during update: invalid repair context"
+
+
+def test_cursor_update_reports_surface_contract_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = HarnessContext(home_dir=tmp_path / "home", guard_home=tmp_path / "guard", workspace_dir=None)
+    store = GuardStore(context.guard_home)
+    store.set_managed_install(
+        "cursor",
+        True,
+        str(tmp_path / "workspace"),
+        {"surface": "editor"},
+        "2026-07-20T00:00:00+00:00",
+    )
+    monkeypatch.setattr(
+        guard_update_commands_module,
+        "cursor_native_hook_state",
+        lambda _context: {"protection_active": False},
+    )
+    monkeypatch.setattr(
+        guard_update_commands_module,
+        "apply_managed_install",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("unsupported repair surface")),
+    )
+
+    repaired, warning = guard_update_commands_module._repair_cursor_install(
+        context=context,
+        store=store,
+        workspace=None,
+        now="2026-07-20T00:01:00+00:00",
+    )
+
+    assert repaired is None
+    assert warning == "Could not repair Cursor protection during update: unsupported repair surface"
 
 
 def test_cursor_install_is_idempotent_across_path_changes(


### PR DESCRIPTION
## Summary
- repair historical Cursor all-surface records through the supported install path
- report Cursor surface contract failures without aborting the full harness repair subprocess
- add regression coverage for both compatibility and failure reporting

## Testing
- `uv run pytest -q tests/test_cursor_hooks.py -k 'cursor_update'`
- `uv run pytest -q tests/test_guard_cli.py -k 'guard_update_repairs'`
- `uv run ruff check src/codex_plugin_scanner/guard/cli/update_commands.py tests/test_cursor_hooks.py`
- `uv run ruff format --check src/codex_plugin_scanner/guard/cli/update_commands.py tests/test_cursor_hooks.py`
- `uv run python scripts/ci/test_inventory.py --output test-inventory.json`
- `uv run python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory test-inventory.json`
