### PR TITLE
feat(protection-center): lead with a tool map instead of a module catalog

### DIFF
--- a/dashboard/e2e/installed-extension-control-center.spec.ts
+++ b/dashboard/e2e/installed-extension-control-center.spec.ts
@@ -100,7 +100,8 @@ async function authenticateAndApply(page: import("@playwright/test").Page, count
 async function selectDensity(page: import("@playwright/test").Page, density: "Simple" | "Advanced" | "Developer") {
   const radio = page.getByRole("radio", { name: density });
   if (!(await radio.isVisible())) {
-    await page.locator("summary", { hasText: "More detail" }).click();
+    await page.getByTestId("protection-more-detail").locator("summary").click();
+    await expect(radio).toBeVisible();
   }
   await radio.click();
   await expect(radio).toHaveAttribute("aria-checked", "true");

--- a/dashboard/e2e/installed-extension-control-center.spec.ts
+++ b/dashboard/e2e/installed-extension-control-center.spec.ts
@@ -98,8 +98,12 @@ async function authenticateAndApply(page: import("@playwright/test").Page, count
 }
 
 async function selectDensity(page: import("@playwright/test").Page, density: "Simple" | "Advanced" | "Developer") {
-  await page.getByRole("radio", { name: density }).click();
-  await expect(page.getByRole("radio", { name: density })).toHaveAttribute("aria-checked", "true");
+  const radio = page.getByRole("radio", { name: density });
+  if (!(await radio.isVisible())) {
+    await page.locator("summary", { hasText: "More detail" }).click();
+  }
+  await radio.click();
+  await expect(radio).toHaveAttribute("aria-checked", "true");
 }
 
 test("installed Protection Center keeps canonical routes and real-daemon inspection", async ({ page }, testInfo) => {

--- a/dashboard/src/protection-center/components/protection-landing-panels.tsx
+++ b/dashboard/src/protection-center/components/protection-landing-panels.tsx
@@ -6,7 +6,6 @@ import {
   HiMiniCloud,
   HiMiniExclamationTriangle,
   HiMiniMagnifyingGlass,
-  HiMiniShieldCheck,
 } from "react-icons/hi2";
 
 import { commandReasonLabel } from "../../command-activity/command-activity-presenters";
@@ -34,23 +33,71 @@ export function CloudContinuityIndicator(props: {
   loading?: boolean;
 }) {
   return <aside aria-label="Cloud continuity" className="flex items-start gap-3 rounded-2xl border border-slate-200 bg-white px-4 py-3">
-    <span className="grid size-9 shrink-0 place-items-center rounded-xl bg-slate-50 text-slate-600" aria-hidden="true">
+    <span className="grid size-9 shrink-0 place-items-center rounded-xl bg-slate-100 text-slate-800" aria-hidden="true">
       {props.loading ? <HiMiniArrowPath className="size-5 animate-spin motion-reduce:animate-none" /> : <HiMiniCloud className="size-5" />}
     </span>
-    <div className="min-w-0"><div className="text-sm font-semibold text-slate-900">{props.loading ? "Checking Cloud continuity…" : props.continuity.label}</div><p className="mt-1 text-xs leading-5 text-slate-600">{props.continuity.detail}</p></div>
+    <div className="min-w-0">
+      <div className="text-sm font-semibold text-slate-950">{props.loading ? "Checking Cloud continuity…" : props.continuity.label}</div>
+      <p className="mt-1 text-xs leading-5 text-slate-800">{props.continuity.detail}</p>
+    </div>
   </aside>;
 }
 
-export function ProtectionCategoryGrid(props: {
+export function ProtectionWatchingMap(props: {
   catalog: readonly ExtensionCatalogItem[];
   effective: EffectiveExtensionControls;
+  inUseExtensionIds?: ReadonlySet<string>;
+  selectedId?: string | null;
+  onSelect?: (searchAlias: string, categoryId: string) => void;
 }) {
-  const categories = useMemo(() => protectionCategorySummary(props.catalog, props.effective), [props.catalog, props.effective]);
+  const areas = useMemo(
+    () => protectionCategorySummary(props.catalog, props.effective, props.inUseExtensionIds),
+    [props.catalog, props.effective, props.inUseExtensionIds],
+  );
+  const featured = areas.filter((area) => area.inUse > 0);
+  const rest = featured.length ? areas.filter((area) => area.inUse === 0) : areas.slice(4);
+  const primary = featured.length ? featured : areas.slice(0, 4);
+
   return <section aria-labelledby="what-guard-protects-heading" className="mt-8">
-    <div><h2 id="what-guard-protects-heading" className="text-xl font-semibold text-slate-950">What HOL Guard protects</h2><p className="mt-1 max-w-3xl text-sm text-slate-600">Guard applies focused protections across the developer actions and tools on this device.</p></div>
-    <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-      {categories.map((category) => <article key={category.id} className="rounded-2xl border border-slate-200 bg-white p-4"><div className="flex items-start justify-between gap-3"><div><h3 className="text-sm font-semibold text-slate-950">{category.label}</h3><p className="mt-1 text-xs leading-5 text-slate-600">{category.description}</p></div><span className="grid size-9 shrink-0 place-items-center rounded-xl bg-blue-50 text-brand-blue" aria-hidden="true"><HiMiniShieldCheck className="size-5" /></span></div><div className="mt-3 text-xs text-slate-500">{category.total} module{category.total === 1 ? "" : "s"} · {category.blocked ? `${category.blocked} locally blocked` : "Guard defaults active"}</div></article>)}
+    <div>
+      <h2 id="what-guard-protects-heading" className="text-xl font-semibold text-slate-950">What HOL Guard protects</h2>
+      <p className="mt-1 max-w-3xl text-sm text-slate-800">Guard is watching the tools your agent uses on this device. Open an area to see the matching protections.</p>
     </div>
+    <ol className="mt-4 divide-y divide-slate-200 border-y border-slate-200">
+      {primary.map((area) => {
+        const selected = props.selectedId === area.id;
+        const status = area.inUse
+          ? `${area.inUse} in use`
+          : area.blocked
+            ? `${area.blocked} blocked locally`
+            : `${area.total} ready`;
+        return <li key={area.id}>
+          <button
+            type="button"
+            aria-pressed={selected}
+            onClick={() => props.onSelect?.(area.searchAlias, area.id)}
+            className={`flex min-h-16 w-full items-baseline justify-between gap-4 py-3 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-blue ${selected ? "text-brand-blue" : "text-slate-950 hover:text-brand-blue"}`}
+          >
+            <span className="min-w-0">
+              <span className="block text-base font-semibold tracking-tight">{area.label}</span>
+              <span className={`mt-0.5 block text-sm ${selected ? "text-brand-blue" : "text-slate-800"}`}>{area.description}</span>
+            </span>
+            <span className={`shrink-0 text-xs font-semibold ${selected ? "text-brand-blue" : "text-slate-800"}`}>{status}</span>
+          </button>
+        </li>;
+      })}
+    </ol>
+    {rest.length ? <details className="mt-3">
+      <summary className="cursor-pointer text-sm font-semibold text-slate-800">More areas</summary>
+      <ol className="mt-2 divide-y divide-slate-200">
+        {rest.map((area) => <li key={area.id}>
+          <button type="button" onClick={() => props.onSelect?.(area.searchAlias, area.id)} className="flex min-h-12 w-full items-baseline justify-between gap-4 py-2 text-left text-sm text-slate-950 hover:text-brand-blue">
+            <span className="font-medium">{area.label}</span>
+            <span className="text-xs font-medium text-slate-800">{area.total} ready</span>
+          </button>
+        </li>)}
+      </ol>
+    </details> : null}
   </section>;
 }
 
@@ -65,26 +112,73 @@ export function ProtectionModuleExplorer(props: {
   effective: EffectiveExtensionControls;
   onOpen: (extension: ExtensionCatalogItem) => void;
   advancedFilters?: React.ReactNode;
+  focusQuery?: string;
 }) {
   const hasInUse = props.modules.some((module) => module.section === "in-use");
   const [section, setSection] = useState<ProtectionModuleSection>(hasInUse ? "in-use" : "recommended");
   const sectionTouched = useRef(false);
   const [query, setQuery] = useState("");
   const [advancedOpen, setAdvancedOpen] = useState(false);
+  const searchRef = useRef<HTMLInputElement>(null);
   useEffect(() => {
     if (hasInUse && !sectionTouched.current && section !== "in-use") setSection("in-use");
   }, [hasInUse, section]);
+  useEffect(() => {
+    if (!props.focusQuery) return;
+    setQuery(props.focusQuery);
+    sectionTouched.current = true;
+    setSection("all");
+    searchRef.current?.focus();
+  }, [props.focusQuery]);
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key !== "/" || event.metaKey || event.ctrlKey || event.altKey) return;
+      const target = event.target as HTMLElement | null;
+      if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)) return;
+      event.preventDefault();
+      searchRef.current?.focus();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
   const queried = useMemo(() => filterProtectionModulesByHumanQuery(props.modules, query), [props.modules, query]);
   const visible = queried.filter((module) => section === "all" || module.section === section);
 
   return <section aria-labelledby="protection-modules-heading" className="mt-8">
-    <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between"><div><h2 id="protection-modules-heading" className="text-xl font-semibold text-slate-950">Protection modules</h2><p className="mt-1 text-sm text-slate-600">Find protections by the thing you use, like Git, packages, secrets, or downloads.</p></div><span className="text-sm text-slate-500">{props.modules.length} available</span></div>
-    <div className="mt-4 flex flex-col gap-3 rounded-2xl border border-slate-200 bg-slate-50 p-3 sm:flex-row sm:items-center">
-      <label className="relative min-w-0 flex-1"><span className="sr-only">Search protection modules</span><HiMiniMagnifyingGlass className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-400" aria-hidden="true" /><input type="search" value={query} onChange={(event) => setQuery(event.target.value.slice(0, 160))} placeholder="Search Git, packages, secrets, downloads…" className="min-h-11 w-full rounded-xl border border-slate-300 bg-white py-2 pl-9 pr-3 text-sm text-slate-900 focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-blue-100" /></label>
-      <div role="tablist" aria-label="Protection module groups" className="flex shrink-0 rounded-xl border border-slate-200 bg-white p-1">{(["in-use", "recommended", "all"] as const).map((id) => <button key={id} type="button" role="tab" aria-selected={section === id} disabled={id === "in-use" && !hasInUse} onClick={() => { sectionTouched.current = true; setSection(id); }} className={`min-h-9 rounded-lg px-3 text-xs font-semibold disabled:opacity-40 ${section === id ? "bg-blue-50 text-brand-blue" : "text-slate-600 hover:bg-slate-50"}`}>{SECTION_LABELS[id]}</button>)}</div>
+    <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+      <div>
+        <h2 id="protection-modules-heading" className="text-xl font-semibold text-slate-950">Protection modules</h2>
+        <p className="mt-1 text-sm text-slate-800">Start with tools already in use. Search or browse all when you need a specific protection.</p>
+      </div>
+      <span className="text-sm font-medium text-slate-800">{props.modules.length} available</span>
     </div>
-    {props.advancedFilters ? <div className="mt-3"><button type="button" aria-expanded={advancedOpen} onClick={() => setAdvancedOpen((value) => !value)} className="inline-flex min-h-10 items-center gap-2 rounded-lg px-2 text-xs font-semibold text-slate-600 hover:bg-slate-100">Advanced filters <HiMiniChevronDown className={`size-4 transition motion-reduce:transition-none ${advancedOpen ? "rotate-180" : ""}`} aria-hidden="true" /></button>{advancedOpen ? <div className="mt-2">{props.advancedFilters}</div> : null}</div> : null}
-    {visible.length ? <div className="mt-4 space-y-2">{visible.map((module) => <ProtectionModuleRow key={module.extension.extension_id} name={module.extension.name} description={module.extension.description} behavior={isExtensionEnabled(props.effective, module.extension) ? "Guard defaults active" : "Blocked on this device"} required={module.extension.required} managed={managedByOrganization(props.effective, module.extension.extension_id)} onOpen={() => props.onOpen(module.extension)} />)}</div> : <div className="mt-4 rounded-2xl border border-dashed border-slate-300 bg-white p-8 text-center"><p className="text-sm font-semibold text-slate-900">No protection modules match this view.</p><p className="mt-1 text-sm text-slate-500">Try All modules or a simpler search.</p></div>}
+    <div className="mt-4 flex flex-col gap-3 rounded-2xl border border-slate-200 bg-slate-100 p-3 sm:flex-row sm:items-center">
+      <label className="relative min-w-0 flex-1">
+        <span className="sr-only">Search protection modules</span>
+        <HiMiniMagnifyingGlass className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-700" aria-hidden="true" />
+        <input ref={searchRef} type="search" value={query} onChange={(event) => setQuery(event.target.value.slice(0, 160))} placeholder="Search Git, packages, secrets, downloads…" className="min-h-11 w-full rounded-xl border border-slate-300 bg-white py-2 pl-9 pr-3 text-sm text-slate-950 focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-blue-100" />
+      </label>
+      <div role="tablist" aria-label="Protection module groups" className="flex shrink-0 rounded-xl border border-slate-200 bg-white p-1">
+        {(["in-use", "recommended", "all"] as const).map((id) => (
+          <button
+            key={id}
+            type="button"
+            role="tab"
+            aria-selected={section === id}
+            disabled={id === "in-use" && !hasInUse}
+            onClick={() => { sectionTouched.current = true; setSection(id); }}
+            className={`min-h-9 rounded-lg px-3 text-xs font-semibold disabled:opacity-40 ${section === id ? "bg-slate-950 text-white" : "text-slate-800 hover:bg-slate-100"}`}
+          >{SECTION_LABELS[id]}</button>
+        ))}
+      </div>
+    </div>
+    {props.advancedFilters ? <div className="mt-3">
+      <button type="button" aria-expanded={advancedOpen} onClick={() => setAdvancedOpen((value) => !value)} className="inline-flex min-h-10 items-center gap-2 rounded-lg px-2 text-xs font-semibold text-slate-800 hover:bg-slate-100">
+        Advanced filters <HiMiniChevronDown className={`size-4 transition motion-reduce:transition-none ${advancedOpen ? "rotate-180" : ""}`} aria-hidden="true" />
+      </button>
+      {advancedOpen ? <div className="mt-2">{props.advancedFilters}</div> : null}
+    </div> : null}
+    {visible.length ? <div className="mt-4 space-y-2">{visible.map((module) => <ProtectionModuleRow key={module.extension.extension_id} name={module.extension.name} description={module.extension.description} behavior={isExtensionEnabled(props.effective, module.extension) ? "Guard defaults active" : "Blocked on this device"} required={module.extension.required} managed={managedByOrganization(props.effective, module.extension.extension_id)} onOpen={() => props.onOpen(module.extension)} />)}</div> : <div className="mt-4 rounded-2xl border border-dashed border-slate-300 bg-white p-8 text-center"><p className="text-sm font-semibold text-slate-950">No protection modules match this view.</p><p className="mt-1 text-sm text-slate-800">Try All modules or a simpler search.</p></div>}
   </section>;
 }
 
@@ -93,9 +187,37 @@ export function RecentProtectionDecisions(props: {
   loading?: boolean;
   unavailable?: boolean;
 }) {
-  if (props.loading) return <section aria-labelledby="recent-protection-decisions-heading" className="mt-8 rounded-2xl border border-slate-200 bg-white p-5" aria-busy="true"><h2 id="recent-protection-decisions-heading" className="text-lg font-semibold text-slate-950">Recent decisions</h2><div className="guard-skeleton mt-4 h-24 w-full" /></section>;
-  if (props.unavailable) return <section aria-labelledby="recent-protection-decisions-heading" className="mt-8 rounded-2xl border border-slate-200 bg-white p-5"><h2 id="recent-protection-decisions-heading" className="text-lg font-semibold text-slate-950">Recent decisions</h2><p className="mt-2 text-sm text-slate-600">Recent local decision evidence could not be loaded. Protection status above remains independent of this activity view.</p></section>;
-  return <section aria-labelledby="recent-protection-decisions-heading" className="mt-8 rounded-2xl border border-slate-200 bg-white p-5"><div><h2 id="recent-protection-decisions-heading" className="text-lg font-semibold text-slate-950">Recent decisions</h2><p className="mt-1 text-sm text-slate-600">Privacy-safe local evidence from Guard's existing command-activity store. Raw commands and paths are not shown here.</p></div>{props.decisions.length ? <div className="mt-4 divide-y divide-slate-100">{props.decisions.map((decision) => <article key={decision.activityId} className="py-3 first:pt-0 last:pb-0"><div className="flex flex-wrap items-center justify-between gap-2"><div className="flex flex-wrap items-center gap-2"><ProtectionDecisionBadge result={decision.result} /><strong className="text-sm text-slate-900">{decision.extensionNames.length ? decision.extensionNames.join(", ") : "Guard protection"}</strong></div><time className="text-xs text-slate-500" dateTime={decision.occurredAt}>{new Date(decision.occurredAt).toLocaleString()}</time></div><details className="mt-2"><summary className="cursor-pointer text-xs font-semibold text-brand-blue">Why?</summary><p className="mt-2 text-sm leading-6 text-slate-600">{commandReasonLabel(decision.reasonCode)}</p></details></article>)}</div> : <p className="mt-4 rounded-xl bg-slate-50 p-4 text-sm text-slate-600">No recent local command decisions are recorded yet. Guard will show real activity here as it is recorded.</p>}</section>;
+  if (props.loading) {
+    return <section aria-labelledby="recent-protection-decisions-heading" className="mt-8" aria-busy="true">
+      <h2 id="recent-protection-decisions-heading" className="text-lg font-semibold text-slate-950">Recent decisions</h2>
+      <div className="guard-skeleton mt-4 h-24 w-full" />
+    </section>;
+  }
+  if (props.unavailable) {
+    return <section aria-labelledby="recent-protection-decisions-heading" className="mt-8">
+      <h2 id="recent-protection-decisions-heading" className="text-lg font-semibold text-slate-950">Recent decisions</h2>
+      <p className="mt-2 text-sm text-slate-800">Recent local decision evidence could not be loaded. Protection status above remains independent of this activity view.</p>
+    </section>;
+  }
+  return <section aria-labelledby="recent-protection-decisions-heading" className="mt-8">
+    <div>
+      <h2 id="recent-protection-decisions-heading" className="text-lg font-semibold text-slate-950">Recent decisions</h2>
+      <p className="mt-1 text-sm text-slate-800">Privacy-safe local evidence. Raw commands and paths are not shown.</p>
+    </div>
+    {props.decisions.length ? <div className="mt-3 divide-y divide-slate-200 border-y border-slate-200">{props.decisions.map((decision) => <article key={decision.activityId} className="py-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <ProtectionDecisionBadge result={decision.result} />
+          <strong className="text-sm text-slate-950">{decision.extensionNames.length ? decision.extensionNames.join(", ") : "Guard protection"}</strong>
+        </div>
+        <time className="text-xs font-medium text-slate-800" dateTime={decision.occurredAt}>{new Date(decision.occurredAt).toLocaleString()}</time>
+      </div>
+      <details className="mt-2">
+        <summary className="cursor-pointer text-xs font-semibold text-brand-blue">Why?</summary>
+        <p className="mt-2 text-sm leading-6 text-slate-800">{commandReasonLabel(decision.reasonCode)}</p>
+      </details>
+    </article>)}</div> : <p className="mt-3 text-sm text-slate-800">No recent local command decisions are recorded yet.</p>}
+  </section>;
 }
 
 export function ProtectionHealthCheckPanel(props: {
@@ -104,5 +226,24 @@ export function ProtectionHealthCheckPanel(props: {
   error?: string | null;
   onRun: () => void;
 }) {
-  return <section aria-labelledby="protection-health-check-heading" className="mt-8 rounded-2xl border border-slate-200 bg-white p-5"><div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between"><div><h2 id="protection-health-check-heading" className="text-lg font-semibold text-slate-950">Protection health check</h2><p className="mt-1 max-w-2xl text-sm text-slate-600">Safely re-read Guard's local catalog, trusted settings, and runtime. This check does not execute a command or change protection.</p></div><button type="button" onClick={props.onRun} disabled={props.busy} aria-busy={props.busy} className="inline-flex min-h-11 shrink-0 items-center gap-2 rounded-xl border border-brand-blue/25 bg-white px-4 text-sm font-semibold text-brand-blue hover:bg-blue-50 disabled:opacity-60">{props.busy ? <HiMiniArrowPath className="size-4 animate-spin motion-reduce:animate-none" aria-hidden="true" /> : <HiMiniCheckCircle className="size-4" aria-hidden="true" />}{props.busy ? "Checking…" : "Run health check"}</button></div>{props.error ? <p role="alert" className="mt-4 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-800">{props.error}</p> : null}{props.result ? <div role="status" aria-live="polite" className={`mt-4 rounded-xl border p-4 ${props.result.status === "healthy" ? "border-emerald-200 bg-emerald-50" : "border-amber-200 bg-amber-50"}`}><div className="flex items-start gap-2">{props.result.status === "healthy" ? <HiMiniCheckCircle className="mt-0.5 size-5 shrink-0 text-emerald-700" /> : <HiMiniExclamationTriangle className="mt-0.5 size-5 shrink-0 text-amber-700" />}<p className="text-sm font-medium text-slate-900">{props.result.summary}</p></div><ul className="mt-3 space-y-1.5">{props.result.checks.map((check) => <li key={check.id} className="flex items-center gap-2 text-xs text-slate-700"><span aria-hidden="true">{check.passed ? "✓" : "•"}</span>{check.label}</li>)}</ul></div> : null}</section>;
+  return <section aria-labelledby="protection-health-check-heading" className="mt-8 rounded-2xl border border-slate-200 bg-white p-5">
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+      <div>
+        <h2 id="protection-health-check-heading" className="text-lg font-semibold text-slate-950">Protection health check</h2>
+        <p className="mt-1 max-w-2xl text-sm text-slate-800">Safely re-read Guard's local catalog, trusted settings, and runtime. This check does not execute a command or change protection.</p>
+      </div>
+      <button type="button" onClick={props.onRun} disabled={props.busy} aria-busy={props.busy} className="inline-flex min-h-11 shrink-0 items-center gap-2 rounded-xl border border-brand-blue/25 bg-white px-4 text-sm font-semibold text-brand-blue hover:bg-blue-50 disabled:opacity-60">
+        {props.busy ? <HiMiniArrowPath className="size-4 animate-spin motion-reduce:animate-none" aria-hidden="true" /> : <HiMiniCheckCircle className="size-4" aria-hidden="true" />}
+        {props.busy ? "Checking…" : "Run health check"}
+      </button>
+    </div>
+    {props.error ? <p role="alert" className="mt-4 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-800">{props.error}</p> : null}
+    {props.result ? <div role="status" aria-live="polite" className={`mt-4 rounded-xl border p-4 ${props.result.status === "healthy" ? "border-emerald-200 bg-emerald-50" : "border-amber-200 bg-amber-50"}`}>
+      <div className="flex items-start gap-2">
+        {props.result.status === "healthy" ? <HiMiniCheckCircle className="mt-0.5 size-5 shrink-0 text-emerald-800" /> : <HiMiniExclamationTriangle className="mt-0.5 size-5 shrink-0 text-amber-800" />}
+        <p className="text-sm font-medium text-slate-950">{props.result.summary}</p>
+      </div>
+      <ul className="mt-3 space-y-1.5">{props.result.checks.map((check) => <li key={check.id} className="flex items-center gap-2 text-xs text-slate-800"><span aria-hidden="true">{check.passed ? "✓" : "•"}</span>{check.label}</li>)}</ul>
+    </div> : null}
+  </section>;
 }

--- a/dashboard/src/protection-center/copy/protection-copy.ts
+++ b/dashboard/src/protection-center/copy/protection-copy.ts
@@ -63,9 +63,14 @@ export const CLOUD_LOCAL_BOUNDARY_COPY = {
   cloudUnavailable: "Cloud sync is temporarily unavailable. Local protection continues.",
 } as const;
 
-export function protectionCenterLoadError(message: string): { title: string; detail: string } {
+function looksLikeUnauthorizedSession(message: string): boolean {
   const lower = message.trim().toLowerCase();
-  if (!lower || lower === "unauthorized" || lower.includes("unauthorized") || lower.includes("401") || lower.includes("session")) {
+  if (!lower || lower === "unauthorized" || lower.includes("unauthorized") || lower.includes("session")) return true;
+  return /(^|[^0-9])401([^0-9]|$)/.test(lower);
+}
+
+export function protectionCenterLoadError(message: string): { title: string; detail: string } {
+  if (looksLikeUnauthorizedSession(message)) {
     return {
       title: "This view needs a signed local session",
       detail: "Local protection is still running on this device. Open Protection Center from the local Guard dashboard and try again after Guard signs this session.",

--- a/dashboard/src/protection-center/copy/protection-copy.ts
+++ b/dashboard/src/protection-center/copy/protection-copy.ts
@@ -62,3 +62,17 @@ export const CLOUD_LOCAL_BOUNDARY_COPY = {
   cloudDisconnected: "Cloud continuity is not connected. Local protection continues.",
   cloudUnavailable: "Cloud sync is temporarily unavailable. Local protection continues.",
 } as const;
+
+export function protectionCenterLoadError(message: string): { title: string; detail: string } {
+  const lower = message.trim().toLowerCase();
+  if (!lower || lower === "unauthorized" || lower.includes("unauthorized") || lower.includes("401") || lower.includes("session")) {
+    return {
+      title: "This view needs a signed local session",
+      detail: "Local protection is still running on this device. Open Protection Center from the local Guard dashboard and try again after Guard signs this session.",
+    };
+  }
+  return {
+    title: "Protection Center unavailable",
+    detail: message.trim() || "Guard could not load protection settings. Local protection continues. Try again.",
+  };
+}

--- a/dashboard/src/protection-center/model/protection-landing.ts
+++ b/dashboard/src/protection-center/model/protection-landing.ts
@@ -164,27 +164,46 @@ export function protectionCloudContinuity(
   };
 }
 
+export type ProtectionAreaView = {
+  id: string;
+  label: string;
+  description: string;
+  searchAlias: string;
+  total: number;
+  allowed: number;
+  blocked: number;
+  inUse: number;
+};
+
 export function protectionCategorySummary(
   catalog: readonly ExtensionCatalogItem[],
   effective: EffectiveExtensionControls,
-) {
-  const groups = new Map<string, { id: string; label: string; description: string; total: number; allowed: number; blocked: number }>();
+  inUseExtensionIds: ReadonlySet<string> = new Set(),
+): ProtectionAreaView[] {
+  const groups = new Map<string, ProtectionAreaView>();
   for (const extension of catalog) {
     const category = protectionCategoryForExtension(extension);
     const group = groups.get(category.id) ?? {
       id: category.id,
       label: category.label,
       description: category.description,
+      searchAlias: category.searchAliases[0] ?? category.label,
       total: 0,
       allowed: 0,
       blocked: 0,
+      inUse: 0,
     };
     group.total += 1;
     if (isExtensionEnabled(effective, extension)) group.allowed += 1;
     else group.blocked += 1;
+    if (inUseExtensionIds.has(extension.extension_id)) group.inUse += 1;
     groups.set(category.id, group);
   }
-  return [...groups.values()].sort((left, right) => left.label.localeCompare(right.label));
+  return [...groups.values()].sort((left, right) =>
+    right.inUse - left.inUse
+    || right.blocked - left.blocked
+    || left.label.localeCompare(right.label)
+  );
 }
 
 export function evaluateProtectionHealth(

--- a/dashboard/src/protection-center/protection-center-workspace.tsx
+++ b/dashboard/src/protection-center/protection-center-workspace.tsx
@@ -299,8 +299,10 @@ export function ProtectionCenterWorkspace() {
 
   useEffect(() => { void load(); }, [load]);
   useEffect(() => {
+    // Open with Advanced/Developer. Stay open on Simple so density radios remain usable after the user reveals them.
     if (density !== "simple") setMoreDetailOpen(true);
   }, [density]);
+
   useEffect(() => {
     const onPopState = () => setRouteState(currentExtensionRouteState());
     window.addEventListener("popstate", onPopState);

--- a/dashboard/src/protection-center/protection-center-workspace.tsx
+++ b/dashboard/src/protection-center/protection-center-workspace.tsx
@@ -280,6 +280,7 @@ export function ProtectionCenterWorkspace() {
   const [recoveryStatus, setRecoveryStatus] = useState<string | null>(null);
   const [filters, setFilters] = useState<ExtensionFilterState>(EMPTY_EXTENSION_FILTERS);
   const [density, setDensity] = useProtectionDensity();
+  const [moreDetailOpen, setMoreDetailOpen] = useState(() => density !== "simple");
   const [provenanceOpen, setProvenanceOpen] = useState(false);
   const [troubleshootingOpen, setTroubleshootingOpen] = useState(false);
   const { resolvedApprovalGate, resolveApprovalGate } = useResolvedApprovalGate(null);
@@ -297,6 +298,9 @@ export function ProtectionCenterWorkspace() {
   }, []);
 
   useEffect(() => { void load(); }, [load]);
+  useEffect(() => {
+    if (density !== "simple") setMoreDetailOpen(true);
+  }, [density]);
   useEffect(() => {
     const onPopState = () => setRouteState(currentExtensionRouteState());
     window.addEventListener("popstate", onPopState);
@@ -454,7 +458,12 @@ export function ProtectionCenterWorkspace() {
   return <main className="mx-auto w-full max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
     <header className="flex flex-col gap-5 border-b border-slate-200 pb-7 lg:flex-row lg:items-end lg:justify-between">
       <div><p className="text-xs font-semibold uppercase tracking-[0.2em] text-brand-blue">Local protection</p><h1 className="mt-2 text-3xl font-semibold tracking-tight text-slate-950">{PROTECTION_TERMS.pageTitle}</h1><p className="mt-2 max-w-2xl text-sm leading-6 text-slate-800">See what Guard is watching on this device, then open a tool to understand or change it.</p></div>
-      <details className="w-full max-w-sm" data-testid="protection-more-detail" open={density !== "simple"}>
+      <details
+        className="w-full max-w-sm"
+        data-testid="protection-more-detail"
+        open={moreDetailOpen}
+        onToggle={(event) => setMoreDetailOpen(event.currentTarget.open)}
+      >
         <summary className="cursor-pointer text-sm font-semibold text-slate-800">More detail</summary>
         <div className="mt-3"><ProtectionDensityControl value={density} onChange={setDensity} /></div>
       </details>

--- a/dashboard/src/protection-center/protection-center-workspace.tsx
+++ b/dashboard/src/protection-center/protection-center-workspace.tsx
@@ -53,7 +53,7 @@ import type { GuardApprovalGatePublicConfig } from "../guard-types";
 import { useDebounce } from "../use-debounce";
 import { useModalDialog } from "../use-modal-dialog";
 import { useResolvedApprovalGate } from "../use-resolved-approval-gate";
-import { PROTECTION_TERMS } from "./copy/protection-copy";
+import { PROTECTION_TERMS, protectionCenterLoadError } from "./copy/protection-copy";
 import { ProtectionLandingExperience } from "./protection-landing-experience";
 import { ProtectionModuleDetail } from "./protection-module-detail";
 import {
@@ -64,7 +64,6 @@ import {
   TechnicalDetails,
   useProtectionDensity,
 } from "./components/protection-primitives";
-import { protectionCategoryForExtension } from "./model/protection-categories";
 import { deriveProtectionStatus } from "./model/protection-presentation";
 
 type LoadState =
@@ -203,7 +202,7 @@ export function ExtensionStatusBanner(props: {
   }
   const repairable = props.effective.health === "tampered" || props.effective.health === "recovery-required" || props.effective.health === "degraded-unacknowledged";
   const busyLabel = props.effective.health === "degraded-unacknowledged" ? "Acknowledging…" : "Repairing…";
-  return <div className="rounded-2xl border border-amber-200 bg-amber-50 p-5"><div className="flex items-start gap-3"><span className="mt-0.5 inline-flex size-9 shrink-0 items-center justify-center rounded-full bg-amber-100 text-amber-700"><HiMiniExclamationTriangle className="size-5" aria-hidden="true" /></span><div className="min-w-0 flex-1"><h2 className="font-semibold text-slate-950">{recovery?.title}</h2><p className="mt-1 text-sm leading-6 text-slate-700">{recovery?.description}</p><div className="mt-4 flex flex-wrap items-center gap-2">{repairable && props.onRecover ? <button type="button" aria-busy={props.busy} disabled={props.busy} onClick={props.onRecover} className="inline-flex min-h-11 items-center gap-2 rounded-lg bg-brand-blue px-4 py-2 text-sm font-semibold text-white disabled:opacity-60">{props.busy ? <HiMiniArrowPath className="size-4 animate-spin motion-reduce:animate-none" aria-hidden="true" /> : <HiMiniShieldCheck className="size-4" aria-hidden="true" />}{props.busy ? busyLabel : recovery?.actionLabel}</button> : null}<button type="button" onClick={props.onRetry} className="inline-flex min-h-11 items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50"><HiMiniArrowPath className="size-4" aria-hidden="true" />Check again</button></div><div className="mt-4 border-t border-amber-200 pt-3"><p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Command-line fallback</p><div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center"><code className="min-w-0 flex-1 overflow-x-auto rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs text-slate-800">{recovery?.command}</code><button type="button" onClick={handleCopy} className="inline-flex min-h-11 shrink-0 items-center justify-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-brand-blue">{copyState === "copied" ? <HiMiniClipboardDocumentCheck className="size-4" aria-hidden="true" /> : <HiMiniClipboard className="size-4" aria-hidden="true" />}{copyState === "copied" ? "Copied" : recovery?.copyLabel}</button></div>{copyState === "failed" ? <span role="status" className="mt-2 block text-sm text-red-700">Copy failed. Select the command above.</span> : null}</div>{props.error ? <p role="alert" className="mt-3 text-sm font-medium text-red-700">{props.error}</p> : null}{props.status ? <p role="status" className="mt-3 text-sm font-medium text-slate-800">{props.status}</p> : null}</div></div></div>;
+  return <div className="rounded-2xl border border-amber-200 bg-amber-50 p-5"><div className="flex items-start gap-3"><span className="mt-0.5 inline-flex size-9 shrink-0 items-center justify-center rounded-full bg-amber-100 text-amber-800"><HiMiniExclamationTriangle className="size-5" aria-hidden="true" /></span><div className="min-w-0 flex-1"><h2 className="font-semibold text-amber-950">{recovery?.title}</h2><p className="mt-1 text-sm leading-6 text-amber-950">{recovery?.description}</p><div className="mt-4 flex flex-wrap items-center gap-2">{repairable && props.onRecover ? <button type="button" aria-busy={props.busy} disabled={props.busy} onClick={props.onRecover} className="inline-flex min-h-11 items-center gap-2 rounded-lg bg-brand-blue px-4 py-2 text-sm font-semibold text-white disabled:opacity-60">{props.busy ? <HiMiniArrowPath className="size-4 animate-spin motion-reduce:animate-none" aria-hidden="true" /> : <HiMiniShieldCheck className="size-4" aria-hidden="true" />}{props.busy ? busyLabel : recovery?.actionLabel}</button> : null}<button type="button" onClick={props.onRetry} className="inline-flex min-h-11 items-center gap-2 rounded-lg border border-amber-300 bg-white px-3 py-2 text-sm font-semibold text-amber-950 hover:bg-amber-100"><HiMiniArrowPath className="size-4" aria-hidden="true" />Check again</button></div><div className="mt-4 border-t border-amber-200 pt-3"><p className="text-xs font-semibold uppercase tracking-wide text-amber-900">Command-line fallback</p><div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center"><code className="min-w-0 flex-1 overflow-x-auto rounded-lg border border-amber-200 bg-white px-3 py-2 text-xs text-amber-950">{recovery?.command}</code><button type="button" onClick={handleCopy} className="inline-flex min-h-11 shrink-0 items-center justify-center gap-2 rounded-lg border border-amber-300 bg-white px-3 py-2 text-sm font-semibold text-brand-blue">{copyState === "copied" ? <HiMiniClipboardDocumentCheck className="size-4" aria-hidden="true" /> : <HiMiniClipboard className="size-4" aria-hidden="true" />}{copyState === "copied" ? "Copied" : recovery?.copyLabel}</button></div>{copyState === "failed" ? <span role="status" className="mt-2 block text-sm text-red-800">Copy failed. Select the command above.</span> : null}</div>{props.error ? <p role="alert" className="mt-3 text-sm font-medium text-red-800">{props.error}</p> : null}{props.status ? <p role="status" className="mt-3 text-sm font-medium text-amber-950">{props.status}</p> : null}</div></div></div>;
 }
 
 export function ReviewModal(props: {
@@ -231,7 +230,38 @@ export function ReviewModal(props: {
     props.onConfirm(buildApprovalProofCredentials(props.approvalGate, { approvalPassword: password, approvalTotpCode: totp }));
   }, [password, props, totp]);
   const submitDisabled = isApprovalProofSubmitDisabled(props.approvalGate, { approvalPassword: password, approvalTotpCode: totp }, props.busy);
-  return <div className="fixed inset-0 z-50 grid place-items-center bg-slate-950/45 p-4 backdrop-blur-sm"><form ref={dialogRef} tabIndex={-1} role="dialog" aria-modal="true" aria-labelledby="protection-review-title" onSubmit={handleSubmit} className="w-full max-w-lg rounded-3xl bg-white p-6 shadow-2xl focus:outline-none"><div className="flex items-start justify-between gap-4"><div><p className="text-xs font-bold uppercase tracking-[0.18em] text-brand-blue">Review protection change</p><h2 id="protection-review-title" className="mt-2 text-xl font-semibold text-slate-950">{title}</h2></div><button type="button" disabled={props.busy} onClick={props.onCancel} aria-label="Close review" className="grid size-11 place-items-center rounded-full text-slate-500 hover:bg-slate-100 disabled:opacity-50"><HiMiniXMark className="size-5" /></button></div><div className="mt-5 grid grid-cols-[1fr_auto_1fr] items-center gap-3 rounded-2xl bg-slate-50 p-4 text-sm"><span className="text-slate-500">Current</span><span aria-hidden="true">→</span><strong className="text-slate-950">Requested</strong><span>{current}</span><span /><span>{requested}</span></div><p className="mt-4 text-sm leading-6 text-slate-600">Guard's built-in minimum safety rules and organization policy remain active. This change does not disable detection.</p><div className="mt-5"><ApprovalProofFieldInputs approvalGate={props.approvalGate} approvalPassword={password} approvalTotpCode={totp} onApprovalPasswordChange={(event) => setPassword(event.target.value)} onApprovalTotpCodeChange={(event) => setTotp(event.target.value)} /></div>{props.error ? <p role="alert" className="mt-4 rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800">{props.error}</p> : null}<div className="mt-6 flex justify-end gap-3"><button type="button" disabled={props.busy} onClick={props.onCancel} className="min-h-11 rounded-xl px-4 text-sm font-semibold text-slate-600 hover:bg-slate-100 disabled:opacity-50">Cancel</button><button type="submit" disabled={submitDisabled} className="min-h-11 rounded-xl bg-brand-blue px-5 text-sm font-semibold text-white hover:bg-brand-dark disabled:opacity-60">{props.busy ? "Verifying…" : "Confirm change"}</button></div></form></div>;
+  return (
+    <div className="fixed inset-0 z-50 grid place-items-center bg-slate-950/45 p-4 backdrop-blur-sm">
+      <form ref={dialogRef} tabIndex={-1} role="dialog" aria-modal="true" aria-labelledby="protection-review-title" onSubmit={handleSubmit} className="w-full max-w-lg rounded-3xl bg-white p-6 shadow-2xl focus:outline-none">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-xs font-bold uppercase tracking-[0.18em] text-brand-blue">Review protection change</p>
+            <h2 id="protection-review-title" className="mt-2 text-xl font-semibold text-slate-950">{title}</h2>
+          </div>
+          <button type="button" disabled={props.busy} onClick={props.onCancel} aria-label="Close review" className="grid size-11 place-items-center rounded-full text-slate-950 hover:bg-slate-100 disabled:opacity-50">
+            <HiMiniXMark className="size-5" />
+          </button>
+        </div>
+        <div className="mt-5 grid grid-cols-[1fr_auto_1fr] items-center gap-3 rounded-2xl bg-slate-100 p-4 text-sm text-slate-950">
+          <span>Current</span>
+          <span aria-hidden="true">→</span>
+          <strong>Requested</strong>
+          <span>{current}</span>
+          <span />
+          <span>{requested}</span>
+        </div>
+        <p className="mt-4 text-sm leading-6 text-slate-950">Guard's built-in minimum safety rules and organization policy remain active. This change does not disable detection.</p>
+        <div className="mt-5">
+          <ApprovalProofFieldInputs approvalGate={props.approvalGate} approvalPassword={password} approvalTotpCode={totp} onApprovalPasswordChange={(event) => setPassword(event.target.value)} onApprovalTotpCodeChange={(event) => setTotp(event.target.value)} />
+        </div>
+        {props.error ? <p role="alert" className="mt-4 rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800">{props.error}</p> : null}
+        <div className="mt-6 flex justify-end gap-3">
+          <button type="button" disabled={props.busy} onClick={props.onCancel} className="min-h-11 rounded-xl px-4 text-sm font-semibold text-slate-950 hover:bg-slate-100 disabled:opacity-50">Cancel</button>
+          <button type="submit" disabled={submitDisabled} className="min-h-11 rounded-xl bg-brand-blue px-5 text-sm font-semibold text-white hover:bg-brand-dark disabled:opacity-60">{props.busy ? "Verifying…" : "Confirm change"}</button>
+        </div>
+      </form>
+    </div>
+  );
 }
 
 function sourceIsManaged(effective: EffectiveExtensionControls, extensionId: string): boolean {
@@ -379,7 +409,10 @@ export function ProtectionCenterWorkspace() {
   }, [resolveApprovalGate, state]);
 
   if (state.kind === "loading") return <main className="grid min-h-[60vh] place-items-center" aria-busy="true"><HiMiniArrowPath className="size-7 animate-spin text-brand-blue motion-reduce:animate-none" aria-label="Loading Protection Center" /></main>;
-  if (state.kind === "error") return <main className="mx-auto max-w-4xl p-6"><div className="rounded-3xl border border-red-200 bg-red-50 p-6"><h1 className="text-xl font-semibold text-red-950">Protection Center unavailable</h1><p role="alert" className="mt-2 text-sm text-red-800">{state.message}</p><button type="button" onClick={load} className="mt-4 min-h-11 rounded-xl bg-red-700 px-4 text-sm font-semibold text-white">Try again</button></div></main>;
+  if (state.kind === "error") {
+    const loadError = protectionCenterLoadError(state.message);
+    return <main className="mx-auto max-w-4xl p-6"><div className="rounded-3xl border border-red-200 bg-red-50 p-6"><h1 className="text-xl font-semibold text-red-950">{loadError.title}</h1><p role="alert" className="mt-2 text-sm text-red-800">{loadError.detail}</p><p className="mt-3 text-xs font-medium text-red-900">Local protection continues on this device.</p><button type="button" onClick={load} className="mt-4 min-h-11 rounded-xl bg-red-800 px-4 text-sm font-semibold text-white">Try again</button></div></main>;
+  }
 
   const recoveryModal = recoveryApprovalOpen ? <ApprovalProofModal
     title={state.effective.health === "degraded-unacknowledged" ? "Confirm limited protection state" : "Repair local protection"}
@@ -420,8 +453,11 @@ export function ProtectionCenterWorkspace() {
 
   return <main className="mx-auto w-full max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
     <header className="flex flex-col gap-5 border-b border-slate-200 pb-7 lg:flex-row lg:items-end lg:justify-between">
-      <div><p className="text-xs font-semibold uppercase tracking-[0.2em] text-brand-blue">Local protection</p><h1 className="mt-2 text-3xl font-semibold tracking-tight text-slate-950">{PROTECTION_TERMS.pageTitle}</h1><p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">See what Guard protects on this device, understand the current behavior, and make deliberate local changes without learning internal policy terminology.</p></div>
-      <ProtectionDensityControl value={density} onChange={setDensity} />
+      <div><p className="text-xs font-semibold uppercase tracking-[0.2em] text-brand-blue">Local protection</p><h1 className="mt-2 text-3xl font-semibold tracking-tight text-slate-950">{PROTECTION_TERMS.pageTitle}</h1><p className="mt-2 max-w-2xl text-sm leading-6 text-slate-800">See what Guard is watching on this device, then open a tool to understand or change it.</p></div>
+      <details className="w-full max-w-sm" data-testid="protection-more-detail" open={density !== "simple"}>
+        <summary className="cursor-pointer text-sm font-semibold text-slate-800">More detail</summary>
+        <div className="mt-3"><ProtectionDensityControl value={density} onChange={setDensity} /></div>
+      </details>
     </header>
 
     <div className="mt-6"><ProtectionStatusHero status={status} busy={recoveryBusy} onPrimaryAction={status.primaryAction === "none" ? undefined : handlePrimaryStatusAction}>
@@ -452,7 +488,7 @@ export function ProtectionCenterWorkspace() {
 
     {density !== "simple" ? <section aria-labelledby="protection-modules-heading" className="mt-8">
       <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between"><div><h2 id="protection-modules-heading" className="text-xl font-semibold text-slate-950">{PROTECTION_TERMS.modules}</h2><p className="mt-1 text-sm text-slate-500">Open a protection to understand its current behavior and available controls.</p></div><span className="text-sm text-slate-500">{catalogExtensions.length} available</span></div>
-      {density !== "simple" ? <div className="mt-4"><ExtensionsFilterBar filters={filters} onChange={(patch) => setFilters((previous) => ({ ...previous, ...patch }))} onClear={() => setFilters(EMPTY_EXTENSION_FILTERS)} extensions={catalogExtensions} effective={state.effective} /></div> : null}
+      <div className="mt-4"><ExtensionsFilterBar filters={filters} onChange={(patch) => setFilters((previous) => ({ ...previous, ...patch }))} onClear={() => setFilters(EMPTY_EXTENSION_FILTERS)} extensions={catalogExtensions} effective={state.effective} /></div>
       {visible.length ? <div className="mt-4 space-y-2">{visible.map((extension) => <ProtectionModuleRow
         key={extension.extension_id}
         name={extension.name}

--- a/dashboard/src/protection-center/protection-center.test.tsx
+++ b/dashboard/src/protection-center/protection-center.test.tsx
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { assertSimpleCopySafe, localSettingChoiceLabel, PROTECTION_TERMS, simpleCopyViolations } from "./copy/protection-copy";
+import { assertSimpleCopySafe, localSettingChoiceLabel, PROTECTION_TERMS, protectionCenterLoadError, simpleCopyViolations } from "./copy/protection-copy";
 import { ProtectionDensityControl, ProtectionModuleRow, ProtectionStatusHero, TechnicalDetails } from "./components/protection-primitives";
 import {
   CLOUD_CONNECTED_FIXTURE,
@@ -98,6 +98,11 @@ assert.deepEqual(simpleCopyViolations("Protection is active on this device."), [
 assert.deepEqual(simpleCopyViolations("Catalog digest is hidden here."), ["catalog digest"]);
 assert.doesNotThrow(() => assertSimpleCopySafe("Guard is protecting source control on this device."));
 assert.throws(() => assertSimpleCopySafe("The semantic blast radius changed."), /semantic blast radius/);
+
+assert.equal(protectionCenterLoadError("unauthorized").title, "This view needs a signed local session");
+assert.match(protectionCenterLoadError("unauthorized").detail, /Local protection is still running/);
+assert.doesNotMatch(protectionCenterLoadError("unauthorized").detail, /^unauthorized$/);
+assert.match(protectionCenterLoadError("catalog mismatch").detail, /catalog mismatch/);
 
 const hero = renderToStaticMarkup(createElement(ProtectionStatusHero, { status: deriveProtectionStatus(PROTECTION_AUTHORITY_FIXTURES.protected) }));
 assert.match(hero, /Local protection/);

--- a/dashboard/src/protection-center/protection-center.test.tsx
+++ b/dashboard/src/protection-center/protection-center.test.tsx
@@ -102,6 +102,8 @@ assert.throws(() => assertSimpleCopySafe("The semantic blast radius changed."), 
 assert.equal(protectionCenterLoadError("unauthorized").title, "This view needs a signed local session");
 assert.match(protectionCenterLoadError("unauthorized").detail, /Local protection is still running/);
 assert.doesNotMatch(protectionCenterLoadError("unauthorized").detail, /^unauthorized$/);
+assert.equal(protectionCenterLoadError("HTTP 401").title, "This view needs a signed local session");
+assert.equal(protectionCenterLoadError("catalog 1401 mismatch").title, "Protection Center unavailable");
 assert.match(protectionCenterLoadError("catalog mismatch").detail, /catalog mismatch/);
 
 const hero = renderToStaticMarkup(createElement(ProtectionStatusHero, { status: deriveProtectionStatus(PROTECTION_AUTHORITY_FIXTURES.protected) }));

--- a/dashboard/src/protection-center/protection-cloud-value.test.tsx
+++ b/dashboard/src/protection-center/protection-cloud-value.test.tsx
@@ -77,7 +77,7 @@ assert.equal(protectionCloudDestination(unsafe), null);
 const html = renderToStaticMarkup(createElement(CloudValueGate, { runtime: localOnly, eligiblePlan: "solo" }));
 assert.match(html, /data-local-protection-independent="true"/);
 assert.match(html, /data-cloud-value-state="optional"/);
-assert.match(html, /Cloud continuity is optional/);
+assert.match(html, /This device is already protected/);
 assert.match(html, /Available on Solo Cloud/);
 assert.match(html, /href="https:\/\/hol\.org\/guard\/connect"/);
 assert.match(html, /Hide Cloud continuity/);

--- a/dashboard/src/protection-center/protection-cloud-value.tsx
+++ b/dashboard/src/protection-center/protection-cloud-value.tsx
@@ -53,8 +53,8 @@ export function protectionCloudValue(runtime: GuardRuntimeSnapshot | null, loadF
     return {
       state: "optional",
       plan: protectionCloudPlan(runtime),
-      label: "Cloud continuity is optional",
-      detail: "Local protection is active on this device. Connect Guard Cloud only if you want continuity, history, or organization coordination.",
+      label: "This device is already protected",
+      detail: "Local protection is active on this device. Guard Cloud keeps the same protections with you: synced module settings, searchable history, and organization policy your laptop cannot weaken.",
     };
   }
   if (runtime.cloud_state === "paired_waiting") {
@@ -102,7 +102,7 @@ function benefitForPlan(plan: ProtectionCloudPlan | null): string {
     case "enterprise":
       return "Centralize oversight and delegated workflows while every device continues enforcing locally.";
     default:
-      return "Add continuity and history without changing how this device protects you locally.";
+      return "Keep module settings and decision history with you across devices without moving local blocking into the Cloud.";
   }
 }
 

--- a/dashboard/src/protection-center/protection-landing-experience.tsx
+++ b/dashboard/src/protection-center/protection-landing-experience.tsx
@@ -10,9 +10,9 @@ import { ExtensionsFilterBar } from "../extensions-filter-bar";
 import type { ExtensionFilterState } from "../extensions-filters";
 import { fetchRuntimeSnapshot } from "../guard-api";
 import {
-  ProtectionCategoryGrid,
   ProtectionHealthCheckPanel,
   ProtectionModuleExplorer,
+  ProtectionWatchingMap,
   RecentProtectionDecisions,
 } from "./components/protection-landing-panels";
 import { CloudValueGate } from "./protection-cloud-value";
@@ -37,8 +37,14 @@ export function ProtectionLandingExperience(props: {
   const [healthBusy, setHealthBusy] = useState(false);
   const [healthResult, setHealthResult] = useState<ProtectionHealthCheck | null>(null);
   const [healthError, setHealthError] = useState<string | null>(null);
+  const [areaQuery, setAreaQuery] = useState("");
+  const [selectedAreaId, setSelectedAreaId] = useState<string | null>(null);
   const modules = useMemo(() => rankProtectionModules(props.catalog, landing.activity), [landing.activity, props.catalog]);
-  const decisions = useMemo(() => recentProtectionDecisions(landing.activity, props.catalog, 5), [landing.activity, props.catalog]);
+  const inUseExtensionIds = useMemo(
+    () => new Set(modules.filter((module) => module.section === "in-use").map((module) => module.extension.extension_id)),
+    [modules],
+  );
+  const decisions = useMemo(() => recentProtectionDecisions(landing.activity, props.catalog, 3), [landing.activity, props.catalog]);
 
   async function runHealthCheck() {
     setHealthBusy(true);
@@ -65,15 +71,25 @@ export function ProtectionLandingExperience(props: {
   }
 
   return <>
-    <div className="mt-4"><CloudValueGate runtime={landing.runtime} loading={landing.runtimeLoading} loadFailed={landing.runtimeError} /></div>
-    <ProtectionCategoryGrid catalog={props.catalog} effective={props.effective} />
+    <ProtectionWatchingMap
+      catalog={props.catalog}
+      effective={props.effective}
+      inUseExtensionIds={inUseExtensionIds}
+      selectedId={selectedAreaId}
+      onSelect={(searchAlias, categoryId) => {
+        setSelectedAreaId(categoryId);
+        setAreaQuery(searchAlias);
+      }}
+    />
     <ProtectionModuleExplorer
       modules={modules}
       effective={props.effective}
       onOpen={props.onOpen}
+      focusQuery={areaQuery}
       advancedFilters={<ExtensionsFilterBar filters={props.filters} onChange={props.onFilters} onClear={props.onClearFilters} extensions={props.catalog as ExtensionCatalogItem[]} effective={props.effective} />}
     />
     <RecentProtectionDecisions decisions={decisions} loading={landing.activityLoading} unavailable={landing.activityError} />
+    <div className="mt-8"><CloudValueGate runtime={landing.runtime} loading={landing.runtimeLoading} loadFailed={landing.runtimeError} /></div>
     <ProtectionHealthCheckPanel result={healthResult} busy={healthBusy} error={healthError} onRun={() => { void runHealthCheck(); }} />
   </>;
 }

--- a/dashboard/src/protection-center/protection-landing.test.tsx
+++ b/dashboard/src/protection-center/protection-landing.test.tsx
@@ -4,11 +4,12 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import type { CommandActivityItem } from "../command-activity/command-activity-types";
 import type { GuardRuntimeSnapshot } from "../guard-types";
-import { CloudContinuityIndicator, RecentProtectionDecisions } from "./components/protection-landing-panels";
+import { CloudContinuityIndicator, ProtectionWatchingMap, RecentProtectionDecisions } from "./components/protection-landing-panels";
 import { PROTECTION_AUTHORITY_FIXTURES, protectionModuleFixture } from "./fixtures/protection-fixtures";
 import {
   evaluateProtectionHealth,
   filterProtectionModulesByHumanQuery,
+  protectionCategorySummary,
   protectionCloudContinuity,
   protectionDecisionForAction,
   rankProtectionModules,
@@ -122,5 +123,19 @@ assert.match(decisionMarkup, /Blocked/);
 assert.match(decisionMarkup, /Allowed/);
 assert.match(decisionMarkup, /Why\?/);
 assert.doesNotMatch(decisionMarkup, /Users\/private|workspace\/secret|\.env\/private/i);
+
+const watching = renderToStaticMarkup(createElement(ProtectionWatchingMap, {
+  catalog,
+  effective: PROTECTION_AUTHORITY_FIXTURES.protected,
+  inUseExtensionIds: new Set(["command.git"]),
+}));
+assert.match(watching, /What HOL Guard protects/);
+assert.match(watching, /Source control/);
+assert.match(watching, /in use/);
+assert.doesNotMatch(watching, /grid size-9 shrink-0 place-items-center rounded-xl bg-blue-50/);
+
+const areas = protectionCategorySummary(catalog, PROTECTION_AUTHORITY_FIXTURES.protected, new Set(["command.git"]));
+assert.equal(areas[0]?.id, "source-control");
+assert.equal(areas[0]?.inUse, 1);
 
 console.log("protection-landing.test.tsx: all assertions passed");

--- a/dashboard/src/protection-center/protection-test-lab.tsx
+++ b/dashboard/src/protection-center/protection-test-lab.tsx
@@ -47,8 +47,9 @@ export function ProtectionTestLab({ extension }: { extension: ExtensionCatalogIt
     <div className="flex items-start gap-3">
       <span className="grid size-10 shrink-0 place-items-center rounded-xl bg-violet-50 text-violet-700" aria-hidden="true"><HiMiniBeaker className="size-5" /></span>
       <div className="min-w-0">
-        <h2 id="protection-test-lab-heading" className="text-lg font-semibold text-slate-950">Test Lab</h2>
-        <p className="mt-1 text-sm leading-6 text-slate-600">See how Guard would handle a command without running it.</p>
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-brand-blue">Try a command</p>
+        <h2 id="protection-test-lab-heading" className="mt-1 text-lg font-semibold text-slate-950">Test Lab</h2>
+        <p className="mt-1 text-sm leading-6 text-slate-800">See how Guard would handle a command without running it.</p>
       </div>
     </div>
     <div className="mt-5 rounded-2xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-950">

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
@@ -1257,9 +1257,13 @@ const PROTECTION_TERMS = {
   pageTitle: "Protection Center",
   modules: "Protection modules"
 };
-function protectionCenterLoadError(message) {
+function looksLikeUnauthorizedSession(message) {
   const lower = message.trim().toLowerCase();
-  if (!lower || lower === "unauthorized" || lower.includes("unauthorized") || lower.includes("401") || lower.includes("session")) {
+  if (!lower || lower === "unauthorized" || lower.includes("unauthorized") || lower.includes("session")) return true;
+  return /(^|[^0-9])401([^0-9]|$)/.test(lower);
+}
+function protectionCenterLoadError(message) {
+  if (looksLikeUnauthorizedSession(message)) {
     return {
       title: "This view needs a signed local session",
       detail: "Local protection is still running on this device. Open Protection Center from the local Guard dashboard and try again after Guard signs this session."

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
@@ -3556,6 +3556,7 @@ function ProtectionCenterWorkspace() {
   const [recoveryStatus, setRecoveryStatus] = reactExports.useState(null);
   const [filters, setFilters] = reactExports.useState(EMPTY_EXTENSION_FILTERS);
   const [density, setDensity] = useProtectionDensity();
+  const [moreDetailOpen, setMoreDetailOpen] = reactExports.useState(() => density !== "simple");
   const [provenanceOpen, setProvenanceOpen] = reactExports.useState(false);
   const [troubleshootingOpen, setTroubleshootingOpen] = reactExports.useState(false);
   const { resolvedApprovalGate, resolveApprovalGate } = useResolvedApprovalGate(null);
@@ -3573,6 +3574,9 @@ function ProtectionCenterWorkspace() {
   reactExports.useEffect(() => {
     void load();
   }, [load]);
+  reactExports.useEffect(() => {
+    if (density !== "simple") setMoreDetailOpen(true);
+  }, [density]);
   reactExports.useEffect(() => {
     const onPopState = () => setRouteState(currentExtensionRouteState());
     window.addEventListener("popstate", onPopState);
@@ -3740,10 +3744,19 @@ function ProtectionCenterWorkspace() {
         /* @__PURE__ */ jsxRuntimeExports.jsx("h1", { className: "mt-2 text-3xl font-semibold tracking-tight text-slate-950", children: PROTECTION_TERMS.pageTitle }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 max-w-2xl text-sm leading-6 text-slate-800", children: "See what Guard is watching on this device, then open a tool to understand or change it." })
       ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("details", { className: "w-full max-w-sm", "data-testid": "protection-more-detail", open: density !== "simple", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("summary", { className: "cursor-pointer text-sm font-semibold text-slate-800", children: "More detail" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ProtectionDensityControl, { value: density, onChange: setDensity }) })
-      ] })
+      /* @__PURE__ */ jsxRuntimeExports.jsxs(
+        "details",
+        {
+          className: "w-full max-w-sm",
+          "data-testid": "protection-more-detail",
+          open: moreDetailOpen,
+          onToggle: (event) => setMoreDetailOpen(event.currentTarget.open),
+          children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("summary", { className: "cursor-pointer text-sm font-semibold text-slate-800", children: "More detail" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ProtectionDensityControl, { value: density, onChange: setDensity }) })
+          ]
+        }
+      )
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-6", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ProtectionStatusHero, { status, busy: recoveryBusy, onPrimaryAction: status.primaryAction === "none" ? void 0 : handlePrimaryStatusAction, children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-600", children: "Cloud continuity is separate from local protection. Signing out or losing Cloud connectivity does not turn local protection off." }) }) }),
     mutationError && !pending ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4", children: /* @__PURE__ */ jsxRuntimeExports.jsx(InlineError, { message: mutationError }) }) : null,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
@@ -1257,6 +1257,19 @@ const PROTECTION_TERMS = {
   pageTitle: "Protection Center",
   modules: "Protection modules"
 };
+function protectionCenterLoadError(message) {
+  const lower = message.trim().toLowerCase();
+  if (!lower || lower === "unauthorized" || lower.includes("unauthorized") || lower.includes("401") || lower.includes("session")) {
+    return {
+      title: "This view needs a signed local session",
+      detail: "Local protection is still running on this device. Open Protection Center from the local Guard dashboard and try again after Guard signs this session."
+    };
+  }
+  return {
+    title: "Protection Center unavailable",
+    detail: message.trim() || "Guard could not load protection settings. Local protection continues. Try again."
+  };
+}
 const PROTECTION_DENSITY_STORAGE_KEY = "guard-protection-center-density-v1";
 function parseProtectionDensity(value) {
   return value === "advanced" || value === "developer" ? value : "simple";
@@ -1574,7 +1587,7 @@ function filterProtectionModulesByHumanQuery(modules, query) {
     return terms.every((term) => text2.includes(term));
   });
 }
-function protectionCategorySummary(catalog, effective) {
+function protectionCategorySummary(catalog, effective, inUseExtensionIds = /* @__PURE__ */ new Set()) {
   const groups = /* @__PURE__ */ new Map();
   for (const extension2 of catalog) {
     const category = protectionCategoryForExtension(extension2);
@@ -1582,16 +1595,21 @@ function protectionCategorySummary(catalog, effective) {
       id: category.id,
       label: category.label,
       description: category.description,
+      searchAlias: category.searchAliases[0] ?? category.label,
       total: 0,
       allowed: 0,
-      blocked: 0
+      blocked: 0,
+      inUse: 0
     };
     group.total += 1;
     if (isExtensionEnabled(effective, extension2)) group.allowed += 1;
     else group.blocked += 1;
+    if (inUseExtensionIds.has(extension2.extension_id)) group.inUse += 1;
     groups.set(category.id, group);
   }
-  return [...groups.values()].sort((left, right) => left.label.localeCompare(right.label));
+  return [...groups.values()].sort(
+    (left, right) => right.inUse - left.inUse || right.blocked - left.blocked || left.label.localeCompare(right.label)
+  );
 }
 function evaluateProtectionHealth(catalogDigest, effective, runtime) {
   const checks = [
@@ -1611,29 +1629,49 @@ function managedByOrganization(effective, extensionId) {
     (layer) => layer.kind === "signed-cloud" && layer.controls.some((control) => control.target_kind === "extension" && control.target_id === extensionId)
   );
 }
-function ProtectionCategoryGrid(props) {
-  const categories = reactExports.useMemo(() => protectionCategorySummary(props.catalog, props.effective), [props.catalog, props.effective]);
+function ProtectionWatchingMap(props) {
+  const areas = reactExports.useMemo(
+    () => protectionCategorySummary(props.catalog, props.effective, props.inUseExtensionIds),
+    [props.catalog, props.effective, props.inUseExtensionIds]
+  );
+  const featured = areas.filter((area) => area.inUse > 0);
+  const rest = featured.length ? areas.filter((area) => area.inUse === 0) : areas.slice(4);
+  const primary = featured.length ? featured : areas.slice(0, 4);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { "aria-labelledby": "what-guard-protects-heading", className: "mt-8", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { id: "what-guard-protects-heading", className: "text-xl font-semibold text-slate-950", children: "What HOL Guard protects" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 max-w-3xl text-sm text-slate-600", children: "Guard applies focused protections across the developer actions and tools on this device." })
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 max-w-3xl text-sm text-slate-800", children: "Guard is watching the tools your agent uses on this device. Open an area to see the matching protections." })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3", children: categories.map((category) => /* @__PURE__ */ jsxRuntimeExports.jsxs("article", { className: "rounded-2xl border border-slate-200 bg-white p-4", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start justify-between gap-3", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "text-sm font-semibold text-slate-950", children: category.label }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs leading-5 text-slate-600", children: category.description })
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "grid size-9 shrink-0 place-items-center rounded-xl bg-blue-50 text-brand-blue", "aria-hidden": "true", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "size-5" }) })
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-3 text-xs text-slate-500", children: [
-        category.total,
-        " module",
-        category.total === 1 ? "" : "s",
-        " · ",
-        category.blocked ? `${category.blocked} locally blocked` : "Guard defaults active"
-      ] })
-    ] }, category.id)) })
+    /* @__PURE__ */ jsxRuntimeExports.jsx("ol", { className: "mt-4 divide-y divide-slate-200 border-y border-slate-200", children: primary.map((area) => {
+      const selected = props.selectedId === area.id;
+      const status = area.inUse ? `${area.inUse} in use` : area.blocked ? `${area.blocked} blocked locally` : `${area.total} ready`;
+      return /* @__PURE__ */ jsxRuntimeExports.jsx("li", { children: /* @__PURE__ */ jsxRuntimeExports.jsxs(
+        "button",
+        {
+          type: "button",
+          "aria-pressed": selected,
+          onClick: () => props.onSelect?.(area.searchAlias, area.id),
+          className: `flex min-h-16 w-full items-baseline justify-between gap-4 py-3 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-blue ${selected ? "text-brand-blue" : "text-slate-950 hover:text-brand-blue"}`,
+          children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "min-w-0", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "block text-base font-semibold tracking-tight", children: area.label }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: `mt-0.5 block text-sm ${selected ? "text-brand-blue" : "text-slate-800"}`, children: area.description })
+            ] }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: `shrink-0 text-xs font-semibold ${selected ? "text-brand-blue" : "text-slate-800"}`, children: status })
+          ]
+        }
+      ) }, area.id);
+    }) }),
+    rest.length ? /* @__PURE__ */ jsxRuntimeExports.jsxs("details", { className: "mt-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("summary", { className: "cursor-pointer text-sm font-semibold text-slate-800", children: "More areas" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("ol", { className: "mt-2 divide-y divide-slate-200", children: rest.map((area) => /* @__PURE__ */ jsxRuntimeExports.jsx("li", { children: /* @__PURE__ */ jsxRuntimeExports.jsxs("button", { type: "button", onClick: () => props.onSelect?.(area.searchAlias, area.id), className: "flex min-h-12 w-full items-baseline justify-between gap-4 py-2 text-left text-sm text-slate-950 hover:text-brand-blue", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-medium", children: area.label }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-xs font-medium text-slate-800", children: [
+          area.total,
+          " ready"
+        ] })
+      ] }) }, area.id)) })
+    ] }) : null
   ] });
 }
 const SECTION_LABELS = {
@@ -1647,73 +1685,108 @@ function ProtectionModuleExplorer(props) {
   const sectionTouched = reactExports.useRef(false);
   const [query, setQuery] = reactExports.useState("");
   const [advancedOpen, setAdvancedOpen] = reactExports.useState(false);
+  const searchRef = reactExports.useRef(null);
   reactExports.useEffect(() => {
     if (hasInUse && !sectionTouched.current && section !== "in-use") setSection("in-use");
   }, [hasInUse, section]);
+  reactExports.useEffect(() => {
+    if (!props.focusQuery) return;
+    setQuery(props.focusQuery);
+    sectionTouched.current = true;
+    setSection("all");
+    searchRef.current?.focus();
+  }, [props.focusQuery]);
+  reactExports.useEffect(() => {
+    const onKey = (event) => {
+      if (event.key !== "/" || event.metaKey || event.ctrlKey || event.altKey) return;
+      const target2 = event.target;
+      if (target2 && (target2.tagName === "INPUT" || target2.tagName === "TEXTAREA" || target2.isContentEditable)) return;
+      event.preventDefault();
+      searchRef.current?.focus();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
   const queried = reactExports.useMemo(() => filterProtectionModulesByHumanQuery(props.modules, query), [props.modules, query]);
   const visible = queried.filter((module) => section === "all" || module.section === section);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { "aria-labelledby": "protection-modules-heading", className: "mt-8", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { id: "protection-modules-heading", className: "text-xl font-semibold text-slate-950", children: "Protection modules" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-600", children: "Find protections by the thing you use, like Git, packages, secrets, or downloads." })
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-800", children: "Start with tools already in use. Search or browse all when you need a specific protection." })
       ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-sm text-slate-500", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-sm font-medium text-slate-800", children: [
         props.modules.length,
         " available"
       ] })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 flex flex-col gap-3 rounded-2xl border border-slate-200 bg-slate-50 p-3 sm:flex-row sm:items-center", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 flex flex-col gap-3 rounded-2xl border border-slate-200 bg-slate-100 p-3 sm:flex-row sm:items-center", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "relative min-w-0 flex-1", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "sr-only", children: "Search protection modules" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniMagnifyingGlass, { className: "pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-400", "aria-hidden": "true" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("input", { type: "search", value: query, onChange: (event) => setQuery(event.target.value.slice(0, 160)), placeholder: "Search Git, packages, secrets, downloads…", className: "min-h-11 w-full rounded-xl border border-slate-300 bg-white py-2 pl-9 pr-3 text-sm text-slate-900 focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-blue-100" })
+        /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniMagnifyingGlass, { className: "pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-700", "aria-hidden": "true" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("input", { ref: searchRef, type: "search", value: query, onChange: (event) => setQuery(event.target.value.slice(0, 160)), placeholder: "Search Git, packages, secrets, downloads…", className: "min-h-11 w-full rounded-xl border border-slate-300 bg-white py-2 pl-9 pr-3 text-sm text-slate-950 focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-blue-100" })
       ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { role: "tablist", "aria-label": "Protection module groups", className: "flex shrink-0 rounded-xl border border-slate-200 bg-white p-1", children: ["in-use", "recommended", "all"].map((id2) => /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", role: "tab", "aria-selected": section === id2, disabled: id2 === "in-use" && !hasInUse, onClick: () => {
-        sectionTouched.current = true;
-        setSection(id2);
-      }, className: `min-h-9 rounded-lg px-3 text-xs font-semibold disabled:opacity-40 ${section === id2 ? "bg-blue-50 text-brand-blue" : "text-slate-600 hover:bg-slate-50"}`, children: SECTION_LABELS[id2] }, id2)) })
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { role: "tablist", "aria-label": "Protection module groups", className: "flex shrink-0 rounded-xl border border-slate-200 bg-white p-1", children: ["in-use", "recommended", "all"].map((id2) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "button",
+        {
+          type: "button",
+          role: "tab",
+          "aria-selected": section === id2,
+          disabled: id2 === "in-use" && !hasInUse,
+          onClick: () => {
+            sectionTouched.current = true;
+            setSection(id2);
+          },
+          className: `min-h-9 rounded-lg px-3 text-xs font-semibold disabled:opacity-40 ${section === id2 ? "bg-slate-950 text-white" : "text-slate-800 hover:bg-slate-100"}`,
+          children: SECTION_LABELS[id2]
+        },
+        id2
+      )) })
     ] }),
     props.advancedFilters ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-3", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("button", { type: "button", "aria-expanded": advancedOpen, onClick: () => setAdvancedOpen((value) => !value), className: "inline-flex min-h-10 items-center gap-2 rounded-lg px-2 text-xs font-semibold text-slate-600 hover:bg-slate-100", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("button", { type: "button", "aria-expanded": advancedOpen, onClick: () => setAdvancedOpen((value) => !value), className: "inline-flex min-h-10 items-center gap-2 rounded-lg px-2 text-xs font-semibold text-slate-800 hover:bg-slate-100", children: [
         "Advanced filters ",
         /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronDown, { className: `size-4 transition motion-reduce:transition-none ${advancedOpen ? "rotate-180" : ""}`, "aria-hidden": "true" })
       ] }),
       advancedOpen ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-2", children: props.advancedFilters }) : null
     ] }) : null,
     visible.length ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 space-y-2", children: visible.map((module) => /* @__PURE__ */ jsxRuntimeExports.jsx(ProtectionModuleRow, { name: module.extension.name, description: module.extension.description, behavior: isExtensionEnabled(props.effective, module.extension) ? "Guard defaults active" : "Blocked on this device", required: module.extension.required, managed: managedByOrganization(props.effective, module.extension.extension_id), onOpen: () => props.onOpen(module.extension) }, module.extension.extension_id)) }) : /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 rounded-2xl border border-dashed border-slate-300 bg-white p-8 text-center", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-slate-900", children: "No protection modules match this view." }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-500", children: "Try All modules or a simpler search." })
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-slate-950", children: "No protection modules match this view." }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-800", children: "Try All modules or a simpler search." })
     ] })
   ] });
 }
 function RecentProtectionDecisions(props) {
-  if (props.loading) return /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { "aria-labelledby": "recent-protection-decisions-heading", className: "mt-8 rounded-2xl border border-slate-200 bg-white p-5", "aria-busy": "true", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { id: "recent-protection-decisions-heading", className: "text-lg font-semibold text-slate-950", children: "Recent decisions" }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-skeleton mt-4 h-24 w-full" })
-  ] });
-  if (props.unavailable) return /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { "aria-labelledby": "recent-protection-decisions-heading", className: "mt-8 rounded-2xl border border-slate-200 bg-white p-5", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { id: "recent-protection-decisions-heading", className: "text-lg font-semibold text-slate-950", children: "Recent decisions" }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-slate-600", children: "Recent local decision evidence could not be loaded. Protection status above remains independent of this activity view." })
-  ] });
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { "aria-labelledby": "recent-protection-decisions-heading", className: "mt-8 rounded-2xl border border-slate-200 bg-white p-5", children: [
+  if (props.loading) {
+    return /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { "aria-labelledby": "recent-protection-decisions-heading", className: "mt-8", "aria-busy": "true", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { id: "recent-protection-decisions-heading", className: "text-lg font-semibold text-slate-950", children: "Recent decisions" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-skeleton mt-4 h-24 w-full" })
+    ] });
+  }
+  if (props.unavailable) {
+    return /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { "aria-labelledby": "recent-protection-decisions-heading", className: "mt-8", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { id: "recent-protection-decisions-heading", className: "text-lg font-semibold text-slate-950", children: "Recent decisions" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-slate-800", children: "Recent local decision evidence could not be loaded. Protection status above remains independent of this activity view." })
+    ] });
+  }
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { "aria-labelledby": "recent-protection-decisions-heading", className: "mt-8", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { id: "recent-protection-decisions-heading", className: "text-lg font-semibold text-slate-950", children: "Recent decisions" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-600", children: "Privacy-safe local evidence from Guard's existing command-activity store. Raw commands and paths are not shown here." })
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-800", children: "Privacy-safe local evidence. Raw commands and paths are not shown." })
     ] }),
