### PR TITLE
feat(dashboard): link Test Lab and command activity to pattern rows

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 14703,
-  "maximum_test_source_lines": 318568,
+  "maximum_test_source_lines": 318570,
   "schema_version": 1
 }

--- a/dashboard/src/command-activity/command-activity-detail.tsx
+++ b/dashboard/src/command-activity/command-activity-detail.tsx
@@ -1,6 +1,7 @@
 import { useCallback, type RefObject } from "react";
 import { HiMiniXMark } from "react-icons/hi2";
 
+import { guardAwareHref } from "../guard-api";
 import { Badge, SectionLabel } from "../approval-center-primitives";
 import {
   commandDecisionLabel,
@@ -73,6 +74,19 @@ function MatchEvidence(props: { match: CommandActivityItem["matches"][number]; c
       <div className="mt-3 flex flex-wrap gap-1.5">
         {effects.length > 0 ? effects.map((effect) => <Badge key={effect}>{effect}</Badge>) : <span className="text-xs text-slate-500">Effect details unavailable</span>}
       </div>
+      <button
+        type="button"
+        onClick={() => {
+          const target = guardAwareHref(`/extensions/${props.match.extension_id}`);
+          const url = new URL(target, window.location.origin);
+          url.hash = `rule-${props.match.rule_id}`;
+          window.history.pushState({}, "", url.toString());
+          window.dispatchEvent(new PopStateEvent("popstate"));
+        }}
+        className="mt-3 min-h-10 rounded-lg border border-brand-blue/25 bg-white px-3 text-left text-sm font-semibold text-brand-blue hover:bg-[rgba(85,153,254,0.08)]"
+      >
+        Adjust protection
+      </button>
     </li>
   );
 }

--- a/dashboard/src/extension-policy-panel.tsx
+++ b/dashboard/src/extension-policy-panel.tsx
@@ -142,7 +142,7 @@ export function PermissionPolicyRow(props: {
   const provenance = controlProvenance(props.effective, "permission", props.permission.permission_id);
   const example = props.permission.example_command ?? (props.extension.executables[0]?.trim() || props.permission.label);
   return (
-    <article className="guard-pattern-row" data-permission-id={props.permission.permission_id}>
+    <article id={`pattern-${props.permission.permission_id}`} className="guard-pattern-row" data-permission-id={props.permission.permission_id}>
       <div className="min-w-0">
         <h3 className="text-sm font-semibold text-brand-dark">{props.permission.label}</h3>
         <p className="guard-pattern-example mt-1">{example}</p>

--- a/dashboard/src/protection-center/protection-module-detail.tsx
+++ b/dashboard/src/protection-center/protection-module-detail.tsx
@@ -1,7 +1,7 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { HiMiniArrowLeft, HiMiniLockClosed } from "react-icons/hi2";
 
-import { controlProvenance, treatmentLabel } from "../extension-control-center-model";
+import { controlProvenance, permissionForRule, treatmentLabel } from "../extension-control-center-model";
 import type { EffectiveExtensionControls, ExtensionCatalogItem } from "../extension-controls-api";
 import { ExtensionPolicyPanel } from "../extension-policy-panel";
 import { ProtectionDensityControl, TechnicalDetails, useProtectionDensity } from "./components/protection-primitives";
@@ -110,6 +110,25 @@ export function ProtectionModuleDetail(props: {
 }) {
   const [density, setDensity] = useProtectionDensity();
   const [policyDirty, setPolicyDirty] = useState(false);
+  useEffect(() => {
+    const anchor = window.location.hash;
+    let rowId: string | null = null;
+    if (anchor.startsWith("#pattern-")) {
+      rowId = anchor.slice(1);
+    } else if (anchor.startsWith("#rule-")) {
+      const ruleId = anchor.slice("#rule-".length);
+      const rule = props.extension.rules.find((item) => item.rule_id === ruleId);
+      const permission = rule ? permissionForRule(props.extension, rule) : null;
+      rowId = permission ? `pattern-${permission.permission_id}` : null;
+    }
+    if (!rowId) return;
+    const row = document.getElementById(rowId);
+    if (!row) return;
+    row.scrollIntoView({ behavior: "smooth", block: "center" });
+    row.classList.add("guard-pattern-row-highlight");
+    const timer = window.setTimeout(() => row.classList.remove("guard-pattern-row-highlight"), 2400);
+    return () => window.clearTimeout(timer);
+  }, [props.extension.extension_id, props.extension.rules]);
   const requiredNote = requiredLine(props.extension);
   const extensionEnabled = !props.effective.layers.some((layer) =>
     layer.controls.some((control) => control.target_kind === "extension" && control.target_id === props.extension.extension_id && control.state === "disabled"),

--- a/dashboard/src/protection-center/protection-test-api.ts
+++ b/dashboard/src/protection-center/protection-test-api.ts
@@ -1,6 +1,7 @@
 import { fetchExtensionControlApi } from "../guard-api";
 
 export type ProtectionTestMatch = {
+  permission_id: string | null;
   extension_id: string;
   extension_name: string;
   rule_id: string;
@@ -62,6 +63,7 @@ function normalizeProtectionTestResult(value: unknown): ProtectionTestResult {
       extension_id: boundedString(match.extension_id, "extension ID", 256),
       extension_name: boundedString(match.extension_name, "extension name", 120),
       rule_id: boundedString(match.rule_id, "rule ID", 256),
+      permission_id: typeof match.permission_id === "string" && match.permission_id.trim() ? match.permission_id : null,
       rule_title: boundedString(match.rule_title, "rule title", 160),
       description: boundedString(match.description, "rule description", 320),
       severity: match.severity as ProtectionTestMatch["severity"],

--- a/dashboard/src/protection-center/protection-test-lab.tsx
+++ b/dashboard/src/protection-center/protection-test-lab.tsx
@@ -48,9 +48,9 @@ export function ProtectionTestLab({ extension }: { extension: ExtensionCatalogIt
     <div className="flex items-start gap-3">
       <span className="grid size-10 shrink-0 place-items-center rounded-xl bg-[rgba(85,153,254,0.1)] text-brand-blue" aria-hidden="true"><HiMiniBeaker className="size-5" /></span>
       <div className="min-w-0">
-        <p className={EXTENSION_KICKER_CLASS}>Try a command</p>
+        <p className={EXTENSION_KICKER_CLASS}>Paste the command Guard stopped</p>
         <h2 id="protection-test-lab-heading" className="mt-2 text-lg font-semibold text-brand-dark">Test Lab</h2>
-        <p className="mt-1 text-sm leading-6 text-brand-dark/80">See how Guard would handle a command without running it.</p>
+        <p className="mt-1 text-sm leading-6 text-brand-dark/80">See how Guard would handle a command without running it, then adjust the exact pattern it matched.</p>
       </div>
     </div>
     <p className="mt-5 max-w-2xl text-sm leading-6 text-brand-dark/80">
@@ -85,6 +85,9 @@ export function ProtectionTestLab({ extension }: { extension: ExtensionCatalogIt
             <span className="text-xs font-semibold capitalize text-brand-dark/55">{match.severity} risk</span>
           </div>
           <p className="mt-1 text-xs leading-5 text-brand-dark/70">{match.description}</p>
+          {match.permission_id ? (
+            <a href={`#pattern-${match.permission_id}`} onClick={(event) => { event.preventDefault(); document.getElementById(`pattern-${match.permission_id}`)?.scrollIntoView({ behavior: "smooth", block: "center" }); }} className="mt-2 inline-flex min-h-9 items-center rounded-lg px-1 text-xs font-semibold text-brand-blue hover:underline">Adjust this pattern</a>
+          ) : null}
         </div>)}</div>
       </div> : null}
       {result.safer_alternatives.length ? <div className="mt-4">

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -639,3 +639,10 @@ a:focus-visible {
 .guard-tool-switch:disabled {
   opacity: 0.45;
 }
+
+.guard-pattern-row-highlight {
+  outline: 2px solid var(--brand-blue);
+  outline-offset: 0.5rem;
+  border-radius: 0.5rem;
+  background: color-mix(in srgb, var(--brand-blue) 6%, transparent);
+}

--- a/src/codex_plugin_scanner/guard/daemon/extension_control_test_api.py
+++ b/src/codex_plugin_scanner/guard/daemon/extension_control_test_api.py
@@ -81,12 +81,14 @@ def evaluate_extension_control_test(
     match_payloads: list[dict[str, object]] = []
     for owned in relevant:
         rule = owned.match.rule
+        permission = registry.permission_for_rule_id(rule.rule_id)
         match_payloads.append(
             {
                 "extension_id": owned.extension.extension_id,
                 "extension_name": _bounded_text(owned.extension.name, limit=120),
                 "rule_id": rule.rule_id,
                 "rule_title": _bounded_text(rule.title, limit=160),
+                "permission_id": permission.permission_id if permission is not None else None,
                 "description": _bounded_text(rule.description),
                 "severity": rule.severity,
                 "risk_classes": list(rule.risk_classes[:16]),

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
@@ -128,6 +128,9 @@ function controlProvenance(effective, kind, targetId2) {
   if (sources.length === 0) sources.push("Built-in default");
   return sources;
 }
+function permissionForRule(extension2, rule2) {
+  return extension2.permissions.find((permission2) => permission2.rule_ids.includes(rule2.rule_id)) ?? null;
+}
 function treatmentLabel(value) {
   const labels = {
     allow: "Allow",
@@ -2563,7 +2566,7 @@ function PermissionPolicyRow(props) {
   const managed = managedPermissionState(props.effective, props.permission.permission_id);
   const provenance = controlProvenance(props.effective, "permission", props.permission.permission_id);
   const example = props.permission.example_command ?? (props.extension.executables[0]?.trim() || props.permission.label);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("article", { className: "guard-pattern-row", "data-permission-id": props.permission.permission_id, children: [
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("article", { id: `pattern-${props.permission.permission_id}`, className: "guard-pattern-row", "data-permission-id": props.permission.permission_id, children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "text-sm font-semibold text-brand-dark", children: props.permission.label }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "guard-pattern-example mt-1", children: example }),
@@ -3186,6 +3189,7 @@ function normalizeProtectionTestResult(value) {
       extension_id: boundedString(match.extension_id, "extension ID", 256),
       extension_name: boundedString(match.extension_name, "extension name", 120),
       rule_id: boundedString(match.rule_id, "rule ID", 256),
+      permission_id: typeof match.permission_id === "string" && match.permission_id.trim() ? match.permission_id : null,
       rule_title: boundedString(match.rule_title, "rule title", 160),
       description: boundedString(match.description, "rule description", 320),
       severity: match.severity,
@@ -3260,9 +3264,9 @@ function ProtectionTestLab({ extension: extension2 }) {
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "grid size-10 shrink-0 place-items-center rounded-xl bg-[rgba(85,153,254,0.1)] text-brand-blue", "aria-hidden": "true", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniBeaker, { className: "size-5" }) }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: EXTENSION_KICKER_CLASS, children: "Try a command" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: EXTENSION_KICKER_CLASS, children: "Paste the command Guard stopped" }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { id: "protection-test-lab-heading", className: "mt-2 text-lg font-semibold text-brand-dark", children: "Test Lab" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm leading-6 text-brand-dark/80", children: "See how Guard would handle a command without running it." })
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm leading-6 text-brand-dark/80", children: "See how Guard would handle a command without running it, then adjust the exact pattern it matched." })
       ] })
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-5 max-w-2xl text-sm leading-6 text-brand-dark/80", children: [
@@ -3317,7 +3321,11 @@ function ProtectionTestLab({ extension: extension2 }) {
               " risk"
             ] })
           ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs leading-5 text-brand-dark/70", children: match.description })
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs leading-5 text-brand-dark/70", children: match.description }),
+          match.permission_id ? /* @__PURE__ */ jsxRuntimeExports.jsx("a", { href: `#pattern-${match.permission_id}`, onClick: (event) => {
+            event.preventDefault();
+            document.getElementById(`pattern-${match.permission_id}`)?.scrollIntoView({ behavior: "smooth", block: "center" });
+          }, className: "mt-2 inline-flex min-h-9 items-center rounded-lg px-1 text-xs font-semibold text-brand-blue hover:underline", children: "Adjust this pattern" }) : null
         ] }, `${match.extension_id}:${match.rule_id}`)) })
       ] }) : null,
       result.safer_alternatives.length ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4", children: [
@@ -3395,6 +3403,25 @@ function DeveloperModuleDetails(props) {
 function ProtectionModuleDetail(props) {
   const [density, setDensity] = useProtectionDensity();
   const [policyDirty, setPolicyDirty] = reactExports.useState(false);
+  reactExports.useEffect(() => {
+    const anchor = window.location.hash;
+    let rowId = null;
+    if (anchor.startsWith("#pattern-")) {
+      rowId = anchor.slice(1);
+    } else if (anchor.startsWith("#rule-")) {
+      const ruleId = anchor.slice("#rule-".length);
+      const rule2 = props.extension.rules.find((item) => item.rule_id === ruleId);
+      const permission2 = rule2 ? permissionForRule(props.extension, rule2) : null;
+      rowId = permission2 ? `pattern-${permission2.permission_id}` : null;
+    }
+    if (!rowId) return;
+    const row = document.getElementById(rowId);
+    if (!row) return;
+    row.scrollIntoView({ behavior: "smooth", block: "center" });
+    row.classList.add("guard-pattern-row-highlight");
+    const timer = window.setTimeout(() => row.classList.remove("guard-pattern-row-highlight"), 2400);
+    return () => window.clearTimeout(timer);
+  }, [props.extension.extension_id, props.extension.rules]);
   const requiredNote = requiredLine(props.extension);
   const extensionEnabled = !props.effective.layers.some(
     (layer) => layer.controls.some((control) => control.target_kind === "extension" && control.target_id === props.extension.extension_id && control.state === "disabled")

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -24750,7 +24750,22 @@ function MatchEvidence(props) {
       /* @__PURE__ */ jsxRuntimeExports.jsx(EvidenceField, { label: "Evidence", value: matchClassLabel(props.match.match_class) }),
       /* @__PURE__ */ jsxRuntimeExports.jsx(EvidenceField, { label: "Policy floor", value: commandDecisionLabel(props.match.default_floor) })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3 flex flex-wrap gap-1.5", children: effects.length > 0 ? effects.map((effect) => /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { children: effect }, effect)) : /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs text-slate-500", children: "Effect details unavailable" }) })
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3 flex flex-wrap gap-1.5", children: effects.length > 0 ? effects.map((effect) => /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { children: effect }, effect)) : /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs text-slate-500", children: "Effect details unavailable" }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "button",
+      {
+        type: "button",
+        onClick: () => {
+          const target = guardAwareHref(`/extensions/${props.match.extension_id}`);
+          const url = new URL(target, window.location.origin);
+          url.hash = `rule-${props.match.rule_id}`;
+          window.history.pushState({}, "", url.toString());
+          window.dispatchEvent(new PopStateEvent("popstate"));
+        },
+        className: "mt-3 min-h-10 rounded-lg border border-brand-blue/25 bg-white px-3 text-left text-sm font-semibold text-brand-blue hover:bg-[rgba(85,153,254,0.08)]",
+        children: "Adjust protection"
+      }
+    )
   ] });
 }
 function CommandActivityDetail(props) {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -7643,6 +7643,19 @@ input:focus-visible, button:focus-visible, a:focus-visible {
   opacity: .45;
 }
 
+.guard-pattern-row-highlight {
+  outline: 2px solid var(--brand-blue);
+  outline-offset: .5rem;
+  background: var(--brand-blue);
+  border-radius: .5rem;
+}
+
+@supports (color: color-mix(in lab, red, red)) {
+  .guard-pattern-row-highlight {
+    background: color-mix(in srgb, var(--brand-blue) 6%, transparent);
+  }
+}
+
 @property --tw-translate-x {
   syntax: "*";
   inherits: false;

--- a/tests/test_guard_extension_control_test_lab.py
+++ b/tests/test_guard_extension_control_test_lab.py
@@ -60,6 +60,7 @@ def test_test_lab_canonicalizes_extension_alias_and_filters_matches() -> None:
 
     for match in result["matches"]:
         assert match["extension_id"] == "command.git"
+        assert match["permission_id"] == "command.git.permission.hard-reset"
 
 
 def test_test_lab_rejects_unknown_or_oversized_inputs() -> None:


### PR DESCRIPTION
## Summary
- Test Lab matches now carry the owning permission, and each matched rule offers an Adjust this pattern jump that anchors and highlights the exact pattern row on the tool page
- Command-activity rule evidence gains an Adjust protection link that opens the tool page with the matching pattern highlighted, so a blocked command leads directly to the setting that blocked it
- Test Lab copy reframes the box as the place to paste the command Guard stopped

## Testing
- `python3 -m pytest tests/test_guard_extension_control_test_lab.py -q`
- `npm test` and `npm run build` in `dashboard/`
