### PR TITLE
feat(mcpb): ship one-click local MCP bundles

### DIFF
--- a/.github/workflows/publish-mcpb.yml
+++ b/.github/workflows/publish-mcpb.yml
@@ -1,0 +1,152 @@
+name: MCPB Distribution
+
+on:
+  pull_request:
+    branches: [release/3.0]
+  push:
+    branches: [main, release/3.0]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate one-click MCP bundle
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out immutable source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - name: Validate Python wrapper
+        run: python -m compileall -q distributions/mcpb/server
+      - name: Validate and pack with pinned MCPB CLI
+        env:
+          NPM_CONFIG_IGNORE_SCRIPTS: "true"
+        run: |
+          set -euo pipefail
+          npm exec --yes --package=@anthropic-ai/mcpb@2.1.2 -- mcpb validate distributions/mcpb
+          npm exec --yes --package=@anthropic-ai/mcpb@2.1.2 -- mcpb pack distributions/mcpb "$RUNNER_TEMP/hol-guard.mcpb"
+          npm exec --yes --package=@anthropic-ai/mcpb@2.1.2 -- mcpb info "$RUNNER_TEMP/hol-guard.mcpb"
+          test -s "$RUNNER_TEMP/hol-guard.mcpb"
+
+  publish:
+    name: Attach versioned MCPB to release
+    if: >-
+      github.event_name == 'push' &&
+      vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
+      !contains(github.event.head_commit.message || '', '[skip release publish]')
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      contents: write
+    steps:
+      - name: Check out exact release source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Wait for canonical release tag
+        id: release
+        env:
+          SOURCE_SHA: ${{ github.sha }}
+          SOURCE_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          tag=""
+          for attempt in $(seq 1 180); do
+            git fetch --force --tags origin
+            if [[ "$SOURCE_REF" == "refs/heads/release/3.0" ]]; then
+              tag=$(git tag --points-at "$SOURCE_SHA" --list 'alpha/v3.0.0a*' | sort -V | tail -n 1)
+            elif [[ "$SOURCE_REF" == "refs/heads/main" ]]; then
+              tag=$(git tag --points-at "$SOURCE_SHA" --list 'v*' | sort -V | tail -n 1)
+            else
+              echo "Unsupported release ref: $SOURCE_REF" >&2
+              exit 1
+            fi
+            [[ -n "$tag" ]] && break
+            [[ "$attempt" == "180" ]] && { echo "No canonical release tag appeared for $SOURCE_SHA" >&2; exit 1; }
+            sleep 10
+          done
+          if [[ "$tag" == alpha/v* ]]; then
+            version="${tag#alpha/v}"
+          else
+            version="${tag#v}"
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for exact PyPI package and GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release.outputs.tag }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 120); do
+            pypi_ok=false
+            release_ok=false
+            curl --fail --silent --show-error --proto '=https' --tlsv1.2 \
+              "https://pypi.org/pypi/hol-guard/${VERSION}/json" -o /tmp/pypi.json && \
+              jq -e --arg version "$VERSION" '.info.version == $version' /tmp/pypi.json >/dev/null && pypi_ok=true
+            gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 && release_ok=true
+            if [[ "$pypi_ok" == true && "$release_ok" == true ]]; then exit 0; fi
+            [[ "$attempt" == "120" ]] && { echo "Release prerequisites did not become available" >&2; exit 1; }
+            sleep 10
+          done
+
+      - name: Stamp exact release into isolated bundle source
+        id: bundle
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          bundle_dir="$RUNNER_TEMP/hol-guard-mcpb"
+          cp -R distributions/mcpb "$bundle_dir"
+          python - "$bundle_dir" "$VERSION" <<'PY'
+          import json
+          import pathlib
+          import re
+          import sys
+
+          root = pathlib.Path(sys.argv[1])
+          version = sys.argv[2]
+          manifest_path = root / "manifest.json"
+          manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+          manifest["version"] = version
+          manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+          pyproject_path = root / "pyproject.toml"
+          text = pyproject_path.read_text(encoding="utf-8")
+          text = re.sub(r'(?m)^version = "[^"]+"$', f'version = "{version}"', text, count=1)
+          text = re.sub(r'"hol-guard==[^"]+"', f'"hol-guard=={version}"', text, count=1)
+          pyproject_path.write_text(text, encoding="utf-8")
+          PY
+          artifact="$RUNNER_TEMP/hol-guard-${VERSION}.mcpb"
+          echo "dir=$bundle_dir" >> "$GITHUB_OUTPUT"
+          echo "artifact=$artifact" >> "$GITHUB_OUTPUT"
+
+      - name: Validate and pack immutable bundle
+        env:
+          NPM_CONFIG_IGNORE_SCRIPTS: "true"
+          BUNDLE_DIR: ${{ steps.bundle.outputs.dir }}
+          ARTIFACT: ${{ steps.bundle.outputs.artifact }}
+        run: |
+          set -euo pipefail
+          npm exec --yes --package=@anthropic-ai/mcpb@2.1.2 -- mcpb validate "$BUNDLE_DIR"
+          npm exec --yes --package=@anthropic-ai/mcpb@2.1.2 -- mcpb pack "$BUNDLE_DIR" "$ARTIFACT"
+          npm exec --yes --package=@anthropic-ai/mcpb@2.1.2 -- mcpb info "$ARTIFACT"
+          sha256sum "$ARTIFACT" > "${ARTIFACT}.sha256"
+
+      - name: Attach bundle and checksum to canonical release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release.outputs.tag }}
+          ARTIFACT: ${{ steps.bundle.outputs.artifact }}
+        run: |
+          set -euo pipefail
+          gh release upload "$TAG" "$ARTIFACT" "${ARTIFACT}.sha256" --clobber --repo "$GITHUB_REPOSITORY"

