### PR TITLE
feat(mcp): harden and expand MCP distribution

### DIFF
--- a/.github/workflows/cline-marketplace.yml
+++ b/.github/workflows/cline-marketplace.yml
@@ -1,0 +1,68 @@
+name: Cline MCP Marketplace
+
+on:
+  pull_request:
+    branches: [release/3.0]
+    paths:
+      - llms-install.md
+      - server.json
+      - .github/workflows/cline-marketplace.yml
+  push:
+    branches: [release/3.0]
+    paths:
+      - llms-install.md
+      - server.json
+      - .github/workflows/cline-marketplace.yml
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate Cline install contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out immutable source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+
+      - name: Set up Node for Cline CLI
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: "22"
+
+      - name: Install pinned official Cline CLI
+        run: |
+          set -euo pipefail
+          npm install --global --no-audit --no-fund cline@3.0.55
+          cline --version
+
+      - name: Verify current Cline CLI exposes MCP installation
+        run: |
+          set -euo pipefail
+          cline mcp install --help > /tmp/cline-mcp-help.txt
+          grep -Fq 'install' /tmp/cline-mcp-help.txt
+          grep -Fq -- '--transport' /tmp/cline-mcp-help.txt
+
+      - name: Verify install guide matches official Registry transport
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          manifest = json.loads(Path("server.json").read_text(encoding="utf-8"))
+          guide = Path("llms-install.md").read_text(encoding="utf-8")
+          package = manifest["packages"][0]
+          assert package["identifier"] == "hol-guard"
+          assert package["transport"] == {"type": "stdio"}
+          args = [item["value"] for item in package["packageArguments"]]
+          assert args == ["mcp", "serve", "--stdio"]
+          expected = "cline mcp install hol-guard -- uvx --from hol-guard hol-guard " + " ".join(args)
+          assert expected in guide
+          assert '"command": "uvx"' in guide
+          assert '"--stdio"' in guide
+          assert "hol-guard guard mcp serve" not in guide
+          PY

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -106,7 +106,8 @@ jobs:
              .packages[0].identifier == "hol-guard" and
              .packages[0].version == $version and
              .version == $version and
-             .packages[0].transport.type == "stdio"' \
+             .packages[0].transport.type == "stdio" and
+             [.packages[0].packageArguments[].value] == ["mcp", "serve", "--stdio"]' \
             server.json >/dev/null
 
       - name: Install pinned MCP Registry publisher