-    props.decisions.length ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 divide-y divide-slate-100", children: props.decisions.map((decision) => /* @__PURE__ */ jsxRuntimeExports.jsxs("article", { className: "py-3 first:pt-0 last:pb-0", children: [
+    props.decisions.length ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3 divide-y divide-slate-200 border-y border-slate-200", children: props.decisions.map((decision) => /* @__PURE__ */ jsxRuntimeExports.jsxs("article", { className: "py-3", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center justify-between gap-2", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx(ProtectionDecisionBadge, { result: decision.result }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("strong", { className: "text-sm text-slate-900", children: decision.extensionNames.length ? decision.extensionNames.join(", ") : "Guard protection" })
+          /* @__PURE__ */ jsxRuntimeExports.jsx("strong", { className: "text-sm text-slate-950", children: decision.extensionNames.length ? decision.extensionNames.join(", ") : "Guard protection" })
         ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("time", { className: "text-xs text-slate-500", dateTime: decision.occurredAt, children: new Date(decision.occurredAt).toLocaleString() })
+        /* @__PURE__ */ jsxRuntimeExports.jsx("time", { className: "text-xs font-medium text-slate-800", dateTime: decision.occurredAt, children: new Date(decision.occurredAt).toLocaleString() })
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("details", { className: "mt-2", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("summary", { className: "cursor-pointer text-xs font-semibold text-brand-blue", children: "Why?" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm leading-6 text-slate-600", children: commandReasonLabel(decision.reasonCode) })
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm leading-6 text-slate-800", children: commandReasonLabel(decision.reasonCode) })
       ] })
-    ] }, decision.activityId)) }) : /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-4 rounded-xl bg-slate-50 p-4 text-sm text-slate-600", children: "No recent local command decisions are recorded yet. Guard will show real activity here as it is recorded." })
+    ] }, decision.activityId)) }) : /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-3 text-sm text-slate-800", children: "No recent local command decisions are recorded yet." })
   ] });
 }
 function ProtectionHealthCheckPanel(props) {
@@ -1721,7 +1794,7 @@ function ProtectionHealthCheckPanel(props) {
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { id: "protection-health-check-heading", className: "text-lg font-semibold text-slate-950", children: "Protection health check" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 max-w-2xl text-sm text-slate-600", children: "Safely re-read Guard's local catalog, trusted settings, and runtime. This check does not execute a command or change protection." })
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 max-w-2xl text-sm text-slate-800", children: "Safely re-read Guard's local catalog, trusted settings, and runtime. This check does not execute a command or change protection." })
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("button", { type: "button", onClick: props.onRun, disabled: props.busy, "aria-busy": props.busy, className: "inline-flex min-h-11 shrink-0 items-center gap-2 rounded-xl border border-brand-blue/25 bg-white px-4 text-sm font-semibold text-brand-blue hover:bg-blue-50 disabled:opacity-60", children: [
         props.busy ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "size-4 animate-spin motion-reduce:animate-none", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "size-4", "aria-hidden": "true" }),
@@ -1731,10 +1804,10 @@ function ProtectionHealthCheckPanel(props) {
     props.error ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { role: "alert", className: "mt-4 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-800", children: props.error }) : null,
     props.result ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { role: "status", "aria-live": "polite", className: `mt-4 rounded-xl border p-4 ${props.result.status === "healthy" ? "border-emerald-200 bg-emerald-50" : "border-amber-200 bg-amber-50"}`, children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-2", children: [
-        props.result.status === "healthy" ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "mt-0.5 size-5 shrink-0 text-emerald-700" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "mt-0.5 size-5 shrink-0 text-amber-700" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-slate-900", children: props.result.summary })
+        props.result.status === "healthy" ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "mt-0.5 size-5 shrink-0 text-emerald-800" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "mt-0.5 size-5 shrink-0 text-amber-800" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-slate-950", children: props.result.summary })
       ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("ul", { className: "mt-3 space-y-1.5", children: props.result.checks.map((check) => /* @__PURE__ */ jsxRuntimeExports.jsxs("li", { className: "flex items-center gap-2 text-xs text-slate-700", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("ul", { className: "mt-3 space-y-1.5", children: props.result.checks.map((check) => /* @__PURE__ */ jsxRuntimeExports.jsxs("li", { className: "flex items-center gap-2 text-xs text-slate-800", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { "aria-hidden": "true", children: check.passed ? "✓" : "•" }),
         check.label
       ] }, check.id)) })
@@ -1836,8 +1909,8 @@ function protectionCloudValue(runtime, loadFailed = false) {
     return {
       state: "optional",
       plan: protectionCloudPlan(runtime),
-      label: "Cloud continuity is optional",
-      detail: "Local protection is active on this device. Connect Guard Cloud only if you want continuity, history, or organization coordination."
+      label: "This device is already protected",
+      detail: "Local protection is active on this device. Guard Cloud keeps the same protections with you: synced module settings, searchable history, and organization policy your laptop cannot weaken."
     };
   }
   if (runtime.cloud_state === "paired_waiting") {
@@ -1880,7 +1953,7 @@ function benefitForPlan(plan) {
     case "enterprise":
       return "Centralize oversight and delegated workflows while every device continues enforcing locally.";
     default:
-      return "Add continuity and history without changing how this device protects you locally.";
+      return "Keep module settings and decision history with you across devices without moving local blocking into the Cloud.";
   }
 }
 function eligiblePlanCopy(plan, eligiblePlan) {
@@ -1974,8 +2047,14 @@ function ProtectionLandingExperience(props) {
   const [healthBusy, setHealthBusy] = reactExports.useState(false);
   const [healthResult, setHealthResult] = reactExports.useState(null);
   const [healthError, setHealthError] = reactExports.useState(null);
+  const [areaQuery, setAreaQuery] = reactExports.useState("");
+  const [selectedAreaId, setSelectedAreaId] = reactExports.useState(null);
   const modules = reactExports.useMemo(() => rankProtectionModules(props.catalog, landing.activity), [landing.activity, props.catalog]);
-  const decisions = reactExports.useMemo(() => recentProtectionDecisions(landing.activity, props.catalog, 5), [landing.activity, props.catalog]);
+  const inUseExtensionIds = reactExports.useMemo(
+    () => new Set(modules.filter((module) => module.section === "in-use").map((module) => module.extension.extension_id)),
+    [modules]
+  );
+  const decisions = reactExports.useMemo(() => recentProtectionDecisions(landing.activity, props.catalog, 3), [landing.activity, props.catalog]);
   async function runHealthCheck() {
     setHealthBusy(true);
     setHealthError(null);
@@ -2000,18 +2079,31 @@ function ProtectionLandingExperience(props) {
     }
   }
   return /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4", children: /* @__PURE__ */ jsxRuntimeExports.jsx(CloudValueGate, { runtime: landing.runtime, loading: landing.runtimeLoading, loadFailed: landing.runtimeError }) }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx(ProtectionCategoryGrid, { catalog: props.catalog, effective: props.effective }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      ProtectionWatchingMap,
+      {
+        catalog: props.catalog,
+        effective: props.effective,
+        inUseExtensionIds,
+        selectedId: selectedAreaId,
+        onSelect: (searchAlias, categoryId) => {
+          setSelectedAreaId(categoryId);
+          setAreaQuery(searchAlias);
+        }
+      }
+    ),
     /* @__PURE__ */ jsxRuntimeExports.jsx(
       ProtectionModuleExplorer,
       {
         modules,
         effective: props.effective,
         onOpen: props.onOpen,
+        focusQuery: areaQuery,
         advancedFilters: /* @__PURE__ */ jsxRuntimeExports.jsx(ExtensionsFilterBar, { filters: props.filters, onChange: props.onFilters, onClear: props.onClearFilters, extensions: props.catalog, effective: props.effective })
       }
     ),
     /* @__PURE__ */ jsxRuntimeExports.jsx(RecentProtectionDecisions, { decisions, loading: landing.activityLoading, unavailable: landing.activityError }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-8", children: /* @__PURE__ */ jsxRuntimeExports.jsx(CloudValueGate, { runtime: landing.runtime, loading: landing.runtimeLoading, loadFailed: landing.runtimeError }) }),
     /* @__PURE__ */ jsxRuntimeExports.jsx(ProtectionHealthCheckPanel, { result: healthResult, busy: healthBusy, error: healthError, onRun: () => {
       void runHealthCheck();
     } })
@@ -2887,8 +2979,9 @@ function ProtectionTestLab({ extension: extension2 }) {
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "grid size-10 shrink-0 place-items-center rounded-xl bg-violet-50 text-violet-700", "aria-hidden": "true", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniBeaker, { className: "size-5" }) }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { id: "protection-test-lab-heading", className: "text-lg font-semibold text-slate-950", children: "Test Lab" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm leading-6 text-slate-600", children: "See how Guard would handle a command without running it." })
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold uppercase tracking-[0.18em] text-brand-blue", children: "Try a command" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { id: "protection-test-lab-heading", className: "mt-1 text-lg font-semibold text-slate-950", children: "Test Lab" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm leading-6 text-slate-800", children: "See how Guard would handle a command without running it." })
       ] })
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-5 rounded-2xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-950", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-2", children: [
@@ -3381,33 +3474,33 @@ function ExtensionStatusBanner(props) {
   const repairable = props.effective.health === "tampered" || props.effective.health === "recovery-required" || props.effective.health === "degraded-unacknowledged";
   const busyLabel = props.effective.health === "degraded-unacknowledged" ? "Acknowledging…" : "Repairing…";
   return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-2xl border border-amber-200 bg-amber-50 p-5", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mt-0.5 inline-flex size-9 shrink-0 items-center justify-center rounded-full bg-amber-100 text-amber-700", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "size-5", "aria-hidden": "true" }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mt-0.5 inline-flex size-9 shrink-0 items-center justify-center rounded-full bg-amber-100 text-amber-800", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "size-5", "aria-hidden": "true" }) }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 flex-1", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { className: "font-semibold text-slate-950", children: recovery?.title }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm leading-6 text-slate-700", children: recovery?.description }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { className: "font-semibold text-amber-950", children: recovery?.title }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm leading-6 text-amber-950", children: recovery?.description }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 flex flex-wrap items-center gap-2", children: [
         repairable && props.onRecover ? /* @__PURE__ */ jsxRuntimeExports.jsxs("button", { type: "button", "aria-busy": props.busy, disabled: props.busy, onClick: props.onRecover, className: "inline-flex min-h-11 items-center gap-2 rounded-lg bg-brand-blue px-4 py-2 text-sm font-semibold text-white disabled:opacity-60", children: [
           props.busy ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "size-4 animate-spin motion-reduce:animate-none", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "size-4", "aria-hidden": "true" }),
           props.busy ? busyLabel : recovery?.actionLabel
         ] }) : null,
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("button", { type: "button", onClick: props.onRetry, className: "inline-flex min-h-11 items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("button", { type: "button", onClick: props.onRetry, className: "inline-flex min-h-11 items-center gap-2 rounded-lg border border-amber-300 bg-white px-3 py-2 text-sm font-semibold text-amber-950 hover:bg-amber-100", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "size-4", "aria-hidden": "true" }),
           "Check again"
         ] })
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 border-t border-amber-200 pt-3", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold uppercase tracking-wide text-slate-500", children: "Command-line fallback" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold uppercase tracking-wide text-amber-900", children: "Command-line fallback" }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-2 flex flex-col gap-2 sm:flex-row sm:items-center", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("code", { className: "min-w-0 flex-1 overflow-x-auto rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs text-slate-800", children: recovery?.command }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("button", { type: "button", onClick: handleCopy, className: "inline-flex min-h-11 shrink-0 items-center justify-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-brand-blue", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("code", { className: "min-w-0 flex-1 overflow-x-auto rounded-lg border border-amber-200 bg-white px-3 py-2 text-xs text-amber-950", children: recovery?.command }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("button", { type: "button", onClick: handleCopy, className: "inline-flex min-h-11 shrink-0 items-center justify-center gap-2 rounded-lg border border-amber-300 bg-white px-3 py-2 text-sm font-semibold text-brand-blue", children: [
             copyState === "copied" ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniClipboardDocumentCheck, { className: "size-4", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniClipboard, { className: "size-4", "aria-hidden": "true" }),
             copyState === "copied" ? "Copied" : recovery?.copyLabel
           ] })
         ] }),
-        copyState === "failed" ? /* @__PURE__ */ jsxRuntimeExports.jsx("span", { role: "status", className: "mt-2 block text-sm text-red-700", children: "Copy failed. Select the command above." }) : null
+        copyState === "failed" ? /* @__PURE__ */ jsxRuntimeExports.jsx("span", { role: "status", className: "mt-2 block text-sm text-red-800", children: "Copy failed. Select the command above." }) : null
       ] }),
