### PR TITLE
feat(secrets): finalize V2 evidence contracts and release claim gate

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-    "maximum_collected_cases": 14806,
-    "maximum_test_source_lines": 319330,
-    "schema_version": 1
+  "maximum_collected_cases": 14828,
+  "maximum_test_source_lines": 319525,
+  "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14773,
-  "maximum_test_source_lines": 319230,
-  "schema_version": 1
+    "maximum_collected_cases": 14773,
+    "maximum_test_source_lines": 319230,
+    "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14780,
-  "maximum_test_source_lines": 319273,
+  "maximum_collected_cases": 14806,
+  "maximum_test_source_lines": 319330,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14778,
-  "maximum_test_source_lines": 319263,
-  "schema_version": 1
+    "maximum_collected_cases": 14778,
+    "maximum_test_source_lines": 319263,
+    "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-    "maximum_collected_cases": 14773,
-    "maximum_test_source_lines": 319230,
-    "schema_version": 1
+  "maximum_collected_cases": 14778,
+  "maximum_test_source_lines": 319263,
+  "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14686,
-  "maximum_test_source_lines": 318138,
+  "maximum_collected_cases": 14762,
+  "maximum_test_source_lines": 319157,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-    "maximum_collected_cases": 14778,
-    "maximum_test_source_lines": 319263,
-    "schema_version": 1
+  "maximum_collected_cases": 14780,
+  "maximum_test_source_lines": 319273,
+  "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-    "maximum_collected_cases": 14828,
-    "maximum_test_source_lines": 319525,
-    "schema_version": 1
+  "maximum_collected_cases": 14856,
+  "maximum_test_source_lines": 319649,
+  "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14764,
-  "maximum_test_source_lines": 319201,
+  "maximum_collected_cases": 14773,
+  "maximum_test_source_lines": 319230,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14828,
-  "maximum_test_source_lines": 319525,
-  "schema_version": 1
+    "maximum_collected_cases": 14828,
+    "maximum_test_source_lines": 319525,
+    "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14762,
-  "maximum_test_source_lines": 319157,
+  "maximum_collected_cases": 14764,
+  "maximum_test_source_lines": 319201,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14806,
-  "maximum_test_source_lines": 319330,
-  "schema_version": 1
+    "maximum_collected_cases": 14806,
+    "maximum_test_source_lines": 319330,
+    "schema_version": 1
 }

--- a/docs/guard/contracts/guard-secrets-capability-evidence.v2.json
+++ b/docs/guard/contracts/guard-secrets-capability-evidence.v2.json
@@ -1,0 +1,345 @@
+{
+  "schema": "guard-secrets-capability-evidence.v2",
+  "generated_at": "2026-08-14",
+  "parity_states": [
+    "unmapped",
+    "designed",
+    "implemented",
+    "tested",
+    "verified_on_release_candidate",
+    "generally_available"
+  ],
+  "claim_policy": {
+    "public_parity_requires": "verified_on_release_candidate",
+    "exact_release_commit_required": true,
+    "remaining_gaps_must_be_labeled": true,
+    "public_parity_claim_enabled": false,
+    "required_capabilities": [
+      "contextual_classification",
+      "unpatterned_credentials",
+      "source_configuration_files",
+      "custom_rules",
+      "ide_prevention",
+      "cli_precommit",
+      "pull_request_checks",
+      "scheduled_scm_ci",
+      "unified_reporting",
+      "organizational_mttr",
+      "centralized_ignore_approval"
+    ]
+  },
+  "capabilities": [
+    {
+      "capability_id": "contextual_classification",
+      "product_boundary": "shared-detection",
+      "surfaces": [
+        "local",
+        "github"
+      ],
+      "plans": [
+        "free",
+        "solo",
+        "pro",
+        "team"
+      ],
+      "owner": "hol-guard",
+      "state": "tested",
+      "acceptance_tests": [
+        "tests/test_guard_secret_detection.py",
+        "tests/test_guard_secret_fixture_precision.py"
+      ],
+      "evidence_artifacts": [],
+      "release_commit": null,
+      "gap_label": "deterministic-context-v1; calibrated model remains gated"
+    },
+    {
+      "capability_id": "unpatterned_credentials",
+      "product_boundary": "shared-detection",
+      "surfaces": [
+        "local",
+        "github"
+      ],
+      "plans": [
+        "free",
+        "solo",
+        "pro",
+        "team"
+      ],
+      "owner": "hol-guard",
+      "state": "tested",
+      "acceptance_tests": [
+        "tests/test_guard_secret_detection.py"
+      ],
+      "evidence_artifacts": [],
+      "release_commit": null,
+      "gap_label": "benchmark certification pending"
+    },
+    {
+      "capability_id": "source_configuration_files",
+      "product_boundary": "shared-detection",
+      "surfaces": [
+        "working_tree",
+        "staged",
+        "history"
+      ],
+      "plans": [
+        "free",
+        "solo",
+        "pro",
+        "team"
+      ],
+      "owner": "hol-guard",
+      "state": "tested",
+      "acceptance_tests": [
+        "tests/test_guard_secret_detection.py",
+        "tests/test_guard_secret_staged_scanner.py"
+      ],
+      "evidence_artifacts": [],
+      "release_commit": null,
+      "gap_label": "archive and binary expansion pending"
+    },
+    {
+      "capability_id": "custom_rules",
+      "product_boundary": "individual-plus",
+      "surfaces": [
+        "local",
+        "github"
+      ],
+      "plans": [
+        "free",
+        "solo",
+        "pro",
+        "team"
+      ],
+      "owner": "cross-repo",
+      "state": "implemented",
+      "acceptance_tests": [
+        "__tests__/guard-secret-monitoring-contract.test.ts"
+      ],
+      "evidence_artifacts": [],
+      "release_commit": null,
+      "gap_label": "cross-surface versioning and governance pending"
+    },
+    {
+      "capability_id": "ide_prevention",
+      "product_boundary": "shared-detection",
+      "surfaces": [
+        "ide"
+      ],
+      "plans": [
+        "free",
+        "solo",
+        "pro",
+        "team"
+      ],
+      "owner": "hol-guard",
+      "state": "designed",
+      "acceptance_tests": [],
+      "evidence_artifacts": [],
+      "release_commit": null,
+      "gap_label": "production adapters pending"
+    },
+    {
+      "capability_id": "cli_precommit",
+      "product_boundary": "free-local",
+      "surfaces": [
+        "cli",
+        "pre_commit"
+      ],
+      "plans": [
+        "free",
+        "solo",
+        "pro",
+        "team"
+      ],
+      "owner": "hol-guard",
+      "state": "tested",
+      "acceptance_tests": [
+        "tests/test_guard_secrets_native_cli.py"
+      ],
+      "evidence_artifacts": [],
+      "release_commit": null,
+      "gap_label": "benchmark and platform certification pending"
+    },
+    {
+      "capability_id": "pull_request_checks",
+      "product_boundary": "cloud-monitoring",
+      "surfaces": [
+        "github_check",
+        "pull_request"
+      ],
+      "plans": [
+        "solo",
+        "pro",
+        "team"
+      ],
+      "owner": "points-portal",
+      "state": "tested",
+      "acceptance_tests": [
+        "__tests__/guard-secret-github-acceptance.test.ts"
+      ],
+      "evidence_artifacts": [],
+      "release_commit": null,
+      "gap_label": "exact release-candidate E2E pending"
+    },
+    {
+      "capability_id": "scheduled_scm_ci",
+      "product_boundary": "cloud-monitoring",
+      "surfaces": [
+        "github",
+        "scheduler"
+      ],
+      "plans": [
+        "solo",
+        "pro",
+        "team"
+      ],
+      "owner": "points-portal",
+      "state": "implemented",
+      "acceptance_tests": [
+        "__tests__/guard-secret-monitoring-contract.test.ts"
+      ],
+      "evidence_artifacts": [],
+      "release_commit": null,
+      "gap_label": "multi-SCM adapters pending"
+    },
+    {
+      "capability_id": "unified_reporting",
+      "product_boundary": "cloud-reporting",
+      "surfaces": [
+        "portal",
+        "api",
+        "export"
+      ],
+      "plans": [
+        "solo",
+        "pro",
+        "team"
+      ],
+      "owner": "points-portal",
+      "state": "tested",
+      "acceptance_tests": [
+        "__tests__/guard-secret-domain-api.test.ts",
+        "__tests__/guard-secret-evidence-contract.test.ts"
+      ],
+      "evidence_artifacts": [],
+      "release_commit": null,
+      "gap_label": "organization reporting certification pending"
+    },
+    {
+      "capability_id": "organizational_mttr",
+      "product_boundary": "organization-operations",
+      "surfaces": [
+        "portal",
+        "api"
+      ],
+      "plans": [
+        "pro",
+        "team"
+      ],
+      "owner": "points-portal",
+      "state": "designed",
+      "acceptance_tests": [],
+      "evidence_artifacts": [],
+      "release_commit": null,
+      "gap_label": "censored-open and recurrence metrics pending"
+    },
+    {
+      "capability_id": "centralized_ignore_approval",
+      "product_boundary": "organization-governance",
+      "surfaces": [
+        "portal",
+        "policy"
+      ],
+      "plans": [
+        "pro",
+        "team"
+      ],
+      "owner": "points-portal",
+      "state": "designed",
+      "acceptance_tests": [],
+      "evidence_artifacts": [],
+      "release_commit": null,
+      "gap_label": "approval workflow pending"
+    },
+    {
+      "capability_id": "every_commit_monitoring",
+      "product_boundary": "cloud-monitoring",
+      "surfaces": [
+        "github_push"
+      ],
+      "plans": [
+        "solo",
+        "pro",
+        "team"
+      ],
+      "owner": "points-portal",
+      "state": "tested",
+      "acceptance_tests": [
+        "__tests__/guard-secret-github-acceptance.test.ts"
+      ],
+      "evidence_artifacts": [],
+      "release_commit": null,
+      "gap_label": "lost-webhook freshness certification pending"
+    },
+    {
+      "capability_id": "external_routing",
+      "product_boundary": "organization-operations",
+      "surfaces": [
+        "slack",
+        "pagerduty",
+        "jira",
+        "notion",
+        "webhook"
+      ],
+      "plans": [
+        "pro",
+        "team"
+      ],
+      "owner": "points-portal",
+      "state": "designed",
+      "acceptance_tests": [],
+      "evidence_artifacts": [],
+      "release_commit": null,
+      "gap_label": "secret-specific payload builders and E2E pending"
+    },
+    {
+      "capability_id": "prevalence_intelligence",
+      "product_boundary": "exposure-intelligence",
+      "surfaces": [
+        "public_intelligence"
+      ],
+      "plans": [
+        "pro",
+        "team"
+      ],
+      "owner": "cross-repo",
+      "state": "designed",
+      "acceptance_tests": [],
+      "evidence_artifacts": [],
+      "release_commit": null,
+      "gap_label": "privacy-reviewed approximate and exact protocols pending"
+    },
+    {
+      "capability_id": "external_public_audit",
+      "product_boundary": "public-funnel",
+      "surfaces": [
+        "public_leak_check"
+      ],
+      "plans": [
+        "free",
+        "solo",
+        "pro",
+        "team"
+      ],
+      "owner": "points-portal",
+      "state": "implemented",
+      "acceptance_tests": [
+        "__tests__/guard-public-leak-check.test.ts"
+      ],
+      "evidence_artifacts": [],
+      "release_commit": null,
+      "gap_label": "ownership detail and anti-enumeration E2E certification pending"
+    }
+  ]
+}

--- a/docs/guard/contracts/guard-secrets-product-boundaries.v2.json
+++ b/docs/guard/contracts/guard-secrets-product-boundaries.v2.json
@@ -1,0 +1,195 @@
+{
+  "schema": "guard-secrets-product-boundaries.v2",
+  "plans": {
+    "free": {
+      "local_scan": true,
+      "staged_precommit": true,
+      "agent_runtime": true,
+      "public_aggregate": true,
+      "private_repositories": 0,
+      "private_repositories_mode": "fixed",
+      "external_routing": false,
+      "governed_ignores": false,
+      "governed_ignores_enforced": false
+    },
+    "solo": {
+      "local_scan": true,
+      "staged_precommit": true,
+      "agent_runtime": true,
+      "public_aggregate": true,
+      "private_repositories": 5,
+      "private_repositories_mode": "fixed",
+      "external_routing": false,
+      "governed_ignores": false,
+      "governed_ignores_enforced": false
+    },
+    "pro": {
+      "local_scan": true,
+      "staged_precommit": true,
+      "agent_runtime": true,
+      "public_aggregate": true,
+      "private_repositories": 5,
+      "private_repositories_mode": "configurable_above_solo",
+      "external_routing": true,
+      "governed_ignores": true,
+      "governed_ignores_enforced": false
+    },
+    "team": {
+      "local_scan": true,
+      "staged_precommit": true,
+      "agent_runtime": true,
+      "public_aggregate": true,
+      "private_repositories": 5,
+      "private_repositories_mode": "policy",
+      "external_routing": true,
+      "governed_ignores": true,
+      "governed_ignores_enforced": true
+    }
+  },
+  "surface_values": [
+    "api",
+    "cli",
+    "export",
+    "github",
+    "github_check",
+    "github_push",
+    "history",
+    "ide",
+    "jira",
+    "local",
+    "notion",
+    "pagerduty",
+    "policy",
+    "portal",
+    "pre_commit",
+    "public_intelligence",
+    "public_leak_check",
+    "pull_request",
+    "scheduler",
+    "slack",
+    "staged",
+    "webhook",
+    "working_tree"
+  ],
+  "product_boundaries": {
+    "shared-detection": {
+      "allowed_plans": [
+        "free",
+        "solo",
+        "pro",
+        "team"
+      ],
+      "allowed_surfaces": [
+        "cli",
+        "github",
+        "history",
+        "ide",
+        "local",
+        "pre_commit",
+        "staged",
+        "working_tree"
+      ]
+    },
+    "individual-plus": {
+      "allowed_plans": [
+        "free",
+        "solo",
+        "pro",
+        "team"
+      ],
+      "allowed_surfaces": [
+        "github",
+        "local"
+      ]
+    },
+    "free-local": {
+      "allowed_plans": [
+        "free",
+        "solo",
+        "pro",
+        "team"
+      ],
+      "allowed_surfaces": [
+        "cli",
+        "pre_commit"
+      ]
+    },
+    "cloud-monitoring": {
+      "allowed_plans": [
+        "solo",
+        "pro",
+        "team"
+      ],
+      "allowed_surfaces": [
+        "github",
+        "github_check",
+        "github_push",
+        "pull_request",
+        "scheduler"
+      ]
+    },
+    "cloud-reporting": {
+      "allowed_plans": [
+        "solo",
+        "pro",
+        "team"
+      ],
+      "allowed_surfaces": [
+        "api",
+        "export",
+        "portal"
+      ]
+    },
+    "organization-operations": {
+      "allowed_plans": [
+        "pro",
+        "team"
+      ],
+      "allowed_surfaces": [
+        "api",
+        "jira",
+        "notion",
+        "pagerduty",
+        "portal",
+        "slack",
+        "webhook"
+      ]
+    },
+    "organization-governance": {
+      "allowed_plans": [
+        "pro",
+        "team"
+      ],
+      "allowed_surfaces": [
+        "policy",
+        "portal"
+      ]
+    },
+    "exposure-intelligence": {
+      "allowed_plans": [
+        "pro",
+        "team"
+      ],
+      "allowed_surfaces": [
+        "public_intelligence"
+      ]
+    },
+    "public-funnel": {
+      "allowed_plans": [
+        "free",
+        "solo",
+        "pro",
+        "team"
+      ],
+      "allowed_surfaces": [
+        "public_leak_check"
+      ]
+    }
+  },
+  "invariants": [
+    "local_detection_unmetered",
+    "cloud_outage_does_not_disable_local",
+    "solo_does_not_receive_general_external_routing",
+    "team_governance_remains_server_authoritative"
+  ]
+}

--- a/docs/guard/contracts/guard-secrets-reason-codes.v2.json
+++ b/docs/guard/contracts/guard-secrets-reason-codes.v2.json
@@ -1,0 +1,40 @@
+{
+  "schema": "guard-secrets-reason-codes.v2",
+  "categories": {
+    "coverage": [
+      "archive_budget_exceeded",
+      "binary_skipped",
+      "encoding_unsupported",
+      "file_changed_during_scan",
+      "git_object_missing",
+      "history_shallow",
+      "lfs_object_missing",
+      "max_bytes",
+      "max_commits",
+      "max_files",
+      "max_findings",
+      "source_unreadable"
+    ],
+    "detector": [
+      "detector_bundle_invalid",
+      "detector_unavailable",
+      "model_bundle_invalid",
+      "model_degraded"
+    ],
+    "validation": [
+      "validation_error",
+      "validation_rate_limited",
+      "validation_unknown",
+      "validation_unsupported"
+    ],
+    "policy": ["policy_block", "policy_refresh_required"],
+    "worker": ["cleanup_failed", "worker_cancelled", "worker_timeout"],
+    "cache": ["cache_stale"]
+  },
+  "rules": {
+    "stable": true,
+    "non_sensitive": true,
+    "unknown_codes_fail_closed": true,
+    "raw_exception_text_forbidden": true
+  }
+}

--- a/docs/guard/contracts/guard-secrets-source-capabilities.v2.json
+++ b/docs/guard/contracts/guard-secrets-source-capabilities.v2.json
@@ -1,0 +1,97 @@
+{
+  "schema": "guard-secrets-source-capabilities.v2",
+  "status_values": [
+    "supported",
+    "partial",
+    "planned",
+    "unsupported"
+  ],
+  "file_classes": {
+    "source_code": "supported",
+    "environment_files": "supported",
+    "configuration_files": "supported",
+    "property_files": "supported",
+    "documentation": "partial",
+    "generated_code": "partial",
+    "lockfiles": "partial",
+    "archives": "planned",
+    "binary_executables": "planned",
+    "mobile_bundles": "planned",
+    "container_layers": "planned",
+    "notebooks": "planned"
+  },
+  "encodings": {
+    "utf8": "supported",
+    "utf8_bom": "supported",
+    "ascii": "supported",
+    "utf16": "planned",
+    "base64_literals": "planned",
+    "hex_literals": "planned",
+    "url_encoding": "planned",
+    "escaped_strings": "partial",
+    "nested_encoding": "planned"
+  },
+  "archives": {
+    "zip": "planned",
+    "tar": "planned",
+    "gzip": "planned",
+    "jar": "planned",
+    "wheel": "planned",
+    "npm_package": "planned"
+  },
+  "git_modes": {
+    "working_tree": "supported",
+    "staged_index": "supported",
+    "bounded_history": "supported",
+    "commit_range": "partial",
+    "all_reachable_refs": "planned",
+    "shallow_clone_detection": "partial",
+    "lfs_pointer_detection": "planned",
+    "submodule_metadata": "planned",
+    "worktrees": "partial",
+    "alternates": "planned",
+    "replace_refs": "planned"
+  },
+  "scm_events": {
+    "github_push": "supported",
+    "github_pull_request": "supported",
+    "github_scheduled": "partial",
+    "gitlab_push": "planned",
+    "gitlab_merge_request": "planned",
+    "bitbucket_push": "planned",
+    "azure_devops_push": "planned"
+  },
+  "editors": {
+    "vscode": "planned",
+    "jetbrains": "planned",
+    "lsp": "planned"
+  },
+  "operating_systems": {
+    "linux": "supported",
+    "macos": "supported",
+    "windows": "supported"
+  },
+  "validators": {
+    "github": "supported",
+    "gitlab": "supported",
+    "aws": "supported",
+    "slack": "supported",
+    "stripe": "supported",
+    "openai": "supported",
+    "anthropic": "supported",
+    "huggingface": "supported",
+    "npm": "supported",
+    "pypi": "supported",
+    "google": "supported",
+    "sendgrid": "supported"
+  },
+  "notification_providers": {
+    "github_checks": "supported",
+    "email_safety_notice": "partial",
+    "slack": "planned",
+    "pagerduty": "planned",
+    "jira": "planned",
+    "notion": "planned",
+    "signed_webhook": "planned"
+  }
+}

--- a/docs/guard/contracts/guard-secrets-v2-exact-head-validation-20260814.md
+++ b/docs/guard/contracts/guard-secrets-v2-exact-head-validation-20260814.md
@@ -1,0 +1,7 @@
+# HOL Guard Secrets V2 exact-head validation boundary
+
+The pull-request head is release-eligible only when the dependency-free release preflight, contract and release-gate tests, release-toolchain tests, Ruff, basedpyright, test-suite ratchet, Security Gates, CodeQL, cross-platform contracts, packaging checks, and protected publish preflight all succeed on the same commit.
+
+Coverage is fail-closed for skipped work, truncation, degradation, scanner errors, empty requested-reference sets, and incomplete requested-reference coverage. These states cannot be represented as clean. Serializable evidence recursively rejects raw credentials, raw-value fields, source content, prompts, tool output, authorization material, provider response bodies, and absolute local paths.
+
+Public parity remains disabled unless the checked-in policy explicitly enables it and every required capability has exact release-commit evidence at the declared minimum state.

--- a/docs/guard/contracts/guard-secrets-v2-final-validation.md
+++ b/docs/guard/contracts/guard-secrets-v2-final-validation.md
@@ -1,0 +1,7 @@
+# HOL Guard Secrets V2 final validation requirements
+
+The exact pull-request head must pass the protected release preflight before dependency installation, the focused V2 contract and claim-gate tests, the release-toolchain tests, Ruff, basedpyright, the test-suite ratchet, Security Gates, CodeQL, cross-platform tests, and package build checks.
+
+The contract is fail-closed for skipped work, truncation, degradation, errors, empty requested-reference sets, and incomplete requested-reference coverage. None of those states may produce a clean outcome. Raw-value key spellings and all other prohibited sensitive payload fields are rejected recursively before serialization.
+
+Public parity remains disabled unless the checked-in claim policy explicitly enables it and exact release-commit evidence satisfies every required capability at the declared minimum state.

--- a/docs/guard/contracts/guard-secrets-v2-rebuilt-exact-head.md
+++ b/docs/guard/contracts/guard-secrets-v2-rebuilt-exact-head.md
@@ -1,0 +1,3 @@
+# HOL Guard Secrets V2 rebuilt exact-head validation
+
+This commit triggers the repository's authoritative pull-request checks after the V2 contracts were rebuilt from the latest `release/3.0` base and validated with the dependency-free release preflight, focused contract and release-toolchain tests, Ruff, basedpyright, and the exact test inventory.

--- a/docs/guard/contracts/guard-secrets-v2-regression-evidence.md
+++ b/docs/guard/contracts/guard-secrets-v2-regression-evidence.md
@@ -1,0 +1,12 @@
+# HOL Guard Secrets V2 false-clean regression evidence
+
+The V2 coverage contract rejects a clean result when any requested work is missing or ambiguous. The exact pull-request head is required to prove all of the following through executable tests:
+
+- raw-value field spellings are rejected at direct and nested serialization boundaries;
+- skipped work requires an explicit partial result and cannot be clean;
+- an empty requested-reference set requires an explicit partial result and cannot be clean;
+- non-partial coverage must complete every requested reference;
+- truncation, degradation, scanner errors, and incomplete reference coverage remain fail-closed;
+- the dependency-free release preflight validates all authoritative manifests before dependency installation and records the successful gate digest and exact source commit in the release toolchain SBOM.
+
+This document contains no raw credentials, source excerpts, local absolute paths, prompts, tool output, provider response bodies, or authorization material.

--- a/docs/guard/contracts/guard-secrets-v2-validation.md
+++ b/docs/guard/contracts/guard-secrets-v2-validation.md
@@ -1,0 +1,9 @@
+# HOL Guard Secrets V2 validation boundary
+
+This document records the executable release boundary for the versioned Secrets contracts.
+
+A public parity claim is denied unless the checked-in capability policy enables it and every required capability has exact release-commit evidence at or above the declared minimum state. The release preflight loads the dependency-free contract module directly, validates the capability, product-boundary, source-capability, and reason-code manifests, and records the successful gate command digest and source commit in the release toolchain SBOM.
+
+Coverage is fail-closed. Clean is invalid when work is partial, degraded, truncated, skipped, errored, has no requested references, or has not completed every requested reference. Serializable evidence rejects raw credentials, raw values, source content, prompts, tool output, authorization material, provider response bodies, and absolute local paths.
+
+The authoritative checks are the focused V2 contract and release-gate tests, the release-toolchain tests, Ruff, basedpyright, the test-suite ratchet, Security Gates, CodeQL, cross-platform tests, and the protected publish preflight on the exact pull-request head.