--- a/distributions/mcpb/manifest.json
+++ b/distributions/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "hol-guard",
   "display_name": "HOL Guard",
-  "version": "2.2.0",
+  "version": "2.2.85",
   "description": "Local-first AI agent security evidence and approval workflows through HOL Guard's MCP server.",
   "long_description": "HOL Guard exposes sanitized local Guard status, security receipts, inventory, policy validation, and approval-backed policy workflows over stdio. The MCP bundle installs the open-source hol-guard Python package locally with uv and does not require Guard Cloud.",
   "author": {
@@ -32,44 +32,17 @@
     }
   },
   "tools": [
-    {
-      "name": "search",
-      "description": "Search sanitized local Guard receipts and inventory."
-    },
-    {
-      "name": "fetch",
-      "description": "Fetch one sanitized Guard receipt or inventory item by opaque ID."
-    },
-    {
-      "name": "get_guard_status",
-      "description": "Report local Guard availability and data freshness."
-    },
-    {
-      "name": "validate_policy",
-      "description": "Validate candidate HOL Guard policy YAML without writing it."
-    },
-    {
-      "name": "create_policy",
-      "description": "Request an approval-backed HOL Guard policy write when local policy authoring is enabled."
-    },
-    {
-      "name": "get_policy_creation",
-      "description": "Inspect a pending or completed policy creation request."
-    }
+    {"name": "search", "description": "Search sanitized local Guard receipts and inventory."},
+    {"name": "fetch", "description": "Fetch one sanitized Guard receipt or inventory item by opaque ID."},
+    {"name": "get_guard_status", "description": "Report local Guard availability and data freshness."},
+    {"name": "validate_policy", "description": "Validate candidate HOL Guard policy YAML without writing it."},
+    {"name": "create_policy", "description": "Request an approval-backed HOL Guard policy write when local policy authoring is enabled."},
+    {"name": "get_policy_creation", "description": "Inspect a pending or completed policy creation request."}
   ],
-  "keywords": [
-    "security",
-    "ai-agent-security",
-    "mcp-security",
-    "guardrails",
-    "policy",
-    "audit"
-  ],
+  "keywords": ["security", "ai-agent-security", "mcp-security", "guardrails", "policy", "audit"],
   "license": "Apache-2.0",
   "compatibility": {
     "platforms": ["darwin", "win32", "linux"],
-    "runtimes": {
-      "python": ">=3.10.0 <4"
-    }
+    "runtimes": {"python": ">=3.10.0 <4"}
   }
 }

