### PR TITLE
fix(mcp): correct standalone Registry launch command

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -106,7 +106,8 @@ jobs:
              .packages[0].identifier == "hol-guard" and
              .packages[0].version == $version and
              .version == $version and
-             .packages[0].transport.type == "stdio"' \
+             .packages[0].transport.type == "stdio" and
+             [.packages[0].packageArguments[].value] == ["mcp", "serve", "--stdio"]' \
             server.json >/dev/null
 
       - name: Install pinned MCP Registry publisher

--- a/server.json
+++ b/server.json
@@ -19,10 +19,6 @@
       "packageArguments": [
         {
           "type": "positional",
-          "value": "guard"
-        },
-        {
-          "type": "positional",
           "value": "mcp"
         },
         {

--- a/tests/test_mcp_registry_manifest.py
+++ b/tests/test_mcp_registry_manifest.py
@@ -27,8 +27,9 @@ def test_official_mcp_registry_manifest_contract() -> None:
     assert package["identifier"] == "hol-guard"
     assert package["runtimeHint"] == "uvx"
     assert package["transport"] == {"type": "stdio"}
+    # `hol-guard` is already the Guard-mode executable. Adding a leading
+    # `guard` would be parsed as an invalid root command and break Registry launches.
     assert [argument["value"] for argument in package["packageArguments"]] == [
-        "guard",
         "mcp",
         "serve",
         "--stdio",


### PR DESCRIPTION
Superseded by #2354. The consolidated branch was rebuilt from the current `release/3.0` tip and contains the Registry correction plus the MCPB and Cline distribution work.