### PR TITLE
refactor(dashboard): flatten extensions surface and widen tool page

### DIFF
--- a/dashboard/src/protection-center/components/protection-primitives.tsx
+++ b/dashboard/src/protection-center/components/protection-primitives.tsx
@@ -46,13 +46,6 @@ export function ProtectionDensityControl(props: {
   </div>;
 }
 
-const HERO_TONE: Record<ProtectionStatusView["tone"], string> = {
-  safe: `${EXTENSION_PANEL_CLASS} guard-extensions-tone-safe`,
-  attention: `${EXTENSION_PANEL_CLASS} guard-extensions-tone-attention`,
-  danger: `${EXTENSION_PANEL_CLASS} guard-extensions-tone-danger`,
-  neutral: `${EXTENSION_PANEL_CLASS} guard-extensions-tone-neutral`,
-};
-
 export function ProtectionStatusHero(props: {
   status: ProtectionStatusView;
   busy?: boolean;
@@ -60,29 +53,25 @@ export function ProtectionStatusHero(props: {
   children?: React.ReactNode;
 }) {
   const safe = props.status.tone === "safe";
-  return <section aria-labelledby="protection-status-heading" className={HERO_TONE[props.status.tone]}>
-    <div className="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
-      <div className="min-w-0">
-        <div className="flex items-center gap-3">
-          <span className="grid size-11 shrink-0 place-items-center rounded-2xl bg-white/80" aria-hidden="true">
-            {safe ? <HiMiniShieldCheck className="size-6" /> : <HiMiniExclamationTriangle className="size-6" />}
-          </span>
-          <div>
-            <p className={EXTENSION_KICKER_CLASS}>Local protection</p>
-            <h2 id="protection-status-heading" className="mt-1 text-2xl font-semibold tracking-tight">{props.status.title}</h2>
-          </div>
-        </div>
-        <p className="mt-4 max-w-2xl text-sm leading-6">{props.status.summary}</p>
+  return <section aria-labelledby="protection-status-heading" className="guard-status-bar">
+    <span className="guard-status-bar-icon" data-tone={safe ? "safe" : "alert"} aria-hidden="true">
+      {safe ? <HiMiniShieldCheck className="size-4" /> : <HiMiniExclamationTriangle className="size-4" />}
+    </span>
+    <div className="min-w-0 flex-1">
+      <p className={EXTENSION_KICKER_CLASS}>Local protection</p>
+      <div className="mt-0.5 flex flex-wrap items-baseline gap-x-2">
+        <h2 id="protection-status-heading" className="text-sm font-semibold text-brand-dark">{props.status.title}</h2>
+        <p className="text-sm leading-5 text-brand-dark/70">{props.status.summary}</p>
       </div>
-      {props.status.primaryActionLabel && props.onPrimaryAction ? <button
-        type="button"
-        aria-busy={props.busy}
-        disabled={props.busy}
-        onClick={props.onPrimaryAction}
-        className="min-h-11 shrink-0 rounded-xl bg-brand-blue px-4 text-sm font-semibold text-white shadow-sm hover:bg-brand-dark disabled:cursor-wait disabled:opacity-60"
-      >{props.busy ? "Working…" : props.status.primaryActionLabel}</button> : <span className="inline-flex min-h-10 items-center gap-2 self-start rounded-full border border-current/15 bg-white/70 px-3 text-xs font-semibold"><HiMiniCheckCircle className="size-4" />No action required</span>}
     </div>
-    {props.children ? <div className="mt-5 border-t border-current/10 pt-4">{props.children}</div> : null}
+    {props.status.primaryActionLabel && props.onPrimaryAction ? <button
+      type="button"
+      aria-busy={props.busy}
+      disabled={props.busy}
+      onClick={props.onPrimaryAction}
+      className="min-h-11 shrink-0 rounded-xl bg-brand-blue px-4 text-sm font-semibold text-white shadow-sm hover:bg-brand-dark disabled:cursor-wait disabled:opacity-60"
+    >{props.busy ? "Working…" : props.status.primaryActionLabel}</button> : <span className="inline-flex min-h-9 shrink-0 items-center gap-1.5 self-center rounded-full border border-emerald-200 bg-[#e8f7ee] px-3 text-xs font-semibold text-emerald-800"><HiMiniCheckCircle className="size-3.5" />No action required</span>}
+    {props.children ? <div className="w-full border-t border-[rgba(63,65,116,0.08)] pt-2">{props.children}</div> : null}
   </section>;
 }
 

--- a/dashboard/src/protection-center/components/protection-primitives.tsx
+++ b/dashboard/src/protection-center/components/protection-primitives.tsx
@@ -54,7 +54,7 @@ export function ProtectionStatusHero(props: {
 }) {
   const safe = props.status.tone === "safe";
   return <section aria-labelledby="protection-status-heading" className="guard-status-bar">
-    <span className="guard-status-bar-icon" data-tone={safe ? "safe" : "alert"} aria-hidden="true">
+    <span className="guard-status-bar-icon" data-tone={props.status.tone} aria-hidden="true">
       {safe ? <HiMiniShieldCheck className="size-4" /> : <HiMiniExclamationTriangle className="size-4" />}
     </span>
     <div className="min-w-0 flex-1">

--- a/dashboard/src/protection-center/protection-module-detail.tsx
+++ b/dashboard/src/protection-center/protection-module-detail.tsx
@@ -164,7 +164,7 @@ export function ProtectionModuleDetail(props: {
   };
 
   return (
-    <main data-testid="protection-module-detail" className={`${EXTENSION_SURFACE_CLASS} mx-auto w-full max-w-3xl px-4 pb-10 pt-5 sm:px-6`}>
+    <main data-testid="protection-module-detail" className={`${EXTENSION_SURFACE_CLASS} mx-auto w-full max-w-6xl px-4 pb-12 pt-6 sm:px-6 lg:px-8`}>
       <button type="button" onClick={handleBack} className="inline-flex min-h-11 items-center gap-2 rounded-lg px-1 text-sm font-semibold text-brand-dark/80 hover:text-brand-dark">
         <HiMiniArrowLeft className="size-4" aria-hidden="true" />
         Extensions

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -616,9 +616,19 @@ a:focus-visible {
   color: #15803d;
 }
 
-.guard-status-bar-icon[data-tone="alert"] {
+.guard-status-bar-icon[data-tone="attention"] {
   background: #fef3c7;
   color: #b45309;
+}
+
+.guard-status-bar-icon[data-tone="danger"] {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.guard-status-bar-icon[data-tone="neutral"] {
+  background: rgba(85, 153, 254, 0.12);
+  color: var(--brand-blue);
 }
 
 .guard-extensions-row:focus-visible {

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -417,10 +417,7 @@ a:focus-visible {
 .guard-extensions-surface {
   position: relative;
   isolation: isolate;
-  background:
-    radial-gradient(ellipse at 16% 0%, rgba(85, 153, 254, 0.12), transparent 42%),
-    radial-gradient(ellipse at 88% 6%, rgba(181, 108, 255, 0.08), transparent 34%),
-    linear-gradient(180deg, #f8fbff 0%, #f2f5fb 72%, #eef2f8 100%);
+  background: var(--surface-1);
 }
 
 .guard-extensions-kicker {
@@ -441,19 +438,19 @@ a:focus-visible {
 }
 
 .guard-extensions-tone-safe {
-  background: linear-gradient(180deg, rgba(220, 252, 231, 0.78), rgba(255, 255, 255, 0.74));
+  background: #f1faf4;
   border-color: rgba(13, 122, 58, 0.16);
   color: #14532d;
 }
 
 .guard-extensions-tone-attention {
-  background: linear-gradient(180deg, rgba(255, 247, 237, 0.86), rgba(255, 255, 255, 0.74));
+  background: #fdf6ec;
   border-color: rgba(180, 83, 9, 0.18);
   color: #7c2d12;
 }
 
 .guard-extensions-tone-danger {
-  background: linear-gradient(180deg, rgba(254, 226, 226, 0.82), rgba(255, 255, 255, 0.74));
+  background: #fdf2f2;
   border-color: rgba(185, 28, 28, 0.18);
   color: #7f1d1d;
 }
@@ -590,8 +587,38 @@ a:focus-visible {
   z-index: 20;
   margin-top: 1.25rem;
   border-top: 1px solid color-mix(in srgb, var(--brand-dark) 12%, transparent);
-  background: var(--surface-1);
+  background: #fff;
   padding: 0.85rem 0;
+}
+
+.guard-status-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  border: 1px solid color-mix(in srgb, var(--brand-dark) 10%, transparent);
+  border-radius: 0.75rem;
+  background: #fff;
+  padding: 0.75rem 1rem;
+}
+
+.guard-status-bar-icon {
+  display: grid;
+  inline-size: 2rem;
+  block-size: 2rem;
+  flex-shrink: 0;
+  place-items: center;
+  border-radius: 999px;
+}
+
+.guard-status-bar-icon[data-tone="safe"] {
+  background: #e8f7ee;
+  color: #15803d;
+}
+
+.guard-status-bar-icon[data-tone="alert"] {
+  background: #fef3c7;
+  color: #b45309;
 }
 
 .guard-extensions-row:focus-visible {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
@@ -1410,42 +1410,32 @@ function ProtectionDensityControl(props) {
     choice.value
   )) });
 }
-const HERO_TONE = {
-  safe: `${EXTENSION_PANEL_CLASS} guard-extensions-tone-safe`,
-  attention: `${EXTENSION_PANEL_CLASS} guard-extensions-tone-attention`,
-  danger: `${EXTENSION_PANEL_CLASS} guard-extensions-tone-danger`,
-  neutral: `${EXTENSION_PANEL_CLASS} guard-extensions-tone-neutral`
-};
 function ProtectionStatusHero(props) {
   const safe = props.status.tone === "safe";
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { "aria-labelledby": "protection-status-heading", className: HERO_TONE[props.status.tone], children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-3", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "grid size-11 shrink-0 place-items-center rounded-2xl bg-white/80", "aria-hidden": "true", children: safe ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "size-6" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "size-6" }) }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: EXTENSION_KICKER_CLASS, children: "Local protection" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { id: "protection-status-heading", className: "mt-1 text-2xl font-semibold tracking-tight", children: props.status.title })
-          ] })
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-4 max-w-2xl text-sm leading-6", children: props.status.summary })
-      ] }),
-      props.status.primaryActionLabel && props.onPrimaryAction ? /* @__PURE__ */ jsxRuntimeExports.jsx(
-        "button",
-        {
-          type: "button",
-          "aria-busy": props.busy,
-          disabled: props.busy,
-          onClick: props.onPrimaryAction,
-          className: "min-h-11 shrink-0 rounded-xl bg-brand-blue px-4 text-sm font-semibold text-white shadow-sm hover:bg-brand-dark disabled:cursor-wait disabled:opacity-60",
-          children: props.busy ? "Working…" : props.status.primaryActionLabel
-        }
-      ) : /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "inline-flex min-h-10 items-center gap-2 self-start rounded-full border border-current/15 bg-white/70 px-3 text-xs font-semibold", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "size-4" }),
-        "No action required"
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { "aria-labelledby": "protection-status-heading", className: "guard-status-bar", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "guard-status-bar-icon", "data-tone": safe ? "safe" : "alert", "aria-hidden": "true", children: safe ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "size-4" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "size-4" }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 flex-1", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: EXTENSION_KICKER_CLASS, children: "Local protection" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-0.5 flex flex-wrap items-baseline gap-x-2", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { id: "protection-status-heading", className: "text-sm font-semibold text-brand-dark", children: props.status.title }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm leading-5 text-brand-dark/70", children: props.status.summary })
       ] })
     ] }),