--- a/.github/workflows/publish-mcpb.yml
+++ b/.github/workflows/publish-mcpb.yml
@@ -1,0 +1,152 @@
+name: MCPB Distribution
+
+on:
+  pull_request:
+    branches: [release/3.0]
+  push:
+    branches: [main, release/3.0]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate one-click MCP bundle
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out immutable source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - name: Validate Python wrapper
+        run: python -m compileall -q distributions/mcpb/server
+      - name: Validate and pack with pinned MCPB CLI
+        env:
+          NPM_CONFIG_IGNORE_SCRIPTS: "true"
+        run: |
+          set -euo pipefail
+          npm exec --yes --package=@anthropic-ai/mcpb@2.1.2 -- mcpb validate distributions/mcpb
+          npm exec --yes --package=@anthropic-ai/mcpb@2.1.2 -- mcpb pack distributions/mcpb "$RUNNER_TEMP/hol-guard.mcpb"
+          npm exec --yes --package=@anthropic-ai/mcpb@2.1.2 -- mcpb info "$RUNNER_TEMP/hol-guard.mcpb"
+          test -s "$RUNNER_TEMP/hol-guard.mcpb"
+
+  publish:
+    name: Attach versioned MCPB to release
+    if: >-
+      github.event_name == 'push' &&
+      vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
+      !contains(github.event.head_commit.message || '', '[skip release publish]')
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      contents: write
+    steps:
+      - name: Check out exact release source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Wait for canonical release tag
+        id: release
+        env:
+          SOURCE_SHA: ${{ github.sha }}
+          SOURCE_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          tag=""
+          for attempt in $(seq 1 180); do
+            git fetch --force --tags origin
+            if [[ "$SOURCE_REF" == "refs/heads/release/3.0" ]]; then
+              tag=$(git tag --points-at "$SOURCE_SHA" --list 'alpha/v3.0.0a*' | sort -V | tail -n 1)
+            elif [[ "$SOURCE_REF" == "refs/heads/main" ]]; then
+              tag=$(git tag --points-at "$SOURCE_SHA" --list 'v*' | sort -V | tail -n 1)
+            else
+              echo "Unsupported release ref: $SOURCE_REF" >&2
+              exit 1
+            fi
+            [[ -n "$tag" ]] && break
+            [[ "$attempt" == "180" ]] && { echo "No canonical release tag appeared for $SOURCE_SHA" >&2; exit 1; }
+            sleep 10
+          done
+          if [[ "$tag" == alpha/v* ]]; then
+            version="${tag#alpha/v}"
+          else
+            version="${tag#v}"
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for exact PyPI package and GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release.outputs.tag }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 120); do
+            pypi_ok=false
+            release_ok=false
+            curl --fail --silent --show-error --proto '=https' --tlsv1.2 \
+              "https://pypi.org/pypi/hol-guard/${VERSION}/json" -o /tmp/pypi.json && \
+              jq -e --arg version "$VERSION" '.info.version == $version' /tmp/pypi.json >/dev/null && pypi_ok=true
+            gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 && release_ok=true
+            if [[ "$pypi_ok" == true && "$release_ok" == true ]]; then exit 0; fi
+            [[ "$attempt" == "120" ]] && { echo "Release prerequisites did not become available" >&2; exit 1; }
+            sleep 10
+          done
+
+      - name: Stamp exact release into isolated bundle source
+        id: bundle
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          bundle_dir="$RUNNER_TEMP/hol-guard-mcpb"
+          cp -R distributions/mcpb "$bundle_dir"
+          python - "$bundle_dir" "$VERSION" <<'PY'
+          import json
+          import pathlib
+          import re
+          import sys
+
+          root = pathlib.Path(sys.argv[1])
+          version = sys.argv[2]
+          manifest_path = root / "manifest.json"
+          manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+          manifest["version"] = version
+          manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+          pyproject_path = root / "pyproject.toml"
+          text = pyproject_path.read_text(encoding="utf-8")
+          text = re.sub(r'(?m)^version = "[^"]+"$', f'version = "{version}"', text, count=1)
+          text = re.sub(r'"hol-guard==[^"]+"', f'"hol-guard=={version}"', text, count=1)
+          pyproject_path.write_text(text, encoding="utf-8")
+          PY
+          artifact="$RUNNER_TEMP/hol-guard-${VERSION}.mcpb"
+          echo "dir=$bundle_dir" >> "$GITHUB_OUTPUT"
+          echo "artifact=$artifact" >> "$GITHUB_OUTPUT"
+
+      - name: Validate and pack immutable bundle
+        env:
+          NPM_CONFIG_IGNORE_SCRIPTS: "true"
+          BUNDLE_DIR: ${{ steps.bundle.outputs.dir }}
+          ARTIFACT: ${{ steps.bundle.outputs.artifact }}
+        run: |
+          set -euo pipefail
+          npm exec --yes --package=@anthropic-ai/mcpb@2.1.2 -- mcpb validate "$BUNDLE_DIR"
+          npm exec --yes --package=@anthropic-ai/mcpb@2.1.2 -- mcpb pack "$BUNDLE_DIR" "$ARTIFACT"
+          npm exec --yes --package=@anthropic-ai/mcpb@2.1.2 -- mcpb info "$ARTIFACT"
+          sha256sum "$ARTIFACT" > "${ARTIFACT}.sha256"
+
+      - name: Attach bundle and checksum to canonical release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release.outputs.tag }}
+          ARTIFACT: ${{ steps.bundle.outputs.artifact }}
+        run: |
+          set -euo pipefail
+          gh release upload "$TAG" "$ARTIFACT" "${ARTIFACT}.sha256" --clobber --repo "$GITHUB_REPOSITORY"

