### PR TITLE
fix(approvals): remember exact package requests

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12596,
-  "maximum_test_source_lines": 288472,
+  "maximum_collected_cases": 12599,
+  "maximum_test_source_lines": 288540,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/approval_scope_support.py
+++ b/src/codex_plugin_scanner/guard/approval_scope_support.py
@@ -227,6 +227,8 @@ def exact_action_allow_persistence_eligible(request: Mapping[str, object]) -> bo
     artifact_type = _string_or_none(request.get("artifact_type"))
     artifact_id = _string_or_none(request.get("artifact_id"))
     artifact_hash = _string_or_none(request.get("artifact_hash"))
+    if artifact_type == "package_request":
+        return bool(artifact_id and artifact_hash and artifact_hash != "unknown")
     if artifact_type == "tool_call":
         return bool(
             artifact_id

--- a/tests/test_guard_approval_scope_contract.py
+++ b/tests/test_guard_approval_scope_contract.py
@@ -167,6 +167,74 @@ def test_package_context_never_invents_workspace_allow() -> None:
     assert supported_request_scopes(request) == ("artifact",)
 
 
+def test_package_request_can_persist_the_exact_context_bound_action() -> None:
+    request = _request(
+        "package-exact-action",
+        artifact_id="codex:project:package-request:package-exact-action",
+        artifact_type="package_request",
+        artifact_hash="package-context-sha256",
+        action_type="package_install",
+    ).to_dict()
+
+    assert request_scope_contract(request).exact_action_persistence_eligible is True
+
+
+def test_package_request_without_a_context_hash_cannot_be_persisted() -> None:
+    request = _request(
+        "package-missing-context",
+        artifact_id="codex:project:package-request:package-missing-context",
+        artifact_type="package_request",
+        artifact_hash="unknown",
+        action_type="package_install",
+    ).to_dict()
+
+    assert request_scope_contract(request).exact_action_persistence_eligible is False
+
+
+def test_saved_package_allow_only_resolves_the_identical_package_context(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    artifact_id = "guard-cli:project:package-request:server-memory"
+    request = _request(
+        "saved-package-exact-action",
+        artifact_id=artifact_id,
+        artifact_type="package_request",
+        artifact_hash="package-context-sha256",
+        action_type="package_install",
+    )
+    row = _store_request(store, request)
+
+    apply_approval_resolution(
+        store=store,
+        request_id=request.request_id,
+        action="allow",
+        scope="artifact",
+        workspace=None,
+        reason="remember exact package request",
+        persist_policy=True,
+        scope_contract_version=str(row["scope_contract_version"]),
+        scope_contract_digest=str(row["scope_contract_digest"]),
+    )
+
+    assert (
+        store.resolve_policy_decision(
+            "codex",
+            artifact_id,
+            "package-context-sha256",
+            consume_one_shot=False,
+        )
+        is not None
+    )
+    assert (
+        store.resolve_policy_decision(
+            "codex",
+            artifact_id,
+            "changed-package-context-sha256",
+            consume_one_shot=False,
+        )
+        is None
+    )
+
+
 @pytest.mark.parametrize(
     ("artifact_type", "family", "action_type", "expected_allow"),
     [


### PR DESCRIPTION
## Summary
- allow reviewed package requests to save an exact context-bound approval
- keep changed package context and unknown package fingerprints review-gated

## Testing
- `uv run pytest -q tests/test_guard_approval_scope_contract.py tests/test_guard_approval_precedence_consumers.py tests/test_guard_package_resume_phase14.py tests/test_guard_package_shims.py`
- `uv run ruff check src/codex_plugin_scanner/guard/approval_scope_support.py tests/test_guard_approval_scope_contract.py`
- `uv build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Package requests can now retain exact-action approvals when a valid artifact identifier and context hash are available.
  * Approvals are limited to the identical package artifact and context, preventing reuse when package details change.
  * Package requests without a known context hash are not persisted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->