-      props.error ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { role: "alert", className: "mt-3 text-sm font-medium text-red-700", children: props.error }) : null,
-      props.status ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { role: "status", className: "mt-3 text-sm font-medium text-slate-800", children: props.status }) : null
+      props.error ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { role: "alert", className: "mt-3 text-sm font-medium text-red-800", children: props.error }) : null,
+      props.status ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { role: "status", className: "mt-3 text-sm font-medium text-amber-950", children: props.status }) : null
     ] })
   ] }) });
 }
@@ -3429,21 +3522,21 @@ function ReviewModal(props) {
         /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-bold uppercase tracking-[0.18em] text-brand-blue", children: "Review protection change" }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { id: "protection-review-title", className: "mt-2 text-xl font-semibold text-slate-950", children: title })
       ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", disabled: props.busy, onClick: props.onCancel, "aria-label": "Close review", className: "grid size-11 place-items-center rounded-full text-slate-500 hover:bg-slate-100 disabled:opacity-50", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniXMark, { className: "size-5" }) })
+      /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", disabled: props.busy, onClick: props.onCancel, "aria-label": "Close review", className: "grid size-11 place-items-center rounded-full text-slate-950 hover:bg-slate-100 disabled:opacity-50", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniXMark, { className: "size-5" }) })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5 grid grid-cols-[1fr_auto_1fr] items-center gap-3 rounded-2xl bg-slate-50 p-4 text-sm", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-slate-500", children: "Current" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5 grid grid-cols-[1fr_auto_1fr] items-center gap-3 rounded-2xl bg-slate-100 p-4 text-sm text-slate-950", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Current" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("span", { "aria-hidden": "true", children: "→" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("strong", { className: "text-slate-950", children: "Requested" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("strong", { children: "Requested" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: current }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("span", {}),
       /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: requested })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-4 text-sm leading-6 text-slate-600", children: "Guard's built-in minimum safety rules and organization policy remain active. This change does not disable detection." }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-4 text-sm leading-6 text-slate-950", children: "Guard's built-in minimum safety rules and organization policy remain active. This change does not disable detection." }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-5", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ApprovalProofFieldInputs, { approvalGate: props.approvalGate, approvalPassword: password, approvalTotpCode: totp, onApprovalPasswordChange: (event) => setPassword(event.target.value), onApprovalTotpCodeChange: (event) => setTotp(event.target.value) }) }),
     props.error ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { role: "alert", className: "mt-4 rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800", children: props.error }) : null,
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-6 flex justify-end gap-3", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", disabled: props.busy, onClick: props.onCancel, className: "min-h-11 rounded-xl px-4 text-sm font-semibold text-slate-600 hover:bg-slate-100 disabled:opacity-50", children: "Cancel" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", disabled: props.busy, onClick: props.onCancel, className: "min-h-11 rounded-xl px-4 text-sm font-semibold text-slate-950 hover:bg-slate-100 disabled:opacity-50", children: "Cancel" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "submit", disabled: submitDisabled, className: "min-h-11 rounded-xl bg-brand-blue px-5 text-sm font-semibold text-white hover:bg-brand-dark disabled:opacity-60", children: props.busy ? "Verifying…" : "Confirm change" })
     ] })
   ] }) });
