### PR TITLE
fix(update): tolerate package index propagation lag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,8 +35,8 @@ permissions:
   pull-requests: read
 
 concurrency:
-  # Isolate by event and SHA so a pending release/3.0 push publish is not
-  # cancelled when another pull_request run shares the branch group.
+  # Serialize publish-capable events for one release branch while keeping
+  # ordinary pull-request validation isolated by its merge ref.
   group: hol-guard-publish-${{ github.event.pull_request.merged && format('refs/heads/{0}', github.event.pull_request.base.ref) || github.ref }}
   cancel-in-progress: false
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ permissions:
 concurrency:
   # Isolate by event and SHA so a pending release/3.0 push publish is not
   # cancelled when another pull_request run shares the branch group.
-  group: hol-guard-publish-${{ github.event_name }}-${{ github.sha }}
+  group: hol-guard-publish-${{ github.event.pull_request.merged && format('refs/heads/{0}', github.event.pull_request.base.ref) || github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14666,
-  "maximum_test_source_lines": 317669,
+  "maximum_collected_cases": 14667,
+  "maximum_test_source_lines": 317822,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14667,
-  "maximum_test_source_lines": 317822,
+  "maximum_collected_cases": 14673,
+  "maximum_test_source_lines": 317898,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -69,6 +69,8 @@ _ALREADY_CURRENT_HINTS = (
 _PIPX_LAUNCHER_FAILURE_HINTS = (
     "ModuleNotFoundError: No module named 'pipx'",
     'ModuleNotFoundError: No module named "pipx"',
+    "venv for 'hol-guard' was not found",
+    'venv for "hol-guard" was not found',
 )
 _PYPI_PROPAGATION_FAILURE_HINTS = (
     "No matching distribution found for hol-guard==",

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -8,6 +8,7 @@ import importlib.metadata
 import json
 import os
 import platform
+import re
 import shlex
 import shutil
 import sqlite3
@@ -74,8 +75,6 @@ _PYPI_PROPAGATION_FAILURE_HINTS = (
     "Could not find a version that satisfies the requirement hol-guard==",
 )
 _PYPI_PROPAGATION_EXCLUSION_HINTS = (
-    "401",
-    "403",
     "authentication",
     "certificate verify failed",
     "connection error",
@@ -93,6 +92,13 @@ _PYPI_PROPAGATION_EXCLUSION_HINTS = (
     "tls",
     "unauthorized",
 )
+_PYPI_AUTH_STATUS_RE = re.compile(
+    r"(?:\b(?:http(?:\s+error)?|status(?:\s+code)?|error:)\s*(?:401|403)\b|"
+    r"\b(?:401|403)\s+(?:unauthorized|forbidden)\b)",
+    re.IGNORECASE,
+)
+_PYPI_PROPAGATION_RETRY_DELAY_SECONDS = 2.0
+_PYPI_PROPAGATION_RETRY_LIMIT = 1
 _PYPI_JSON_URL = "https://pypi.org/pypi/hol-guard/json"
 _PYPI_TIMEOUT_SECONDS = 3.0
 _PYPI_RESPONSE_LIMIT_BYTES = 8 * 1024 * 1024
@@ -612,6 +618,7 @@ def run_guard_update(
         return result
 
     attempted_pipx_recovery = False
+    propagation_retries = 0
     installer_execution_started = False
     while True:
         try:
@@ -692,6 +699,11 @@ def run_guard_update(
                 payload["installer_recovery"] = "trusted_python_pip"
                 continue
             if requested_wheel_path is None and _is_pypi_propagation_failure(installer_output):
+                if propagation_retries < _PYPI_PROPAGATION_RETRY_LIMIT:
+                    propagation_retries += 1
+                    payload["propagation_retries"] = propagation_retries
+                    time.sleep(_PYPI_PROPAGATION_RETRY_DELAY_SECONDS)
+                    continue
                 payload["status"] = "deferred"
                 payload["changed"] = False
                 payload["reason_code"] = "update_release_propagating"
@@ -1580,7 +1592,9 @@ def _is_pypi_propagation_failure(installer_output: str) -> bool:
     if not _contains_any(installer_output, _PYPI_PROPAGATION_FAILURE_HINTS):
         return False
     lowered = installer_output.lower()
-    return not _contains_any(lowered, _PYPI_PROPAGATION_EXCLUSION_HINTS)
+    return not _contains_any(lowered, _PYPI_PROPAGATION_EXCLUSION_HINTS) and not _PYPI_AUTH_STATUS_RE.search(
+        installer_output
+    )
 
 
 def _dependency_conflict_message(installer_output: str) -> str | None:
@@ -1611,7 +1625,7 @@ def _update_command(
         if installer == "uv":
             return ["uv", "tool", "install", "--force", wheel]
         if installer == "pipx":
-            return ["pipx", "install", "--force", wheel]
+            return ["pipx", "runpip", "hol-guard", "install", "--force-reinstall", wheel]
         return [sys.executable, "-m", "pip", "install", "--force-reinstall", wheel]
     package = _hol_guard_package_spec(target_version)
     allow_prerelease = _target_version_is_prerelease(target_version)
@@ -1623,9 +1637,10 @@ def _update_command(
             command.append(package)
             return command
         if installer == "pipx":
-            command = ["pipx", "install", "--force", package]
+            command = ["pipx", "runpip", "hol-guard", "install", "--upgrade", "--force-reinstall"]
             if allow_prerelease:
-                command.append("--pip-args=--pre")
+                command.append("--pre")
+            command.append(package)
             return command
         command = [sys.executable, "-m", "pip", "install", "--upgrade", "--force-reinstall"]
         if allow_prerelease:

--- a/src/codex_plugin_scanner/guard/cli/update_subprocess.py
+++ b/src/codex_plugin_scanner/guard/cli/update_subprocess.py
@@ -1587,6 +1587,26 @@ def _pipx_execution_command(executable: str, args: list[str], *, python: str, in
             python,
             *args[1:],
         ]
+    if len(args) >= 5 and args[:3] == ["runpip", "hol-guard", "install"]:
+        install_args = args[3:]
+        target = install_args[-1]
+        flags = install_args[:-1]
+        allowed_flags = (
+            ["--force-reinstall"],
+            ["--upgrade", "--force-reinstall"],
+            ["--upgrade", "--force-reinstall", "--pre"],
+        )
+        if flags in allowed_flags and target and not target.startswith("-"):
+            return [
+                executable,
+                "runpip",
+                "hol-guard",
+                "install",
+                *flags,
+                target,
+                "--index-url",
+                index_url,
+            ]
     raise UpdateSubprocessError("update_installer_command_invalid")
 
 

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -6919,7 +6919,15 @@ url = http://127.0.0.1:8787/guard-canary
             {
                 "current_version": "2.2.1",
                 "installer": "pipx",
-                "command": ["pipx", "install", "--force", "hol-guard==2.2.3"],
+                "command": [
+                    "pipx",
+                    "runpip",
+                    "hol-guard",
+                    "install",
+                    "--upgrade",
+                    "--force-reinstall",
+                    "hol-guard==2.2.3",
+                ],
                 "dry_run": False,
                 "resulting_version": "2.2.1",
                 "status": "deferred",

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -353,8 +353,16 @@ def test_update_retries_release_that_appears_during_index_propagation(
     assert sleep_calls == [2.0]
 
 
+@pytest.mark.parametrize(
+    "pipx_error",
+    [
+        "ModuleNotFoundError: No module named 'pipx'",
+        "venv for 'hol-guard' was not found",
+    ],
+)
 def test_update_recovers_from_broken_pipx_launcher_with_trusted_python(
     monkeypatch: pytest.MonkeyPatch,
+    pipx_error: str,
 ) -> None:
     monkeypatch.setattr(update_commands, "_current_version", lambda: "2.2.1")
     resulting_versions = iter(("2.2.1", "2.2.3"))
@@ -378,7 +386,7 @@ def test_update_recovers_from_broken_pipx_launcher_with_trusted_python(
                 command,
                 1,
                 "",
-                "ModuleNotFoundError: No module named 'pipx'",
+                pipx_error,
             )
         return subprocess.CompletedProcess(command, 0, "installed hol-guard 2.2.3", "")
 

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -280,16 +280,26 @@ def test_update_defers_when_latest_release_is_still_propagating(monkeypatch: pyt
     monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.2.3")
     monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
     monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
-    monkeypatch.setattr(
-        update_commands.subprocess,
-        "run",
-        lambda command, **_: subprocess.CompletedProcess(
+    installer_calls: list[list[str]] = []
+    sleep_calls: list[float] = []
+
+    def unavailable_release(command: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        installer_calls.append(command)
+        return subprocess.CompletedProcess(
             command,
             1,
             "",
+            "ERROR: Could not find a version that satisfies the requirement hol-guard==2.2.3 "
+            "(from versions: 2.0.401, 2.0.403, 2.2.1)\n"
             "ERROR: No matching distribution found for hol-guard==2.2.3",
-        ),
+        )
+
+    monkeypatch.setattr(
+        update_commands.subprocess,
+        "run",
+        unavailable_release,
     )
+    monkeypatch.setattr(update_commands.time, "sleep", sleep_calls.append)
 
     payload, exit_code = update_commands.run_guard_update(dry_run=False)
 
@@ -297,8 +307,50 @@ def test_update_defers_when_latest_release_is_still_propagating(monkeypatch: pyt
     assert payload["status"] == "deferred"
     assert payload["reason_code"] == "update_release_propagating"
     assert payload["changed"] is False
+    assert payload["propagation_retries"] == 1
     assert "current installation remains active" in str(payload["message"])
     assert "retry_command" not in payload
+    assert len(installer_calls) == 2
+    assert sleep_calls == [2.0]
+
+
+def test_update_retries_release_that_appears_during_index_propagation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.2.1")
+    resulting_versions = iter(("2.2.1", "2.2.3"))
+    monkeypatch.setattr(
+        update_commands,
+        "_current_version_from_subprocess",
+        lambda *_args, **_kwargs: next(resulting_versions),
+    )
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.2.3")
+    monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+    results = iter(
+        (
+            subprocess.CompletedProcess(
+                [],
+                1,
+                "",
+                "ERROR: No matching distribution found for hol-guard==2.2.3",
+            ),
+            subprocess.CompletedProcess([], 0, "installed", ""),
+        )
+    )
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(update_commands.subprocess, "run", lambda *_args, **_kwargs: next(results))
+    monkeypatch.setattr(update_commands.time, "sleep", sleep_calls.append)
+    monkeypatch.setattr(update_commands, "_refresh_package_shims_after_update", lambda **_: (None, None))
+    monkeypatch.setattr(update_commands, "_repair_supported_harnesses", lambda **_: ([], []))
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=False)
+
+    assert exit_code == 0, json.dumps(payload, sort_keys=True)
+    assert payload["status"] == "updated"
+    assert payload["resulting_version"] == "2.2.3"
+    assert payload["propagation_retries"] == 1
+    assert sleep_calls == [2.0]
 
 
 def test_update_recovers_from_broken_pipx_launcher_with_trusted_python(
@@ -338,7 +390,7 @@ def test_update_recovers_from_broken_pipx_launcher_with_trusted_python(
     assert payload["status"] == "updated"
     assert payload["installer_recovery"] == "trusted_python_pip"
     assert commands == [
-        ["pipx", "install", "--force", "hol-guard==2.2.3"],
+        ["pipx", "runpip", "hol-guard", "install", "--upgrade", "--force-reinstall", "hol-guard==2.2.3"],
         [
             "/opt/guard/bin/python",
             "-m",
@@ -399,7 +451,7 @@ def test_update_preserves_requested_wheel_during_broken_pipx_recovery(
         str(wheel),
     ]
     assert commands == [
-        ["pipx", "install", "--force", str(wheel)],
+        ["pipx", "runpip", "hol-guard", "install", "--force-reinstall", str(wheel)],
         [
             "/opt/guard/bin/python",
             "-m",
@@ -574,7 +626,15 @@ def test_update_uses_real_pipx_binary_when_guard_package_shims_are_installed(
     monkeypatch.setattr(update_commands, "_refresh_package_shims_after_update", lambda **_: (None, None))
 
     def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        assert command == ["pipx", "install", "--force", "hol-guard==2.0.830"]
+        assert command == [
+            "pipx",
+            "runpip",
+            "hol-guard",
+            "install",
+            "--upgrade",
+            "--force-reinstall",
+            "hol-guard==2.0.830",
+        ]
         return subprocess.CompletedProcess(command, 0, "installed hol-guard 2.0.830", "")
 
     monkeypatch.setattr(update_commands.subprocess, "run", fake_run)
@@ -583,7 +643,15 @@ def test_update_uses_real_pipx_binary_when_guard_package_shims_are_installed(
 
     assert exit_code == 0
     assert payload["status"] == "updated"
-    assert payload["command"] == ["pipx", "install", "--force", "hol-guard==2.0.830"]
+    assert payload["command"] == [
+        "pipx",
+        "runpip",
+        "hol-guard",
+        "install",
+        "--upgrade",
+        "--force-reinstall",
+        "hol-guard==2.0.830",
+    ]
 
 
 def test_build_guard_install_surface_payload_stays_local(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -722,7 +790,7 @@ def test_update_requested_local_wheel_bypasses_python_incompatible_latest_releas
     payload, exit_code = update_commands.run_guard_update(dry_run=False, wheel=str(wheel))
 
     assert exit_code == 0
-    assert captured_commands == [["pipx", "install", "--force", str(wheel)]]
+    assert captured_commands == [["pipx", "runpip", "hol-guard", "install", "--force-reinstall", str(wheel)]]
     assert payload["status"] == "updated"
     assert payload["upgrade_source"] == "local_wheel"
     assert payload["requested_wheel"] == str(wheel)
@@ -787,7 +855,15 @@ def test_update_repairs_missing_pipx_local_source_install(monkeypatch: pytest.Mo
     payload, exit_code = update_commands.run_guard_update(dry_run=False)
 
     assert exit_code == 0
-    assert captured_commands[0] == ["pipx", "install", "--force", "hol-guard==2.0.489"]
+    assert captured_commands[0] == [
+        "pipx",
+        "runpip",
+        "hol-guard",
+        "install",
+        "--upgrade",
+        "--force-reinstall",
+        "hol-guard==2.0.489",
+    ]
     assert payload["recovery_source_install"] is True
     assert payload["source_install"]["path_exists"] is False
     assert payload["status"] == "updated"
@@ -815,7 +891,15 @@ def test_update_rejects_nonzero_pipx_result_even_when_version_changed(
     )
 
     def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        assert command == ["pipx", "install", "--force", "hol-guard==2.0.628"]
+        assert command == [
+            "pipx",
+            "runpip",
+            "hol-guard",
+            "install",
+            "--upgrade",
+            "--force-reinstall",
+            "hol-guard==2.0.628",
+        ]
         return subprocess.CompletedProcess(
             command,
             1,
@@ -937,7 +1021,7 @@ def test_update_installs_requested_local_wheel_with_pipx(monkeypatch: pytest.Mon
     payload, exit_code = update_commands.run_guard_update(dry_run=False, wheel=str(wheel))
 
     assert exit_code == 0
-    assert captured_commands == [["pipx", "install", "--force", str(wheel)]]
+    assert captured_commands == [["pipx", "runpip", "hol-guard", "install", "--force-reinstall", str(wheel)]]
     assert payload["upgrade_source"] == "local_wheel"
     assert payload["requested_wheel"] == str(wheel)
     assert payload["resulting_version"] == "2.0.345"
@@ -1020,7 +1104,7 @@ def test_update_installs_requested_local_wheel_from_editable_install(
     payload, exit_code = update_commands.run_guard_update(dry_run=False, wheel=str(wheel))
 
     assert exit_code == 0
-    assert captured_commands == [["pipx", "install", "--force", str(wheel)]]
+    assert captured_commands == [["pipx", "runpip", "hol-guard", "install", "--force-reinstall", str(wheel)]]
     assert payload["upgrade_source"] == "local_wheel"
 
 
@@ -1045,8 +1129,10 @@ def test_update_resolves_requested_wheel_from_directory(monkeypatch: pytest.Monk
     assert payload["requested_wheel"] == str(newer_wheel)
     assert payload["command"] == [
         "pipx",
+        "runpip",
+        "hol-guard",
         "install",
-        "--force",
+        "--force-reinstall",
         str(newer_wheel),
     ]
     assert payload["message"] == "Review the planned local wheel install command before updating."
@@ -1558,7 +1644,9 @@ def test_update_does_not_sync_dashboard_assets_from_caller_checkout(monkeypatch:
     payload, exit_code = update_commands.run_guard_update(dry_run=False)
 
     assert exit_code == 0
-    assert captured_commands == [["pipx", "install", "--force", "hol-guard==2.0.489"]]
+    assert captured_commands == [
+        ["pipx", "runpip", "hol-guard", "install", "--upgrade", "--force-reinstall", "hol-guard==2.0.489"]
+    ]
     assert payload["status"] == "stale"
     assert payload["changed"] is True
     assert "dashboard_sync" not in payload
@@ -1644,7 +1732,15 @@ def test_update_records_package_shim_refresh_after_successful_update(
     )
 
     def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        assert command == ["pipx", "install", "--force", "hol-guard==2.0.830"]
+        assert command == [
+            "pipx",
+            "runpip",
+            "hol-guard",
+            "install",
+            "--upgrade",
+            "--force-reinstall",
+            "hol-guard==2.0.830",
+        ]
         return subprocess.CompletedProcess(command, 0, "installed hol-guard 2.0.830", "")
 
     monkeypatch.setattr(update_commands.subprocess, "run", fake_run)
@@ -1678,7 +1774,15 @@ def test_update_keeps_success_when_package_shim_refresh_warns(
     )
 
     def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        assert command == ["pipx", "install", "--force", "hol-guard==2.0.830"]
+        assert command == [
+            "pipx",
+            "runpip",
+            "hol-guard",
+            "install",
+            "--upgrade",
+            "--force-reinstall",
+            "hol-guard==2.0.830",
+        ]
         return subprocess.CompletedProcess(command, 0, "installed hol-guard 2.0.830", "")
 
     monkeypatch.setattr(update_commands.subprocess, "run", fake_run)
@@ -1814,7 +1918,9 @@ def test_update_skips_package_shim_refresh_for_stale_no_change(
     payload, exit_code = update_commands.run_guard_update(dry_run=False)
 
     assert exit_code == 0
-    assert captured_commands == [["pipx", "install", "--force", "hol-guard==2.0.585"]]
+    assert captured_commands == [
+        ["pipx", "runpip", "hol-guard", "install", "--upgrade", "--force-reinstall", "hol-guard==2.0.585"]
+    ]
     assert payload["status"] == "stale"
     assert refresh_attempted is False
 
@@ -1849,7 +1955,9 @@ def test_update_marks_pinned_pipx_install_as_stale_when_version_does_not_change(
     payload, exit_code = update_commands.run_guard_update(dry_run=False)
 
     assert exit_code == 0
-    assert captured_commands == [["pipx", "install", "--force", "hol-guard==2.0.585"]]
+    assert captured_commands == [
+        ["pipx", "runpip", "hol-guard", "install", "--upgrade", "--force-reinstall", "hol-guard==2.0.585"]
+    ]
     assert payload["status"] == "stale"
     assert payload["changed"] is False
     assert payload["resulting_version"] == "2.0.584"
@@ -1872,7 +1980,15 @@ def test_update_reports_blocked_when_force_install_hits_dependency_conflict(
     )
 
     def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        assert command == ["pipx", "install", "--force", "hol-guard==2.0.749"]
+        assert command == [
+            "pipx",
+            "runpip",
+            "hol-guard",
+            "install",
+            "--upgrade",
+            "--force-reinstall",
+            "hol-guard==2.0.749",
+        ]
         return subprocess.CompletedProcess(
             command,
             1,
@@ -1910,7 +2026,15 @@ def test_update_installs_detected_pipx_release_directly(
 
     def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
         captured_commands.append(command)
-        assert command == ["pipx", "install", "--force", "hol-guard==2.0.585"]
+        assert command == [
+            "pipx",
+            "runpip",
+            "hol-guard",
+            "install",
+            "--upgrade",
+            "--force-reinstall",
+            "hol-guard==2.0.585",
+        ]
         return subprocess.CompletedProcess(command, 0, "installed hol-guard 2.0.585", "")
 
     monkeypatch.setattr(update_commands.subprocess, "run", fake_run)
@@ -1918,7 +2042,9 @@ def test_update_installs_detected_pipx_release_directly(
     payload, exit_code = update_commands.run_guard_update(dry_run=False)
 
     assert exit_code == 0
-    assert captured_commands == [["pipx", "install", "--force", "hol-guard==2.0.585"]]
+    assert captured_commands == [
+        ["pipx", "runpip", "hol-guard", "install", "--upgrade", "--force-reinstall", "hol-guard==2.0.585"]
+    ]
     assert payload["status"] == "updated"
     assert payload["resulting_version"] == "2.0.585"
 
@@ -1957,7 +2083,15 @@ def test_update_switches_git_install_to_pypi_when_release_is_newer(monkeypatch: 
     payload, exit_code = update_commands.run_guard_update(dry_run=False)
 
     assert exit_code == 0
-    assert captured_commands[0] == ["pipx", "install", "--force", "hol-guard==2.0.489"]
+    assert captured_commands[0] == [
+        "pipx",
+        "runpip",
+        "hol-guard",
+        "install",
+        "--upgrade",
+        "--force-reinstall",
+        "hol-guard==2.0.489",
+    ]
     assert payload["upgrade_source"] == "pypi"
     assert payload["status"] == "updated"
     assert payload["message"] == "Updated HOL Guard from 2.0.345 to 2.0.489."
@@ -1997,7 +2131,15 @@ def test_update_marks_git_install_stale_when_pypi_upgrade_leaves_old_version(mon
     payload, exit_code = update_commands.run_guard_update(dry_run=False)
 
     assert exit_code == 0
-    assert captured_commands[0] == ["pipx", "install", "--force", "hol-guard==2.0.489"]
+    assert captured_commands[0] == [
+        "pipx",
+        "runpip",
+        "hol-guard",
+        "install",
+        "--upgrade",
+        "--force-reinstall",
+        "hol-guard==2.0.489",
+    ]
     assert payload["status"] == "stale"
     assert "behind PyPI 2.0.489" in str(payload["message"])
     assert "hol-guard update" in str(payload["message"])

--- a/tests/test_guard_phase03_remainder.py
+++ b/tests/test_guard_phase03_remainder.py
@@ -101,10 +101,13 @@ def test_update_alpha_pins_latest_alpha_release(monkeypatch: pytest.MonkeyPatch)
     assert exit_code == 0
     assert payload["command"] == [
         "pipx",
+        "runpip",
+        "hol-guard",
         "install",
-        "--force",
+        "--upgrade",
+        "--force-reinstall",
+        "--pre",
         "hol-guard==2.1.0a35",
-        "--pip-args=--pre",
     ]
     assert payload["retry_command"] == "hol-guard update --alpha"
     assert payload["release_channel"] == "alpha"
@@ -130,7 +133,7 @@ def test_update_command_allows_prerelease_for_alpha_pins() -> None:
         "pipx",
         use_pypi=True,
         target_version="2.1.0a51",
-    ) == ["pipx", "install", "--force", "hol-guard==2.1.0a51", "--pip-args=--pre"]
+    ) == ["pipx", "runpip", "hol-guard", "install", "--upgrade", "--force-reinstall", "--pre", "hol-guard==2.1.0a51"]
     assert update_commands._update_command(
         "pip",
         use_pypi=True,

--- a/tests/test_guard_phase03_remainder.py
+++ b/tests/test_guard_phase03_remainder.py
@@ -681,6 +681,7 @@ def test_install_native_contract_output_prefers_native_hooks_for_supported_harne
     assert managed_install["primary_integration"] == "native_hooks"
     assert managed_install["manifest"]["mode"] == "codex-mcp-proxy"
 
+
 def test_success_status_treats_uv_pin_noop_as_current() -> None:
     payload = {
         "current_version": "3.0.0a9",
@@ -710,4 +711,3 @@ def test_success_status_marks_equal_versions_current_without_installer_hints() -
         "version_check": {"update_available": False, "latest_version": "3.0.0a9"},
     }
     assert update_commands._success_status(payload) == "current"
-

--- a/tests/test_guard_update_subprocess.py
+++ b/tests/test_guard_update_subprocess.py
@@ -805,6 +805,74 @@ def test_pipx_execution_argv_is_absolute_and_source_pinned(
     assert context.environment["PIPX_FETCH_PYTHON"] == "never"
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="uses an extensionless POSIX shebang executable as the pipx manager fixture",
+)
+def test_pipx_runpip_execution_is_source_pinned(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context, manager = _build_manager_context(
+        tmp_path,
+        monkeypatch,
+        "pipx",
+        source_url="https://packages.enterprise.example/simple",
+    )
+
+    command = context.build_installer_command(
+        [
+            "pipx",
+            "runpip",
+            "hol-guard",
+            "install",
+            "--upgrade",
+            "--force-reinstall",
+            "--pre",
+            "hol-guard==3.0.0a116",
+        ]
+    )
+
+    assert command == [
+        str(manager),
+        "runpip",
+        "hol-guard",
+        "install",
+        "--upgrade",
+        "--force-reinstall",
+        "--pre",
+        "hol-guard==3.0.0a116",
+        "--index-url",
+        "https://packages.enterprise.example/simple",
+    ]
+
+
+@pytest.mark.parametrize(
+    "display",
+    [
+        ["pipx", "runpip", "other", "install", "--force-reinstall", "hol-guard==3.0.0"],
+        ["pipx", "runpip", "hol-guard", "uninstall", "hol-guard"],
+        ["pipx", "runpip", "hol-guard", "install", "--index-url", "https://example.test", "hol-guard"],
+        ["pipx", "runpip", "hol-guard", "install", "--force-reinstall"],
+    ],
+)
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="uses an extensionless POSIX shebang executable as the pipx manager fixture",
+)
+def test_pipx_runpip_rejects_untrusted_shapes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    display: list[str],
+) -> None:
+    context, _manager = _build_manager_context(tmp_path, monkeypatch, "pipx")
+
+    with pytest.raises(UpdateSubprocessError) as error:
+        context.build_installer_command(display)
+
+    assert _error_reason(error) == "update_installer_command_invalid"
+
+
 @pytest.mark.parametrize("installer_kind", ["uv", "pipx"])
 @pytest.mark.skipif(
     os.name == "nt",


### PR DESCRIPTION
## Summary
- retry a pinned update once while a newly published release reaches the package index
- update pipx-managed installations through their existing environment so failed resolution cannot remove Guard
- distinguish HTTP authorization failures from version numbers containing 401 or 403
- preserve the active installation and report a deferred update when propagation continues

## Testing
- `uv run --no-sync pytest -q tests/test_guard_phase03_local_install.py tests/test_guard_phase03_remainder.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/cli/update_commands.py tests/test_guard_phase03_local_install.py`
- `uv run --no-sync basedpyright --level error src/codex_plugin_scanner/guard/cli/update_commands.py`
- `uv build`