--- a/distributions/mcpb/manifest.json
+++ b/distributions/mcpb/manifest.json
@@ -1,0 +1,48 @@
+{
+  "manifest_version": "0.4",
+  "name": "hol-guard",
+  "display_name": "HOL Guard",
+  "version": "2.2.87",
+  "description": "Local-first AI agent security evidence and approval workflows through HOL Guard's MCP server.",
+  "long_description": "HOL Guard exposes sanitized local Guard status, security receipts, inventory, policy validation, and approval-backed policy workflows over stdio. The MCP bundle installs the open-source hol-guard Python package locally with uv and does not require Guard Cloud.",
+  "author": {
+    "name": "Hashgraph Online",
+    "email": "support@hol.org",
+    "url": "https://hol.org"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashgraph-online/hol-guard.git"
+  },
+  "homepage": "https://hol.org/guard",
+  "documentation": "https://github.com/hashgraph-online/hol-guard/tree/main/docs/guard",
+  "support": "https://github.com/hashgraph-online/hol-guard/issues",
+  "icon": "https://raw.githubusercontent.com/hashgraph-online/hol-guard-plugin/main/assets/icon.png",
+  "server": {
+    "type": "uv",
+    "entry_point": "server/main.py",
+    "mcp_config": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory",
+        "${__dirname}",
+        "server/main.py"
+      ]
+    }
+  },
+  "tools": [
+    {"name": "search", "description": "Search sanitized local Guard receipts and inventory."},
+    {"name": "fetch", "description": "Fetch one sanitized Guard receipt or inventory item by opaque ID."},
+    {"name": "get_guard_status", "description": "Report local Guard availability and data freshness."},
+    {"name": "validate_policy", "description": "Validate candidate HOL Guard policy YAML without writing it."},
+    {"name": "create_policy", "description": "Request an approval-backed HOL Guard policy write when local policy authoring is enabled."},
+    {"name": "get_policy_creation", "description": "Inspect a pending or completed policy creation request."}
+  ],
+  "keywords": ["security", "ai-agent-security", "mcp-security", "guardrails", "policy", "audit"],
+  "license": "Apache-2.0",
+  "compatibility": {
+    "platforms": ["darwin", "win32", "linux"],
+    "runtimes": {"python": ">=3.10.0 <4"}
+  }
+}

--- a/distributions/mcpb/pyproject.toml
+++ b/distributions/mcpb/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "hol-guard-mcpb-runtime"
+version = "2.2.87"
+description = "Runtime wrapper for the HOL Guard MCP Bundle"
+requires-python = ">=3.10,<4"
+dependencies = [
+    "hol-guard==2.2.87",
+]

--- a/distributions/mcpb/server/main.py
+++ b/distributions/mcpb/server/main.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+
+
+def main() -> int:
+    executable = shutil.which("hol-guard")
+    if executable is None:
+        print("HOL Guard CLI was not installed into the MCPB uv environment.", file=sys.stderr)
+        return 127
+
+    completed = subprocess.run(
+        [executable, "mcp", "serve", "--stdio"],
+        check=False,
+    )
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/llms-install.md
+++ b/llms-install.md
@@ -1,0 +1,64 @@
+# HOL Guard MCP installation for Cline
+
+HOL Guard exposes a local stdio MCP server for sanitized Guard status, receipts, inventory, policy validation, and approval-backed policy workflows.
+
+No Guard Cloud account, API key, or remote MCP endpoint is required for the local server.
+
+## Recommended one-command setup
+
+Cline's current CLI can prefill a stdio MCP server with `cline mcp install`. Run:
+
+```bash
+cline mcp install hol-guard -- uvx --from hol-guard hol-guard mcp serve --stdio
+```
+
+Cline opens its add-server wizard with the name and command prefilled. Review the local command, accept it, and let Cline save the MCP configuration.
+
+If `uvx` is not installed, install `uv` from Astral's official installer/package manager first, or install HOL Guard in an isolated CLI environment with `pipx install hol-guard` and use:
+
+```bash
+cline mcp install hol-guard -- hol-guard mcp serve --stdio
+```
+
+## Equivalent MCP configuration
+
+For clients that accept raw MCP configuration, the server is:
+
+```json
+{
+  "mcpServers": {
+    "hol-guard": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "hol-guard",
+        "hol-guard",
+        "mcp",
+        "serve",
+        "--stdio"
+      ]
+    }
+  }
+}
+```
+
+## Verify
+
+After Cline saves the server, open Cline's MCP server list and confirm `hol-guard` connects. The server exposes these current tools:
+
+- `search`: search sanitized local Guard receipts and inventory.
+- `fetch`: fetch one sanitized Guard receipt or inventory item by opaque ID.
+- `get_guard_status`: report Guard availability and data freshness.
+- `validate_policy`: validate candidate HOL Guard policy YAML without writing it.
+- `create_policy`: request an approval-backed policy write when local policy authoring is enabled.
+- `get_policy_creation`: inspect a pending or completed policy request.
+
+The server must remain stdio. Do not add a remote URL or credentials that are not required by HOL Guard.
+
+## Security and privacy
+
+HOL Guard's MCP surface intentionally returns sanitized local evidence. It does not require uploading workspace file contents to Guard Cloud. Policy writes remain subject to HOL Guard's local write enablement and approval flow.
+
+Project: https://github.com/hashgraph-online/hol-guard
+
+Issues/support: https://github.com/hashgraph-online/hol-guard/issues