@@ -3579,11 +3672,15 @@ function ProtectionCenterWorkspace() {
     }
   }, [resolveApprovalGate, state]);
   if (state.kind === "loading") return /* @__PURE__ */ jsxRuntimeExports.jsx("main", { className: "grid min-h-[60vh] place-items-center", "aria-busy": "true", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "size-7 animate-spin text-brand-blue motion-reduce:animate-none", "aria-label": "Loading Protection Center" }) });
-  if (state.kind === "error") return /* @__PURE__ */ jsxRuntimeExports.jsx("main", { className: "mx-auto max-w-4xl p-6", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-3xl border border-red-200 bg-red-50 p-6", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("h1", { className: "text-xl font-semibold text-red-950", children: "Protection Center unavailable" }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { role: "alert", className: "mt-2 text-sm text-red-800", children: state.message }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", onClick: load, className: "mt-4 min-h-11 rounded-xl bg-red-700 px-4 text-sm font-semibold text-white", children: "Try again" })
-  ] }) });
+  if (state.kind === "error") {
+    const loadError = protectionCenterLoadError(state.message);
+    return /* @__PURE__ */ jsxRuntimeExports.jsx("main", { className: "mx-auto max-w-4xl p-6", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-3xl border border-red-200 bg-red-50 p-6", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("h1", { className: "text-xl font-semibold text-red-950", children: loadError.title }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { role: "alert", className: "mt-2 text-sm text-red-800", children: loadError.detail }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-3 text-xs font-medium text-red-900", children: "Local protection continues on this device." }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", onClick: load, className: "mt-4 min-h-11 rounded-xl bg-red-800 px-4 text-sm font-semibold text-white", children: "Try again" })
+    ] }) });
+  }
   const recoveryModal = recoveryApprovalOpen ? /* @__PURE__ */ jsxRuntimeExports.jsx(
     ApprovalProofModal,
     {
@@ -3641,9 +3738,12 @@ function ProtectionCenterWorkspace() {
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold uppercase tracking-[0.2em] text-brand-blue", children: "Local protection" }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("h1", { className: "mt-2 text-3xl font-semibold tracking-tight text-slate-950", children: PROTECTION_TERMS.pageTitle }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 max-w-2xl text-sm leading-6 text-slate-600", children: "See what Guard protects on this device, understand the current behavior, and make deliberate local changes without learning internal policy terminology." })
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 max-w-2xl text-sm leading-6 text-slate-800", children: "See what Guard is watching on this device, then open a tool to understand or change it." })
       ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(ProtectionDensityControl, { value: density, onChange: setDensity })
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("details", { className: "w-full max-w-sm", "data-testid": "protection-more-detail", open: density !== "simple", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("summary", { className: "cursor-pointer text-sm font-semibold text-slate-800", children: "More detail" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ProtectionDensityControl, { value: density, onChange: setDensity }) })
+      ] })
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-6", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ProtectionStatusHero, { status, busy: recoveryBusy, onPrimaryAction: status.primaryAction === "none" ? void 0 : handlePrimaryStatusAction, children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-600", children: "Cloud continuity is separate from local protection. Signing out or losing Cloud connectivity does not turn local protection off." }) }) }),
     mutationError && !pending ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4", children: /* @__PURE__ */ jsxRuntimeExports.jsx(InlineError, { message: mutationError }) }) : null,
