### PR TITLE
fix(release): backport blocked action recovery

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 14705,
-  "maximum_test_source_lines": 318666,
+  "maximum_test_source_lines": 318668,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 14705,
-  "maximum_test_source_lines": 318662,
+  "maximum_test_source_lines": 318666,
   "schema_version": 1
 }

--- a/dashboard/src/supply-chain-audit-connect.test.tsx
+++ b/dashboard/src/supply-chain-audit-connect.test.tsx
@@ -85,8 +85,8 @@ const workspaceError = new GuardHarnessActionError(400, {
   operation: "audit",
 });
 assert(
-  supplyChainAuditUserMessage(workspaceError)?.includes("project folder"),
-  "workspace audit errors should surface actionable copy instead of raw codes",
+  supplyChainAuditUserMessage(workspaceError)?.includes("hol-guard supply-chain audit --json"),
+  "workspace audit errors should provide the exact project-folder fallback command",
 );
 assert(
   !isSupplyChainAuditConnectError(workspaceError),

--- a/dashboard/src/supply-chain-audit-connect.ts
+++ b/dashboard/src/supply-chain-audit-connect.ts
@@ -109,10 +109,7 @@ export function supplyChainAuditConnectUserMessage(error: unknown): string | nul
 export function supplyChainAuditUserMessage(error: unknown): string | null {
   if (error instanceof GuardHarnessActionError) {
     if (error.payload?.error === "workspace_dir_required") {
-      return (
-        error.payload.message ??
-        "Guard needs a connected app project folder with package manifests before it can run the workspace audit."
-      );
+      return "Open Guard from the project you want to audit, or run `hol-guard supply-chain audit --json` from that project folder. The folder must contain a supported package manifest or lockfile.";
     }
     return supplyChainAuditConnectUserMessage(error);
   }

--- a/src/codex_plugin_scanner/guard/adapters/pi_extension_approval_source.py
+++ b/src/codex_plugin_scanner/guard/adapters/pi_extension_approval_source.py
@@ -41,7 +41,7 @@ function approvalBlockedReason(response: GuardResponse, fallbackReason: string):
   const approvalUrl = approvalUrlFromResponse(response);
   if (!approvalUrl) return reason;
   const urlLine = `HOL Guard approval page: ${approvalUrl}`;
-  const waitLine = 'HOL Guard is already waiting for this approval and will resume this Pi session automatically after the user approves.';
+  const waitLine = 'HOL Guard is waiting for this decision. This exact tool call remains blocked; after approval, Guard will ask Pi to retry it unchanged.';
   const noAskLine = 'Do not call ask for this HOL Guard approval as the approval mechanism; HOL Guard is already polling the request.';
   const askFallbackLine = `If you are already showing a broader recovery menu, include an option labeled "I've approved this request in HOL Guard" and include this exact URL: ${approvalUrl}`;
   const additions = [urlLine, waitLine, noAskLine, askFallbackLine].filter(line => !reason.includes(line));
@@ -111,8 +111,8 @@ function approvalResumeMessage(details: {
   const toolPart = details.toolName ? ` for ${details.toolName}` : '';
   return [
     `HOL Guard approved the blocked Pi tool call${toolPart}.`,
-    'Continue the original user task now. Retry that tool call once if it is still required; '
-      + 'the saved HOL Guard approval should allow it.',
+    'Continue the original user task now. Retry the exact same tool call once if it is still required; '
+      + 'changing the command, arguments, or working directory creates a new action that may need another decision.',
     'Do not ask the user to retry the same action manually.',
   ].join('\n\n');
 }

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -6239,7 +6239,11 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     payload,
                     params,
                     default_harness=default_harness,
-                    reason="HOL Guard could not complete isolated local hook review safely.",
+                    reason=(
+                        "HOL Guard blocked this action because isolated local review could not complete safely. "
+                        "The agent may continue with a different, lower-risk action. "
+                        "Retry this exact action after local review recovers."
+                    ),
                     reason_code=admission.reason_code or "daemon_hook_process_not_ready",
                 )
             )
@@ -6272,7 +6276,11 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 payload,
                 params,
                 default_harness=default_harness,
-                reason="HOL Guard could not complete isolated local hook review safely.",
+                reason=(
+                    "HOL Guard blocked this action because isolated local review could not complete safely. "
+                    "The agent may continue with a different, lower-risk action. "
+                    "Retry this exact action after local review recovers."
+                ),
                 reason_code=reason_code,
             )
         )

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-hub-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-hub-workspace.js
@@ -654,7 +654,7 @@ function supplyChainAuditConnectUserMessage(error) {
 function supplyChainAuditUserMessage(error) {
   if (error instanceof GuardHarnessActionError) {
     if (error.payload?.error === "workspace_dir_required") {
-      return error.payload.message ?? "Guard needs a connected app project folder with package manifests before it can run the workspace audit.";
+      return "Open Guard from the project you want to audit, or run `hol-guard supply-chain audit --json` from that project folder. The folder must contain a supported package manifest or lockfile.";
     }
     return supplyChainAuditConnectUserMessage(error);
   }

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -1002,7 +1002,9 @@ class TestGuardSurfaceServer:
             )
             with urllib.request.urlopen(hook_request, timeout=5) as response:
                 hook_payload = json.loads(response.read().decode("utf-8"))
-            if hook_payload.get("reason") == "HOL Guard could not complete isolated local hook review safely.":
+            if str(hook_payload.get("reason", "")).startswith(
+                "HOL Guard blocked this action because isolated local review could not complete safely."
+            ):
                 assert daemon._server.hook_process_runner.wait_for_capacity(  # pyright: ignore[reportPrivateUsage]
                     minimum_workers=1,
                     timeout_seconds=15,

--- a/tests/test_pi_adapter.py
+++ b/tests/test_pi_adapter.py
@@ -281,6 +281,10 @@ class TestPiInstall:
         assert "/v1/hooks/pi?" in text
         assert "approval_request_id?: string" in text
         assert "approvalBlockedReason" in text
+        assert "This exact tool call remains blocked" in text
+        assert "Retry the exact same tool call once" in text
+        assert "changing the command, arguments, or working directory creates a new action" in text
+        assert "the saved HOL Guard approval should allow it" not in text
         assert "Do not call ask for this HOL Guard approval" in text
         assert 'option labeled "I\'ve approved this request in HOL Guard"' in text
         assert "void openApprovalUrl(response, openedApprovalUrls)" in text


### PR DESCRIPTION
## Summary

- clarify that OMP blocks the reviewed call while allowing distinct lower-risk actions to continue
- require an approved tool retry to keep the same command, arguments, and working directory
- provide an actionable project-folder fallback when workspace audit context is unavailable

## Testing

- `uv run --no-sync pytest -q tests/test_pi_adapter.py tests/test_guard_headless_daemon_api.py tests/test_guard_surface_server.py -k 'pi or fail_safe or process_not_ready or blocked_runtime_review_payload'`
- `uv run --no-sync python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory <inventory>`
- `uv run --no-sync python -m ruff check src/ tests/test_pi_adapter.py tests/test_guard_surface_server.py`
- `uv run --no-sync python -m ruff format --check src/ tests/test_pi_adapter.py tests/test_guard_surface_server.py`
- `uv run --no-sync basedpyright --level error`
- `uv build --wheel`
