### PR TITLE
chore: expose canonical security links in package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,7 @@ markers = [
   "daemon_bundle_refresh: enables the daemon supply-chain bundle refresh worker for focused tests",
   "daemon_headless_queue: enables request-triggered daemon cloud sync for focused tests",
   "daemon_headless_refresh: enables the daemon headless cloud sync worker for focused tests",
-  "daemon_service_workers: enables command queue and live request sync for focused tests",
+  "daemon_service_workers: enables command queue and live request sync workers for focused tests",
   "installed: requires verification through an installed package artifact",
   "integration: verifies multiple Guard subsystems together",
   "parser: verifies parsing or normalization security semantics",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,8 @@ plugin-ecosystem-scanner = "codex_plugin_scanner.cli:main"
 
 [project.urls]
 Homepage = "https://hol.org/guard"
+Security = "https://hol.org/guard/security"
+"Security Policy" = "https://github.com/hashgraph-online/hol-guard/blob/main/SECURITY.md"
 Documentation = "https://github.com/hashgraph-online/hol-guard/tree/main/docs/guard"
 Repository = "https://github.com/hashgraph-online/hol-guard"
 Issues = "https://github.com/hashgraph-online/hol-guard/issues"
@@ -151,7 +153,7 @@ markers = [
   "daemon_bundle_refresh: enables the daemon supply-chain bundle refresh worker for focused tests",
   "daemon_headless_queue: enables request-triggered daemon cloud sync for focused tests",
   "daemon_headless_refresh: enables the daemon headless cloud sync worker for focused tests",
-  "daemon_service_workers: enables command queue and live request sync workers for focused tests",
+  "daemon_service_workers: enables command queue and live request sync for focused tests",
   "installed: requires verification through an installed package artifact",
   "integration: verifies multiple Guard subsystems together",
   "parser: verifies parsing or normalization security semantics",


### PR DESCRIPTION
## Summary

Adds two standard project URLs to the Python package metadata:

- `Security` → `https://hol.org/guard/security`
- `Security Policy` → the repository's public `SECURITY.md`

## Why

PyPI and downstream package intelligence/catalog services consume `project.urls`. Publishing the canonical security page and disclosure policy makes those trust surfaces directly discoverable from package metadata instead of relying on README parsing.

## Scope

Metadata only. The final diff is exactly two added lines in `pyproject.toml`; there are no runtime, dependency, test, release, or policy changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added links to the project’s security information and security policy in its metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->