-    props.children ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-5 border-t border-current/10 pt-4", children: props.children }) : null
+    props.status.primaryActionLabel && props.onPrimaryAction ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "button",
+      {
+        type: "button",
+        "aria-busy": props.busy,
+        disabled: props.busy,
+        onClick: props.onPrimaryAction,
+        className: "min-h-11 shrink-0 rounded-xl bg-brand-blue px-4 text-sm font-semibold text-white shadow-sm hover:bg-brand-dark disabled:cursor-wait disabled:opacity-60",
+        children: props.busy ? "Working…" : props.status.primaryActionLabel
+      }
+    ) : /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "inline-flex min-h-9 shrink-0 items-center gap-1.5 self-center rounded-full border border-emerald-200 bg-[#e8f7ee] px-3 text-xs font-semibold text-emerald-800", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "size-3.5" }),
+      "No action required"
+    ] }),
+    props.children ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "w-full border-t border-[rgba(63,65,116,0.08)] pt-2", children: props.children }) : null
   ] });
 }
 function ProtectionDecisionBadge({ result }) {
@@ -3467,7 +3457,7 @@ function ProtectionModuleDetail(props) {
     if (policyDirty && !window.confirm("Discard your unreviewed protection setting changes?")) return;
     props.onBack();
   };
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("main", { "data-testid": "protection-module-detail", className: `${EXTENSION_SURFACE_CLASS} mx-auto w-full max-w-3xl px-4 pb-10 pt-5 sm:px-6`, children: [
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("main", { "data-testid": "protection-module-detail", className: `${EXTENSION_SURFACE_CLASS} mx-auto w-full max-w-6xl px-4 pb-12 pt-6 sm:px-6 lg:px-8`, children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("button", { type: "button", onClick: handleBack, className: "inline-flex min-h-11 items-center gap-2 rounded-lg px-1 text-sm font-semibold text-brand-dark/80 hover:text-brand-dark", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowLeft, { className: "size-4", "aria-hidden": "true" }),
       "Extensions"

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
@@ -1413,7 +1413,7 @@ function ProtectionDensityControl(props) {
 function ProtectionStatusHero(props) {
   const safe = props.status.tone === "safe";
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { "aria-labelledby": "protection-status-heading", className: "guard-status-bar", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "guard-status-bar-icon", "data-tone": safe ? "safe" : "alert", "aria-hidden": "true", children: safe ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "size-4" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "size-4" }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "guard-status-bar-icon", "data-tone": props.status.tone, "aria-hidden": "true", children: safe ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "size-4" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "size-4" }) }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 flex-1", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: EXTENSION_KICKER_CLASS, children: "Local protection" }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-0.5 flex flex-wrap items-baseline gap-x-2", children: [

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -7606,9 +7606,19 @@ input:focus-visible, button:focus-visible, a:focus-visible {
   background: #e8f7ee;
 }
 
-.guard-status-bar-icon[data-tone="alert"] {
+.guard-status-bar-icon[data-tone="attention"] {
   color: #b45309;
   background: #fef3c7;
+}
+
+.guard-status-bar-icon[data-tone="danger"] {
+  color: #b91c1c;
+  background: #fee2e2;
+}
+
+.guard-status-bar-icon[data-tone="neutral"] {
+  color: var(--brand-blue);
+  background: #5599fe1f;
 }
 
 .guard-extensions-row:focus-visible {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -964,6 +964,11 @@
     height: calc(var(--spacing) * 3);
   }
 
+  .size-3\.5 {
+    width: calc(var(--spacing) * 3.5);
+    height: calc(var(--spacing) * 3.5);
+  }
+
   .size-4 {
     width: calc(var(--spacing) * 4);
     height: calc(var(--spacing) * 4);
@@ -2375,26 +2380,6 @@
     }
   }
 
-  .border-current\/10 {
-    border-color: currentColor;
-  }
-
-  @supports (color: color-mix(in lab, red, red)) {
-    .border-current\/10 {
-      border-color: color-mix(in oklab, currentcolor 10%, transparent);
-    }
-  }
-
-  .border-current\/15 {
-    border-color: currentColor;
-  }
-
-  @supports (color: color-mix(in lab, red, red)) {
-    .border-current\/15 {
-      border-color: color-mix(in oklab, currentcolor 15%, transparent);
-    }
-  }
-
   .border-current\/30 {
     border-color: currentColor;
   }
@@ -2691,6 +2676,10 @@
 
   .bg-\[\#059669\] {
     background-color: #059669;
+  }
+
+  .bg-\[\#e8f7ee\] {
+    background-color: #e8f7ee;
   }
 
   .bg-\[\#f8fafc\] {
@@ -4242,6 +4231,10 @@
 
   .pb-10 {
     padding-bottom: calc(var(--spacing) * 10);
+  }
+
+  .pb-12 {
+    padding-bottom: calc(var(--spacing) * 12);
   }
 
   .pl-3 {
@@ -7338,7 +7331,7 @@ input:focus-visible, button:focus-visible, a:focus-visible {
 
 .guard-extensions-surface {
   isolation: isolate;
-  background: radial-gradient(at 16% 0, #5599fe1f, #0000 42%), radial-gradient(at 88% 6%, #b56cff14, #0000 34%), linear-gradient(#f8fbff 0%, #f2f5fb 72%, #eef2f8 100%);
+  background: var(--surface-1);
   position: relative;
 }
 
@@ -7361,19 +7354,19 @@ input:focus-visible, button:focus-visible, a:focus-visible {
 
 .guard-extensions-tone-safe {
   color: #14532d;
-  background: linear-gradient(#dcfce7c7, #ffffffbd);
+  background: #f1faf4;
   border-color: #0d7a3a29;
 }
 
 .guard-extensions-tone-attention {
   color: #7c2d12;
-  background: linear-gradient(#fff7eddb, #ffffffbd);
+  background: #fdf6ec;
   border-color: #b453092e;
 }
 
 .guard-extensions-tone-danger {
   color: #7f1d1d;
-  background: linear-gradient(#fee2e2d1, #ffffffbd);
+  background: #fdf2f2;
   border-color: #b91c1c2e;
 }
 
@@ -7575,8 +7568,47 @@ input:focus-visible, button:focus-visible, a:focus-visible {
 }
 
 .guard-review-bar {
-  background: var(--surface-1);
+  background: #fff;
   padding: .85rem 0;
+}
+
+.guard-status-bar {
+  border: 1px solid var(--brand-dark);
+  flex-wrap: wrap;
+  align-items: center;
+  gap: .75rem;
+  display: flex;
+}
+
+@supports (color: color-mix(in lab, red, red)) {
+  .guard-status-bar {
+    border: 1px solid color-mix(in srgb, var(--brand-dark) 10%, transparent);
+  }
+}
+
+.guard-status-bar {
+  background: #fff;
+  border-radius: .75rem;
+  padding: .75rem 1rem;
+}
+
+.guard-status-bar-icon {
+  border-radius: 999px;
+  flex-shrink: 0;
+  place-items: center;
+  block-size: 2rem;
+  inline-size: 2rem;
+  display: grid;
+}
+
+.guard-status-bar-icon[data-tone="safe"] {
+  color: #15803d;
+  background: #e8f7ee;
+}
+
+.guard-status-bar-icon[data-tone="alert"] {
+  color: #b45309;
+  background: #fef3c7;
 }
 
 .guard-extensions-row:focus-visible {


### PR DESCRIPTION
## Summary

The Extensions console still carried decorative weight from its first draft: a
radial blue/purple page gradient, a large gradient status hero card, and a tool
detail page squeezed into a 768px center column that wasted most of a desktop
viewport. This flattens the surface so the pattern lists are the visual focus.

## Changes

- Extensions surface background is a single flat tone (no radial or linear
  gradients) on the landing, detail, and error states.
- The large protection status hero is now a compact single-line status bar:
  small status icon, kicker, title and summary inline, action on the right.
  The accessibility contract is unchanged (labelled section heading, primary
  action button, "No action required" status text).
- Tone panels (repair banner, load-error and not-found states) use flat solid
  tints instead of gradient washes.
- The tool detail page container now matches the landing console width so
  Recommended / Allow / Block pattern rows get room; previously it rendered in
  a narrow center column.
- The sticky review bar uses a white background so it stays readable over the
  flat surface.

## Verification

- Full dashboard unit suite passes.
- Installed-wheel browser suite passes in both policy phases (apply and
  verify), including preview, proof apply, undo toast, and authority
  persistence across daemon restart.
- Desktop-width screenshots of the landing console and the Git tool page
  confirm the flat surface, compact status bar, and wide pattern rows.