--- a/distributions/mcpb/manifest.json
+++ b/distributions/mcpb/manifest.json
@@ -1,0 +1,75 @@
+{
+  "manifest_version": "0.4",
+  "name": "hol-guard",
+  "display_name": "HOL Guard",
+  "version": "2.2.0",
+  "description": "Local-first AI agent security evidence and approval workflows through HOL Guard's MCP server.",
+  "long_description": "HOL Guard exposes sanitized local Guard status, security receipts, inventory, policy validation, and approval-backed policy workflows over stdio. The MCP bundle installs the open-source hol-guard Python package locally with uv and does not require Guard Cloud.",
+  "author": {
+    "name": "Hashgraph Online",
+    "email": "support@hol.org",
+    "url": "https://hol.org"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashgraph-online/hol-guard.git"
+  },
+  "homepage": "https://hol.org/guard",
+  "documentation": "https://github.com/hashgraph-online/hol-guard/tree/main/docs/guard",
+  "support": "https://github.com/hashgraph-online/hol-guard/issues",
+  "icon": "https://raw.githubusercontent.com/hashgraph-online/hol-guard-plugin/main/assets/icon.png",
+  "server": {
+    "type": "uv",
+    "entry_point": "server/main.py",
+    "mcp_config": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory",
+        "${__dirname}",
+        "server/main.py"
+      ]
+    }
+  },
+  "tools": [
+    {
+      "name": "search",
+      "description": "Search sanitized local Guard receipts and inventory."
+    },
+    {
+      "name": "fetch",
+      "description": "Fetch one sanitized Guard receipt or inventory item by opaque ID."
+    },
+    {
+      "name": "get_guard_status",
+      "description": "Report local Guard availability and data freshness."
+    },
+    {
+      "name": "validate_policy",
+      "description": "Validate candidate HOL Guard policy YAML without writing it."
+    },
+    {
+      "name": "create_policy",
+      "description": "Request an approval-backed HOL Guard policy write when local policy authoring is enabled."
+    },
+    {
+      "name": "get_policy_creation",
+      "description": "Inspect a pending or completed policy creation request."
+    }
+  ],
+  "keywords": [
+    "security",
+    "ai-agent-security",
+    "mcp-security",
+    "guardrails",
+    "policy",
+    "audit"
+  ],
+  "license": "Apache-2.0",
+  "compatibility": {
+    "platforms": ["darwin", "win32", "linux"],
+    "runtimes": {
+      "python": ">=3.10.0 <4"
+    }
+  }
+}

--- a/distributions/mcpb/pyproject.toml
+++ b/distributions/mcpb/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
 name = "hol-guard-mcpb-runtime"
-version = "2.2.0"
+version = "2.2.85"
 description = "Runtime wrapper for the HOL Guard MCP Bundle"
 requires-python = ">=3.10,<4"
 dependencies = [
-    "hol-guard==2.2.0",
+    "hol-guard==2.2.85",
 ]

--- a/distributions/mcpb/pyproject.toml
+++ b/distributions/mcpb/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "hol-guard-mcpb-runtime"
+version = "2.2.0"
+description = "Runtime wrapper for the HOL Guard MCP Bundle"
+requires-python = ">=3.10,<4"
+dependencies = [
+    "hol-guard==2.2.0",
+]

--- a/distributions/mcpb/server/main.py
+++ b/distributions/mcpb/server/main.py
@@ -12,7 +12,7 @@ def main() -> int:
         return 127
 
     completed = subprocess.run(
-        [executable, "guard", "mcp", "serve", "--stdio"],
+        [executable, "mcp", "serve", "--stdio"],
         check=False,
     )
     return completed.returncode

--- a/distributions/mcpb/server/main.py
+++ b/distributions/mcpb/server/main.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+
+
+def main() -> int:
+    executable = shutil.which("hol-guard")
+    if executable is None:
+        print("HOL Guard CLI was not installed into the MCPB uv environment.", file=sys.stderr)
+        return 127
+
+    completed = subprocess.run(
+        [executable, "guard", "mcp", "serve", "--stdio"],
+        check=False,
+    )
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Superseded by #2354, which rebases the validated MCPB distribution work onto the current `release/3.0` tip and includes the corrected standalone MCP launch contract.