### PR TITLE
fix(ci): publish 3.0 alphas when a merged PR never emits push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,14 +28,14 @@ on:
     branches: [main, release/3.0]
   pull_request:
     branches: [main, release/3.0]
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, labeled, closed]
 
 permissions:
   contents: read
   pull-requests: read
 
 concurrency:
-  group: hol-guard-publish-${{ github.ref }}
+  group: hol-guard-publish-${{ github.event.pull_request.merged && format('refs/heads/{0}', github.event.pull_request.base.ref) || github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -79,9 +79,10 @@ jobs:
   build:
     name: Build + Verify
     if: >-
+      (github.event.action != 'closed' || github.event.pull_request.merged) &&
       (github.event_name != 'workflow_dispatch' || github.run_attempt == 1) &&
       (github.event_name != 'push' || github.run_attempt == 1) &&
-      (github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip release publish]')) &&
+      (github.event_name != 'push' || !contains(github.event.head_commit.message || '', '[skip release publish]')) &&
       (github.event.action != 'labeled' || github.event.label.name == 'publish-testpypi-canary')
     needs: authorize-release
     runs-on: ubuntu-latest
@@ -94,7 +95,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ (github.event.pull_request.merged && github.event.pull_request.merge_commit_sha) || (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.12"
@@ -120,7 +121,13 @@ jobs:
           GITHUB_REF: ${{ github.ref }}
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_EVENT_ACTION: ${{ github.event.action }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
           GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
           GITHUB_ACTOR_ID: ${{ github.actor_id }}
@@ -200,18 +207,25 @@ jobs:
           print(f"{os.environ['BASE_VERSION']}.dev{pair(pair(int(os.environ['PR_NUMBER']), int(os.environ['GITHUB_RUN_NUMBER'])), int(os.environ['GITHUB_RUN_ATTEMPT']))}")
           PY
             )
-          elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/release/3.0" ]]; then
+          elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/release/3.0" ]] || [[ "$GITHUB_EVENT_NAME" == "pull_request" && "$GITHUB_EVENT_ACTION" == "closed" && "$PR_MERGED" == "true" && "$PR_BASE_REF" == "release/3.0" && "$PR_HEAD_REPO" == "$GITHUB_REPOSITORY" && -n "$PR_MERGE_SHA" ]]; then
             if [[ "$RELEASE_PUBLISHING_ENABLED" != "true" ]]; then
               echo "Release publishing is disabled until protected environments are verified" >&2
               exit 1
             fi
-            if [[ "$SOURCE_SHA" != "$GITHUB_SHA" ]]; then
-              echo "Checked-out source does not match the immutable push source" >&2
+            TRAIN="3.0"
+            TRAIN_REF="refs/heads/release/${TRAIN}"
+            ACTUAL_REF="$GITHUB_REF"
+            EXPECTED_SOURCE="$GITHUB_SHA"
+            if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+              SOURCE_SHA="$PR_MERGE_SHA"
+              EXPECTED_SOURCE="$PR_MERGE_SHA"
+              ACTUAL_REF="$TRAIN_REF"
+            fi
+            if [[ "$SOURCE_SHA" != "$EXPECTED_SOURCE" ]]; then
+              echo "Checked-out source does not match the immutable release source" >&2
               exit 1
             fi
             CHANNEL="alpha"
-            TRAIN="3.0"
-            TRAIN_REF="refs/heads/release/${TRAIN}"
             PYPI_VERSIONS=$(uv run --no-sync python scripts/verify_release_registry.py \
               list-versions --registry pypi)
             TESTPYPI_VERSIONS=$(uv run --no-sync python scripts/verify_release_registry.py \
@@ -247,7 +261,7 @@ jobs:
               --channel "$CHANNEL"
               --version "$RELEASE_VERSION"
               --git-ref "$TRAIN_REF"
-              --actual-ref "$GITHUB_REF"
+              --actual-ref "$ACTUAL_REF"
               --github-sha "$SOURCE_SHA"
               --expected-sha "$SOURCE_SHA"
             )
@@ -398,7 +412,7 @@ jobs:
         (
           needs.build.outputs.channel == 'alpha' &&
           (
-            (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0') ||
+            (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0') || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged && github.event.pull_request.base.ref == 'release/3.0' && github.event.pull_request.head.repo.full_name == github.repository) ||
             (github.event_name == 'workflow_dispatch' && github.event.inputs.release_train == '3.0')
           )
         )
@@ -764,7 +778,7 @@ jobs:
       needs.build.outputs.channel == 'alpha' &&
       (
         (github.event_name == 'workflow_dispatch' && github.run_attempt == 1) ||
-        (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0')
+        (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0') || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged && github.event.pull_request.base.ref == 'release/3.0' && github.event.pull_request.head.repo.full_name == github.repository)
       )
     needs: [build]
     runs-on: ubuntu-latest
@@ -821,7 +835,7 @@ jobs:
       needs.build.outputs.channel == 'alpha' &&
       (
         (github.event_name == 'workflow_dispatch' && github.run_attempt == 1) ||
-        (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0')
+        (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0') || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged && github.event.pull_request.base.ref == 'release/3.0' && github.event.pull_request.head.repo.full_name == github.repository)
       )
     needs: [build, reserve-alpha-tag, assemble-native-guard-distributions]
     runs-on: ubuntu-latest
@@ -926,7 +940,7 @@ jobs:
       needs.build.outputs.channel == 'alpha' &&
       (
         (github.event_name == 'workflow_dispatch' && github.run_attempt == 1) ||
-        (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0')
+        (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0') || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged && github.event.pull_request.base.ref == 'release/3.0' && github.event.pull_request.head.repo.full_name == github.repository)
       )
     needs: [build, reserve-alpha-tag, assemble-native-guard-distributions]
     runs-on: ubuntu-latest
@@ -1367,7 +1381,7 @@ jobs:
       needs.build.outputs.channel == 'alpha' &&
       (
         (github.event_name == 'workflow_dispatch' && github.run_attempt == 1) ||
-        (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0')
+        (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0') || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged && github.event.pull_request.base.ref == 'release/3.0' && github.event.pull_request.head.repo.full_name == github.repository)
       )
     needs: [build, publish-alpha-pypi]
     runs-on: ubuntu-latest
@@ -1476,7 +1490,7 @@ jobs:
         (
           (
             (github.event_name == 'workflow_dispatch' && github.run_attempt == 1) ||
-            (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0')
+            (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0') || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged && github.event.pull_request.base.ref == 'release/3.0' && github.event.pull_request.head.repo.full_name == github.repository)
           ) &&
           needs.build.outputs.channel == 'alpha' &&
           needs.publish-alpha-pypi.result == 'success' &&

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14635,
+  "maximum_collected_cases": 14636,
   "maximum_test_source_lines": 317605,
   "schema_version": 1
 }

--- a/tests/test_pr_testpypi_canary_workflow.py
+++ b/tests/test_pr_testpypi_canary_workflow.py
@@ -13,7 +13,7 @@ def test_pr_canary_requires_maintainer_opt_in_for_same_repository_prs() -> None:
 
     assert workflow[True]["pull_request"] == {
         "branches": ["main", "release/3.0"],
-        "types": ["opened", "synchronize", "reopened", "labeled"],
+        "types": ["opened", "synchronize", "reopened", "labeled", "closed"],
     }
     assert workflow["permissions"] == {"contents": "read", "pull-requests": "read"}
     job = workflow["jobs"]["publish-testpypi"]

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -38,6 +38,13 @@ def test_release_branches_run_ci_and_pr_canaries() -> None:
     assert ci[True]["pull_request"]["branches"] == PR_CANARY_BRANCHES
     assert publish[True]["push"]["branches"] == RELEASE_BRANCHES
     assert publish[True]["pull_request"]["branches"] == PR_CANARY_BRANCHES
+    assert publish[True]["pull_request"]["types"] == [
+        "opened",
+        "synchronize",
+        "reopened",
+        "labeled",
+        "closed",
+    ]
     assert "tags" not in publish[True]["push"]
 
 
@@ -55,6 +62,9 @@ def test_release_branch_pushes_publish_alpha_while_main_pushes_publish_stable() 
         assert "github.event_name == 'workflow_dispatch'" in condition
         assert "github.event_name == 'push'" in condition
         assert "github.ref == 'refs/heads/release/3.0'" in condition
+        assert "github.event.action == 'closed'" in condition
+        assert "github.event.pull_request.merged" in condition
+        assert "github.event.pull_request.base.ref == 'release/3.0'" in condition
     for job_name in ("publish-main-testpypi", "publish-main-pypi", "release-main"):
         condition = jobs[job_name]["if"]
         assert "github.event_name == 'push'" in condition
@@ -80,7 +90,11 @@ def test_main_push_build_computes_a_registry_derived_stable_version() -> None:
 
     assert 'VERSION="$BASE_VERSION"' in compute_run
     assert 'elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/release/3.0" ]]' in compute_run
-    assert 'SOURCE_SHA" != "$GITHUB_SHA"' in compute_run
+    assert "pull_request" in compute_run
+    assert "PR_MERGE_SHA" in compute_run
+    assert 'SOURCE_SHA="$PR_MERGE_SHA"' in compute_run
+    assert 'ACTUAL_REF="$TRAIN_REF"' in compute_run
+    assert 'SOURCE_SHA" != "$EXPECTED_SOURCE"' in compute_run
     assert 'TRAIN="3.0"' in compute_run
     assert "compute_alpha_release_version.py" in compute_run
     assert "validate_alpha_release.py" in compute_run
@@ -475,5 +489,26 @@ def test_release_push_can_be_explicitly_suppressed_by_merge_marker() -> None:
     condition = workflow["jobs"]["build"]["if"]
 
     assert "github.event_name != 'push'" in condition
-    assert "github.event.head_commit.message" in condition
+    assert "github.event.head_commit.message || ''" in condition
     assert "[skip release publish]" in condition
+    assert "github.event.action != 'closed'" in workflow["jobs"]["build"]["if"]
+    assert "github.event.pull_request.merged" in workflow["jobs"]["build"]["if"]
+
+
+def test_release_merged_same_repo_pr_publishes_alpha_when_push_is_missing() -> None:
+    workflow = _workflow(PUBLISH_WORKFLOW)
+    jobs = workflow["jobs"]
+    workflow_text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "closed" in workflow[True]["pull_request"]["types"]
+    assert "github.event.pull_request.merge_commit_sha" in workflow_text
+    assert "hol-guard-publish-${{ github.event.pull_request.merged && format('refs/heads/{0}', github.event.pull_request.base.ref) || github.ref }}" in workflow_text
+    for job_name in (
+        "reserve-alpha-tag",
+        "publish-alpha-testpypi",
+        "publish-alpha-pypi",
+        "release-alpha",
+    ):
+        condition = jobs[job_name]["if"]
+        assert "github.event.action == 'closed'" in condition
+        assert "github.event.pull_request.head.repo.full_name == github.repository" in condition


### PR DESCRIPTION
## Summary
- Alpha publish now also runs when a same-repo PR is merged into `release/3.0`, using the merge commit SHA, so a missing `push` webhook cannot skip the alpha.
- Skip-publish detection treats a missing `head_commit.message` as empty instead of failing the whole build condition closed.
- Merged-PR publishes share the `release/3.0` concurrency group with branch pushes. Unmerged `closed` events do not build.

## Testing
- `uv run pytest -q tests/test_release_train_workflow.py`

## Notes
- This does not change the dashboard itself. Merging it onto `release/3.0` should cut the next alpha from HEAD, which already includes the Protection Center Watching map.
