### PR TITLE
fix(guard): clarify blocked action recovery

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 12599,
-  "maximum_test_source_lines": 288540,
+  "maximum_test_source_lines": 288544,
   "schema_version": 1
 }

--- a/dashboard/src/supply-chain-audit-connect.test.tsx
+++ b/dashboard/src/supply-chain-audit-connect.test.tsx
@@ -85,8 +85,8 @@ const workspaceError = new GuardHarnessActionError(400, {
   operation: "audit",
 });
 assert(
-  supplyChainAuditUserMessage(workspaceError)?.includes("project folder"),
-  "workspace audit errors should surface actionable copy instead of raw codes",
+  supplyChainAuditUserMessage(workspaceError)?.includes("hol-guard supply-chain audit --json"),
+  "workspace audit errors should provide the exact project-folder fallback command",
 );
 assert(
   !isSupplyChainAuditConnectError(workspaceError),

--- a/dashboard/src/supply-chain-audit-connect.ts
+++ b/dashboard/src/supply-chain-audit-connect.ts
@@ -109,10 +109,7 @@ export function supplyChainAuditConnectUserMessage(error: unknown): string | nul
 export function supplyChainAuditUserMessage(error: unknown): string | null {
   if (error instanceof GuardHarnessActionError) {
     if (error.payload?.error === "workspace_dir_required") {
-      return (
-        error.payload.message ??
-        "Guard needs a connected app project folder with package manifests before it can run the workspace audit."
-      );
+      return "Open Guard from the project you want to audit, or run `hol-guard supply-chain audit --json` from that project folder. The folder must contain a supported package manifest or lockfile.";
     }
     return supplyChainAuditConnectUserMessage(error);
   }

--- a/src/codex_plugin_scanner/guard/adapters/pi_extension_approval_source.py
+++ b/src/codex_plugin_scanner/guard/adapters/pi_extension_approval_source.py
@@ -41,7 +41,7 @@ function approvalBlockedReason(response: GuardResponse, fallbackReason: string):
   const approvalUrl = approvalUrlFromResponse(response);
   if (!approvalUrl) return reason;
   const urlLine = `HOL Guard approval page: ${approvalUrl}`;
-  const waitLine = 'HOL Guard is already waiting for this approval and will resume this Pi session automatically after the user approves.';
+  const waitLine = 'HOL Guard is waiting for this decision. This exact tool call remains blocked; after approval, Guard will ask Pi to retry it unchanged.';
   const noAskLine = 'Do not call ask for this HOL Guard approval as the approval mechanism; HOL Guard is already polling the request.';
   const askFallbackLine = `If you are already showing a broader recovery menu, include an option labeled "I've approved this request in HOL Guard" and include this exact URL: ${approvalUrl}`;
   const additions = [urlLine, waitLine, noAskLine, askFallbackLine].filter(line => !reason.includes(line));
@@ -111,8 +111,8 @@ function approvalResumeMessage(details: {
   const toolPart = details.toolName ? ` for ${details.toolName}` : '';
   return [
     `HOL Guard approved the blocked Pi tool call${toolPart}.`,
-    'Continue the original user task now. Retry that tool call once if it is still required; '
-      + 'the saved HOL Guard approval should allow it.',
+    'Continue the original user task now. Retry the exact same tool call once if it is still required; '
+      + 'changing the command, arguments, or working directory creates a new action that may need another decision.',
     'Do not ask the user to retry the same action manually.',
   ].join('\n\n');
 }

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -5953,7 +5953,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     payload,
                     params,
                     default_harness=default_harness,
-                    reason="HOL Guard could not complete isolated local hook review safely.",
+                    reason=(
+                        "HOL Guard blocked this action because isolated local review could not complete safely. "
+                        "The agent may continue with a different, lower-risk action. Retry this exact action after local review recovers."
+                    ),
                     reason_code=admission.reason_code or "daemon_hook_process_not_ready",
                 )
             )
@@ -5986,7 +5989,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 payload,
                 params,
                 default_harness=default_harness,
-                reason="HOL Guard could not complete isolated local hook review safely.",
+                reason=(
+                    "HOL Guard blocked this action because isolated local review could not complete safely. "
+                    "The agent may continue with a different, lower-risk action. Retry this exact action after local review recovers."
+                ),
                 reason_code=reason_code,
             )
         )

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -5955,7 +5955,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     default_harness=default_harness,
                     reason=(
                         "HOL Guard blocked this action because isolated local review could not complete safely. "
-                        "The agent may continue with a different, lower-risk action. Retry this exact action after local review recovers."
+                        "The agent may continue with a different, lower-risk action. "
+                        "Retry this exact action after local review recovers."
                     ),
                     reason_code=admission.reason_code or "daemon_hook_process_not_ready",
                 )
@@ -5991,7 +5992,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 default_harness=default_harness,
                 reason=(
                     "HOL Guard blocked this action because isolated local review could not complete safely. "
-                    "The agent may continue with a different, lower-risk action. Retry this exact action after local review recovers."
+                    "The agent may continue with a different, lower-risk action. "
+                    "Retry this exact action after local review recovers."
                 ),
                 reason_code=reason_code,
             )

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-hub-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-hub-workspace.js
@@ -691,7 +691,7 @@ function supplyChainAuditConnectUserMessage(error) {
 function supplyChainAuditUserMessage(error) {
   if (error instanceof GuardHarnessActionError) {
     if (error.payload?.error === "workspace_dir_required") {
-      return error.payload.message ?? "Guard needs a connected app project folder with package manifests before it can run the workspace audit.";
+      return "Open Guard from the project you want to audit, or run `hol-guard supply-chain audit --json` from that project folder. The folder must contain a supported package manifest or lockfile.";
     }
     return supplyChainAuditConnectUserMessage(error);
   }

--- a/tests/test_pi_adapter.py
+++ b/tests/test_pi_adapter.py
@@ -281,6 +281,10 @@ class TestPiInstall:
         assert "/v1/hooks/pi?" in text
         assert "approval_request_id?: string" in text
         assert "approvalBlockedReason" in text
+        assert "This exact tool call remains blocked" in text
+        assert "Retry the exact same tool call once" in text
+        assert "changing the command, arguments, or working directory creates a new action" in text
+        assert "the saved HOL Guard approval should allow it" not in text
         assert "Do not call ask for this HOL Guard approval" in text
         assert 'option labeled "I\'ve approved this request in HOL Guard"' in text
         assert "const openedApprovalCenters = new Set<string>()" in text


### PR DESCRIPTION
## Summary

- distinguish a blocked OMP tool call from the agent continuing with a different lower-risk action
- tell OMP to retry an approved action unchanged and stop describing one-time approval as saved
- give workspace-audit users an exact project-folder CLI fallback

## Verification

- `uv run pytest -q tests/test_pi_adapter.py tests/test_guard_headless_daemon_api.py -k 'pi or fail_safe or process_not_ready'`
- `pnpm exec tsx src/supply-chain-audit-connect.test.tsx`
- `pnpm run build`
- `uv build --wheel`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved guidance when workspace audits run outside a supported project, including the correct fallback command and supported manifest or lockfile requirements.
  - Clarified that blocked actions should be retried exactly as originally issued after approval or review recovery.
  - Added warnings that changing a command, its arguments, or working directory may require new approval.
  - Clarified failures caused by incomplete isolated review and provided safer retry instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->