--- a/server.json
+++ b/server.json
@@ -19,10 +19,6 @@
       "packageArguments": [
         {
           "type": "positional",
-          "value": "guard"
-        },
-        {
-          "type": "positional",
           "value": "mcp"
         },
         {

--- a/tests/test_mcp_registry_manifest.py
+++ b/tests/test_mcp_registry_manifest.py
@@ -27,8 +27,7 @@ def test_official_mcp_registry_manifest_contract() -> None:
     assert package["identifier"] == "hol-guard"
     assert package["runtimeHint"] == "uvx"
     assert package["transport"] == {"type": "stdio"}
-    # `hol-guard` is already the Guard-mode executable. Adding a leading
-    # `guard` would be parsed as an invalid root command and break Registry launches.
+    # `hol-guard` is already Guard-mode; a leading `guard` would break Registry launches.
     assert [argument["value"] for argument in package["packageArguments"]] == [
         "mcp",
         "serve",

--- a/tests/test_mcp_registry_manifest.py
+++ b/tests/test_mcp_registry_manifest.py
@@ -27,8 +27,9 @@ def test_official_mcp_registry_manifest_contract() -> None:
     assert package["identifier"] == "hol-guard"
     assert package["runtimeHint"] == "uvx"
     assert package["transport"] == {"type": "stdio"}
+    # `hol-guard` is already the Guard-mode executable. Adding a leading
+    # `guard` would be parsed as an invalid root command and break Registry launches.
     assert [argument["value"] for argument in package["packageArguments"]] == [
-        "guard",
         "mcp",
         "serve",
         "--stdio",


### PR DESCRIPTION
## Summary

- fix the official MCP Registry launch command to `hol-guard mcp serve --stdio`
- lock the Registry argv in tests and release validation
- add a validated MCPB 0.4 bundle with release attachment automation
- add a deterministic Cline MCP installation guide and contract check using the official Cline CLI

## Why this is consolidated

The original Registry correction, MCPB, and Cline branches were cut before `release/3.0` advanced and became conflict-prone. This branch is rebuilt from the current `release/3.0` tip and supersedes #2351, #2340, and #2341 while preserving their validated work.

## Safety

- local stdio only; no Guard Cloud credentials required
- MCPB release artifacts are stamped from the canonical release version and attached to the existing release
- no release renumbering and no merge to `main`
- Cline CLI validation is pinned to the current official 3.0.55 distribution
- Registry publishing rejects any reintroduction of the invalid double-`guard` argv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an MCPB distribution bundle for installing and running HOL Guard through supported Python environments.
  * Added local Cline MCP installation instructions, configuration examples, verification steps, available tools, and privacy details.
  * Updated the server launch command to use the MCP stdio interface.

* **Bug Fixes**
  * Improved registry manifest validation to ensure the correct MCP launch arguments are used.

* **Chores**
  * Added automated validation and release workflows for marketplace, registry, and MCPB distributions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->