### PR TITLE
feat(mcp): make Cline Marketplace installation deterministic

### DIFF
--- a/.github/workflows/cline-marketplace.yml
+++ b/.github/workflows/cline-marketplace.yml
@@ -55,9 +55,10 @@ jobs:
           assert package["identifier"] == "hol-guard"
           assert package["transport"] == {"type": "stdio"}
           args = [item["value"] for item in package["packageArguments"]]
-          assert args == ["guard", "mcp", "serve", "--stdio"]
+          assert args == ["mcp", "serve", "--stdio"]
           expected = "cline mcp install hol-guard -- uvx --from hol-guard hol-guard " + " ".join(args)
           assert expected in guide
           assert '"command": "uvx"' in guide
           assert '"--stdio"' in guide
+          assert "hol-guard guard mcp serve" not in guide
           PY

--- a/.github/workflows/cline-marketplace.yml
+++ b/.github/workflows/cline-marketplace.yml
@@ -1,0 +1,63 @@
+name: Cline MCP Marketplace
+
+on:
+  pull_request:
+    branches: [release/3.0]
+    paths:
+      - llms-install.md
+      - server.json
+      - .github/workflows/cline-marketplace.yml
+  push:
+    branches: [release/3.0]
+    paths:
+      - llms-install.md
+      - server.json
+      - .github/workflows/cline-marketplace.yml
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate Cline install contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out immutable source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+
+      - name: Set up Node for Cline CLI
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: "22"
+
+      - name: Verify current Cline CLI exposes MCP installation
+        env:
+          NPM_CONFIG_IGNORE_SCRIPTS: "true"
+        run: |
+          set -euo pipefail
+          npm exec --yes --package=cline@3.0.55 -- cline --version
+          npm exec --yes --package=cline@3.0.55 -- cline mcp install --help > /tmp/cline-mcp-help.txt
+          grep -Fq 'install' /tmp/cline-mcp-help.txt
+
+      - name: Verify install guide matches official Registry transport
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          manifest = json.loads(Path("server.json").read_text(encoding="utf-8"))
+          guide = Path("llms-install.md").read_text(encoding="utf-8")
+          package = manifest["packages"][0]
+          assert package["identifier"] == "hol-guard"
+          assert package["transport"] == {"type": "stdio"}
+          args = [item["value"] for item in package["packageArguments"]]
+          assert args == ["guard", "mcp", "serve", "--stdio"]
+          expected = "cline mcp install hol-guard -- uvx --from hol-guard hol-guard " + " ".join(args)
+          assert expected in guide
+          assert '"command": "uvx"' in guide
+          assert '"--stdio"' in guide
+          PY

--- a/.github/workflows/cline-marketplace.yml
+++ b/.github/workflows/cline-marketplace.yml
@@ -33,14 +33,18 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Verify current Cline CLI exposes MCP installation
-        env:
-          NPM_CONFIG_IGNORE_SCRIPTS: "true"
+      - name: Install pinned official Cline CLI
         run: |
           set -euo pipefail
-          npm exec --yes --package=cline@3.0.55 -- cline --version
-          npm exec --yes --package=cline@3.0.55 -- cline mcp install --help > /tmp/cline-mcp-help.txt
+          npm install --global --no-audit --no-fund cline@3.0.55
+          cline --version
+
+      - name: Verify current Cline CLI exposes MCP installation
+        run: |
+          set -euo pipefail
+          cline mcp install --help > /tmp/cline-mcp-help.txt
           grep -Fq 'install' /tmp/cline-mcp-help.txt
+          grep -Fq -- '--transport' /tmp/cline-mcp-help.txt
 
       - name: Verify install guide matches official Registry transport
         run: |