@@ -3684,7 +3784,7 @@ function ProtectionCenterWorkspace() {
           " available"
         ] })
       ] }),
-      density !== "simple" ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ExtensionsFilterBar, { filters, onChange: (patch) => setFilters((previous) => ({ ...previous, ...patch })), onClear: () => setFilters(EMPTY_EXTENSION_FILTERS), extensions: catalogExtensions, effective: state.effective }) }) : null,
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ExtensionsFilterBar, { filters, onChange: (patch) => setFilters((previous) => ({ ...previous, ...patch })), onClear: () => setFilters(EMPTY_EXTENSION_FILTERS), extensions: catalogExtensions, effective: state.effective }) }),
       visible.length ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 space-y-2", children: visible.map((extension2) => /* @__PURE__ */ jsxRuntimeExports.jsx(
         ProtectionModuleRow,
         {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -1877,6 +1877,10 @@
     border-color: var(--color-slate-100);
   }
 
+  :where(.divide-slate-200 > :not(:last-child)) {
+    border-color: var(--color-slate-200);
+  }
+
   .self-center {
     align-self: center;
   }
@@ -3433,6 +3437,10 @@
 
   .bg-red-700 {
     background-color: var(--color-red-700);
+  }
+
+  .bg-red-800 {
+    background-color: var(--color-red-800);
   }
 
   .bg-rose-50 {
@@ -5440,6 +5448,10 @@
 
     .hover\:bg-amber-50:hover {
       background-color: var(--color-amber-50);
+    }
+
+    .hover\:bg-amber-100:hover {
+      background-color: var(--color-amber-100);
     }
 
     .hover\:bg-blue-50:hover {


### PR DESCRIPTION
## Summary
- Protection Center now leads with a ranked Watching map of in-use tools instead of a grid of identical category cards.
- Simple landing hides density controls behind More detail, keeps search and a compact recent-decisions strip, and treats Cloud as continuity rather than the source of local protection.
- Unauthorized loads use human copy that never implies this device is unprotected. Test Lab keeps a Try a command eyebrow without changing the Test Lab heading.

## Testing
- `cd dashboard && bun test src/protection-center/protection-landing.test.tsx src/protection-center/protection-center.test.tsx src/protection-center/protection-cloud-value.test.tsx src/protection-center/protection-final-a11y.test.tsx src/protection-center/protection-test-lab.test.tsx src/protection-center/protection-terminology.test.tsx src/protection-center/protection-module-detail.test.tsx src/extensions-workspace.test.ts`
- `cd dashboard && bun run build`