--- a/scripts/ci/guard_secrets_release_claim_gate.py
+++ b/scripts/ci/guard_secrets_release_claim_gate.py
@@ -77,6 +77,7 @@ def _contract_api() -> tuple[
     Callable[[Mapping[str, object]], _CapabilityManifest],
     Callable[[Mapping[str, object]], object],
     Callable[[Mapping[str, object]], object],
+    Callable[[Mapping[str, object]], object],
     _CapabilityValidator,
 ]:
     module = _load_contracts_module()
@@ -94,6 +95,10 @@ def _contract_api() -> tuple[
         cast(
             Callable[[Mapping[str, object]], object],
             _symbol(module, "parse_source_capabilities_manifest"),
+        ),
+        cast(
+            Callable[[Mapping[str, object]], object],
+            _symbol(module, "parse_reason_codes_manifest"),
         ),
         cast(
             _CapabilityValidator,
@@ -119,6 +124,7 @@ def validate_manifest(
     *,
     product_boundary_payload: Mapping[str, object],
     source_capability_payload: Mapping[str, object],
+    reason_code_payload: Mapping[str, object],
     exact_release_commit: str | None,
     require_parity: bool,
     required_capabilities: frozenset[str],
@@ -131,6 +137,7 @@ def validate_manifest(
         parse_capability_evidence_manifest,
         parse_product_boundaries_manifest,
         parse_source_capabilities_manifest,
+        parse_reason_codes_manifest,
         validate_capability_manifest,
     ) = _contract_api()
 
@@ -142,6 +149,7 @@ def validate_manifest(
     try:
         _ = parse_product_boundaries_manifest(product_boundary_payload)
         _ = parse_source_capabilities_manifest(source_capability_payload)
+        _ = parse_reason_codes_manifest(reason_code_payload)
         manifest = parse_capability_evidence_manifest(capability_payload)
     except secret_contract_error as error:
         raise ClaimGateError(str(error)) from error
@@ -181,6 +189,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--manifest", type=Path, required=True)
     parser.add_argument("--product-boundaries", type=Path, required=True)
     parser.add_argument("--source-capabilities", type=Path, required=True)
+    parser.add_argument("--reason-codes", type=Path, required=True)
     parser.add_argument("--release-commit", required=True)
     parser.add_argument("--require-parity", action="store_true")
     parser.add_argument("--required-capability", action="append", default=[])
@@ -196,6 +205,7 @@ def main(argv: list[str] | None = None) -> int:
             load_manifest(args.manifest),
             product_boundary_payload=load_manifest(args.product_boundaries),
             source_capability_payload=load_manifest(args.source_capabilities),
+            reason_code_payload=load_manifest(args.reason_codes),
             exact_release_commit=args.release_commit,
             require_parity=args.require_parity,
             required_capabilities=frozenset(args.required_capability),

--- a/scripts/ci/guard_secrets_release_claim_gate.py
+++ b/scripts/ci/guard_secrets_release_claim_gate.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Validate HOL Guard Secrets evidence before any protected publication path."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from types import ModuleType
+from typing import Protocol, cast
+
+
+class ClaimGateError(ValueError):
+    """Raised when release-gate input cannot be interpreted safely."""
+
+
+class _CapabilityManifest(Protocol):
+    """Runtime shape returned by the directly loaded V2 contract module."""
+
+    required_capability_ids: frozenset[str]
+    public_parity_claim_enabled: bool
+    row_errors: tuple[str, ...]
+    capabilities: Sequence[object]
+    public_parity_requires: object
+
+
+class _CapabilityValidator(Protocol):
+    def __call__(
+        self,
+        capabilities: Sequence[object],
+        *,
+        required_capability_ids: frozenset[str],
+        exact_release_commit: str,
+        minimum_state: object,
+    ) -> None: ...
+
+
+_CONTRACTS_PATH = Path(__file__).resolve().parents[2] / "src/codex_plugin_scanner/guard/secrets/contracts_v2.py"
+_CONTRACTS_MODULE_NAME = "_hol_guard_secrets_contracts_v2"
+
+
+def _load_contracts_module() -> ModuleType:
+    """Load the dependency-free contract module without importing package initializers."""
+
+    existing = sys.modules.get(_CONTRACTS_MODULE_NAME)
+    if isinstance(existing, ModuleType):
+        return existing
+    spec = importlib.util.spec_from_file_location(
+        _CONTRACTS_MODULE_NAME,
+        _CONTRACTS_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise ClaimGateError(f"unable to load Secrets contracts from {_CONTRACTS_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception as error:
+        sys.modules.pop(spec.name, None)
+        raise ClaimGateError(f"unable to load Secrets contracts: {error}") from error
+    return module
+
+
+def _symbol(module: ModuleType, name: str) -> object:
+    try:
+        return getattr(module, name)
+    except AttributeError as error:
+        raise ClaimGateError(f"Secrets contracts do not export {name}") from error
+
+
+def _contract_api() -> tuple[
+    type[Exception],
+    Callable[[str], bool],
+    Callable[[Mapping[str, object]], _CapabilityManifest],
+    Callable[[Mapping[str, object]], object],
+    Callable[[Mapping[str, object]], object],
+    _CapabilityValidator,
+]:
+    module = _load_contracts_module()
+    return (
+        cast(type[Exception], _symbol(module, "SecretContractError")),
+        cast(Callable[[str], bool], _symbol(module, "is_exact_commit_sha")),
+        cast(
+            Callable[[Mapping[str, object]], _CapabilityManifest],
+            _symbol(module, "parse_capability_evidence_manifest"),
+        ),
+        cast(
+            Callable[[Mapping[str, object]], object],
+            _symbol(module, "parse_product_boundaries_manifest"),
+        ),
+        cast(
+            Callable[[Mapping[str, object]], object],
+            _symbol(module, "parse_source_capabilities_manifest"),
+        ),
+        cast(
+            _CapabilityValidator,
+            _symbol(module, "validate_capability_manifest"),
+        ),
+    )
+
+
+def _mapping(value: object, *, label: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise ClaimGateError(f"{label} must be an object")
+    return cast(Mapping[str, object], value)
+
+
+def load_manifest(path: Path) -> Mapping[str, object]:
+    """Load a JSON manifest without weakening runtime schema validation."""
+
+    return _mapping(json.loads(path.read_text(encoding="utf-8")), label=str(path))
+
+
+def validate_manifest(
+    capability_payload: Mapping[str, object],
+    *,
+    product_boundary_payload: Mapping[str, object],
+    source_capability_payload: Mapping[str, object],
+    exact_release_commit: str | None,
+    require_parity: bool,
+    required_capabilities: frozenset[str],
+) -> tuple[str, ...]:
+    """Validate all authoritative manifests and optional exact parity evidence."""
+
+    (
+        secret_contract_error,
+        is_exact_commit_sha,
+        parse_capability_evidence_manifest,
+        parse_product_boundaries_manifest,
+        parse_source_capabilities_manifest,
+        validate_capability_manifest,
+    ) = _contract_api()
+
+    if exact_release_commit is None:
+        raise ClaimGateError("release validation requires an exact release commit")
+    if not is_exact_commit_sha(exact_release_commit):
+        raise ClaimGateError("exact release commit must be a full lowercase SHA")
+
+    try:
+        _ = parse_product_boundaries_manifest(product_boundary_payload)
+        _ = parse_source_capabilities_manifest(source_capability_payload)
+        manifest = parse_capability_evidence_manifest(capability_payload)
+    except secret_contract_error as error:
+        raise ClaimGateError(str(error)) from error
+
+    if required_capabilities != manifest.required_capability_ids:
+        missing = sorted(manifest.required_capability_ids - required_capabilities)
+        extra = sorted(required_capabilities - manifest.required_capability_ids)
+        parts: list[str] = []
+        if missing:
+            parts.append(f"missing: {', '.join(missing)}")
+        if extra:
+            parts.append(f"unexpected: {', '.join(extra)}")
+        detail = "; ".join(parts) or "mismatch"
+        raise ClaimGateError(f"required capability list does not match claim policy ({detail})")
+
+    if require_parity != manifest.public_parity_claim_enabled:
+        if manifest.public_parity_claim_enabled:
+            raise ClaimGateError("claim policy enables public parity; --require-parity cannot be omitted")
+        raise ClaimGateError("claim policy disables public parity; --require-parity is not authorized")
+
+    errors = list(manifest.row_errors)
+    if require_parity and not errors:
+        try:
+            validate_capability_manifest(
+                manifest.capabilities,
+                required_capability_ids=manifest.required_capability_ids,
+                exact_release_commit=exact_release_commit,
+                minimum_state=manifest.public_parity_requires,
+            )
+        except secret_contract_error as error:
+            errors.append(str(error))
+    return tuple(errors)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--product-boundaries", type=Path, required=True)
+    parser.add_argument("--source-capabilities", type=Path, required=True)
+    parser.add_argument("--release-commit", required=True)
+    parser.add_argument("--require-parity", action="store_true")
+    parser.add_argument("--required-capability", action="append", default=[])
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the gate with stable success, validation, and input exit codes."""
+
+    args = _parse_args(argv)
+    try:
+        errors = validate_manifest(
+            load_manifest(args.manifest),
+            product_boundary_payload=load_manifest(args.product_boundaries),
+            source_capability_payload=load_manifest(args.source_capabilities),
+            exact_release_commit=args.release_commit,
+            require_parity=args.require_parity,
+            required_capabilities=frozenset(args.required_capability),
+        )
+    except (ClaimGateError, json.JSONDecodeError, OSError) as error:
+        print(f"guard-secrets-claim-gate: {error}", file=sys.stderr)
+        return 2
+    for error in errors:
+        print(f"guard-secrets-claim-gate: {error}", file=sys.stderr)
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/write_release_toolchain_sbom.py
+++ b/scripts/write_release_toolchain_sbom.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Verify uv and write a CycloneDX release-toolchain SBOM."""
+"""Verify release tooling, enforce Secrets claims, and write a toolchain SBOM."""
 
 from __future__ import annotations
 
@@ -10,13 +10,20 @@ import re
 import shutil
 import subprocess
 import sys
+from collections.abc import Mapping, Sequence
 from pathlib import Path
+from typing import cast
 
 _UV_VERSION_OUTPUT = re.compile(r"^uv\s+(?P<version>\d+\.\d+\.\d+)(?:\s+.*)?$")
+_GIT_COMMIT = re.compile(r"^[a-f0-9]{40}$")
+_CAPABILITY_MANIFEST = Path("docs/guard/contracts/guard-secrets-capability-evidence.v2.json")
+_PRODUCT_BOUNDARIES_MANIFEST = Path("docs/guard/contracts/guard-secrets-product-boundaries.v2.json")
+_SOURCE_CAPABILITIES_MANIFEST = Path("docs/guard/contracts/guard-secrets-source-capabilities.v2.json")
+_CLAIM_GATE = Path("scripts/ci/guard_secrets_release_claim_gate.py")
 
 
 class ToolchainVerificationError(RuntimeError):
-    """Raised when the installed release toolchain is not the reviewed toolchain."""
+    """Raised when release tooling or claim evidence is not reviewed and exact."""
 
 
 def _sha256(path: Path) -> str:
@@ -42,6 +49,112 @@ def _installed_uv_version(executable: Path) -> str:
     return match.group("version")
 
 
+def _mapping(value: object, *, label: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise ToolchainVerificationError(f"{label} must be an object")
+    return cast(Mapping[str, object], value)
+
+
+def _string_list(value: object, *, label: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or not value or any(not isinstance(item, str) for item in value):
+        raise ToolchainVerificationError(f"{label} must be a non-empty array of strings")
+    result = tuple(cast(list[str], value))
+    if len(set(result)) != len(result):
+        raise ToolchainVerificationError(f"{label} must contain unique values")
+    return result
+
+
+def resolve_release_commit(repository_root: Path) -> str:
+    """Resolve the exact checked-out commit used by the protected build job."""
+
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD^{commit}"],
+        cwd=repository_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    commit = result.stdout.strip()
+    if result.returncode != 0 or _GIT_COMMIT.fullmatch(commit) is None:
+        detail = result.stderr.strip() or "git did not return a canonical commit"
+        raise ToolchainVerificationError(f"unable to resolve release commit: {detail}")
+    return commit
+
+
+def build_guard_secrets_claim_gate_command(
+    *,
+    repository_root: Path,
+    release_commit: str,
+    python_executable: str = sys.executable,
+) -> tuple[str, ...]:
+    """Build the complete fail-closed Secrets gate command from checked-in policy."""
+
+    if _GIT_COMMIT.fullmatch(release_commit) is None:
+        raise ToolchainVerificationError("release commit must be a full lowercase SHA")
+    capability_path = repository_root / _CAPABILITY_MANIFEST
+    try:
+        capability_payload = _mapping(
+            json.loads(capability_path.read_text(encoding="utf-8")),
+            label=str(_CAPABILITY_MANIFEST),
+        )
+    except (json.JSONDecodeError, OSError) as error:
+        raise ToolchainVerificationError(f"unable to read Secrets capability policy: {error}") from error
+    policy = _mapping(capability_payload.get("claim_policy"), label="claim_policy")
+    required_capabilities = _string_list(
+        policy.get("required_capabilities"),
+        label="claim_policy.required_capabilities",
+    )
+    public_parity_enabled = policy.get("public_parity_claim_enabled")
+    if not isinstance(public_parity_enabled, bool):
+        raise ToolchainVerificationError("claim_policy.public_parity_claim_enabled must be boolean")
+
+    command: list[str] = [
+        python_executable,
+        str(repository_root / _CLAIM_GATE),
+        "--manifest",
+        str(capability_path),
+        "--product-boundaries",
+        str(repository_root / _PRODUCT_BOUNDARIES_MANIFEST),
+        "--source-capabilities",
+        str(repository_root / _SOURCE_CAPABILITIES_MANIFEST),
+        "--release-commit",
+        release_commit,
+    ]
+    if public_parity_enabled:
+        command.append("--require-parity")
+    for capability_id in required_capabilities:
+        command.extend(("--required-capability", capability_id))
+    return tuple(command)
+
+
+def run_guard_secrets_claim_gate(
+    *,
+    repository_root: Path,
+    release_commit: str,
+    python_executable: str = sys.executable,
+) -> tuple[str, ...]:
+    """Run the exact checked-in claim gate before release tooling can succeed."""
+
+    command = build_guard_secrets_claim_gate_command(
+        repository_root=repository_root,
+        release_commit=release_commit,
+        python_executable=python_executable,
+    )
+    result = subprocess.run(
+        command,
+        cwd=repository_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "no diagnostic output"
+        raise ToolchainVerificationError(
+            f"HOL Guard Secrets release claim gate failed with exit code {result.returncode}: {detail}"
+        )
+    return command
+
+
 def write_release_toolchain_sbom(
     *,
     output: Path,
@@ -49,6 +162,8 @@ def write_release_toolchain_sbom(
     expected_uv_version: str,
     setup_action_ref: str,
     uv_executable: Path | None = None,
+    claim_gate_command: Sequence[str] = (),
+    release_commit: str | None = None,
 ) -> dict[str, object]:
     """Verify the exact uv runtime and persist its digest as CycloneDX."""
 
@@ -64,6 +179,25 @@ def write_release_toolchain_sbom(
         raise ToolchainVerificationError(
             f"uv version mismatch: expected {expected_uv_version}, received {actual_uv_version}"
         )
+
+    properties: list[dict[str, str]] = [
+        {"name": "hol-guard:installer-action", "value": "astral-sh/setup-uv"},
+        {"name": "hol-guard:installer-action-ref", "value": setup_action_ref},
+    ]
+    if claim_gate_command:
+        properties.extend(
+            (
+                {"name": "hol-guard:secrets-claim-gate", "value": "passed"},
+                {
+                    "name": "hol-guard:secrets-claim-gate-command-sha256",
+                    "value": hashlib.sha256("\0".join(claim_gate_command).encode("utf-8")).hexdigest(),
+                },
+            )
+        )
+    if release_commit is not None:
+        if _GIT_COMMIT.fullmatch(release_commit) is None:
+            raise ToolchainVerificationError("release commit must be a full lowercase SHA")
+        properties.append({"name": "hol-guard:source-commit", "value": release_commit})
 
     payload: dict[str, object] = {
         "bomFormat": "CycloneDX",
@@ -82,10 +216,7 @@ def write_release_toolchain_sbom(
                 "name": "uv",
                 "version": actual_uv_version,
                 "hashes": [{"alg": "SHA-256", "content": _sha256(resolved_executable)}],
-                "properties": [
-                    {"name": "hol-guard:installer-action", "value": "astral-sh/setup-uv"},
-                    {"name": "hol-guard:installer-action-ref", "value": setup_action_ref},
-                ],
+                "properties": properties,
             }
         ],
     }
@@ -101,18 +232,31 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser.add_argument("--expected-uv-version", required=True)
     parser.add_argument("--setup-action-ref", required=True)
     parser.add_argument("--uv-executable", type=Path)
+    parser.add_argument("--repository-root", type=Path)
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
+    repository_root = (
+        args.repository_root.resolve(strict=True)
+        if args.repository_root is not None
+        else Path(__file__).resolve().parents[1]
+    )
     try:
+        release_commit = resolve_release_commit(repository_root)
+        claim_gate_command = run_guard_secrets_claim_gate(
+            repository_root=repository_root,
+            release_commit=release_commit,
+        )
         write_release_toolchain_sbom(
             output=args.output,
             release_version=args.release_version,
             expected_uv_version=args.expected_uv_version,
             setup_action_ref=args.setup_action_ref,
             uv_executable=args.uv_executable,
+            claim_gate_command=claim_gate_command,
+            release_commit=release_commit,
         )
     except (OSError, ToolchainVerificationError) as exc:
         print(f"Release toolchain verification failed: {exc}", file=sys.stderr)

--- a/scripts/write_release_toolchain_sbom.py
+++ b/scripts/write_release_toolchain_sbom.py
@@ -19,6 +19,7 @@ _GIT_COMMIT = re.compile(r"^[a-f0-9]{40}$")
 _CAPABILITY_MANIFEST = Path("docs/guard/contracts/guard-secrets-capability-evidence.v2.json")
 _PRODUCT_BOUNDARIES_MANIFEST = Path("docs/guard/contracts/guard-secrets-product-boundaries.v2.json")
 _SOURCE_CAPABILITIES_MANIFEST = Path("docs/guard/contracts/guard-secrets-source-capabilities.v2.json")
+_REASON_CODES_MANIFEST = Path("docs/guard/contracts/guard-secrets-reason-codes.v2.json")
 _CLAIM_GATE = Path("scripts/ci/guard_secrets_release_claim_gate.py")
 
 
@@ -117,6 +118,8 @@ def build_guard_secrets_claim_gate_command(
         str(repository_root / _PRODUCT_BOUNDARIES_MANIFEST),
         "--source-capabilities",
         str(repository_root / _SOURCE_CAPABILITIES_MANIFEST),
+        "--reason-codes",
+        str(repository_root / _REASON_CODES_MANIFEST),
         "--release-commit",
         release_commit,
     ]

--- a/src/codex_plugin_scanner/guard/secrets/contracts_v2.py
+++ b/src/codex_plugin_scanner/guard/secrets/contracts_v2.py
@@ -1,0 +1,1373 @@
+"""Versioned cross-surface contracts for HOL Guard Secrets.
+
+The contracts in this module are dependency-free so the same semantics can be
+used by the local CLI, hooks, IDE bridge, isolated workers, and release evidence
+tooling. Serializable forms are strict and explicitly exclude raw credential
+material and arbitrary source context.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from types import MappingProxyType
+from typing import Final, cast
+
+
+class SecretContractError(ValueError):
+    """Raised when an external Secrets contract is invalid or unsafe."""
+
+
+class ParityState(str, Enum):
+    """Evidence state for one public capability claim."""
+
+    UNMAPPED = "unmapped"
+    DESIGNED = "designed"
+    IMPLEMENTED = "implemented"
+    TESTED = "tested"
+    VERIFIED_ON_RELEASE_CANDIDATE = "verified_on_release_candidate"
+    GENERALLY_AVAILABLE = "generally_available"
+
+
+class PreventionOutcome(str, Enum):
+    """Canonical cross-surface prevention outcomes."""
+
+    CLEAN = "clean"
+    WARN = "warn"
+    SOFT_BLOCK = "soft_block"
+    POLICY_BLOCK = "policy_block"
+    PARTIAL = "partial"
+    DEGRADED = "degraded"
+    ERROR = "error"
+
+
+class SecretClass(str, Enum):
+    """Canonical candidate classification labels."""
+
+    REAL = "real"
+    PLACEHOLDER_OR_EXAMPLE = "placeholder_or_example"
+    WEAK_OR_AMBIGUOUS = "weak_or_ambiguous"
+    UNKNOWN = "unknown"
+
+
+class SecretValidity(str, Enum):
+    """Safe normalized result of optional credential validation."""
+
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+    UNKNOWN = "unknown"
+    UNSUPPORTED = "unsupported"
+    RATE_LIMITED = "rate_limited"
+    ERROR = "error"
+
+
+class SecretExposure(str, Enum):
+    """Normalized exposure surface for one occurrence."""
+
+    LOCAL_ONLY = "local_only"
+    PRIVATE_REPOSITORY = "private_repository"
+    PUBLIC_REPOSITORY = "public_repository"
+    PUBLIC_EXTERNAL_SURFACE = "public_external_surface"
+    UNKNOWN = "unknown"
+
+
+class SecretLifecycle(str, Enum):
+    """Canonical logical-finding lifecycle."""
+
+    NEW = "new"
+    TRIAGED = "triaged"
+    REMEDIATING = "remediating"
+    AWAITING_REVERIFICATION = "awaiting_reverification"
+    RESOLVED = "resolved"
+    SUPPRESSED = "suppressed"
+    REOPENED = "reopened"
+
+
+class SecretIgnoreScope(str, Enum):
+    """Supported exact suppression scopes."""
+
+    OCCURRENCE = "occurrence"
+    SECRET_IDENTITY = "secret_identity"
+    PATH_HASH = "path_hash"
+    DETECTOR = "detector"
+    FIXTURE = "fixture"
+    REPOSITORY = "repository"
+    LOCAL_WORKSPACE = "local_workspace"
+
+
+class SecretIgnoreState(str, Enum):
+    """Lifecycle states for an ignore decision."""
+
+    REQUESTED = "requested"
+    APPROVED = "approved"
+    DENIED = "denied"
+    CHANGES_REQUESTED = "changes_requested"
+    REVOKED = "revoked"
+    EXPIRED = "expired"
+
+
+class SecretRuleMatcherKind(str, Enum):
+    """Bounded declarative custom-rule matcher kinds."""
+
+    PREFIX = "prefix"
+    REGEX = "regex"
+    ASSIGNMENT = "assignment"
+    STRUCTURED = "structured"
+
+
+class SecretRuleCompileState(str, Enum):
+    """Safe custom-rule compilation states."""
+
+    PENDING = "pending"
+    VALID = "valid"
+    INVALID = "invalid"
+    TOO_COMPLEX = "too_complex"
+
+
+class SecretRolloutState(str, Enum):
+    """Versioned custom-rule rollout states."""
+
+    DRAFT = "draft"
+    SHADOW = "shadow"
+    CANARY = "canary"
+    ACTIVE = "active"
+    REVOKED = "revoked"
+
+
+class SourceCapabilityStatus(str, Enum):
+    """Stable support states used by the source-capability manifest."""
+
+    SUPPORTED = "supported"
+    PARTIAL = "partial"
+    PLANNED = "planned"
+    UNSUPPORTED = "unsupported"
+
+
+_ACTIVE_IGNORE_STATES: Final = frozenset(
+    {
+        SecretIgnoreState.REQUESTED,
+        SecretIgnoreState.APPROVED,
+        SecretIgnoreState.CHANGES_REQUESTED,
+    }
+)
+_PROHIBITED_KEY = re.compile(
+    r"(?:^|_)(?:raw_?secret|candidate(?:_value)?|credential(?:_value)?|"
+    r"secret_?value|token_?value|source_(?:line|content|excerpt)|prompt|"
+    r"tool_(?:output|result)|environment_?value|auth(?:orization)?_?header|"
+    r"provider_?response(?:_body)?|absolute_?path)(?:$|_)",
+    re.IGNORECASE,
+)
+_SECRET_LIKE_PATTERNS: Final[tuple[re.Pattern[str], ...]] = (
+    re.compile(r"\b(?:gh[pousr]_[A-Za-z0-9_]{20,255}|github_pat_[A-Za-z0-9_]{20,255})\b"),
+    re.compile(r"\bglpat-[A-Za-z0-9_-]{20,255}\b"),
+    re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b"),
+    re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,255}\b"),
+    re.compile(r"https://hooks\.slack\.com/services/[A-Za-z0-9/_-]{24,255}"),
+    re.compile(r"\b(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{16,255}\b"),
+    re.compile(r"\bsk-(?:(?:proj|svcacct|ant)-)?[A-Za-z0-9_-]{20,255}\b"),
+    re.compile(r"\bhf_[A-Za-z0-9]{24,255}\b"),
+    re.compile(r"\bnpm_[A-Za-z0-9]{30,255}\b"),
+    re.compile(r"\bpypi-[A-Za-z0-9_-]{24,255}\b"),
+    re.compile(r"\bAIza[0-9A-Za-z_-]{35}\b"),
+    re.compile(r"\bSG\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}\b"),
+    re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----"),
+    re.compile(r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b"),
+    re.compile(r"(?i)\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis|https?)://[^\s:/@]+:[^\s/@]{6,}@"),
+    re.compile(
+        r"(?i)\b(?:api[_-]?key|access[_-]?token|auth[_-]?token|password|passwd|"
+        r"private[_-]?key|secret|token)\s*[:=]\s*[\"']?[^\s\"']{16,}"
+    ),
+)
+_CONTROL_CHARACTERS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+_DIGEST = re.compile(r"^[a-f0-9]{64}$")
+_COMMIT_SHA = re.compile(r"^[a-f0-9]{40}$")
+_IDENTIFIER = re.compile(r"^[A-Za-z0-9_.:@/-]{1,160}$")
+_SCHEMA_COVERAGE: Final = "guard-secret-coverage.v2"
+_SCHEMA_IGNORE: Final = "guard-secret-ignore-decision.v2"
+_SCHEMA_RULE: Final = "guard-secret-custom-rule.v2"
+_SCHEMA_CAPABILITY_EVIDENCE: Final = "guard-secrets-capability-evidence.v2"
+_SCHEMA_PRODUCT_BOUNDARIES: Final = "guard-secrets-product-boundaries.v2"
+_SCHEMA_SOURCE_CAPABILITIES: Final = "guard-secrets-source-capabilities.v2"
+
+PARITY_STATES_V2: Final[tuple[str, ...]] = tuple(state.value for state in ParityState)
+SOURCE_CAPABILITY_STATUS_VALUES_V2: Final[tuple[str, ...]] = tuple(state.value for state in SourceCapabilityStatus)
+_RELEASE_STATES: Final = frozenset(
+    {
+        ParityState.VERIFIED_ON_RELEASE_CANDIDATE,
+        ParityState.GENERALLY_AVAILABLE,
+    }
+)
+_PARITY_STATE_RANK: Final = {state: index for index, state in enumerate(ParityState)}
+
+REASON_CODES_V2: Final[frozenset[str]] = frozenset(
+    {
+        "archive_budget_exceeded",
+        "binary_skipped",
+        "cache_stale",
+        "cleanup_failed",
+        "detector_bundle_invalid",
+        "detector_unavailable",
+        "encoding_unsupported",
+        "file_changed_during_scan",
+        "git_object_missing",
+        "history_shallow",
+        "lfs_object_missing",
+        "max_bytes",
+        "max_commits",
+        "max_files",
+        "max_findings",
+        "model_bundle_invalid",
+        "model_degraded",
+        "policy_block",
+        "policy_refresh_required",
+        "source_unreadable",
+        "validation_error",
+        "validation_rate_limited",
+        "validation_unknown",
+        "validation_unsupported",
+        "worker_cancelled",
+        "worker_timeout",
+    }
+)
+IGNORE_REASON_CODES_V2: Final[frozenset[str]] = frozenset(
+    {
+        "approved_fixture",
+        "duplicate_finding",
+        "false_positive",
+        "historical_decision",
+        "known_public_value",
+        "non_secret_identifier",
+        "pending_review",
+        "policy_exception",
+        "revoked_credential",
+        "test_fixture",
+    }
+)
+FIXTURE_JUSTIFICATION_CODES_V2: Final[frozenset[str]] = frozenset(
+    {
+        "fixture_is_public_example",
+        "fixture_is_redacted",
+        "fixture_is_revoked",
+        "fixture_is_synthetic",
+    }
+)
+
+_PLAN_POLICIES_MUTABLE: dict[str, dict[str, object]] = {
+    "free": {
+        "local_scan": True,
+        "staged_precommit": True,
+        "agent_runtime": True,
+        "public_aggregate": True,
+        "private_repositories": 0,
+        "private_repositories_mode": "fixed",
+        "external_routing": False,
+        "governed_ignores": False,
+        "governed_ignores_enforced": False,
+    },
+    "solo": {
+        "local_scan": True,
+        "staged_precommit": True,
+        "agent_runtime": True,
+        "public_aggregate": True,
+        "private_repositories": 5,
+        "private_repositories_mode": "fixed",
+        "external_routing": False,
+        "governed_ignores": False,
+        "governed_ignores_enforced": False,
+    },
+    "pro": {
+        "local_scan": True,
+        "staged_precommit": True,
+        "agent_runtime": True,
+        "public_aggregate": True,
+        "private_repositories": 5,
+        "private_repositories_mode": "configurable_above_solo",
+        "external_routing": True,
+        "governed_ignores": True,
+        "governed_ignores_enforced": False,
+    },
+    "team": {
+        "local_scan": True,
+        "staged_precommit": True,
+        "agent_runtime": True,
+        "public_aggregate": True,
+        "private_repositories": 5,
+        "private_repositories_mode": "policy",
+        "external_routing": True,
+        "governed_ignores": True,
+        "governed_ignores_enforced": True,
+    },
+}
+PLAN_POLICIES_V2: Final[Mapping[str, Mapping[str, object]]] = MappingProxyType(
+    {plan: MappingProxyType(dict(policy)) for plan, policy in _PLAN_POLICIES_MUTABLE.items()}
+)
+
+_PRODUCT_BOUNDARIES_MUTABLE: dict[str, dict[str, tuple[str, ...]]] = {
+    "shared-detection": {
+        "allowed_plans": ("free", "solo", "pro", "team"),
+        "allowed_surfaces": (
+            "cli",
+            "github",
+            "history",
+            "ide",
+            "local",
+            "pre_commit",
+            "staged",
+            "working_tree",
+        ),
+    },
+    "individual-plus": {
+        "allowed_plans": ("free", "solo", "pro", "team"),
+        "allowed_surfaces": ("github", "local"),
+    },
+    "free-local": {
+        "allowed_plans": ("free", "solo", "pro", "team"),
+        "allowed_surfaces": ("cli", "pre_commit"),
+    },
+    "cloud-monitoring": {
+        "allowed_plans": ("solo", "pro", "team"),
+        "allowed_surfaces": ("github", "github_check", "github_push", "pull_request", "scheduler"),
+    },
+    "cloud-reporting": {
+        "allowed_plans": ("solo", "pro", "team"),
+        "allowed_surfaces": ("api", "export", "portal"),
+    },
+    "organization-operations": {
+        "allowed_plans": ("pro", "team"),
+        "allowed_surfaces": ("api", "jira", "notion", "pagerduty", "portal", "slack", "webhook"),
+    },
+    "organization-governance": {
+        "allowed_plans": ("pro", "team"),
+        "allowed_surfaces": ("policy", "portal"),
+    },
+    "exposure-intelligence": {
+        "allowed_plans": ("pro", "team"),
+        "allowed_surfaces": ("public_intelligence",),
+    },
+    "public-funnel": {
+        "allowed_plans": ("free", "solo", "pro", "team"),
+        "allowed_surfaces": ("public_leak_check",),
+    },
+}
+PRODUCT_BOUNDARIES_V2: Final[Mapping[str, Mapping[str, tuple[str, ...]]]] = MappingProxyType(
+    {boundary: MappingProxyType(dict(policy)) for boundary, policy in _PRODUCT_BOUNDARIES_MUTABLE.items()}
+)
+PRODUCT_SURFACES_V2: Final[tuple[str, ...]] = tuple(
+    sorted({surface for policy in _PRODUCT_BOUNDARIES_MUTABLE.values() for surface in policy["allowed_surfaces"]})
+)
+PRODUCT_INVARIANTS_V2: Final[tuple[str, ...]] = (
+    "local_detection_unmetered",
+    "cloud_outage_does_not_disable_local",
+    "solo_does_not_receive_general_external_routing",
+    "team_governance_remains_server_authoritative",
+)
+
+_SOURCE_CAPABILITY_SECTIONS_MUTABLE: dict[str, dict[str, str]] = {
+    "file_classes": {
+        "source_code": "supported",
+        "environment_files": "supported",
+        "configuration_files": "supported",
+        "property_files": "supported",
+        "documentation": "partial",
+        "generated_code": "partial",
+        "lockfiles": "partial",
+        "archives": "planned",
+        "binary_executables": "planned",
+        "mobile_bundles": "planned",
+        "container_layers": "planned",
+        "notebooks": "planned",
+    },
+    "encodings": {
+        "utf8": "supported",
+        "utf8_bom": "supported",
+        "ascii": "supported",
+        "utf16": "planned",
+        "base64_literals": "planned",
+        "hex_literals": "planned",
+        "url_encoding": "planned",
+        "escaped_strings": "partial",
+        "nested_encoding": "planned",
+    },
+    "archives": {
+        "zip": "planned",
+        "tar": "planned",
+        "gzip": "planned",
+        "jar": "planned",
+        "wheel": "planned",
+        "npm_package": "planned",
+    },
+    "git_modes": {
+        "working_tree": "supported",
+        "staged_index": "supported",
+        "bounded_history": "supported",
+        "commit_range": "partial",
+        "all_reachable_refs": "planned",
+        "shallow_clone_detection": "partial",
+        "lfs_pointer_detection": "planned",
+        "submodule_metadata": "planned",
+        "worktrees": "partial",
+        "alternates": "planned",
+        "replace_refs": "planned",
+    },
+    "scm_events": {
+        "github_push": "supported",
+        "github_pull_request": "supported",
+        "github_scheduled": "partial",
+        "gitlab_push": "planned",
+        "gitlab_merge_request": "planned",
+        "bitbucket_push": "planned",
+        "azure_devops_push": "planned",
+    },
+    "editors": {"vscode": "planned", "jetbrains": "planned", "lsp": "planned"},
+    "operating_systems": {"linux": "supported", "macos": "supported", "windows": "supported"},
+    "validators": {
+        "github": "supported",
+        "gitlab": "supported",
+        "aws": "supported",
+        "slack": "supported",
+        "stripe": "supported",
+        "openai": "supported",
+        "anthropic": "supported",
+        "huggingface": "supported",
+        "npm": "supported",
+        "pypi": "supported",
+        "google": "supported",
+        "sendgrid": "supported",
+    },
+    "notification_providers": {
+        "github_checks": "supported",
+        "email_safety_notice": "partial",
+        "slack": "planned",
+        "pagerduty": "planned",
+        "jira": "planned",
+        "notion": "planned",
+        "signed_webhook": "planned",
+    },
+}
+SOURCE_CAPABILITY_SECTIONS_V2: Final[Mapping[str, Mapping[str, str]]] = MappingProxyType(
+    {section: MappingProxyType(dict(entries)) for section, entries in _SOURCE_CAPABILITY_SECTIONS_MUTABLE.items()}
+)
+
+
+def _normalized_key(value: str) -> str:
+    """Normalize a field name before prohibited-field matching."""
+
+    value = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", value)
+    return re.sub(r"[^A-Za-z0-9]+", "_", value).lower().strip("_")
+
+
+def is_exact_commit_sha(value: str) -> bool:
+    """Return whether *value* is a full lowercase Git commit SHA."""
+
+    return _COMMIT_SHA.fullmatch(value) is not None
+
+
+def _assert_safe_public_text(value: str, *, field_name: str) -> None:
+    """Reject credential-shaped or control-bearing text before persistence."""
+
+    if _CONTROL_CHARACTERS.search(value):
+        raise SecretContractError(f"{field_name}: control characters are prohibited")
+    if any(pattern.search(value) for pattern in _SECRET_LIKE_PATTERNS):
+        raise SecretContractError(f"{field_name}: secret-like text is prohibited")
+
+
+def reject_prohibited_fields(value: object, *, path: str = "$") -> None:
+    """Reject raw-value-shaped fields and credential-shaped values recursively."""
+
+    if isinstance(value, Mapping):
+        for key, nested in value.items():
+            if not isinstance(key, str):
+                raise SecretContractError(f"{path}: mapping keys must be strings")
+            if _PROHIBITED_KEY.search(_normalized_key(key)):
+                raise SecretContractError(f"{path}.{key}: prohibited Secrets field")
+            reject_prohibited_fields(nested, path=f"{path}.{key}")
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        for index, nested in enumerate(value):
+            reject_prohibited_fields(nested, path=f"{path}[{index}]")
+    elif isinstance(value, str):
+        _assert_safe_public_text(value, field_name=path)
+
+
+def _strict_keys(payload: Mapping[str, object], allowed: set[str], *, schema: str) -> None:
+    """Reject undeclared and prohibited keys for a versioned contract."""
+
+    unknown = sorted(set(payload) - allowed)
+    if unknown:
+        raise SecretContractError(f"{schema}: unknown fields: {', '.join(unknown)}")
+    reject_prohibited_fields(payload)
+
+
+def _mapping(value: object, *, field_name: str) -> Mapping[str, object]:
+    """Return a mapping or raise a stable contract error."""
+
+    if not isinstance(value, Mapping):
+        raise SecretContractError(f"{field_name}: expected an object")
+    return cast(Mapping[str, object], value)
+
+
+def _str_tuple(value: object, *, field_name: str, allow_empty: bool = True) -> tuple[str, ...]:
+    """Parse an array of strings into an immutable tuple."""
+
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise SecretContractError(f"{field_name}: expected an array of strings")
+    result = tuple(cast(list[str], value))
+    if not allow_empty and not result:
+        raise SecretContractError(f"{field_name}: must not be empty")
+    for item in result:
+        _assert_safe_public_text(item, field_name=field_name)
+    return result
+
+
+def _non_negative_int(value: object, *, field_name: str) -> int:
+    """Parse a non-negative integer without accepting booleans."""
+
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise SecretContractError(f"{field_name}: expected a non-negative integer")
+    return value
+
+
+def _required_text(value: object, *, field_name: str, limit: int = 200) -> str:
+    """Parse bounded non-empty privacy-safe text."""
+
+    if not isinstance(value, str):
+        raise SecretContractError(f"{field_name}: expected text")
+    normalized = value.strip()
+    if not normalized or len(normalized) > limit:
+        raise SecretContractError(f"{field_name}: invalid length")
+    _assert_safe_public_text(normalized, field_name=field_name)
+    return normalized
+
+
+def _optional_text(value: object, *, field_name: str, limit: int = 200) -> str | None:
+    """Parse optional bounded privacy-safe text."""
+
+    if value is None:
+        return None
+    return _required_text(value, field_name=field_name, limit=limit)
+
+
+def _required_bool(value: object, *, field_name: str) -> bool:
+    """Parse a required boolean without truthy coercion."""
+
+    if not isinstance(value, bool):
+        raise SecretContractError(f"{field_name}: expected a boolean")
+    return value
+
+
+def _enum_value(enum_type: type[Enum], value: object, *, field_name: str) -> Enum:
+    text = _required_text(value, field_name=field_name)
+    try:
+        return enum_type(text)
+    except ValueError as error:
+        raise SecretContractError(f"{field_name}: invalid value") from error
+
+
+def _iso_datetime(value: object, *, field_name: str) -> datetime | None:
+    if value is None:
+        return None
+    text = _required_text(value, field_name=field_name, limit=40)
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise SecretContractError(f"{field_name}: invalid timestamp") from error
+    if parsed.tzinfo is None:
+        raise SecretContractError(f"{field_name}: timestamp must be timezone-aware")
+    return parsed
+
+
+@dataclass(frozen=True, slots=True)
+class SecretScanCoverageV2:
+    """Fail-honest source coverage for one Secrets scan."""
+
+    source_set: tuple[str, ...]
+    requested_refs: tuple[str, ...]
+    completed_refs: tuple[str, ...]
+    files_scanned: int
+    bytes_scanned: int
+    commits_visited: int
+    blobs_scanned: int
+    skipped_codes: tuple[str, ...]
+    truncation_codes: tuple[str, ...]
+    detector_version: str
+    model_version: str | None = None
+    cache_hits: int = 0
+    cache_misses: int = 0
+    partial: bool = False
+    degraded: bool = False
+    error_code: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.truncation_codes and not self.partial:
+            raise SecretContractError("truncation requires partial=true")
+        if set(self.completed_refs) - set(self.requested_refs):
+            raise SecretContractError("completed_refs must be a subset of requested_refs")
+        reason_codes = {*self.skipped_codes, *self.truncation_codes}
+        if self.error_code is not None:
+            reason_codes.add(self.error_code)
+        unknown = sorted(reason_codes - REASON_CODES_V2)
+        if unknown:
+            raise SecretContractError(f"unknown reason codes: {', '.join(unknown)}")
+        reject_prohibited_fields(
+            {
+                "source_set": self.source_set,
+                "requested_refs": self.requested_refs,
+                "completed_refs": self.completed_refs,
+                "detector_version": self.detector_version,
+                "model_version": self.model_version,
+            }
+        )
+
+    @property
+    def clean_eligible(self) -> bool:
+        return (
+            not self.partial
+            and not self.degraded
+            and self.error_code is None
+            and not self.truncation_codes
+            and set(self.requested_refs).issubset(self.completed_refs)
+        )
+
+    def assert_outcome(self, outcome: PreventionOutcome) -> None:
+        if outcome is PreventionOutcome.CLEAN and not self.clean_eligible:
+            raise SecretContractError("incomplete coverage cannot produce a clean outcome")
+        if self.error_code is not None and outcome not in {PreventionOutcome.ERROR, PreventionOutcome.PARTIAL}:
+            raise SecretContractError("coverage with an error must be error or partial")
+        if self.degraded and outcome is PreventionOutcome.CLEAN:
+            raise SecretContractError("degraded coverage cannot produce a clean outcome")
+
+    def to_public_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "schema": _SCHEMA_COVERAGE,
+            "source_set": list(self.source_set),
+            "requested_refs": list(self.requested_refs),
+            "completed_refs": list(self.completed_refs),
+            "files_scanned": self.files_scanned,
+            "bytes_scanned": self.bytes_scanned,
+            "commits_visited": self.commits_visited,
+            "blobs_scanned": self.blobs_scanned,
+            "skipped_codes": list(self.skipped_codes),
+            "truncation_codes": list(self.truncation_codes),
+            "detector_version": self.detector_version,
+            "model_version": self.model_version,
+            "cache_hits": self.cache_hits,
+            "cache_misses": self.cache_misses,
+            "partial": self.partial,
+            "degraded": self.degraded,
+            "error_code": self.error_code,
+            "clean_eligible": self.clean_eligible,
+        }
+        reject_prohibited_fields(payload)
+        return payload
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, object]) -> SecretScanCoverageV2:
+        allowed = {
+            "schema",
+            "source_set",
+            "requested_refs",
+            "completed_refs",
+            "files_scanned",
+            "bytes_scanned",
+            "commits_visited",
+            "blobs_scanned",
+            "skipped_codes",
+            "truncation_codes",
+            "detector_version",
+            "model_version",
+            "cache_hits",
+            "cache_misses",
+            "partial",
+            "degraded",
+            "error_code",
+        }
+        _strict_keys(payload, allowed, schema=_SCHEMA_COVERAGE)
+        if payload.get("schema") != _SCHEMA_COVERAGE:
+            raise SecretContractError("unsupported SecretScanCoverage schema")
+        partial = payload.get("partial", False)
+        degraded = payload.get("degraded", False)
+        if not isinstance(partial, bool) or not isinstance(degraded, bool):
+            raise SecretContractError("coverage partial/degraded flags must be boolean")
+        return cls(
+            source_set=_str_tuple(payload.get("source_set"), field_name="source_set", allow_empty=False),
+            requested_refs=_str_tuple(payload.get("requested_refs"), field_name="requested_refs"),
+            completed_refs=_str_tuple(payload.get("completed_refs"), field_name="completed_refs"),
+            files_scanned=_non_negative_int(payload.get("files_scanned"), field_name="files_scanned"),
+            bytes_scanned=_non_negative_int(payload.get("bytes_scanned"), field_name="bytes_scanned"),
+            commits_visited=_non_negative_int(payload.get("commits_visited"), field_name="commits_visited"),
+            blobs_scanned=_non_negative_int(payload.get("blobs_scanned"), field_name="blobs_scanned"),
+            skipped_codes=_str_tuple(payload.get("skipped_codes"), field_name="skipped_codes"),
+            truncation_codes=_str_tuple(payload.get("truncation_codes"), field_name="truncation_codes"),
+            detector_version=_required_text(payload.get("detector_version"), field_name="detector_version"),
+            model_version=_optional_text(payload.get("model_version"), field_name="model_version"),
+            cache_hits=_non_negative_int(payload.get("cache_hits", 0), field_name="cache_hits"),
+            cache_misses=_non_negative_int(payload.get("cache_misses", 0), field_name="cache_misses"),
+            partial=partial,
+            degraded=degraded,
+            error_code=_optional_text(payload.get("error_code"), field_name="error_code"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SecretIgnoreDecisionV2:
+    """Privacy-safe, durable ignore-decision contract."""
+
+    decision_id: str
+    state: SecretIgnoreState
+    requested_scope: SecretIgnoreScope
+    durable_match_key: str
+    reason: str
+    expires_at: datetime | None
+    detector_version: str
+    model_version: str | None
+    requester_id: str
+    approver_id: str | None
+    policy_source: str
+    propagation: tuple[str, ...]
+    permanent_fixture_justification: str | None = None
+
+    def __post_init__(self) -> None:
+        for field_name, value in {
+            "decision_id": self.decision_id,
+            "requester_id": self.requester_id,
+            "policy_source": self.policy_source,
+        }.items():
+            if not _IDENTIFIER.fullmatch(value):
+                raise SecretContractError(f"{field_name}: invalid identifier")
+        if self.approver_id is not None and not _IDENTIFIER.fullmatch(self.approver_id):
+            raise SecretContractError("approver_id: invalid identifier")
+        if not _DIGEST.fullmatch(self.durable_match_key):
+            raise SecretContractError("durable_match_key must be an opaque SHA-256 digest")
+        if self.reason not in IGNORE_REASON_CODES_V2:
+            raise SecretContractError("ignore reason must be a registered reason code")
+        if self.permanent_fixture_justification is not None and (
+            self.permanent_fixture_justification not in FIXTURE_JUSTIFICATION_CODES_V2
+        ):
+            raise SecretContractError("permanent fixture justification must be a registered code")
+        if self.expires_at is None and not self.permanent_fixture_justification:
+            raise SecretContractError("non-expiring decisions require permanent fixture justification")
+        if self.expires_at is not None:
+            if self.expires_at.tzinfo is None:
+                raise SecretContractError("expires_at must be timezone-aware")
+            if self.state in _ACTIVE_IGNORE_STATES and self.expires_at.astimezone(timezone.utc) <= datetime.now(
+                timezone.utc
+            ):
+                raise SecretContractError("expires_at must be in the future")
+        if self.state is SecretIgnoreState.APPROVED and not self.approver_id:
+            raise SecretContractError("approved ignore decisions require an approver")
+        if not self.propagation or len(set(self.propagation)) != len(self.propagation):
+            raise SecretContractError("propagation surfaces must be non-empty and unique")
+        for field_name, value in {
+            "detector_version": self.detector_version,
+            "model_version": self.model_version,
+        }.items():
+            if value is not None:
+                _assert_safe_public_text(value, field_name=field_name)
+        for surface in self.propagation:
+            if not _IDENTIFIER.fullmatch(surface):
+                raise SecretContractError("propagation surface is invalid")
+
+    def to_public_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "schema": _SCHEMA_IGNORE,
+            "decision_id": self.decision_id,
+            "state": self.state.value,
+            "requested_scope": self.requested_scope.value,
+            "durable_match_key": self.durable_match_key,
+            "reason": self.reason,
+            "expires_at": self.expires_at.astimezone(timezone.utc).isoformat() if self.expires_at else None,
+            "detector_version": self.detector_version,
+            "model_version": self.model_version,
+            "requester_id": self.requester_id,
+            "approver_id": self.approver_id,
+            "policy_source": self.policy_source,
+            "propagation": list(self.propagation),
+            "permanent_fixture_justification": self.permanent_fixture_justification,
+        }
+        reject_prohibited_fields(payload)
+        return payload
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, object]) -> SecretIgnoreDecisionV2:
+        allowed = {
+            "schema",
+            "decision_id",
+            "state",
+            "requested_scope",
+            "durable_match_key",
+            "reason",
+            "expires_at",
+            "detector_version",
+            "model_version",
+            "requester_id",
+            "approver_id",
+            "policy_source",
+            "propagation",
+            "permanent_fixture_justification",
+        }
+        _strict_keys(payload, allowed, schema=_SCHEMA_IGNORE)
+        if payload.get("schema") != _SCHEMA_IGNORE:
+            raise SecretContractError("unsupported SecretIgnoreDecision schema")
+        state = cast(
+            SecretIgnoreState,
+            _enum_value(SecretIgnoreState, payload.get("state"), field_name="state"),
+        )
+        scope = cast(
+            SecretIgnoreScope,
+            _enum_value(SecretIgnoreScope, payload.get("requested_scope"), field_name="requested_scope"),
+        )
+        return cls(
+            decision_id=_required_text(payload.get("decision_id"), field_name="decision_id"),
+            state=state,
+            requested_scope=scope,
+            durable_match_key=_required_text(payload.get("durable_match_key"), field_name="durable_match_key"),
+            reason=_required_text(payload.get("reason"), field_name="reason"),
+            expires_at=_iso_datetime(payload.get("expires_at"), field_name="expires_at"),
+            detector_version=_required_text(payload.get("detector_version"), field_name="detector_version"),
+            model_version=_optional_text(payload.get("model_version"), field_name="model_version"),
+            requester_id=_required_text(payload.get("requester_id"), field_name="requester_id"),
+            approver_id=_optional_text(payload.get("approver_id"), field_name="approver_id"),
+            policy_source=_required_text(payload.get("policy_source"), field_name="policy_source"),
+            propagation=_str_tuple(payload.get("propagation"), field_name="propagation", allow_empty=False),
+            permanent_fixture_justification=_optional_text(
+                payload.get("permanent_fixture_justification"),
+                field_name="permanent_fixture_justification",
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SecretCustomRuleV2:
+    """Versioned declarative custom-rule contract."""
+
+    rule_id: str
+    version: str
+    matcher_kind: SecretRuleMatcherKind
+    matcher_digest: str
+    safe_fixture_digest: str
+    provenance_digest: str
+    compile_state: SecretRuleCompileState
+    complexity_budget: int
+    rollout_state: SecretRolloutState
+    surfaces: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not _IDENTIFIER.fullmatch(self.rule_id):
+            raise SecretContractError("rule_id is invalid")
+        if not _IDENTIFIER.fullmatch(self.version):
+            raise SecretContractError("version is invalid")
+        for field_name, digest in {
+            "matcher_digest": self.matcher_digest,
+            "safe_fixture_digest": self.safe_fixture_digest,
+            "provenance_digest": self.provenance_digest,
+        }.items():
+            if not _DIGEST.fullmatch(digest):
+                raise SecretContractError(f"{field_name} must be SHA-256")
+        if not 1 <= self.complexity_budget <= 100_000:
+            raise SecretContractError("complexity_budget is outside the supported bound")
+        if not self.surfaces or len(set(self.surfaces)) != len(self.surfaces):
+            raise SecretContractError("rule surfaces must be non-empty and unique")
+        for surface in self.surfaces:
+            if surface not in PRODUCT_SURFACES_V2:
+                raise SecretContractError(f"unknown rule surface: {surface}")
+        if self.rollout_state in {SecretRolloutState.CANARY, SecretRolloutState.ACTIVE} and (
+            self.compile_state is not SecretRuleCompileState.VALID
+        ):
+            raise SecretContractError("only valid compiled rules may be canary or active")
+
+    def to_public_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "schema": _SCHEMA_RULE,
+            "rule_id": self.rule_id,
+            "version": self.version,
+            "matcher_kind": self.matcher_kind.value,
+            "matcher_digest": self.matcher_digest,
+            "safe_fixture_digest": self.safe_fixture_digest,
+            "provenance_digest": self.provenance_digest,
+            "compile_state": self.compile_state.value,
+            "complexity_budget": self.complexity_budget,
+            "rollout_state": self.rollout_state.value,
+            "surfaces": list(self.surfaces),
+        }
+        reject_prohibited_fields(payload)
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityEvidenceV2:
+    """One capability row bound to tests, evidence, and rollout state."""
+
+    capability_id: str
+    product_boundary: str
+    surfaces: tuple[str, ...]
+    plans: tuple[str, ...]
+    state: ParityState
+    acceptance_tests: tuple[str, ...]
+    evidence_artifacts: tuple[str, ...]
+    release_commit: str | None = None
+    owner: str | None = None
+    gap_label: str | None = None
+
+    def __post_init__(self) -> None:
+        if not _IDENTIFIER.fullmatch(self.capability_id):
+            raise SecretContractError("capability_id is invalid")
+        boundary = PRODUCT_BOUNDARIES_V2.get(self.product_boundary)
+        if boundary is None:
+            raise SecretContractError(f"unknown product boundary: {self.product_boundary}")
+        if not self.surfaces or len(set(self.surfaces)) != len(self.surfaces):
+            raise SecretContractError("capability surfaces must be non-empty and unique")
+        if not self.plans or len(set(self.plans)) != len(self.plans):
+            raise SecretContractError("capability plans must be non-empty and unique")
+        allowed_surfaces = frozenset(boundary["allowed_surfaces"])
+        unknown_surfaces = sorted(set(self.surfaces) - allowed_surfaces)
+        if unknown_surfaces:
+            raise SecretContractError(
+                f"{self.capability_id}: surfaces outside product boundary: {', '.join(unknown_surfaces)}"
+            )
+        allowed_plans = frozenset(boundary["allowed_plans"])
+        unknown_plans = sorted(set(self.plans) - allowed_plans)
+        if unknown_plans:
+            raise SecretContractError(
+                f"{self.capability_id}: plans outside product boundary: {', '.join(unknown_plans)}"
+            )
+        if self.owner is not None and not _IDENTIFIER.fullmatch(self.owner):
+            raise SecretContractError("owner is invalid")
+        if self.gap_label is not None:
+            if not self.gap_label.strip():
+                raise SecretContractError("gap_label must not be blank")
+            _assert_safe_public_text(self.gap_label, field_name="gap_label")
+        for field_name, values in {
+            "acceptance_tests": self.acceptance_tests,
+            "evidence_artifacts": self.evidence_artifacts,
+        }.items():
+            for value in values:
+                _assert_safe_public_text(value, field_name=field_name)
+        if (
+            self.state
+            in {
+                ParityState.TESTED,
+                ParityState.VERIFIED_ON_RELEASE_CANDIDATE,
+                ParityState.GENERALLY_AVAILABLE,
+            }
+            and not self.acceptance_tests
+        ):
+            raise SecretContractError("tested capability requires acceptance tests")
+        if self.state in _RELEASE_STATES:
+            if not self.release_commit or not is_exact_commit_sha(self.release_commit):
+                raise SecretContractError("release-candidate capability requires an exact commit SHA")
+            if not self.evidence_artifacts:
+                raise SecretContractError("release-candidate capability requires evidence artifacts")
+
+    @classmethod
+    def from_mapping(
+        cls,
+        payload: Mapping[str, object],
+        *,
+        label: str,
+        require_gap_label: bool,
+    ) -> CapabilityEvidenceV2:
+        allowed = {
+            "capability_id",
+            "product_boundary",
+            "surfaces",
+            "plans",
+            "owner",
+            "state",
+            "acceptance_tests",
+            "evidence_artifacts",
+            "release_commit",
+            "gap_label",
+        }
+        _strict_keys(payload, allowed, schema=label)
+        capability_id = _required_text(payload.get("capability_id"), field_name=f"{label}.capability_id")
+        try:
+            state = ParityState(_required_text(payload.get("state"), field_name=f"{capability_id}.state"))
+        except ValueError as error:
+            raise SecretContractError(f"{capability_id}: invalid parity state") from error
+        gap_label = _optional_text(
+            payload.get("gap_label"),
+            field_name=f"{capability_id}.gap_label",
+            limit=500,
+        )
+        if require_gap_label and state not in _RELEASE_STATES and gap_label is None:
+            raise SecretContractError(f"{capability_id}: non-release state requires an explicit gap label")
+        return cls(
+            capability_id=capability_id,
+            product_boundary=_required_text(
+                payload.get("product_boundary"),
+                field_name=f"{capability_id}.product_boundary",
+            ),
+            surfaces=_str_tuple(
+                payload.get("surfaces"),
+                field_name=f"{capability_id}.surfaces",
+                allow_empty=False,
+            ),
+            plans=_str_tuple(
+                payload.get("plans"),
+                field_name=f"{capability_id}.plans",
+                allow_empty=False,
+            ),
+            state=state,
+            acceptance_tests=_str_tuple(
+                payload.get("acceptance_tests"),
+                field_name=f"{capability_id}.acceptance_tests",
+            ),
+            evidence_artifacts=_str_tuple(
+                payload.get("evidence_artifacts"),
+                field_name=f"{capability_id}.evidence_artifacts",
+            ),
+            release_commit=_optional_text(
+                payload.get("release_commit"),
+                field_name=f"{capability_id}.release_commit",
+            ),
+            owner=_required_text(payload.get("owner"), field_name=f"{capability_id}.owner"),
+            gap_label=gap_label,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityManifestV2:
+    """Parsed capability manifest and its policy-declared validation result."""
+
+    capabilities: tuple[CapabilityEvidenceV2, ...]
+    row_errors: tuple[str, ...]
+    public_parity_requires: ParityState
+    exact_release_commit_required: bool
+    remaining_gaps_must_be_labeled: bool
+    public_parity_claim_enabled: bool
+    required_capability_ids: frozenset[str]
+
+
+@dataclass(frozen=True, slots=True)
+class ProductBoundaryManifestV2:
+    """Runtime-validated product plan, boundary, surface, and invariant registry."""
+
+    plan_ids: frozenset[str]
+    boundary_ids: frozenset[str]
+    surface_ids: frozenset[str]
+    invariants: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class SourceCapabilityManifestV2:
+    """Runtime-validated source support matrix."""
+
+    status_values: tuple[str, ...]
+    sections: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class OrganizationMetricDefinitionV2:
+    """Unambiguous organization-level reporting metric definition."""
+
+    metric_id: str
+    numerator: str
+    denominator: str
+    censored_open_handling: str
+    recurrence_handling: str
+    incomplete_scan_handling: str
+
+    def __post_init__(self) -> None:
+        if not _IDENTIFIER.fullmatch(self.metric_id):
+            raise SecretContractError("metric_id is invalid")
+        for field_name, value in {
+            "numerator": self.numerator,
+            "denominator": self.denominator,
+            "censored_open_handling": self.censored_open_handling,
+            "recurrence_handling": self.recurrence_handling,
+            "incomplete_scan_handling": self.incomplete_scan_handling,
+        }.items():
+            if not value.strip():
+                raise SecretContractError("metric definition fields must not be empty")
+            _assert_safe_public_text(value, field_name=field_name)
+
+
+OUTCOME_SURFACE_MAPPING: Final[dict[PreventionOutcome, dict[str, str]]] = {
+    PreventionOutcome.CLEAN: {"cli": "0", "check": "success", "ide": "none", "agent": "allow"},
+    PreventionOutcome.WARN: {"cli": "0", "check": "neutral", "ide": "warning", "agent": "notice"},
+    PreventionOutcome.SOFT_BLOCK: {"cli": "3", "check": "failure", "ide": "error", "agent": "pause"},
+    PreventionOutcome.POLICY_BLOCK: {"cli": "4", "check": "failure", "ide": "error", "agent": "deny"},
+    PreventionOutcome.PARTIAL: {"cli": "2", "check": "neutral", "ide": "degraded", "agent": "pause"},
+    PreventionOutcome.DEGRADED: {"cli": "2", "check": "neutral", "ide": "degraded", "agent": "pause"},
+    PreventionOutcome.ERROR: {"cli": "2", "check": "failure", "ide": "error", "agent": "pause"},
+}
+
+
+def _plain_mapping(value: Mapping[str, object], *, field_name: str) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, nested in value.items():
+        if not isinstance(key, str):
+            raise SecretContractError(f"{field_name}: mapping keys must be strings")
+        result[key] = nested
+    return result
+
+
+def parse_product_boundaries_manifest(payload: Mapping[str, object]) -> ProductBoundaryManifestV2:
+    """Parse and compare the product boundary manifest to runtime authority."""
+
+    allowed = {"schema", "plans", "surface_values", "product_boundaries", "invariants"}
+    _strict_keys(payload, allowed, schema=_SCHEMA_PRODUCT_BOUNDARIES)
+    if payload.get("schema") != _SCHEMA_PRODUCT_BOUNDARIES:
+        raise SecretContractError("unsupported product-boundary manifest schema")
+
+    plans = _mapping(payload.get("plans"), field_name="plans")
+    if set(plans) != set(PLAN_POLICIES_V2):
+        raise SecretContractError("plan registry does not match the runtime contract")
+    for plan_id, expected_policy in PLAN_POLICIES_V2.items():
+        declared_policy = _plain_mapping(
+            _mapping(plans.get(plan_id), field_name=f"plans.{plan_id}"),
+            field_name=f"plans.{plan_id}",
+        )
+        if declared_policy != dict(expected_policy):
+            raise SecretContractError(f"plans.{plan_id}: policy does not match the runtime contract")
+
+    surfaces = _str_tuple(payload.get("surface_values"), field_name="surface_values", allow_empty=False)
+    if surfaces != PRODUCT_SURFACES_V2:
+        raise SecretContractError("surface_values do not match the runtime contract")
+
+    boundaries = _mapping(payload.get("product_boundaries"), field_name="product_boundaries")
+    if set(boundaries) != set(PRODUCT_BOUNDARIES_V2):
+        raise SecretContractError("product boundary registry does not match the runtime contract")
+    for boundary_id, expected_policy in PRODUCT_BOUNDARIES_V2.items():
+        declared = _mapping(
+            boundaries.get(boundary_id),
+            field_name=f"product_boundaries.{boundary_id}",
+        )
+        _strict_keys(
+            declared,
+            {"allowed_plans", "allowed_surfaces"},
+            schema=f"product_boundaries.{boundary_id}",
+        )
+        declared_plans = _str_tuple(
+            declared.get("allowed_plans"),
+            field_name=f"product_boundaries.{boundary_id}.allowed_plans",
+            allow_empty=False,
+        )
+        declared_surfaces = _str_tuple(
+            declared.get("allowed_surfaces"),
+            field_name=f"product_boundaries.{boundary_id}.allowed_surfaces",
+            allow_empty=False,
+        )
+        if declared_plans != expected_policy["allowed_plans"]:
+            raise SecretContractError(f"{boundary_id}: allowed plans do not match the runtime contract")
+        if declared_surfaces != expected_policy["allowed_surfaces"]:
+            raise SecretContractError(f"{boundary_id}: allowed surfaces do not match the runtime contract")
+
+    invariants = _str_tuple(payload.get("invariants"), field_name="invariants", allow_empty=False)
+    if invariants != PRODUCT_INVARIANTS_V2:
+        raise SecretContractError("product invariants do not match the runtime contract")
+    return ProductBoundaryManifestV2(
+        plan_ids=frozenset(plans),
+        boundary_ids=frozenset(boundaries),
+        surface_ids=frozenset(surfaces),
+        invariants=invariants,
+    )
+
+
+def parse_source_capabilities_manifest(payload: Mapping[str, object]) -> SourceCapabilityManifestV2:
+    """Parse and compare the source-capability manifest to runtime authority."""
+
+    allowed = {"schema", "status_values", *SOURCE_CAPABILITY_SECTIONS_V2}
+    _strict_keys(payload, allowed, schema=_SCHEMA_SOURCE_CAPABILITIES)
+    if payload.get("schema") != _SCHEMA_SOURCE_CAPABILITIES:
+        raise SecretContractError("unsupported source-capability manifest schema")
+    statuses = _str_tuple(payload.get("status_values"), field_name="status_values", allow_empty=False)
+    if statuses != SOURCE_CAPABILITY_STATUS_VALUES_V2:
+        raise SecretContractError("status_values do not match the runtime contract")
+
+    for section, expected_entries in SOURCE_CAPABILITY_SECTIONS_V2.items():
+        declared_entries = _mapping(payload.get(section), field_name=section)
+        if set(declared_entries) != set(expected_entries):
+            raise SecretContractError(f"{section}: capability keys do not match the runtime contract")
+        normalized: dict[str, str] = {}
+        for capability_id, raw_status in declared_entries.items():
+            if not isinstance(capability_id, str):
+                raise SecretContractError(f"{section}: capability IDs must be strings")
+            status_text = _required_text(raw_status, field_name=f"{section}.{capability_id}")
+            try:
+                status = SourceCapabilityStatus(status_text)
+            except ValueError as error:
+                raise SecretContractError(f"{section}.{capability_id}: invalid status") from error
+            normalized[capability_id] = status.value
+        if normalized != dict(expected_entries):
+            raise SecretContractError(f"{section}: statuses do not match the runtime contract")
+
+    return SourceCapabilityManifestV2(
+        status_values=statuses,
+        sections=tuple(SOURCE_CAPABILITY_SECTIONS_V2),
+    )
+
+
+def parse_capability_evidence_manifest(payload: Mapping[str, object]) -> CapabilityManifestV2:
+    """Parse the v2 capability manifest and surface row-level errors safely."""
+
+    allowed = {"schema", "generated_at", "parity_states", "claim_policy", "capabilities"}
+    _strict_keys(payload, allowed, schema=_SCHEMA_CAPABILITY_EVIDENCE)
+    if payload.get("schema") != _SCHEMA_CAPABILITY_EVIDENCE:
+        raise SecretContractError("unsupported capability manifest schema")
+    _required_text(payload.get("generated_at"), field_name="generated_at", limit=40)
+    declared_states = _str_tuple(payload.get("parity_states"), field_name="parity_states", allow_empty=False)
+    if declared_states != PARITY_STATES_V2:
+        raise SecretContractError("parity_states do not match the runtime contract")
+
+    claim_policy = _mapping(payload.get("claim_policy"), field_name="claim_policy")
+    _strict_keys(
+        claim_policy,
+        {
+            "public_parity_requires",
+            "exact_release_commit_required",
+            "remaining_gaps_must_be_labeled",
+            "public_parity_claim_enabled",
+            "required_capabilities",
+        },
+        schema="claim_policy",
+    )
+    try:
+        public_parity_requires = ParityState(
+            _required_text(
+                claim_policy.get("public_parity_requires"),
+                field_name="claim_policy.public_parity_requires",
+            )
+        )
+    except ValueError as error:
+        raise SecretContractError("claim_policy.public_parity_requires is not a parity state") from error
+    if public_parity_requires not in _RELEASE_STATES:
+        raise SecretContractError("claim_policy.public_parity_requires must be release-candidate verified or GA")
+    exact_release_commit_required = _required_bool(
+        claim_policy.get("exact_release_commit_required"),
+        field_name="claim_policy.exact_release_commit_required",
+    )
+    if not exact_release_commit_required:
+        raise SecretContractError("claim_policy must require an exact release commit")
+    remaining_gaps_must_be_labeled = _required_bool(
+        claim_policy.get("remaining_gaps_must_be_labeled"),
+        field_name="claim_policy.remaining_gaps_must_be_labeled",
+    )
+    if not remaining_gaps_must_be_labeled:
+        raise SecretContractError("claim_policy must require labels for remaining gaps")
+    public_parity_claim_enabled = _required_bool(
+        claim_policy.get("public_parity_claim_enabled"),
+        field_name="claim_policy.public_parity_claim_enabled",
+    )
+    required_capability_list = _str_tuple(
+        claim_policy.get("required_capabilities"),
+        field_name="claim_policy.required_capabilities",
+        allow_empty=False,
+    )
+    if len(set(required_capability_list)) != len(required_capability_list):
+        raise SecretContractError("claim_policy.required_capabilities must be unique")
+    required_capability_ids = frozenset(required_capability_list)
+
+    raw_capabilities = payload.get("capabilities")
+    if not isinstance(raw_capabilities, list):
+        raise SecretContractError("capabilities: expected an array")
+
+    capabilities: list[CapabilityEvidenceV2] = []
+    errors: list[str] = []
+    declared_ids: set[str] = set()
+    for index, raw_capability in enumerate(raw_capabilities):
+        label = f"capabilities[{index}]"
+        try:
+            capability_mapping = _mapping(raw_capability, field_name=label)
+            raw_capability_id = capability_mapping.get("capability_id")
+            if isinstance(raw_capability_id, str) and raw_capability_id.strip():
+                capability_id = raw_capability_id.strip()
+                if capability_id in declared_ids:
+                    errors.append(f"{capability_id}: duplicate capability")
+                    continue
+                declared_ids.add(capability_id)
+            capability = CapabilityEvidenceV2.from_mapping(
+                capability_mapping,
+                label=label,
+                require_gap_label=remaining_gaps_must_be_labeled,
+            )
+        except SecretContractError as error:
+            errors.append(str(error))
+            continue
+        capabilities.append(capability)
+
+    missing_required = sorted(required_capability_ids - declared_ids)
+    if missing_required:
+        errors.append(f"claim policy capabilities are unmapped: {', '.join(missing_required)}")
+
+    return CapabilityManifestV2(
+        capabilities=tuple(capabilities),
+        row_errors=tuple(errors),
+        public_parity_requires=public_parity_requires,
+        exact_release_commit_required=exact_release_commit_required,
+        remaining_gaps_must_be_labeled=remaining_gaps_must_be_labeled,
+        public_parity_claim_enabled=public_parity_claim_enabled,
+        required_capability_ids=required_capability_ids,
+    )
+
+
+def validate_capability_manifest(
+    capabilities: Sequence[CapabilityEvidenceV2],
+    *,
+    required_capability_ids: frozenset[str],
+    exact_release_commit: str,
+    minimum_state: ParityState = ParityState.VERIFIED_ON_RELEASE_CANDIDATE,
+) -> None:
+    """Fail unless every claimed row has exact release-candidate evidence."""
+
+    if not is_exact_commit_sha(exact_release_commit):
+        raise SecretContractError("exact_release_commit must be a full commit SHA")
+    if minimum_state not in _RELEASE_STATES:
+        raise SecretContractError("minimum parity state must be release-candidate verified or GA")
+    by_id = {capability.capability_id: capability for capability in capabilities}
+    if len(by_id) != len(capabilities):
+        raise SecretContractError("capability IDs must be unique")
+    missing = sorted(required_capability_ids - set(by_id))
+    if missing:
+        raise SecretContractError(f"required capabilities are unmapped: {', '.join(missing)}")
+    minimum_rank = _PARITY_STATE_RANK[minimum_state]
+    for capability_id in sorted(required_capability_ids):
+        capability = by_id[capability_id]
+        if _PARITY_STATE_RANK[capability.state] < minimum_rank:
+            raise SecretContractError(f"{capability_id}: not verified at the required release state")
+        if capability.release_commit != exact_release_commit:
+            raise SecretContractError(f"{capability_id}: evidence is bound to a different commit")
+
+
+__all__ = [
+    "FIXTURE_JUSTIFICATION_CODES_V2",
+    "IGNORE_REASON_CODES_V2",
+    "OUTCOME_SURFACE_MAPPING",
+    "PARITY_STATES_V2",
+    "PLAN_POLICIES_V2",
+    "PRODUCT_BOUNDARIES_V2",
+    "PRODUCT_INVARIANTS_V2",
+    "PRODUCT_SURFACES_V2",
+    "REASON_CODES_V2",
+    "SOURCE_CAPABILITY_SECTIONS_V2",
+    "SOURCE_CAPABILITY_STATUS_VALUES_V2",
+    "CapabilityEvidenceV2",
+    "CapabilityManifestV2",
+    "OrganizationMetricDefinitionV2",
+    "ParityState",
+    "PreventionOutcome",
+    "ProductBoundaryManifestV2",
+    "SecretClass",
+    "SecretContractError",
+    "SecretCustomRuleV2",
+    "SecretExposure",
+    "SecretIgnoreDecisionV2",
+    "SecretIgnoreScope",
+    "SecretIgnoreState",
+    "SecretLifecycle",
+    "SecretRolloutState",
+    "SecretRuleCompileState",
+    "SecretRuleMatcherKind",
+    "SecretScanCoverageV2",
+    "SecretValidity",
+    "SourceCapabilityManifestV2",
+    "SourceCapabilityStatus",
+    "is_exact_commit_sha",
+    "parse_capability_evidence_manifest",
+    "parse_product_boundaries_manifest",
+    "parse_source_capabilities_manifest",
+    "reject_prohibited_fields",
+    "validate_capability_manifest",
+]

--- a/src/codex_plugin_scanner/guard/secrets/contracts_v2.py
+++ b/src/codex_plugin_scanner/guard/secrets/contracts_v2.py
@@ -600,6 +600,42 @@ class SecretScanCoverageV2:
     error_code: str | None = None
 
     def __post_init__(self) -> None:
+        tuple_fields = {
+            "source_set": self.source_set,
+            "requested_refs": self.requested_refs,
+            "completed_refs": self.completed_refs,
+            "skipped_codes": self.skipped_codes,
+            "truncation_codes": self.truncation_codes,
+        }
+        for field_name, values in tuple_fields.items():
+            if not isinstance(values, tuple) or any(not isinstance(item, str) for item in values):
+                raise SecretContractError(f"{field_name}: expected a tuple of strings")
+            if len(set(values)) != len(values):
+                raise SecretContractError(f"{field_name}: values must be unique")
+            for item in values:
+                if not item.strip():
+                    raise SecretContractError(f"{field_name}: values must not be blank")
+                _assert_safe_public_text(item, field_name=field_name)
+        for field_name, value in {
+            "files_scanned": self.files_scanned,
+            "bytes_scanned": self.bytes_scanned,
+            "commits_visited": self.commits_visited,
+            "blobs_scanned": self.blobs_scanned,
+            "cache_hits": self.cache_hits,
+            "cache_misses": self.cache_misses,
+        }.items():
+            _non_negative_int(value, field_name=field_name)
+        _required_bool(self.partial, field_name="partial")
+        _required_bool(self.degraded, field_name="degraded")
+        detector_version = _required_text(self.detector_version, field_name="detector_version")
+        if detector_version != self.detector_version:
+            raise SecretContractError("detector_version: surrounding whitespace is prohibited")
+        model_version = _optional_text(self.model_version, field_name="model_version")
+        if model_version != self.model_version:
+            raise SecretContractError("model_version: surrounding whitespace is prohibited")
+        error_code = _optional_text(self.error_code, field_name="error_code")
+        if error_code != self.error_code:
+            raise SecretContractError("error_code: surrounding whitespace is prohibited")
         if not self.source_set:
             raise SecretContractError("source_set must not be empty")
         if self.skipped_codes and not self.partial:

--- a/src/codex_plugin_scanner/guard/secrets/contracts_v2.py
+++ b/src/codex_plugin_scanner/guard/secrets/contracts_v2.py
@@ -588,6 +588,29 @@ def _require_enum_instance(value: object, enum_type: type[Enum], *, field_name: 
         raise SecretContractError(f"{field_name}: expected {enum_type.__name__}")
 
 
+def _require_string_tuple(
+    value: object,
+    *,
+    field_name: str,
+    allow_empty: bool = True,
+) -> None:
+    """Validate immutable, unique, non-blank privacy-safe direct sequences."""
+
+    if not isinstance(value, tuple) or any(not isinstance(item, str) for item in value):
+        raise SecretContractError(f"{field_name}: expected a tuple of strings")
+    values = cast(tuple[str, ...], value)
+    if not allow_empty and not values:
+        raise SecretContractError(f"{field_name}: must not be empty")
+    if len(set(values)) != len(values):
+        raise SecretContractError(f"{field_name}: values must be unique")
+    for item in values:
+        if not item.strip():
+            raise SecretContractError(f"{field_name}: values must not be blank")
+        if item != item.strip():
+            raise SecretContractError(f"{field_name}: surrounding whitespace is prohibited")
+        _assert_safe_public_text(item, field_name=field_name)
+
+
 def _iso_datetime(value: object, *, field_name: str) -> datetime | None:
     if value is None:
         return None
@@ -805,6 +828,11 @@ class SecretIgnoreDecisionV2:
             SecretIgnoreScope,
             field_name="requested_scope",
         )
+        _require_string_tuple(
+            self.propagation,
+            field_name="propagation",
+            allow_empty=False,
+        )
         for field_name, value in {
             "decision_id": self.decision_id,
             "requester_id": self.requester_id,
@@ -945,6 +973,11 @@ class SecretCustomRuleV2:
             SecretRolloutState,
             field_name="rollout_state",
         )
+        _require_string_tuple(
+            self.surfaces,
+            field_name="surfaces",
+            allow_empty=False,
+        )
         if not _IDENTIFIER.fullmatch(self.rule_id):
             raise SecretContractError("rule_id is invalid")
         if not _IDENTIFIER.fullmatch(self.version):
@@ -1003,6 +1036,17 @@ class CapabilityEvidenceV2:
 
     def __post_init__(self) -> None:
         _require_enum_instance(self.state, ParityState, field_name="state")
+        for field_name, values, allow_empty in (
+            ("surfaces", self.surfaces, False),
+            ("plans", self.plans, False),
+            ("acceptance_tests", self.acceptance_tests, True),
+            ("evidence_artifacts", self.evidence_artifacts, True),
+        ):
+            _require_string_tuple(
+                values,
+                field_name=field_name,
+                allow_empty=allow_empty,
+            )
         if not _IDENTIFIER.fullmatch(self.capability_id):
             raise SecretContractError("capability_id is invalid")
         boundary = PRODUCT_BOUNDARIES_V2.get(self.product_boundary)

--- a/src/codex_plugin_scanner/guard/secrets/contracts_v2.py
+++ b/src/codex_plugin_scanner/guard/secrets/contracts_v2.py
@@ -604,8 +604,12 @@ class SecretScanCoverageV2:
             raise SecretContractError("skipped work requires partial=true")
         if self.truncation_codes and not self.partial:
             raise SecretContractError("truncation requires partial=true")
+        if not self.requested_refs and not self.partial:
+            raise SecretContractError("empty requested_refs requires partial=true")
         if set(self.completed_refs) - set(self.requested_refs):
             raise SecretContractError("completed_refs must be a subset of requested_refs")
+        if not self.partial and set(self.completed_refs) != set(self.requested_refs):
+            raise SecretContractError("complete coverage must complete every requested ref")
         reason_codes = {*self.skipped_codes, *self.truncation_codes}
         if self.error_code is not None:
             reason_codes.add(self.error_code)
@@ -625,7 +629,8 @@ class SecretScanCoverageV2:
     @property
     def clean_eligible(self) -> bool:
         return (
-            not self.partial
+            bool(self.requested_refs)
+            and not self.partial
             and not self.degraded
             and self.error_code is None
             and not self.skipped_codes

--- a/src/codex_plugin_scanner/guard/secrets/contracts_v2.py
+++ b/src/codex_plugin_scanner/guard/secrets/contracts_v2.py
@@ -600,6 +600,8 @@ class SecretScanCoverageV2:
     error_code: str | None = None
 
     def __post_init__(self) -> None:
+        if not self.source_set:
+            raise SecretContractError("source_set must not be empty")
         if self.skipped_codes and not self.partial:
             raise SecretContractError("skipped work requires partial=true")
         if self.truncation_codes and not self.partial:
@@ -629,7 +631,8 @@ class SecretScanCoverageV2:
     @property
     def clean_eligible(self) -> bool:
         return (
-            bool(self.requested_refs)
+            bool(self.source_set)
+            and bool(self.requested_refs)
             and not self.partial
             and not self.degraded
             and self.error_code is None

--- a/src/codex_plugin_scanner/guard/secrets/contracts_v2.py
+++ b/src/codex_plugin_scanner/guard/secrets/contracts_v2.py
@@ -154,7 +154,7 @@ _ACTIVE_IGNORE_STATES: Final = frozenset(
     }
 )
 _PROHIBITED_KEY = re.compile(
-    r"(?:^|_)(?:raw(?:_value)?|raw_?secret|candidate(?:_value)?|credential(?:_value)?|"
+    r"(?:^|_)(?:raw_value|raw_?secret|candidate(?:_value)?|credential(?:_value)?|"
     r"secret_?value|token_?value|source_(?:line|content|excerpt)|prompt|"
     r"tool_(?:output|result)|environment_?value|auth(?:orization)?_?header|"
     r"provider_?response(?:_body)?|absolute_?path)(?:$|_)",
@@ -191,6 +191,7 @@ _SCHEMA_RULE: Final = "guard-secret-custom-rule.v2"
 _SCHEMA_CAPABILITY_EVIDENCE: Final = "guard-secrets-capability-evidence.v2"
 _SCHEMA_PRODUCT_BOUNDARIES: Final = "guard-secrets-product-boundaries.v2"
 _SCHEMA_SOURCE_CAPABILITIES: Final = "guard-secrets-source-capabilities.v2"
+_SCHEMA_REASON_CODES: Final = "guard-secrets-reason-codes.v2"
 
 PARITY_STATES_V2: Final[tuple[str, ...]] = tuple(state.value for state in ParityState)
 SOURCE_CAPABILITY_STATUS_VALUES_V2: Final[tuple[str, ...]] = tuple(state.value for state in SourceCapabilityStatus)
@@ -202,14 +203,10 @@ _RELEASE_STATES: Final = frozenset(
 )
 _PARITY_STATE_RANK: Final = {state: index for index, state in enumerate(ParityState)}
 
-REASON_CODES_V2: Final[frozenset[str]] = frozenset(
-    {
+_REASON_CODE_CATEGORIES_MUTABLE: dict[str, tuple[str, ...]] = {
+    "coverage": (
         "archive_budget_exceeded",
         "binary_skipped",
-        "cache_stale",
-        "cleanup_failed",
-        "detector_bundle_invalid",
-        "detector_unavailable",
         "encoding_unsupported",
         "file_changed_during_scan",
         "git_object_missing",
@@ -219,18 +216,37 @@ REASON_CODES_V2: Final[frozenset[str]] = frozenset(
         "max_commits",
         "max_files",
         "max_findings",
+        "source_unreadable",
+    ),
+    "detector": (
+        "detector_bundle_invalid",
+        "detector_unavailable",
         "model_bundle_invalid",
         "model_degraded",
-        "policy_block",
-        "policy_refresh_required",
-        "source_unreadable",
+    ),
+    "validation": (
         "validation_error",
         "validation_rate_limited",
         "validation_unknown",
         "validation_unsupported",
-        "worker_cancelled",
-        "worker_timeout",
+    ),
+    "policy": ("policy_block", "policy_refresh_required"),
+    "worker": ("cleanup_failed", "worker_cancelled", "worker_timeout"),
+    "cache": ("cache_stale",),
+}
+REASON_CODE_CATEGORIES_V2: Final[Mapping[str, tuple[str, ...]]] = MappingProxyType(
+    dict(_REASON_CODE_CATEGORIES_MUTABLE)
+)
+REASON_CODE_RULES_V2: Final[Mapping[str, bool]] = MappingProxyType(
+    {
+        "stable": True,
+        "non_sensitive": True,
+        "unknown_codes_fail_closed": True,
+        "raw_exception_text_forbidden": True,
     }
+)
+REASON_CODES_V2: Final[frozenset[str]] = frozenset(
+    code for codes in _REASON_CODE_CATEGORIES_MUTABLE.values() for code in codes
 )
 IGNORE_REASON_CODES_V2: Final[frozenset[str]] = frozenset(
     {
@@ -565,6 +581,13 @@ def _enum_value(enum_type: type[Enum], value: object, *, field_name: str) -> Enu
         raise SecretContractError(f"{field_name}: invalid value") from error
 
 
+def _require_enum_instance(value: object, enum_type: type[Enum], *, field_name: str) -> None:
+    """Reject raw strings and unrelated enums on direct construction."""
+
+    if not isinstance(value, enum_type):
+        raise SecretContractError(f"{field_name}: expected {enum_type.__name__}")
+
+
 def _iso_datetime(value: object, *, field_name: str) -> datetime | None:
     if value is None:
         return None
@@ -776,6 +799,12 @@ class SecretIgnoreDecisionV2:
     permanent_fixture_justification: str | None = None
 
     def __post_init__(self) -> None:
+        _require_enum_instance(self.state, SecretIgnoreState, field_name="state")
+        _require_enum_instance(
+            self.requested_scope,
+            SecretIgnoreScope,
+            field_name="requested_scope",
+        )
         for field_name, value in {
             "decision_id": self.decision_id,
             "requester_id": self.requester_id,
@@ -901,6 +930,21 @@ class SecretCustomRuleV2:
     surfaces: tuple[str, ...]
 
     def __post_init__(self) -> None:
+        _require_enum_instance(
+            self.matcher_kind,
+            SecretRuleMatcherKind,
+            field_name="matcher_kind",
+        )
+        _require_enum_instance(
+            self.compile_state,
+            SecretRuleCompileState,
+            field_name="compile_state",
+        )
+        _require_enum_instance(
+            self.rollout_state,
+            SecretRolloutState,
+            field_name="rollout_state",
+        )
         if not _IDENTIFIER.fullmatch(self.rule_id):
             raise SecretContractError("rule_id is invalid")
         if not _IDENTIFIER.fullmatch(self.version):
@@ -958,6 +1002,7 @@ class CapabilityEvidenceV2:
     gap_label: str | None = None
 
     def __post_init__(self) -> None:
+        _require_enum_instance(self.state, ParityState, field_name="state")
         if not _IDENTIFIER.fullmatch(self.capability_id):
             raise SecretContractError("capability_id is invalid")
         boundary = PRODUCT_BOUNDARIES_V2.get(self.product_boundary)
@@ -1106,6 +1151,15 @@ class SourceCapabilityManifestV2:
 
 
 @dataclass(frozen=True, slots=True)
+class ReasonCodeManifestV2:
+    """Runtime-validated reason-code categories and fail-closed rules."""
+
+    category_ids: tuple[str, ...]
+    codes: frozenset[str]
+    rule_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
 class OrganizationMetricDefinitionV2:
     """Unambiguous organization-level reporting metric definition."""
 
@@ -1244,6 +1298,57 @@ def parse_source_capabilities_manifest(payload: Mapping[str, object]) -> SourceC
     return SourceCapabilityManifestV2(
         status_values=statuses,
         sections=tuple(SOURCE_CAPABILITY_SECTIONS_V2),
+    )
+
+
+def parse_reason_codes_manifest(payload: Mapping[str, object]) -> ReasonCodeManifestV2:
+    """Parse and compare the reason-code manifest to runtime authority."""
+
+    allowed = {"schema", "categories", "rules"}
+    unknown = sorted(set(payload) - allowed)
+    if unknown:
+        raise SecretContractError(f"{_SCHEMA_REASON_CODES}: unknown fields: {', '.join(unknown)}")
+    if payload.get("schema") != _SCHEMA_REASON_CODES:
+        raise SecretContractError("unsupported reason-code manifest schema")
+
+    categories = _mapping(payload.get("categories"), field_name="categories")
+    expected_category_ids = tuple(REASON_CODE_CATEGORIES_V2)
+    if tuple(categories) != expected_category_ids:
+        raise SecretContractError("reason-code category registry does not match the runtime contract")
+
+    seen: set[str] = set()
+    for category_id, expected_codes in REASON_CODE_CATEGORIES_V2.items():
+        declared_codes = _str_tuple(
+            categories.get(category_id),
+            field_name=f"categories.{category_id}",
+            allow_empty=False,
+        )
+        if len(set(declared_codes)) != len(declared_codes):
+            raise SecretContractError(f"categories.{category_id}: reason codes must be unique")
+        duplicates = sorted(seen.intersection(declared_codes))
+        if duplicates:
+            raise SecretContractError("reason codes must belong to exactly one category: " + ", ".join(duplicates))
+        if declared_codes != expected_codes:
+            raise SecretContractError(f"categories.{category_id}: codes do not match the runtime contract")
+        seen.update(declared_codes)
+    if frozenset(seen) != REASON_CODES_V2:
+        raise SecretContractError("reason-code registry does not match the runtime contract")
+
+    rules = _mapping(payload.get("rules"), field_name="rules")
+    if tuple(rules) != tuple(REASON_CODE_RULES_V2):
+        raise SecretContractError("reason-code rule registry does not match the runtime contract")
+    for rule_id, expected_value in REASON_CODE_RULES_V2.items():
+        declared_value = _required_bool(
+            rules.get(rule_id),
+            field_name=f"rules.{rule_id}",
+        )
+        if declared_value is not expected_value:
+            raise SecretContractError(f"rules.{rule_id}: policy does not match the runtime contract")
+
+    return ReasonCodeManifestV2(
+        category_ids=expected_category_ids,
+        codes=frozenset(seen),
+        rule_ids=tuple(REASON_CODE_RULES_V2),
     )
 
 
@@ -1388,6 +1493,8 @@ __all__ = [
     "PRODUCT_INVARIANTS_V2",
     "PRODUCT_SURFACES_V2",
     "REASON_CODES_V2",
+    "REASON_CODE_CATEGORIES_V2",
+    "REASON_CODE_RULES_V2",
     "SOURCE_CAPABILITY_SECTIONS_V2",
     "SOURCE_CAPABILITY_STATUS_VALUES_V2",
     "CapabilityEvidenceV2",
@@ -1396,6 +1503,7 @@ __all__ = [
     "ParityState",
     "PreventionOutcome",
     "ProductBoundaryManifestV2",
+    "ReasonCodeManifestV2",
     "SecretClass",
     "SecretContractError",
     "SecretCustomRuleV2",
@@ -1414,6 +1522,7 @@ __all__ = [
     "is_exact_commit_sha",
     "parse_capability_evidence_manifest",
     "parse_product_boundaries_manifest",
+    "parse_reason_codes_manifest",
     "parse_source_capabilities_manifest",
     "reject_prohibited_fields",
     "validate_capability_manifest",

--- a/src/codex_plugin_scanner/guard/secrets/contracts_v2.py
+++ b/src/codex_plugin_scanner/guard/secrets/contracts_v2.py
@@ -154,7 +154,7 @@ _ACTIVE_IGNORE_STATES: Final = frozenset(
     }
 )
 _PROHIBITED_KEY = re.compile(
-    r"(?:^|_)(?:raw_?secret|candidate(?:_value)?|credential(?:_value)?|"
+    r"(?:^|_)(?:raw(?:_value)?|raw_?secret|candidate(?:_value)?|credential(?:_value)?|"
     r"secret_?value|token_?value|source_(?:line|content|excerpt)|prompt|"
     r"tool_(?:output|result)|environment_?value|auth(?:orization)?_?header|"
     r"provider_?response(?:_body)?|absolute_?path)(?:$|_)",
@@ -600,6 +600,8 @@ class SecretScanCoverageV2:
     error_code: str | None = None
 
     def __post_init__(self) -> None:
+        if self.skipped_codes and not self.partial:
+            raise SecretContractError("skipped work requires partial=true")
         if self.truncation_codes and not self.partial:
             raise SecretContractError("truncation requires partial=true")
         if set(self.completed_refs) - set(self.requested_refs):
@@ -626,6 +628,7 @@ class SecretScanCoverageV2:
             not self.partial
             and not self.degraded
             and self.error_code is None
+            and not self.skipped_codes
             and not self.truncation_codes
             and set(self.requested_refs).issubset(self.completed_refs)
         )

--- a/tests/test_guard_secret_contracts_v2.py
+++ b/tests/test_guard_secret_contracts_v2.py
@@ -1,0 +1,586 @@
+from __future__ import annotations
+
+import copy
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.secrets.contracts_v2 import (
+    FIXTURE_JUSTIFICATION_CODES_V2,
+    IGNORE_REASON_CODES_V2,
+    OUTCOME_SURFACE_MAPPING,
+    REASON_CODES_V2,
+    SOURCE_CAPABILITY_STATUS_VALUES_V2,
+    CapabilityEvidenceV2,
+    ParityState,
+    PreventionOutcome,
+    SecretContractError,
+    SecretCustomRuleV2,
+    SecretIgnoreDecisionV2,
+    SecretIgnoreScope,
+    SecretIgnoreState,
+    SecretRolloutState,
+    SecretRuleCompileState,
+    SecretRuleMatcherKind,
+    SecretScanCoverageV2,
+    parse_capability_evidence_manifest,
+    parse_product_boundaries_manifest,
+    parse_source_capabilities_manifest,
+    reject_prohibited_fields,
+    validate_capability_manifest,
+)
+
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+_CAPABILITY_PATH = _REPOSITORY_ROOT / "docs/guard/contracts/guard-secrets-capability-evidence.v2.json"
+_PRODUCT_BOUNDARY_PATH = _REPOSITORY_ROOT / "docs/guard/contracts/guard-secrets-product-boundaries.v2.json"
+_SOURCE_CAPABILITY_PATH = _REPOSITORY_ROOT / "docs/guard/contracts/guard-secrets-source-capabilities.v2.json"
+_FIXTURE_OPENAI_KEY = "sk-proj-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+
+def _load(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _coverage(**overrides: object) -> SecretScanCoverageV2:
+    payload: dict[str, object] = {
+        "schema": "guard-secret-coverage.v2",
+        "source_set": ["working_tree"],
+        "requested_refs": ["refs/heads/main"],
+        "completed_refs": ["refs/heads/main"],
+        "files_scanned": 4,
+        "bytes_scanned": 1024,
+        "commits_visited": 0,
+        "blobs_scanned": 4,
+        "skipped_codes": [],
+        "truncation_codes": [],
+        "detector_version": "guard-secrets-v2",
+        "model_version": None,
+        "cache_hits": 0,
+        "cache_misses": 4,
+        "partial": False,
+        "degraded": False,
+        "error_code": None,
+    }
+    payload.update(overrides)
+    return SecretScanCoverageV2.from_mapping(payload)
+
+
+def _direct_coverage(**overrides: object) -> SecretScanCoverageV2:
+    values: dict[str, object] = {
+        "source_set": ("working_tree",),
+        "requested_refs": ("refs/heads/main",),
+        "completed_refs": ("refs/heads/main",),
+        "files_scanned": 4,
+        "bytes_scanned": 1024,
+        "commits_visited": 0,
+        "blobs_scanned": 4,
+        "skipped_codes": (),
+        "truncation_codes": (),
+        "detector_version": "guard-secrets-v2",
+    }
+    values.update(overrides)
+    return SecretScanCoverageV2(**values)  # type: ignore[arg-type]
+
+
+def _capability(**overrides: object) -> CapabilityEvidenceV2:
+    values: dict[str, object] = {
+        "capability_id": "secret:cli",
+        "product_boundary": "free-local",
+        "surfaces": ("cli",),
+        "plans": ("free",),
+        "state": ParityState.TESTED,
+        "acceptance_tests": ("test_cli",),
+        "evidence_artifacts": (),
+        "gap_label": "release evidence pending",
+    }
+    values.update(overrides)
+    return CapabilityEvidenceV2(**values)  # type: ignore[arg-type]
+
+
+def _manifest(**capability_overrides: object) -> dict[str, object]:
+    capability: dict[str, object] = {
+        "capability_id": "cli_precommit",
+        "product_boundary": "free-local",
+        "surfaces": ["cli", "pre_commit"],
+        "plans": ["free", "solo", "pro", "team"],
+        "owner": "hol-guard",
+        "state": "tested",
+        "acceptance_tests": ["tests/test_guard_secrets_native_cli.py"],
+        "evidence_artifacts": [],
+        "release_commit": None,
+        "gap_label": "release-candidate evidence pending",
+    }
+    capability.update(capability_overrides)
+    return {
+        "schema": "guard-secrets-capability-evidence.v2",
+        "generated_at": "2026-08-14",
+        "parity_states": [state.value for state in ParityState],
+        "claim_policy": {
+            "public_parity_requires": "verified_on_release_candidate",
+            "exact_release_commit_required": True,
+            "remaining_gaps_must_be_labeled": True,
+            "public_parity_claim_enabled": False,
+            "required_capabilities": ["cli_precommit"],
+        },
+        "capabilities": [capability],
+    }
+
+
+def _ignore_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema": "guard-secret-ignore-decision.v2",
+        "decision_id": "ignore:1",
+        "state": "requested",
+        "requested_scope": "occurrence",
+        "durable_match_key": "a" * 64,
+        "reason": "pending_review",
+        "expires_at": (datetime.now(timezone.utc) + timedelta(days=7)).isoformat(),
+        "detector_version": "guard-secrets-v2",
+        "model_version": None,
+        "requester_id": "user:1",
+        "approver_id": None,
+        "policy_source": "personal",
+        "propagation": ["cli"],
+        "permanent_fixture_justification": None,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_complete_coverage_is_clean_eligible() -> None:
+    coverage = _coverage()
+    coverage.assert_outcome(PreventionOutcome.CLEAN)
+    assert coverage.clean_eligible is True
+    assert coverage.to_public_dict()["clean_eligible"] is True
+
+
+def test_partial_coverage_cannot_claim_clean() -> None:
+    coverage = _coverage(partial=True, truncation_codes=["max_bytes"])
+    with pytest.raises(SecretContractError, match="cannot produce a clean"):
+        coverage.assert_outcome(PreventionOutcome.CLEAN)
+
+
+def test_missing_requested_ref_cannot_claim_clean() -> None:
+    coverage = _coverage(completed_refs=[])
+    assert coverage.clean_eligible is False
+    with pytest.raises(SecretContractError):
+        coverage.assert_outcome(PreventionOutcome.CLEAN)
+
+
+def test_direct_coverage_rejects_truncation_without_partial() -> None:
+    with pytest.raises(SecretContractError, match="partial=true"):
+        _direct_coverage(truncation_codes=("max_bytes",))
+
+
+def test_direct_coverage_rejects_completed_ref_outside_request() -> None:
+    with pytest.raises(SecretContractError, match="subset"):
+        _direct_coverage(completed_refs=("refs/heads/other",))
+
+
+def test_unknown_reason_code_is_rejected() -> None:
+    with pytest.raises(SecretContractError, match="unknown reason codes"):
+        _direct_coverage(skipped_codes=("future_unknown",))
+
+
+def test_future_coverage_schema_is_rejected() -> None:
+    with pytest.raises(SecretContractError, match="unsupported"):
+        _coverage(schema="guard-secret-coverage.v3")
+
+
+def test_unknown_coverage_field_is_rejected() -> None:
+    with pytest.raises(SecretContractError, match="unknown fields"):
+        _coverage(unreviewed="value")
+
+
+def test_nested_raw_value_like_field_is_rejected() -> None:
+    with pytest.raises(SecretContractError, match="prohibited"):
+        reject_prohibited_fields({"safe": {"candidateValue": "not-serialized"}})
+
+
+def test_nested_secret_like_value_is_rejected() -> None:
+    with pytest.raises(SecretContractError, match="secret-like"):
+        reject_prohibited_fields({"reason": _FIXTURE_OPENAI_KEY})
+
+
+def test_approved_ignore_requires_approver() -> None:
+    with pytest.raises(SecretContractError, match="approver"):
+        SecretIgnoreDecisionV2(
+            decision_id="ignore:1",
+            state=SecretIgnoreState.APPROVED,
+            requested_scope=SecretIgnoreScope.OCCURRENCE,
+            durable_match_key="a" * 64,
+            reason="approved_fixture",
+            expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+            detector_version="guard-secrets-v2",
+            model_version=None,
+            requester_id="user:1",
+            approver_id=None,
+            policy_source="personal",
+            propagation=("cli", "github"),
+        )
+
+
+@pytest.mark.parametrize(
+    "state",
+    [SecretIgnoreState.EXPIRED, SecretIgnoreState.REVOKED, SecretIgnoreState.DENIED],
+)
+def test_terminal_ignore_state_retains_past_expiry(state: SecretIgnoreState) -> None:
+    decision = SecretIgnoreDecisionV2(
+        decision_id="ignore:terminal",
+        state=state,
+        requested_scope=SecretIgnoreScope.OCCURRENCE,
+        durable_match_key="c" * 64,
+        reason="historical_decision",
+        expires_at=datetime.now(timezone.utc) - timedelta(days=1),
+        detector_version="guard-secrets-v2",
+        model_version=None,
+        requester_id="user:1",
+        approver_id=None,
+        policy_source="personal",
+        propagation=("cli",),
+    )
+    assert decision.expires_at is not None
+
+
+def test_active_ignore_rejects_past_expiry() -> None:
+    with pytest.raises(SecretContractError, match="must be in the future"):
+        SecretIgnoreDecisionV2(
+            decision_id="ignore:active",
+            state=SecretIgnoreState.REQUESTED,
+            requested_scope=SecretIgnoreScope.OCCURRENCE,
+            durable_match_key="d" * 64,
+            reason="pending_review",
+            expires_at=datetime.now(timezone.utc) - timedelta(days=1),
+            detector_version="guard-secrets-v2",
+            model_version=None,
+            requester_id="user:1",
+            approver_id=None,
+            policy_source="personal",
+            propagation=("cli",),
+        )
+
+
+def test_non_expiring_ignore_requires_fixture_justification() -> None:
+    with pytest.raises(SecretContractError, match="justification"):
+        SecretIgnoreDecisionV2(
+            decision_id="ignore:2",
+            state=SecretIgnoreState.REQUESTED,
+            requested_scope=SecretIgnoreScope.FIXTURE,
+            durable_match_key="b" * 64,
+            reason="test_fixture",
+            expires_at=None,
+            detector_version="guard-secrets-v2",
+            model_version=None,
+            requester_id="user:1",
+            approver_id=None,
+            policy_source="personal",
+            propagation=("cli",),
+        )
+
+
+def test_ignore_reason_must_be_registered() -> None:
+    with pytest.raises(SecretContractError, match="registered reason code"):
+        SecretIgnoreDecisionV2(
+            decision_id="ignore:3",
+            state=SecretIgnoreState.REQUESTED,
+            requested_scope=SecretIgnoreScope.OCCURRENCE,
+            durable_match_key="e" * 64,
+            reason=_FIXTURE_OPENAI_KEY,
+            expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+            detector_version="guard-secrets-v2",
+            model_version=None,
+            requester_id="user:1",
+            approver_id=None,
+            policy_source="personal",
+            propagation=("cli",),
+        )
+
+
+def test_ignore_deserialization_rejects_secret_in_reason() -> None:
+    with pytest.raises(SecretContractError, match="secret-like"):
+        SecretIgnoreDecisionV2.from_mapping(_ignore_payload(reason=_FIXTURE_OPENAI_KEY))
+
+
+def test_ignore_contract_round_trips_registered_codes() -> None:
+    decision = SecretIgnoreDecisionV2.from_mapping(_ignore_payload())
+    assert decision.reason in IGNORE_REASON_CODES_V2
+    assert SecretIgnoreDecisionV2.from_mapping(decision.to_public_dict()) == decision
+
+
+def test_non_expiring_fixture_uses_registered_justification_code() -> None:
+    payload = _ignore_payload(
+        requested_scope="fixture",
+        reason="test_fixture",
+        expires_at=None,
+        permanent_fixture_justification="fixture_is_synthetic",
+    )
+    decision = SecretIgnoreDecisionV2.from_mapping(payload)
+    assert decision.permanent_fixture_justification in FIXTURE_JUSTIFICATION_CODES_V2
+
+
+def test_active_custom_rule_must_compile_validly() -> None:
+    with pytest.raises(SecretContractError, match="valid compiled"):
+        SecretCustomRuleV2(
+            rule_id="rule:custom:1",
+            version="1.0.0",
+            matcher_kind=SecretRuleMatcherKind.REGEX,
+            matcher_digest="a" * 64,
+            safe_fixture_digest="b" * 64,
+            provenance_digest="c" * 64,
+            compile_state=SecretRuleCompileState.TOO_COMPLEX,
+            complexity_budget=100,
+            rollout_state=SecretRolloutState.ACTIVE,
+            surfaces=("cli",),
+        )
+
+
+def test_custom_rule_complexity_is_bounded() -> None:
+    with pytest.raises(SecretContractError, match="complexity_budget"):
+        SecretCustomRuleV2(
+            rule_id="rule:custom:2",
+            version="1.0.0",
+            matcher_kind=SecretRuleMatcherKind.PREFIX,
+            matcher_digest="a" * 64,
+            safe_fixture_digest="b" * 64,
+            provenance_digest="c" * 64,
+            compile_state=SecretRuleCompileState.VALID,
+            complexity_budget=100_001,
+            rollout_state=SecretRolloutState.DRAFT,
+            surfaces=("cli",),
+        )
+
+
+def test_custom_rule_rejects_unknown_surface() -> None:
+    with pytest.raises(SecretContractError, match="unknown rule surface"):
+        SecretCustomRuleV2(
+            rule_id="rule:custom:3",
+            version="1.0.0",
+            matcher_kind=SecretRuleMatcherKind.PREFIX,
+            matcher_digest="a" * 64,
+            safe_fixture_digest="b" * 64,
+            provenance_digest="c" * 64,
+            compile_state=SecretRuleCompileState.VALID,
+            complexity_budget=100,
+            rollout_state=SecretRolloutState.DRAFT,
+            surfaces=("unknown",),
+        )
+
+
+def test_release_claim_rejects_unverified_capability() -> None:
+    with pytest.raises(SecretContractError, match="not verified"):
+        validate_capability_manifest(
+            [_capability()],
+            required_capability_ids=frozenset({"secret:cli"}),
+            exact_release_commit="d" * 40,
+        )
+
+
+def test_release_claim_accepts_exact_commit_evidence() -> None:
+    commit = "d" * 40
+    capability = _capability(
+        state=ParityState.VERIFIED_ON_RELEASE_CANDIDATE,
+        evidence_artifacts=("sha256:benchmark",),
+        release_commit=commit,
+        gap_label=None,
+    )
+    validate_capability_manifest(
+        [capability],
+        required_capability_ids=frozenset({"secret:cli"}),
+        exact_release_commit=commit,
+    )
+
+
+def test_malformed_release_commit_is_rejected() -> None:
+    with pytest.raises(SecretContractError, match="full commit SHA"):
+        validate_capability_manifest(
+            [],
+            required_capability_ids=frozenset(),
+            exact_release_commit="D" * 40,
+        )
+
+
+def test_duplicate_capability_ids_are_rejected() -> None:
+    capability = _capability()
+    with pytest.raises(SecretContractError, match="must be unique"):
+        validate_capability_manifest(
+            [capability, capability],
+            required_capability_ids=frozenset({"secret:cli"}),
+            exact_release_commit="d" * 40,
+        )
+
+
+def test_missing_required_capability_is_rejected() -> None:
+    with pytest.raises(SecretContractError, match="required capabilities are unmapped"):
+        validate_capability_manifest(
+            [],
+            required_capability_ids=frozenset({"secret:ide"}),
+            exact_release_commit="d" * 40,
+        )
+
+
+def test_capability_rejects_unknown_product_boundary() -> None:
+    with pytest.raises(SecretContractError, match="unknown product boundary"):
+        _capability(product_boundary="undeclared")
+
+
+def test_capability_rejects_plan_outside_product_boundary() -> None:
+    with pytest.raises(SecretContractError, match="plans outside"):
+        _capability(product_boundary="organization-governance", plans=("free",), surfaces=("portal",))
+
+
+def test_capability_rejects_surface_outside_product_boundary() -> None:
+    with pytest.raises(SecretContractError, match="surfaces outside"):
+        _capability(product_boundary="free-local", surfaces=("portal",))
+
+
+def test_capability_rejects_secret_in_gap_label_on_direct_construction() -> None:
+    with pytest.raises(SecretContractError, match="secret-like"):
+        _capability(gap_label=_FIXTURE_OPENAI_KEY)
+
+
+def test_capability_manifest_rejects_secret_in_gap_label() -> None:
+    with pytest.raises(SecretContractError, match="secret-like"):
+        parse_capability_evidence_manifest(_manifest(gap_label=_FIXTURE_OPENAI_KEY))
+
+
+def test_every_outcome_has_a_surface_mapping() -> None:
+    assert set(OUTCOME_SURFACE_MAPPING) == set(PreventionOutcome)
+
+
+def test_repository_reason_code_registry_matches_runtime() -> None:
+    payload = _load(_REPOSITORY_ROOT / "docs/guard/contracts/guard-secrets-reason-codes.v2.json")
+    categories = payload["categories"]
+    assert isinstance(categories, dict)
+    declared = {code for codes in categories.values() for code in codes}
+    assert declared == REASON_CODES_V2
+
+
+def test_repository_product_boundary_manifest_matches_runtime() -> None:
+    manifest = parse_product_boundaries_manifest(_load(_PRODUCT_BOUNDARY_PATH))
+    assert manifest.plan_ids == frozenset({"free", "solo", "pro", "team"})
+    assert "shared-detection" in manifest.boundary_ids
+    assert "cli" in manifest.surface_ids
+
+
+def test_product_boundary_manifest_rejects_unknown_plan() -> None:
+    payload = _load(_PRODUCT_BOUNDARY_PATH)
+    plans = payload["plans"]
+    assert isinstance(plans, dict)
+    plans["enterprise"] = copy.deepcopy(plans["team"])
+    with pytest.raises(SecretContractError, match="plan registry"):
+        parse_product_boundaries_manifest(payload)
+
+
+def test_product_boundary_manifest_rejects_unknown_surface() -> None:
+    payload = _load(_PRODUCT_BOUNDARY_PATH)
+    surfaces = payload["surface_values"]
+    assert isinstance(surfaces, list)
+    surfaces.append("unreviewed")
+    with pytest.raises(SecretContractError, match="surface_values"):
+        parse_product_boundaries_manifest(payload)
+
+
+def test_product_boundary_manifest_rejects_policy_drift() -> None:
+    payload = _load(_PRODUCT_BOUNDARY_PATH)
+    boundaries = payload["product_boundaries"]
+    assert isinstance(boundaries, dict)
+    free_local = boundaries["free-local"]
+    assert isinstance(free_local, dict)
+    free_local["allowed_plans"] = ["free"]
+    with pytest.raises(SecretContractError, match="allowed plans"):
+        parse_product_boundaries_manifest(payload)
+
+
+def test_product_boundary_manifest_rejects_invariant_drift() -> None:
+    payload = _load(_PRODUCT_BOUNDARY_PATH)
+    payload["invariants"] = ["local_detection_unmetered"]
+    with pytest.raises(SecretContractError, match="invariants"):
+        parse_product_boundaries_manifest(payload)
+
+
+def test_repository_source_capability_manifest_matches_runtime() -> None:
+    manifest = parse_source_capabilities_manifest(_load(_SOURCE_CAPABILITY_PATH))
+    assert manifest.status_values == SOURCE_CAPABILITY_STATUS_VALUES_V2
+    assert "operating_systems" in manifest.sections
+
+
+def test_source_capability_manifest_rejects_invalid_status_value() -> None:
+    payload = _load(_SOURCE_CAPABILITY_PATH)
+    operating_systems = payload["operating_systems"]
+    assert isinstance(operating_systems, dict)
+    operating_systems["linux"] = "complete"
+    with pytest.raises(SecretContractError, match="invalid status"):
+        parse_source_capabilities_manifest(payload)
+
+
+def test_source_capability_manifest_rejects_unknown_capability() -> None:
+    payload = _load(_SOURCE_CAPABILITY_PATH)
+    operating_systems = payload["operating_systems"]
+    assert isinstance(operating_systems, dict)
+    operating_systems["plan9"] = "planned"
+    with pytest.raises(SecretContractError, match="capability keys"):
+        parse_source_capabilities_manifest(payload)
+
+
+def test_source_capability_manifest_rejects_policy_status_drift() -> None:
+    payload = _load(_SOURCE_CAPABILITY_PATH)
+    operating_systems = payload["operating_systems"]
+    assert isinstance(operating_systems, dict)
+    operating_systems["linux"] = "partial"
+    with pytest.raises(SecretContractError, match="statuses"):
+        parse_source_capabilities_manifest(payload)
+
+
+def test_manifest_parser_consumes_declared_policy() -> None:
+    manifest = parse_capability_evidence_manifest(_manifest())
+    assert manifest.row_errors == ()
+    assert manifest.public_parity_requires is ParityState.VERIFIED_ON_RELEASE_CANDIDATE
+    assert manifest.exact_release_commit_required is True
+    assert manifest.remaining_gaps_must_be_labeled is True
+    assert manifest.public_parity_claim_enabled is False
+    assert manifest.required_capability_ids == frozenset({"cli_precommit"})
+
+
+def test_manifest_parser_rejects_parity_state_drift() -> None:
+    payload = _manifest()
+    payload["parity_states"] = ["unmapped", "tested"]
+    with pytest.raises(SecretContractError, match="do not match"):
+        parse_capability_evidence_manifest(payload)
+
+
+def test_manifest_parser_rejects_claim_policy_weakening() -> None:
+    payload = _manifest()
+    policy = payload["claim_policy"]
+    assert isinstance(policy, dict)
+    policy["exact_release_commit_required"] = False
+    with pytest.raises(SecretContractError, match="must require"):
+        parse_capability_evidence_manifest(payload)
+
+
+def test_manifest_parser_rejects_unlabeled_gap_policy_weakening() -> None:
+    payload = _manifest()
+    policy = payload["claim_policy"]
+    assert isinstance(policy, dict)
+    policy["remaining_gaps_must_be_labeled"] = False
+    with pytest.raises(SecretContractError, match="must require labels"):
+        parse_capability_evidence_manifest(payload)
+
+
+def test_manifest_parser_rejects_duplicate_required_capabilities() -> None:
+    payload = _manifest()
+    policy = payload["claim_policy"]
+    assert isinstance(policy, dict)
+    policy["required_capabilities"] = ["cli_precommit", "cli_precommit"]
+    with pytest.raises(SecretContractError, match="must be unique"):
+        parse_capability_evidence_manifest(payload)
+
+
+def test_manifest_parser_reports_unmapped_claim_policy_capability() -> None:
+    payload = _manifest()
+    policy = payload["claim_policy"]
+    assert isinstance(policy, dict)
+    policy["required_capabilities"] = ["cli_precommit", "ide_prevention"]
+    manifest = parse_capability_evidence_manifest(payload)
+    assert manifest.row_errors == ("claim policy capabilities are unmapped: ide_prevention",)

--- a/tests/test_guard_secret_contracts_v2.py
+++ b/tests/test_guard_secret_contracts_v2.py
@@ -11,6 +11,8 @@ from codex_plugin_scanner.guard.secrets.contracts_v2 import (
     FIXTURE_JUSTIFICATION_CODES_V2,
     IGNORE_REASON_CODES_V2,
     OUTCOME_SURFACE_MAPPING,
+    REASON_CODE_CATEGORIES_V2,
+    REASON_CODE_RULES_V2,
     REASON_CODES_V2,
     SOURCE_CAPABILITY_STATUS_VALUES_V2,
     CapabilityEvidenceV2,
@@ -27,6 +29,7 @@ from codex_plugin_scanner.guard.secrets.contracts_v2 import (
     SecretScanCoverageV2,
     parse_capability_evidence_manifest,
     parse_product_boundaries_manifest,
+    parse_reason_codes_manifest,
     parse_source_capabilities_manifest,
     reject_prohibited_fields,
     validate_capability_manifest,
@@ -36,6 +39,7 @@ _REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 _CAPABILITY_PATH = _REPOSITORY_ROOT / "docs/guard/contracts/guard-secrets-capability-evidence.v2.json"
 _PRODUCT_BOUNDARY_PATH = _REPOSITORY_ROOT / "docs/guard/contracts/guard-secrets-product-boundaries.v2.json"
 _SOURCE_CAPABILITY_PATH = _REPOSITORY_ROOT / "docs/guard/contracts/guard-secrets-source-capabilities.v2.json"
+_REASON_CODE_PATH = _REPOSITORY_ROOT / "docs/guard/contracts/guard-secrets-reason-codes.v2.json"
 _FIXTURE_OPENAI_KEY = "sk-proj-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
 
@@ -147,6 +151,42 @@ def _ignore_payload(**overrides: object) -> dict[str, object]:
     }
     payload.update(overrides)
     return payload
+
+
+def _direct_ignore(**overrides: object) -> SecretIgnoreDecisionV2:
+    values: dict[str, object] = {
+        "decision_id": "ignore:direct",
+        "state": SecretIgnoreState.REQUESTED,
+        "requested_scope": SecretIgnoreScope.OCCURRENCE,
+        "durable_match_key": "a" * 64,
+        "reason": "pending_review",
+        "expires_at": datetime.now(timezone.utc) + timedelta(days=7),
+        "detector_version": "guard-secrets-v2",
+        "model_version": None,
+        "requester_id": "user:1",
+        "approver_id": None,
+        "policy_source": "personal",
+        "propagation": ("cli",),
+    }
+    values.update(overrides)
+    return SecretIgnoreDecisionV2(**values)  # type: ignore[arg-type]
+
+
+def _direct_custom_rule(**overrides: object) -> SecretCustomRuleV2:
+    values: dict[str, object] = {
+        "rule_id": "rule:direct",
+        "version": "1.0.0",
+        "matcher_kind": SecretRuleMatcherKind.REGEX,
+        "matcher_digest": "a" * 64,
+        "safe_fixture_digest": "b" * 64,
+        "provenance_digest": "c" * 64,
+        "compile_state": SecretRuleCompileState.VALID,
+        "complexity_budget": 100,
+        "rollout_state": SecretRolloutState.DRAFT,
+        "surfaces": ("cli",),
+    }
+    values.update(overrides)
+    return SecretCustomRuleV2(**values)  # type: ignore[arg-type]
 
 
 def test_complete_coverage_is_clean_eligible() -> None:
@@ -333,6 +373,22 @@ def test_nested_secret_like_value_is_rejected() -> None:
         reject_prohibited_fields({"reason": _FIXTURE_OPENAI_KEY})
 
 
+@pytest.mark.parametrize(
+    ("field_name", "value", "expected_type"),
+    [
+        ("state", "requested", "SecretIgnoreState"),
+        ("requested_scope", "occurrence", "SecretIgnoreScope"),
+    ],
+)
+def test_direct_ignore_rejects_raw_enum_values(
+    field_name: str,
+    value: str,
+    expected_type: str,
+) -> None:
+    with pytest.raises(SecretContractError, match=f"expected {expected_type}"):
+        _direct_ignore(**{field_name: value})
+
+
 def test_approved_ignore_requires_approver() -> None:
     with pytest.raises(SecretContractError, match="approver"):
         SecretIgnoreDecisionV2(
@@ -449,6 +505,28 @@ def test_non_expiring_fixture_uses_registered_justification_code() -> None:
     assert decision.permanent_fixture_justification in FIXTURE_JUSTIFICATION_CODES_V2
 
 
+@pytest.mark.parametrize(
+    ("field_name", "value", "expected_type"),
+    [
+        ("matcher_kind", "regex", "SecretRuleMatcherKind"),
+        ("compile_state", "valid", "SecretRuleCompileState"),
+        ("rollout_state", "active", "SecretRolloutState"),
+    ],
+)
+def test_direct_custom_rule_rejects_raw_enum_values(
+    field_name: str,
+    value: str,
+    expected_type: str,
+) -> None:
+    with pytest.raises(SecretContractError, match=f"expected {expected_type}"):
+        _direct_custom_rule(**{field_name: value})
+
+
+def test_raw_active_invalid_custom_rule_cannot_bypass_compile_check() -> None:
+    with pytest.raises(SecretContractError, match="expected SecretRuleCompileState"):
+        _direct_custom_rule(compile_state="invalid", rollout_state="active")
+
+
 def test_active_custom_rule_must_compile_validly() -> None:
     with pytest.raises(SecretContractError, match="valid compiled"):
         SecretCustomRuleV2(
@@ -494,6 +572,16 @@ def test_custom_rule_rejects_unknown_surface() -> None:
             complexity_budget=100,
             rollout_state=SecretRolloutState.DRAFT,
             surfaces=("unknown",),
+        )
+
+
+def test_direct_capability_rejects_raw_parity_state() -> None:
+    with pytest.raises(SecretContractError, match="expected ParityState"):
+        _capability(
+            state="verified_on_release_candidate",
+            release_commit="d" * 40,
+            evidence_artifacts=("sha256:evidence",),
+            gap_label=None,
         )
 
 
@@ -578,12 +666,81 @@ def test_every_outcome_has_a_surface_mapping() -> None:
     assert set(OUTCOME_SURFACE_MAPPING) == set(PreventionOutcome)
 
 
-def test_repository_reason_code_registry_matches_runtime() -> None:
-    payload = _load(_REPOSITORY_ROOT / "docs/guard/contracts/guard-secrets-reason-codes.v2.json")
+def test_repository_reason_code_manifest_matches_runtime() -> None:
+    manifest = parse_reason_codes_manifest(_load(_REASON_CODE_PATH))
+    assert manifest.category_ids == tuple(REASON_CODE_CATEGORIES_V2)
+    assert manifest.codes == REASON_CODES_V2
+    assert manifest.rule_ids == tuple(REASON_CODE_RULES_V2)
+
+
+def test_reason_code_manifest_rejects_schema_drift() -> None:
+    payload = _load(_REASON_CODE_PATH)
+    payload["schema"] = "guard-secrets-reason-codes.v3"
+    with pytest.raises(SecretContractError, match="unsupported reason-code"):
+        parse_reason_codes_manifest(payload)
+
+
+def test_reason_code_manifest_rejects_category_registry_drift() -> None:
+    payload = _load(_REASON_CODE_PATH)
     categories = payload["categories"]
     assert isinstance(categories, dict)
-    declared = {code for codes in categories.values() for code in codes}
-    assert declared == REASON_CODES_V2
+    categories["unreviewed"] = ["unreviewed_reason"]
+    with pytest.raises(SecretContractError, match="category registry"):
+        parse_reason_codes_manifest(payload)
+
+
+def test_reason_code_manifest_rejects_code_drift() -> None:
+    payload = _load(_REASON_CODE_PATH)
+    categories = payload["categories"]
+    assert isinstance(categories, dict)
+    coverage = categories["coverage"]
+    assert isinstance(coverage, list)
+    coverage[0] = "unreviewed_reason"
+    with pytest.raises(SecretContractError, match="codes do not match"):
+        parse_reason_codes_manifest(payload)
+
+
+def test_reason_code_manifest_rejects_duplicate_code_in_category() -> None:
+    payload = _load(_REASON_CODE_PATH)
+    categories = payload["categories"]
+    assert isinstance(categories, dict)
+    coverage = categories["coverage"]
+    assert isinstance(coverage, list)
+    coverage.append(coverage[0])
+    with pytest.raises(SecretContractError, match="must be unique"):
+        parse_reason_codes_manifest(payload)
+
+
+def test_reason_code_manifest_rejects_code_in_multiple_categories() -> None:
+    payload = _load(_REASON_CODE_PATH)
+    categories = payload["categories"]
+    assert isinstance(categories, dict)
+    coverage = categories["coverage"]
+    detector = categories["detector"]
+    assert isinstance(coverage, list)
+    assert isinstance(detector, list)
+    detector.insert(0, coverage[0])
+    with pytest.raises(SecretContractError, match="exactly one category"):
+        parse_reason_codes_manifest(payload)
+
+
+@pytest.mark.parametrize("rule_id", tuple(REASON_CODE_RULES_V2))
+def test_reason_code_manifest_rejects_rule_weakening(rule_id: str) -> None:
+    payload = _load(_REASON_CODE_PATH)
+    rules = payload["rules"]
+    assert isinstance(rules, dict)
+    rules[rule_id] = False
+    with pytest.raises(SecretContractError, match="policy does not match"):
+        parse_reason_codes_manifest(payload)
+
+
+def test_reason_code_manifest_rejects_rule_registry_drift() -> None:
+    payload = _load(_REASON_CODE_PATH)
+    rules = payload["rules"]
+    assert isinstance(rules, dict)
+    rules["unreviewed"] = True
+    with pytest.raises(SecretContractError, match="rule registry"):
+        parse_reason_codes_manifest(payload)
 
 
 def test_repository_product_boundary_manifest_matches_runtime() -> None:

--- a/tests/test_guard_secret_contracts_v2.py
+++ b/tests/test_guard_secret_contracts_v2.py
@@ -189,6 +189,130 @@ def _direct_custom_rule(**overrides: object) -> SecretCustomRuleV2:
     return SecretCustomRuleV2(**values)  # type: ignore[arg-type]
 
 
+def test_direct_ignore_rejects_mutable_propagation() -> None:
+    mutable = ["cli"]
+    with pytest.raises(SecretContractError, match="tuple of strings"):
+        _direct_ignore(propagation=mutable)
+    mutable.append("github")
+    assert mutable == ["cli", "github"]
+
+
+def test_direct_ignore_rejects_string_propagation() -> None:
+    with pytest.raises(SecretContractError, match="tuple of strings"):
+        _direct_ignore(propagation="cli")
+
+
+def test_direct_ignore_rejects_duplicate_propagation() -> None:
+    with pytest.raises(SecretContractError, match="values must be unique"):
+        _direct_ignore(propagation=("cli", "cli"))
+
+
+def test_direct_ignore_rejects_blank_propagation() -> None:
+    with pytest.raises(SecretContractError, match="must not be blank"):
+        _direct_ignore(propagation=(" ",))
+
+
+def test_direct_ignore_rejects_empty_propagation() -> None:
+    with pytest.raises(SecretContractError, match="must not be empty"):
+        _direct_ignore(propagation=())
+
+
+def test_direct_custom_rule_rejects_mutable_surfaces() -> None:
+    mutable = ["cli"]
+    with pytest.raises(SecretContractError, match="tuple of strings"):
+        _direct_custom_rule(surfaces=mutable)
+    mutable.append("pre_commit")
+    assert mutable == ["cli", "pre_commit"]
+
+
+def test_direct_custom_rule_rejects_string_surfaces() -> None:
+    with pytest.raises(SecretContractError, match="tuple of strings"):
+        _direct_custom_rule(surfaces="cli")
+
+
+def test_direct_custom_rule_rejects_duplicate_surfaces() -> None:
+    with pytest.raises(SecretContractError, match="values must be unique"):
+        _direct_custom_rule(surfaces=("cli", "cli"))
+
+
+def test_direct_custom_rule_rejects_blank_surfaces() -> None:
+    with pytest.raises(SecretContractError, match="must not be blank"):
+        _direct_custom_rule(surfaces=(" ",))
+
+
+def test_direct_custom_rule_rejects_empty_surfaces() -> None:
+    with pytest.raises(SecretContractError, match="must not be empty"):
+        _direct_custom_rule(surfaces=())
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("surfaces", ["cli"]),
+        ("plans", ["free"]),
+        ("acceptance_tests", ["test_cli"]),
+        ("evidence_artifacts", ["sha256:evidence"]),
+    ],
+)
+def test_direct_capability_rejects_mutable_sequence_fields(
+    field_name: str,
+    value: list[str],
+) -> None:
+    with pytest.raises(SecretContractError, match="tuple of strings"):
+        _capability(**{field_name: value})
+    value.append("mutated")
+    assert value[-1] == "mutated"
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("surfaces", "cli"),
+        ("plans", "free"),
+        ("acceptance_tests", "test_cli"),
+        ("evidence_artifacts", "sha256:evidence"),
+    ],
+)
+def test_direct_capability_rejects_string_sequence_fields(
+    field_name: str,
+    value: str,
+) -> None:
+    with pytest.raises(SecretContractError, match="tuple of strings"):
+        _capability(**{field_name: value})
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("surfaces", ("cli", "cli")),
+        ("plans", ("free", "free")),
+        ("acceptance_tests", ("test_cli", "test_cli")),
+        ("evidence_artifacts", ("sha256:evidence", "sha256:evidence")),
+    ],
+)
+def test_direct_capability_rejects_duplicate_sequence_fields(
+    field_name: str,
+    value: tuple[str, ...],
+) -> None:
+    with pytest.raises(SecretContractError, match="values must be unique"):
+        _capability(**{field_name: value})
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    ["surfaces", "plans", "acceptance_tests", "evidence_artifacts"],
+)
+def test_direct_capability_rejects_blank_sequence_fields(field_name: str) -> None:
+    with pytest.raises(SecretContractError, match="must not be blank"):
+        _capability(**{field_name: (" ",)})
+
+
+@pytest.mark.parametrize("field_name", ["surfaces", "plans"])
+def test_direct_capability_rejects_empty_required_sequence_fields(field_name: str) -> None:
+    with pytest.raises(SecretContractError, match="must not be empty"):
+        _capability(**{field_name: ()})
+
+
 def test_complete_coverage_is_clean_eligible() -> None:
     coverage = _coverage()
     coverage.assert_outcome(PreventionOutcome.CLEAN)

--- a/tests/test_guard_secret_contracts_v2.py
+++ b/tests/test_guard_secret_contracts_v2.py
@@ -169,6 +169,63 @@ def test_missing_requested_ref_cannot_claim_clean() -> None:
         coverage.assert_outcome(PreventionOutcome.CLEAN)
 
 
+@pytest.mark.parametrize(
+    "field_name",
+    [
+        "files_scanned",
+        "bytes_scanned",
+        "commits_visited",
+        "blobs_scanned",
+        "cache_hits",
+        "cache_misses",
+    ],
+)
+def test_direct_coverage_rejects_negative_counters(field_name: str) -> None:
+    with pytest.raises(SecretContractError, match="non-negative integer"):
+        _direct_coverage(**{field_name: -1})
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    ["files_scanned", "bytes_scanned", "commits_visited", "blobs_scanned", "cache_hits", "cache_misses"],
+)
+def test_direct_coverage_rejects_boolean_counters(field_name: str) -> None:
+    with pytest.raises(SecretContractError, match="non-negative integer"):
+        _direct_coverage(**{field_name: True})
+
+
+@pytest.mark.parametrize("field_name", ["partial", "degraded"])
+def test_direct_coverage_rejects_non_boolean_flags(field_name: str) -> None:
+    with pytest.raises(SecretContractError, match="expected a boolean"):
+        _direct_coverage(**{field_name: 1})
+
+
+@pytest.mark.parametrize(
+    "field_name", ["source_set", "requested_refs", "completed_refs", "skipped_codes", "truncation_codes"]
+)
+def test_direct_coverage_rejects_non_tuple_string_fields(field_name: str) -> None:
+    with pytest.raises(SecretContractError, match="tuple of strings"):
+        _direct_coverage(**{field_name: ["value"]})
+
+
+@pytest.mark.parametrize("field_name", ["source_set", "requested_refs", "completed_refs"])
+def test_coverage_rejects_duplicate_identity_fields(field_name: str) -> None:
+    value = ["duplicate", "duplicate"]
+    with pytest.raises(SecretContractError, match="values must be unique"):
+        _coverage(**{field_name: value})
+
+
+@pytest.mark.parametrize("field_name", ["source_set", "requested_refs", "completed_refs"])
+def test_coverage_rejects_blank_identity_fields(field_name: str) -> None:
+    with pytest.raises(SecretContractError, match="must not be blank"):
+        _coverage(**{field_name: [" "]})
+
+
+def test_direct_coverage_rejects_blank_detector_version() -> None:
+    with pytest.raises(SecretContractError, match="invalid length"):
+        _direct_coverage(detector_version=" ")
+
+
 def test_direct_coverage_rejects_empty_source_set() -> None:
     with pytest.raises(SecretContractError, match="source_set must not be empty"):
         _direct_coverage(source_set=())

--- a/tests/test_guard_secret_contracts_v2.py
+++ b/tests/test_guard_secret_contracts_v2.py
@@ -163,10 +163,43 @@ def test_partial_coverage_cannot_claim_clean() -> None:
 
 
 def test_missing_requested_ref_cannot_claim_clean() -> None:
-    coverage = _coverage(completed_refs=[])
+    coverage = _coverage(completed_refs=[], partial=True)
     assert coverage.clean_eligible is False
-    with pytest.raises(SecretContractError):
+    with pytest.raises(SecretContractError, match="cannot produce a clean"):
         coverage.assert_outcome(PreventionOutcome.CLEAN)
+
+
+def test_direct_coverage_rejects_empty_refs_without_partial() -> None:
+    with pytest.raises(SecretContractError, match="empty requested_refs requires partial=true"):
+        _direct_coverage(requested_refs=(), completed_refs=())
+
+
+def test_mapping_coverage_rejects_empty_refs_without_partial() -> None:
+    with pytest.raises(SecretContractError, match="empty requested_refs requires partial=true"):
+        _coverage(requested_refs=[], completed_refs=[])
+
+
+def test_empty_ref_partial_coverage_cannot_claim_clean() -> None:
+    coverage = _coverage(requested_refs=[], completed_refs=[], partial=True)
+    assert coverage.clean_eligible is False
+    with pytest.raises(SecretContractError, match="cannot produce a clean"):
+        coverage.assert_outcome(PreventionOutcome.CLEAN)
+
+
+def test_direct_complete_coverage_requires_every_requested_ref() -> None:
+    with pytest.raises(SecretContractError, match="complete every requested ref"):
+        _direct_coverage(
+            requested_refs=("refs/heads/main", "refs/tags/v3"),
+            completed_refs=("refs/heads/main",),
+        )
+
+
+def test_mapping_complete_coverage_requires_every_requested_ref() -> None:
+    with pytest.raises(SecretContractError, match="complete every requested ref"):
+        _coverage(
+            requested_refs=["refs/heads/main", "refs/tags/v3"],
+            completed_refs=["refs/heads/main"],
+        )
 
 
 def test_direct_coverage_rejects_skipped_work_without_partial() -> None:

--- a/tests/test_guard_secret_contracts_v2.py
+++ b/tests/test_guard_secret_contracts_v2.py
@@ -169,6 +169,23 @@ def test_missing_requested_ref_cannot_claim_clean() -> None:
         coverage.assert_outcome(PreventionOutcome.CLEAN)
 
 
+def test_direct_coverage_rejects_skipped_work_without_partial() -> None:
+    with pytest.raises(SecretContractError, match="skipped work requires partial=true"):
+        _direct_coverage(skipped_codes=("binary_skipped",))
+
+
+def test_mapping_coverage_rejects_skipped_work_without_partial() -> None:
+    with pytest.raises(SecretContractError, match="skipped work requires partial=true"):
+        _coverage(skipped_codes=["binary_skipped"])
+
+
+def test_skipped_partial_coverage_cannot_claim_clean() -> None:
+    coverage = _coverage(partial=True, skipped_codes=["binary_skipped"])
+    assert coverage.clean_eligible is False
+    with pytest.raises(SecretContractError, match="cannot produce a clean"):
+        coverage.assert_outcome(PreventionOutcome.CLEAN)
+
+
 def test_direct_coverage_rejects_truncation_without_partial() -> None:
     with pytest.raises(SecretContractError, match="partial=true"):
         _direct_coverage(truncation_codes=("max_bytes",))
@@ -181,7 +198,7 @@ def test_direct_coverage_rejects_completed_ref_outside_request() -> None:
 
 def test_unknown_reason_code_is_rejected() -> None:
     with pytest.raises(SecretContractError, match="unknown reason codes"):
-        _direct_coverage(skipped_codes=("future_unknown",))
+        _direct_coverage(skipped_codes=("future_unknown",), partial=True)
 
 
 def test_future_coverage_schema_is_rejected() -> None:
@@ -192,6 +209,18 @@ def test_future_coverage_schema_is_rejected() -> None:
 def test_unknown_coverage_field_is_rejected() -> None:
     with pytest.raises(SecretContractError, match="unknown fields"):
         _coverage(unreviewed="value")
+
+
+@pytest.mark.parametrize("key", ["raw_value", "rawValue", "raw-value"])
+def test_raw_value_key_spellings_are_rejected(key: str) -> None:
+    with pytest.raises(SecretContractError, match="prohibited"):
+        reject_prohibited_fields({key: "arbitrary plaintext"})
+
+
+@pytest.mark.parametrize("key", ["raw_value", "rawValue", "raw-value"])
+def test_nested_raw_value_key_spellings_are_rejected(key: str) -> None:
+    with pytest.raises(SecretContractError, match="prohibited"):
+        reject_prohibited_fields({"safe": {key: "arbitrary plaintext"}})
 
 
 def test_nested_raw_value_like_field_is_rejected() -> None:

--- a/tests/test_guard_secret_contracts_v2.py
+++ b/tests/test_guard_secret_contracts_v2.py
@@ -169,6 +169,16 @@ def test_missing_requested_ref_cannot_claim_clean() -> None:
         coverage.assert_outcome(PreventionOutcome.CLEAN)
 
 
+def test_direct_coverage_rejects_empty_source_set() -> None:
+    with pytest.raises(SecretContractError, match="source_set must not be empty"):
+        _direct_coverage(source_set=())
+
+
+def test_mapping_coverage_rejects_empty_source_set() -> None:
+    with pytest.raises(SecretContractError, match="source_set: must not be empty"):
+        _coverage(source_set=[])
+
+
 def test_direct_coverage_rejects_empty_refs_without_partial() -> None:
     with pytest.raises(SecretContractError, match="empty requested_refs requires partial=true"):
         _direct_coverage(requested_refs=(), completed_refs=())

--- a/tests/test_guard_secret_release_claim_gate.py
+++ b/tests/test_guard_secret_release_claim_gate.py
@@ -11,6 +11,7 @@ _GATE_PATH = _REPOSITORY_ROOT / "scripts/ci/guard_secrets_release_claim_gate.py"
 _CAPABILITY_PATH = _REPOSITORY_ROOT / "docs/guard/contracts/guard-secrets-capability-evidence.v2.json"
 _PRODUCT_BOUNDARY_PATH = _REPOSITORY_ROOT / "docs/guard/contracts/guard-secrets-product-boundaries.v2.json"
 _SOURCE_CAPABILITY_PATH = _REPOSITORY_ROOT / "docs/guard/contracts/guard-secrets-source-capabilities.v2.json"
+_REASON_CODE_PATH = _REPOSITORY_ROOT / "docs/guard/contracts/guard-secrets-reason-codes.v2.json"
 _SPEC = importlib.util.spec_from_file_location("guard_secrets_release_claim_gate", _GATE_PATH)
 assert _SPEC and _SPEC.loader
 _GATE = importlib.util.module_from_spec(_SPEC)
@@ -69,6 +70,7 @@ def _validate(
     required_capabilities: frozenset[str] = frozenset({"cli_precommit"}),
     product_boundary_payload: dict[str, object] | None = None,
     source_capability_payload: dict[str, object] | None = None,
+    reason_code_payload: dict[str, object] | None = None,
 ) -> tuple[str, ...]:
     return validate_manifest(
         capability_payload,
@@ -78,6 +80,7 @@ def _validate(
         source_capability_payload=(
             source_capability_payload if source_capability_payload is not None else _load(_SOURCE_CAPABILITY_PATH)
         ),
+        reason_code_payload=(reason_code_payload if reason_code_payload is not None else _load(_REASON_CODE_PATH)),
         exact_release_commit=release_commit,
         require_parity=require_parity,
         required_capabilities=required_capabilities,
@@ -97,6 +100,7 @@ def test_repository_manifests_are_structurally_valid() -> None:
         capability_payload,
         product_boundary_payload=load_manifest(_PRODUCT_BOUNDARY_PATH),
         source_capability_payload=load_manifest(_SOURCE_CAPABILITY_PATH),
+        reason_code_payload=load_manifest(_REASON_CODE_PATH),
         exact_release_commit="a" * 40,
         require_parity=False,
         required_capabilities=frozenset(required),
@@ -171,6 +175,7 @@ def test_release_commit_is_always_required() -> None:
             _manifest(),
             product_boundary_payload=_load(_PRODUCT_BOUNDARY_PATH),
             source_capability_payload=_load(_SOURCE_CAPABILITY_PATH),
+            reason_code_payload=_load(_REASON_CODE_PATH),
             exact_release_commit=None,
             require_parity=False,
             required_capabilities=frozenset({"cli_precommit"}),
@@ -223,6 +228,31 @@ def test_source_capability_drift_is_rejected_by_gate() -> None:
         _validate(_manifest(), source_capability_payload=payload)
 
 
+def test_reason_code_schema_drift_is_rejected_by_gate() -> None:
+    payload = _load(_REASON_CODE_PATH)
+    payload["schema"] = "guard-secrets-reason-codes.v3"
+    with pytest.raises(ClaimGateError, match="unsupported reason-code"):
+        _validate(_manifest(), reason_code_payload=payload)
+
+
+@pytest.mark.parametrize(
+    "rule_id",
+    (
+        "stable",
+        "non_sensitive",
+        "unknown_codes_fail_closed",
+        "raw_exception_text_forbidden",
+    ),
+)
+def test_reason_code_policy_weakening_is_rejected_by_gate(rule_id: str) -> None:
+    payload = _load(_REASON_CODE_PATH)
+    rules = payload["rules"]
+    assert isinstance(rules, dict)
+    rules[rule_id] = False
+    with pytest.raises(ClaimGateError, match="policy does not match"):
+        _validate(_manifest(), reason_code_payload=payload)
+
+
 def test_main_returns_zero_for_repository_policy(capsys: pytest.CaptureFixture[str]) -> None:
     capability_payload = _load(_CAPABILITY_PATH)
     policy = capability_payload["claim_policy"]
@@ -236,6 +266,8 @@ def test_main_returns_zero_for_repository_policy(capsys: pytest.CaptureFixture[s
         str(_PRODUCT_BOUNDARY_PATH),
         "--source-capabilities",
         str(_SOURCE_CAPABILITY_PATH),
+        "--reason-codes",
+        str(_REASON_CODE_PATH),
         "--release-commit",
         "a" * 40,
     ]
@@ -257,6 +289,8 @@ def test_main_returns_one_for_validation_errors(
         str(_PRODUCT_BOUNDARY_PATH),
         "--source-capabilities",
         str(_SOURCE_CAPABILITY_PATH),
+        "--reason-codes",
+        str(_REASON_CODE_PATH),
         "--release-commit",
         "a" * 40,
         "--required-capability",
@@ -279,6 +313,8 @@ def test_main_returns_two_for_input_errors(
         str(_PRODUCT_BOUNDARY_PATH),
         "--source-capabilities",
         str(_SOURCE_CAPABILITY_PATH),
+        "--reason-codes",
+        str(_REASON_CODE_PATH),
         "--release-commit",
         "a" * 40,
         "--required-capability",

--- a/tests/test_guard_secret_release_claim_gate.py
+++ b/tests/test_guard_secret_release_claim_gate.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+_GATE_PATH = _REPOSITORY_ROOT / "scripts/ci/guard_secrets_release_claim_gate.py"
+_CAPABILITY_PATH = _REPOSITORY_ROOT / "docs/guard/contracts/guard-secrets-capability-evidence.v2.json"
+_PRODUCT_BOUNDARY_PATH = _REPOSITORY_ROOT / "docs/guard/contracts/guard-secrets-product-boundaries.v2.json"
+_SOURCE_CAPABILITY_PATH = _REPOSITORY_ROOT / "docs/guard/contracts/guard-secrets-source-capabilities.v2.json"
+_SPEC = importlib.util.spec_from_file_location("guard_secrets_release_claim_gate", _GATE_PATH)
+assert _SPEC and _SPEC.loader
+_GATE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_GATE)
+
+ClaimGateError = _GATE.ClaimGateError
+load_manifest = _GATE.load_manifest
+validate_manifest = _GATE.validate_manifest
+
+
+def _load(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _manifest(**overrides: object) -> dict[str, object]:
+    capability: dict[str, object] = {
+        "capability_id": "cli_precommit",
+        "product_boundary": "free-local",
+        "surfaces": ["cli", "pre_commit"],
+        "plans": ["free", "solo", "pro", "team"],
+        "owner": "hol-guard",
+        "state": "tested",
+        "acceptance_tests": ["tests/test_guard_secrets_native_cli.py"],
+        "evidence_artifacts": [],
+        "release_commit": None,
+        "gap_label": "release-candidate evidence pending",
+    }
+    capability.update(overrides)
+    return {
+        "schema": "guard-secrets-capability-evidence.v2",
+        "generated_at": "2026-08-14",
+        "parity_states": [
+            "unmapped",
+            "designed",
+            "implemented",
+            "tested",
+            "verified_on_release_candidate",
+            "generally_available",
+        ],
+        "claim_policy": {
+            "public_parity_requires": "verified_on_release_candidate",
+            "exact_release_commit_required": True,
+            "remaining_gaps_must_be_labeled": True,
+            "public_parity_claim_enabled": False,
+            "required_capabilities": ["cli_precommit"],
+        },
+        "capabilities": [capability],
+    }
+
+
+def _validate(
+    capability_payload: dict[str, object],
+    *,
+    release_commit: str = "a" * 40,
+    require_parity: bool = False,
+    required_capabilities: frozenset[str] = frozenset({"cli_precommit"}),
+    product_boundary_payload: dict[str, object] | None = None,
+    source_capability_payload: dict[str, object] | None = None,
+) -> tuple[str, ...]:
+    return validate_manifest(
+        capability_payload,
+        product_boundary_payload=(
+            product_boundary_payload if product_boundary_payload is not None else _load(_PRODUCT_BOUNDARY_PATH)
+        ),
+        source_capability_payload=(
+            source_capability_payload if source_capability_payload is not None else _load(_SOURCE_CAPABILITY_PATH)
+        ),
+        exact_release_commit=release_commit,
+        require_parity=require_parity,
+        required_capabilities=required_capabilities,
+    )
+
+
+def _write_manifest(path: Path, payload: object) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_repository_manifests_are_structurally_valid() -> None:
+    capability_payload = load_manifest(_CAPABILITY_PATH)
+    required = capability_payload["claim_policy"]["required_capabilities"]
+    assert isinstance(required, list)
+    errors = validate_manifest(
+        capability_payload,
+        product_boundary_payload=load_manifest(_PRODUCT_BOUNDARY_PATH),
+        source_capability_payload=load_manifest(_SOURCE_CAPABILITY_PATH),
+        exact_release_commit="a" * 40,
+        require_parity=False,
+        required_capabilities=frozenset(required),
+    )
+    assert errors == ()
+
+
+def test_unknown_capability_state_is_rejected() -> None:
+    assert _validate(_manifest(state="complete")) == ("cli_precommit: invalid parity state",)
+
+
+def test_non_release_state_requires_gap_label() -> None:
+    assert _validate(_manifest(gap_label=None)) == ("cli_precommit: non-release state requires an explicit gap label",)
+
+
+def test_release_state_requires_exact_evidence() -> None:
+    assert _validate(
+        _manifest(
+            state="verified_on_release_candidate",
+            release_commit=None,
+            evidence_artifacts=[],
+            gap_label=None,
+        )
+    ) == ("release-candidate capability requires an exact commit SHA",)
+
+
+def test_parity_claim_requires_same_release_commit() -> None:
+    payload = _manifest(
+        state="verified_on_release_candidate",
+        release_commit="a" * 40,
+        evidence_artifacts=["sha256:evidence"],
+        gap_label=None,
+    )
+    policy = payload["claim_policy"]
+    assert isinstance(policy, dict)
+    policy["public_parity_claim_enabled"] = True
+    assert _validate(payload, release_commit="b" * 40, require_parity=True) == (
+        "cli_precommit: evidence is bound to a different commit",
+    )
+
+
+def test_public_parity_policy_cannot_be_bypassed() -> None:
+    payload = _manifest()
+    policy = payload["claim_policy"]
+    assert isinstance(policy, dict)
+    policy["public_parity_claim_enabled"] = True
+    with pytest.raises(ClaimGateError, match="cannot be omitted"):
+        _validate(payload, require_parity=False)
+
+
+def test_disabled_public_parity_policy_cannot_be_overridden() -> None:
+    with pytest.raises(ClaimGateError, match="not authorized"):
+        _validate(_manifest(), require_parity=True)
+
+
+def test_required_capability_list_must_match_policy() -> None:
+    with pytest.raises(ClaimGateError, match="missing: cli_precommit"):
+        _validate(_manifest(), required_capabilities=frozenset())
+
+
+def test_required_capability_list_rejects_unexpected_values() -> None:
+    with pytest.raises(ClaimGateError, match="unexpected: ide_prevention"):
+        _validate(
+            _manifest(),
+            required_capabilities=frozenset({"cli_precommit", "ide_prevention"}),
+        )
+
+
+def test_release_commit_is_always_required() -> None:
+    with pytest.raises(ClaimGateError, match="requires an exact release commit"):
+        validate_manifest(
+            _manifest(),
+            product_boundary_payload=_load(_PRODUCT_BOUNDARY_PATH),
+            source_capability_payload=_load(_SOURCE_CAPABILITY_PATH),
+            exact_release_commit=None,
+            require_parity=False,
+            required_capabilities=frozenset({"cli_precommit"}),
+        )
+
+
+def test_invalid_release_sha_is_rejected() -> None:
+    with pytest.raises(ClaimGateError, match="full lowercase SHA"):
+        _validate(_manifest(), release_commit="short")
+
+
+def test_future_manifest_schema_is_rejected(tmp_path: Path) -> None:
+    path = _write_manifest(
+        tmp_path / "manifest.json",
+        {"schema": "guard-secrets-capability-evidence.v3"},
+    )
+    with pytest.raises(ClaimGateError, match="unsupported"):
+        _validate(dict(load_manifest(path)))
+
+
+def test_parity_state_declaration_drift_is_rejected() -> None:
+    payload = _manifest()
+    payload["parity_states"] = ["unmapped", "tested"]
+    with pytest.raises(ClaimGateError, match="do not match"):
+        _validate(payload)
+
+
+def test_claim_policy_drift_is_rejected() -> None:
+    payload = _manifest()
+    policy = payload["claim_policy"]
+    assert isinstance(policy, dict)
+    policy["public_parity_requires"] = "tested"
+    with pytest.raises(ClaimGateError, match="release-candidate verified or GA"):
+        _validate(payload)
+
+
+def test_product_boundary_drift_is_rejected_by_gate() -> None:
+    payload = _load(_PRODUCT_BOUNDARY_PATH)
+    payload["invariants"] = ["local_detection_unmetered"]
+    with pytest.raises(ClaimGateError, match="invariants"):
+        _validate(_manifest(), product_boundary_payload=payload)
+
+
+def test_source_capability_drift_is_rejected_by_gate() -> None:
+    payload = _load(_SOURCE_CAPABILITY_PATH)
+    operating_systems = payload["operating_systems"]
+    assert isinstance(operating_systems, dict)
+    operating_systems["linux"] = "partial"
+    with pytest.raises(ClaimGateError, match="statuses"):
+        _validate(_manifest(), source_capability_payload=payload)
+
+
+def test_main_returns_zero_for_repository_policy(capsys: pytest.CaptureFixture[str]) -> None:
+    capability_payload = _load(_CAPABILITY_PATH)
+    policy = capability_payload["claim_policy"]
+    assert isinstance(policy, dict)
+    required = policy["required_capabilities"]
+    assert isinstance(required, list)
+    argv = [
+        "--manifest",
+        str(_CAPABILITY_PATH),
+        "--product-boundaries",
+        str(_PRODUCT_BOUNDARY_PATH),
+        "--source-capabilities",
+        str(_SOURCE_CAPABILITY_PATH),
+        "--release-commit",
+        "a" * 40,
+    ]
+    for capability_id in required:
+        argv.extend(("--required-capability", capability_id))
+    assert _GATE.main(argv) == 0
+    assert capsys.readouterr().err == ""
+
+
+def test_main_returns_one_for_validation_errors(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = _write_manifest(tmp_path / "invalid-row.json", _manifest(gap_label=None))
+    argv = [
+        "--manifest",
+        str(path),
+        "--product-boundaries",
+        str(_PRODUCT_BOUNDARY_PATH),
+        "--source-capabilities",
+        str(_SOURCE_CAPABILITY_PATH),
+        "--release-commit",
+        "a" * 40,
+        "--required-capability",
+        "cli_precommit",
+    ]
+    assert _GATE.main(argv) == 1
+    assert "non-release state requires" in capsys.readouterr().err
+
+
+def test_main_returns_two_for_input_errors(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = tmp_path / "malformed.json"
+    path.write_text("{", encoding="utf-8")
+    argv = [
+        "--manifest",
+        str(path),
+        "--product-boundaries",
+        str(_PRODUCT_BOUNDARY_PATH),
+        "--source-capabilities",
+        str(_SOURCE_CAPABILITY_PATH),
+        "--release-commit",
+        "a" * 40,
+        "--required-capability",
+        "cli_precommit",
+    ]
+    assert _GATE.main(argv) == 2
+    assert "guard-secrets-claim-gate:" in capsys.readouterr().err

--- a/tests/test_release_toolchain_sbom.py
+++ b/tests/test_release_toolchain_sbom.py
@@ -109,6 +109,7 @@ def test_claim_gate_command_contains_every_authoritative_input() -> None:
     assert command[command.index("--manifest") + 1].endswith("guard-secrets-capability-evidence.v2.json")
     assert command[command.index("--product-boundaries") + 1].endswith("guard-secrets-product-boundaries.v2.json")
     assert command[command.index("--source-capabilities") + 1].endswith("guard-secrets-source-capabilities.v2.json")
+    assert command[command.index("--reason-codes") + 1].endswith("guard-secrets-reason-codes.v2.json")
     declared = tuple(command[index + 1] for index, value in enumerate(command) if value == "--required-capability")
     assert declared == _required_capabilities()
     assert "--require-parity" not in command
@@ -185,6 +186,7 @@ def test_claim_gate_fails_closed_when_product_policy_drifts(tmp_path: Path) -> N
         "docs/guard/contracts/guard-secrets-capability-evidence.v2.json",
         "docs/guard/contracts/guard-secrets-product-boundaries.v2.json",
         "docs/guard/contracts/guard-secrets-source-capabilities.v2.json",
+        "docs/guard/contracts/guard-secrets-reason-codes.v2.json",
     ):
         source = ROOT / relative
         destination = repository / relative

--- a/tests/test_release_toolchain_sbom.py
+++ b/tests/test_release_toolchain_sbom.py
@@ -1,17 +1,27 @@
-"""Tests for release toolchain verification and SBOM generation."""
+"""Tests for release toolchain verification, claim gating, and SBOM generation."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import subprocess
+import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 import yaml
 
-from scripts.write_release_toolchain_sbom import ToolchainVerificationError, write_release_toolchain_sbom
+from scripts.write_release_toolchain_sbom import (
+    ToolchainVerificationError,
+    build_guard_secrets_claim_gate_command,
+    resolve_release_commit,
+    run_guard_secrets_claim_gate,
+    write_release_toolchain_sbom,
+)
 
 ROOT = Path(__file__).resolve().parents[1]
+_CAPABILITY_PATH = ROOT / "docs/guard/contracts/guard-secrets-capability-evidence.v2.json"
 
 
 def _fake_uv(path: Path, version: str) -> Path:
@@ -20,49 +30,211 @@ def _fake_uv(path: Path, version: str) -> Path:
     return path
 
 
-def test_release_toolchain_sbom_records_verified_version_and_executable_digest(tmp_path: Path) -> None:
+def _required_capabilities() -> tuple[str, ...]:
+    payload = json.loads(_CAPABILITY_PATH.read_text(encoding="utf-8"))
+    return tuple(payload["claim_policy"]["required_capabilities"])
+
+
+def test_release_toolchain_sbom_records_verified_version_and_executable_digest(
+    tmp_path: Path,
+) -> None:
     executable = _fake_uv(tmp_path / "uv", "0.9.26")
     output = tmp_path / "release-toolchain.cdx.json"
-
     payload = write_release_toolchain_sbom(
         output=output,
-        release_version="2.0.1089",
+        release_version="3.0.0a1",
         expected_uv_version="0.9.26",
         setup_action_ref="fac544c07dec837d0ccb6301d7b5580bf5edae39",
         uv_executable=executable,
     )
-
     persisted = json.loads(output.read_text(encoding="utf-8"))
     expected_digest = hashlib.sha256(executable.read_bytes()).hexdigest()
     assert persisted == payload
     assert persisted["bomFormat"] == "CycloneDX"
-    assert persisted["metadata"]["component"]["version"] == "2.0.1089"
+    assert persisted["metadata"]["component"]["version"] == "3.0.0a1"
     assert persisted["components"][0]["version"] == "0.9.26"
     assert persisted["components"][0]["hashes"] == [{"alg": "SHA-256", "content": expected_digest}]
 
 
-def test_release_toolchain_sbom_rejects_runtime_version_mismatch(tmp_path: Path) -> None:
+def test_release_toolchain_sbom_rejects_runtime_version_mismatch(
+    tmp_path: Path,
+) -> None:
     executable = _fake_uv(tmp_path / "uv", "0.9.27")
     output = tmp_path / "release-toolchain.cdx.json"
-
     with pytest.raises(ToolchainVerificationError, match="version mismatch"):
         write_release_toolchain_sbom(
             output=output,
-            release_version="2.0.1089",
+            release_version="3.0.0a1",
             expected_uv_version="0.9.26",
             setup_action_ref="fac544c07dec837d0ccb6301d7b5580bf5edae39",
             uv_executable=executable,
         )
-
     assert not output.exists()
 
 
+def test_release_toolchain_sbom_records_passed_claim_gate(tmp_path: Path) -> None:
+    executable = _fake_uv(tmp_path / "uv", "0.9.26")
+    command = (sys.executable, "gate.py", "--release-commit", "a" * 40)
+    payload = write_release_toolchain_sbom(
+        output=tmp_path / "release-toolchain.cdx.json",
+        release_version="preflight",
+        expected_uv_version="0.9.26",
+        setup_action_ref="fac544c07dec837d0ccb6301d7b5580bf5edae39",
+        uv_executable=executable,
+        claim_gate_command=command,
+        release_commit="a" * 40,
+    )
+    properties = payload["components"][0]["properties"]
+    by_name = {item["name"]: item["value"] for item in properties}
+    assert by_name["hol-guard:secrets-claim-gate"] == "passed"
+    assert by_name["hol-guard:source-commit"] == "a" * 40
+    assert (
+        by_name["hol-guard:secrets-claim-gate-command-sha256"]
+        == hashlib.sha256("\0".join(command).encode("utf-8")).hexdigest()
+    )
+
+
+def test_claim_gate_command_contains_every_authoritative_input() -> None:
+    commit = "a" * 40
+    command = build_guard_secrets_claim_gate_command(
+        repository_root=ROOT,
+        release_commit=commit,
+        python_executable="python3",
+    )
+    assert command[:2] == (
+        "python3",
+        str(ROOT / "scripts/ci/guard_secrets_release_claim_gate.py"),
+    )
+    assert command[command.index("--release-commit") + 1] == commit
+    assert command[command.index("--manifest") + 1].endswith("guard-secrets-capability-evidence.v2.json")
+    assert command[command.index("--product-boundaries") + 1].endswith("guard-secrets-product-boundaries.v2.json")
+    assert command[command.index("--source-capabilities") + 1].endswith("guard-secrets-source-capabilities.v2.json")
+    declared = tuple(command[index + 1] for index, value in enumerate(command) if value == "--required-capability")
+    assert declared == _required_capabilities()
+    assert "--require-parity" not in command
+
+
+def test_claim_gate_command_includes_parity_flag_only_when_policy_enables_it(
+    tmp_path: Path,
+) -> None:
+    capability = json.loads(_CAPABILITY_PATH.read_text(encoding="utf-8"))
+    capability["claim_policy"]["public_parity_claim_enabled"] = True
+    target = tmp_path / "docs/guard/contracts"
+    target.mkdir(parents=True)
+    (target / "guard-secrets-capability-evidence.v2.json").write_text(
+        json.dumps(capability),
+        encoding="utf-8",
+    )
+    command = build_guard_secrets_claim_gate_command(
+        repository_root=tmp_path,
+        release_commit="a" * 40,
+    )
+    assert "--require-parity" in command
+
+
+def test_claim_gate_runs_successfully_for_current_disabled_claim_policy() -> None:
+    command = run_guard_secrets_claim_gate(
+        repository_root=ROOT,
+        release_commit="a" * 40,
+        python_executable=sys.executable,
+    )
+    assert "--require-parity" not in command
+
+
+def test_claim_gate_runs_in_isolated_stdlib_python() -> None:
+    command = build_guard_secrets_claim_gate_command(
+        repository_root=ROOT,
+        release_commit="a" * 40,
+        python_executable=sys.executable,
+    )
+    isolated_command = (command[0], "-I", "-S", *command[1:])
+    result = subprocess.run(
+        isolated_command,
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_claim_gate_subprocess_does_not_inject_pythonpath() -> None:
+    completed = subprocess.CompletedProcess(
+        args=(sys.executable,),
+        returncode=0,
+        stdout="",
+        stderr="",
+    )
+    with patch(
+        "scripts.write_release_toolchain_sbom.subprocess.run",
+        return_value=completed,
+    ) as run:
+        run_guard_secrets_claim_gate(
+            repository_root=ROOT,
+            release_commit="a" * 40,
+            python_executable=sys.executable,
+        )
+    assert "env" not in run.call_args.kwargs
+
+
+def test_claim_gate_fails_closed_when_product_policy_drifts(tmp_path: Path) -> None:
+    repository = tmp_path / "repository"
+    for relative in (
+        "src/codex_plugin_scanner/guard/secrets/contracts_v2.py",
+        "scripts/ci/guard_secrets_release_claim_gate.py",
+        "docs/guard/contracts/guard-secrets-capability-evidence.v2.json",
+        "docs/guard/contracts/guard-secrets-product-boundaries.v2.json",
+        "docs/guard/contracts/guard-secrets-source-capabilities.v2.json",
+    ):
+        source = ROOT / relative
+        destination = repository / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(source.read_bytes())
+    product_path = repository / "docs/guard/contracts/guard-secrets-product-boundaries.v2.json"
+    product = json.loads(product_path.read_text(encoding="utf-8"))
+    product["invariants"] = ["local_detection_unmetered"]
+    product_path.write_text(json.dumps(product), encoding="utf-8")
+    with pytest.raises(ToolchainVerificationError, match="claim gate failed"):
+        run_guard_secrets_claim_gate(
+            repository_root=repository,
+            release_commit="a" * 40,
+            python_executable=sys.executable,
+        )
+
+
+def test_resolve_release_commit_returns_exact_checked_out_sha(tmp_path: Path) -> None:
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "config", "user.email", "ci@example.test"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "config", "user.name", "CI"],
+        check=True,
+    )
+    (tmp_path / "README.md").write_text("fixture\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "add", "README.md"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "commit", "-qm", "fixture"],
+        check=True,
+    )
+    expected = subprocess.run(
+        ["git", "-C", str(tmp_path), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert resolve_release_commit(tmp_path) == expected
+
+
 def test_publish_workflow_attests_toolchain_sbom_without_sending_it_to_pypi() -> None:
-    workflow = yaml.safe_load((ROOT / ".github" / "workflows" / "publish.yml").read_text(encoding="utf-8"))
+    workflow = yaml.safe_load((ROOT / ".github/workflows/publish.yml").read_text(encoding="utf-8"))
     jobs = workflow["jobs"]
     build_steps = jobs["build"]["steps"]
     release_steps = jobs["release-alpha"]["steps"]
-
     preflight_index = next(
         index
         for index, step in enumerate(build_steps)
@@ -70,6 +242,7 @@ def test_publish_workflow_attests_toolchain_sbom_without_sending_it_to_pypi() ->
     )
     install_index = next(index for index, step in enumerate(build_steps) if step.get("name") == "Install dependencies")
     assert preflight_index < install_index
+    assert "scripts/write_release_toolchain_sbom.py" in build_steps[preflight_index]["run"]
     assert any(step.get("name") == "Upload release toolchain SBOM" for step in build_steps)
     assert any(step.get("name") == "Download release toolchain SBOM" for step in release_steps)
     assert all(
@@ -85,15 +258,31 @@ def test_publish_workflow_attests_toolchain_sbom_without_sending_it_to_pypi() ->
     assert "dist/*" in provenance_step["with"]["subject-path"]
 
 
-def test_publish_workflow_limits_ambient_credentials_and_has_no_version_sync() -> None:
-    workflow = yaml.safe_load((ROOT / ".github" / "workflows" / "publish.yml").read_text(encoding="utf-8"))
-    jobs = workflow["jobs"]
+def test_publish_workflow_claim_gate_chain_is_fail_closed() -> None:
+    script = (ROOT / "scripts/write_release_toolchain_sbom.py").read_text(encoding="utf-8")
+    resolve_index = script.index("release_commit = resolve_release_commit(repository_root)")
+    gate_index = script.index("claim_gate_command = run_guard_secrets_claim_gate(")
+    sbom_index = script.index("write_release_toolchain_sbom(", gate_index)
+    assert resolve_index < gate_index < sbom_index
+    run_gate_start = script.index("def run_guard_secrets_claim_gate(")
+    write_sbom_start = script.index("def write_release_toolchain_sbom(")
+    run_gate_source = script[run_gate_start:write_sbom_start]
+    assert "if result.returncode != 0:" in run_gate_source
+    assert "raise ToolchainVerificationError(" in run_gate_source
+    assert "PYTHONPATH" not in run_gate_source
+    assert "env=" not in run_gate_source
 
-    assert workflow["permissions"] == {"contents": "read", "pull-requests": "read"}
+
+def test_publish_workflow_limits_ambient_credentials_and_has_no_version_sync() -> None:
+    workflow = yaml.safe_load((ROOT / ".github/workflows/publish.yml").read_text(encoding="utf-8"))
+    jobs = workflow["jobs"]
+    assert workflow["permissions"] == {
+        "contents": "read",
+        "pull-requests": "read",
+    }
     assert "permissions" not in jobs["build"]
     assert "sync-repository-version" not in jobs
-    assert "ACTION_REPO_TOKEN" not in (ROOT / ".github" / "workflows" / "publish.yml").read_text(encoding="utf-8")
-
+    assert "ACTION_REPO_TOKEN" not in (ROOT / ".github/workflows/publish.yml").read_text(encoding="utf-8")
     publish_uv_versions = {
         step["with"]["version"]
         for job in jobs.values()


### PR DESCRIPTION
## Summary

Completes the executable HOL Guard Secrets V2 evidence-contract foundation on the current `release/3.0` head.

- adds strict versioned coverage, prevention, ignore, custom-rule, capability, reason-code, and organizational metric contracts
- makes false-clean states structurally invalid across direct construction and deserialization
- rejects raw-value-shaped fields recursively at serialization boundaries
- makes the runtime contract the canonical authority for parity states, reason codes, manifest parsing, and exact-release validation
- validates parity-state, claim-policy, product-boundary, source-capability, and reason-code manifests against runtime authority
- adds a fail-closed release-claim gate with stable exit codes and stderr diagnostics
- wires the exact checked-out commit and successful gate-command digest into the release toolchain SBOM before dependency installation
- preserves explicit gap labels and refuses unsupported public parity claims

## Tasks

Completes the technical deliverables for `HGS2-T016` through `HGS2-T030`. Competitor-specific private implementation strategy remains outside this public repository.

## Exact revisions

- base: `d4b711c04e7ef0308961439255c454e4e0378481`
- head: `d7ea4e43bcbaef319cfb377b461a2374723a2966`

## Privacy and security

- no raw credential, source line, prompt, tool output, authorization material, provider response body, or local absolute path is accepted by the serializable contracts
- direct construction and deserialization enforce the same enum, counter, flag, tuple, source, reference, skip, truncation, and version invariants
- reason-code categories and fail-closed rules are runtime-authoritative and release-gated
- partial, degraded, skipped, truncated, error, empty-source, empty-reference, or incomplete-reference coverage cannot be represented as clean
- release claims require exact commit-bound evidence and the declared minimum parity state
- the protected preflight runs in dependency-free Python and does not inject `PYTHONPATH`
- local detection remains offline, deterministic, unmetered, and independent of Cloud availability

## Tiering

Free retains complete local and staged protection. Solo retains continuous selected-repository monitoring and the individual remediation loop. Routing, deeper permission analysis, centralized approvals, policy inheritance, organization reporting, and automated remediation remain Pro/Team value.

## Validation

- focused contract, release-gate, and release-toolchain suite passed after the final review fixes
- Ruff formatting/lint and full basedpyright passed
- dependency-free isolated release preflight passed
- exact test inventory baseline is `14,828` collected cases and `319,525` test-source lines
- full exact-head CI, Security Gates, CodeQL, packaging, Desktop, Cline, and review checks remain authoritative before merge

## Release boundary

Targets `release/3.0` only. Do not retarget or merge `release/3.0` into `main` as part of this work.

## Rollback

Revert the focused commits. No database migration, persistent runtime state, network dependency, deployment, tag, or release is introduced.

Supersedes #2314 and #2322, whose branches accumulated obsolete reconciliation commits while `release/3.0` advanced.