--- a/llms-install.md
+++ b/llms-install.md
@@ -1,0 +1,65 @@
+# HOL Guard MCP installation for Cline
+
+HOL Guard exposes a local stdio MCP server for sanitized Guard status, receipts, inventory, policy validation, and approval-backed policy workflows.
+
+No Guard Cloud account, API key, or remote MCP endpoint is required for the local server.
+
+## Recommended one-command setup
+
+Cline's current CLI can prefill a stdio MCP server with `cline mcp install`. Run:
+
+```bash
+cline mcp install hol-guard -- uvx --from hol-guard hol-guard guard mcp serve --stdio
+```
+
+Cline opens its add-server wizard with the name and command prefilled. Review the local command, accept it, and let Cline save the MCP configuration.
+
+If `uvx` is not installed, install `uv` from Astral's official installer/package manager first, or install HOL Guard in an isolated CLI environment with `pipx install hol-guard` and use:
+
+```bash
+cline mcp install hol-guard -- hol-guard guard mcp serve --stdio
+```
+
+## Equivalent MCP configuration
+
+For clients that accept raw MCP configuration, the server is:
+
+```json
+{
+  "mcpServers": {
+    "hol-guard": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "hol-guard",
+        "hol-guard",
+        "guard",
+        "mcp",
+        "serve",
+        "--stdio"
+      ]
+    }
+  }
+}
+```
+
+## Verify
+
+After Cline saves the server, open Cline's MCP server list and confirm `hol-guard` connects. The server exposes these current tools:
+
+- `search`: search sanitized local Guard receipts and inventory.
+- `fetch`: fetch one sanitized receipt or inventory item by opaque ID.
+- `get_guard_status`: report Guard availability and data freshness.
+- `validate_policy`: validate candidate policy YAML without writing it.
+- `create_policy`: request an approval-backed policy write when local policy authoring is enabled.
+- `get_policy_creation`: inspect a pending or completed policy request.
+
+The server must remain stdio. Do not add a remote URL or credentials that are not required by HOL Guard.
+
+## Security and privacy
+
+HOL Guard's MCP surface intentionally returns sanitized local evidence. It does not require uploading workspace file contents to Guard Cloud. Policy writes remain subject to HOL Guard's local write enablement and approval flow.
+
+Project: https://github.com/hashgraph-online/hol-guard
+
+Issues/support: https://github.com/hashgraph-online/hol-guard/issues

--- a/llms-install.md
+++ b/llms-install.md
@@ -9,7 +9,7 @@ No Guard Cloud account, API key, or remote MCP endpoint is required for the loca
 Cline's current CLI can prefill a stdio MCP server with `cline mcp install`. Run:
 
 ```bash
-cline mcp install hol-guard -- uvx --from hol-guard hol-guard guard mcp serve --stdio
+cline mcp install hol-guard -- uvx --from hol-guard hol-guard mcp serve --stdio
 ```
 
 Cline opens its add-server wizard with the name and command prefilled. Review the local command, accept it, and let Cline save the MCP configuration.
@@ -17,7 +17,7 @@ Cline opens its add-server wizard with the name and command prefilled. Review th
 If `uvx` is not installed, install `uv` from Astral's official installer/package manager first, or install HOL Guard in an isolated CLI environment with `pipx install hol-guard` and use:
 
 ```bash
-cline mcp install hol-guard -- hol-guard guard mcp serve --stdio
+cline mcp install hol-guard -- hol-guard mcp serve --stdio
 ```
 
 ## Equivalent MCP configuration
@@ -33,7 +33,6 @@ For clients that accept raw MCP configuration, the server is:
         "--from",
         "hol-guard",
         "hol-guard",
-        "guard",
         "mcp",
         "serve",
         "--stdio"

--- a/server.json
+++ b/server.json
@@ -19,10 +19,6 @@
       "packageArguments": [
         {
           "type": "positional",
-          "value": "guard"
-        },
-        {
-          "type": "positional",
           "value": "mcp"
         },
         {


### PR DESCRIPTION
Superseded by #2354, which rebases the Cline Marketplace install work onto the current `release/3.0` tip, fixes the official Cline CLI validation path, and includes the corrected standalone MCP launch contract.