### PR TITLE
fix(cursor): resolve inbox request after native Accept

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12609,
-  "maximum_test_source_lines": 288621,
+  "maximum_collected_cases": 12611,
+  "maximum_test_source_lines": 288789,
   "schema_version": 1
 }

--- a/docs/guard/cursor-local-cloud-contract.md
+++ b/docs/guard/cursor-local-cloud-contract.md
@@ -32,6 +32,8 @@ Guard installs command hooks documented by Cursor:
 
 Hooks call a managed bridge script (`.cursor/hooks/hol-guard-cursor-hook.py`) that forwards stdin JSON to `hol-guard hook --harness cursor --json` and maps Guard policy results to Cursor `permission` responses (`allow`, `deny`, `ask`).
 
+Review decisions still appear in the approval inbox so the same request is visible outside Cursor. Accepting the native Cursor prompt resolves that inbox item after the attested `afterShellExecution` or `afterMCPExecution` observer runs. The native Accept is the approval; the inbox should not require a second decision.
+
 Restart Cursor after install so hook config reloads.
 
 ## Claude-compatible hooks inside Cursor

--- a/src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py
@@ -292,19 +292,37 @@ def _resolve_cursor_pending_approval_requests(
     reason: str,
     now: str,
 ) -> None:
-    request_ids = pending.get("approval_request_ids")
-    if not isinstance(request_ids, list):
-        return
+    request_ids: list[str] = []
+    raw_ids = pending.get("approval_request_ids")
+    if isinstance(raw_ids, list):
+        for request_id in raw_ids:
+            if isinstance(request_id, str) and request_id.strip():
+                request_ids.append(request_id.strip())
+    artifact_id = _optional_string(pending.get("artifact_id"))
+    artifact_hash = _optional_string(pending.get("artifact_hash"))
+    if artifact_id is not None:
+        with suppress(OSError, sqlite3.Error):
+            for item in store.list_approval_requests(status="pending", harness="cursor", limit=50):
+                if not isinstance(item, Mapping):
+                    continue
+                item_id = _optional_string(item.get("request_id"))
+                if item_id is None or item_id in request_ids:
+                    continue
+                if _optional_string(item.get("artifact_id")) != artifact_id:
+                    continue
+                stored_hash = _optional_string(item.get("artifact_hash"))
+                if artifact_hash is not None and stored_hash is not None and stored_hash != artifact_hash:
+                    continue
+                request_ids.append(item_id)
     for request_id in request_ids:
-        if not isinstance(request_id, str) or not request_id.strip():
-            continue
-        with suppress(ApprovalGateError, OSError, sqlite3.Error):
-            store.resolve_approval_request(
-                request_id.strip(),
-                resolution_action="allow",
-                resolution_scope="artifact",
+        with suppress(OSError, sqlite3.Error):
+            store.resolve_harness_native_approval_request(
+                request_id,
                 reason=reason,
                 resolved_at=now,
+                expected_harness="cursor",
+                expected_artifact_id=artifact_id,
+                expected_artifact_hash=artifact_hash,
             )
 
 

--- a/src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py
@@ -313,7 +313,7 @@ def _resolve_cursor_pending_approval_requests(
                 continue
             request_ids.append(item_id)
     for request_id in request_ids:
-        with suppress(OSError, sqlite3.Error):
+        with suppress(OSError, sqlite3.Error, ValueError):
             store.resolve_harness_native_approval_request(
                 request_id,
                 reason=reason,

--- a/src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py
@@ -291,6 +291,8 @@ def _resolve_cursor_pending_approval_requests(
     pending: Mapping[str, object],
     reason: str,
     now: str,
+    artifact_id: str,
+    artifact_hash: str,
 ) -> None:
     request_ids: list[str] = []
     raw_ids = pending.get("approval_request_ids")
@@ -298,22 +300,18 @@ def _resolve_cursor_pending_approval_requests(
         for request_id in raw_ids:
             if isinstance(request_id, str) and request_id.strip():
                 request_ids.append(request_id.strip())
-    artifact_id = _optional_string(pending.get("artifact_id"))
-    artifact_hash = _optional_string(pending.get("artifact_hash"))
-    if artifact_id is not None:
-        with suppress(OSError, sqlite3.Error):
-            for item in store.list_approval_requests(status="pending", harness="cursor", limit=50):
-                if not isinstance(item, Mapping):
-                    continue
-                item_id = _optional_string(item.get("request_id"))
-                if item_id is None or item_id in request_ids:
-                    continue
-                if _optional_string(item.get("artifact_id")) != artifact_id:
-                    continue
-                stored_hash = _optional_string(item.get("artifact_hash"))
-                if artifact_hash is not None and stored_hash is not None and stored_hash != artifact_hash:
-                    continue
-                request_ids.append(item_id)
+    with suppress(OSError, sqlite3.Error):
+        for item in store.list_approval_requests(status="pending", harness="cursor", limit=50):
+            if not isinstance(item, Mapping):
+                continue
+            item_id = _optional_string(item.get("request_id"))
+            if item_id is None or item_id in request_ids:
+                continue
+            if _optional_string(item.get("artifact_id")) != artifact_id:
+                continue
+            if _optional_string(item.get("artifact_hash")) != artifact_hash:
+                continue
+            request_ids.append(item_id)
     for request_id in request_ids:
         with suppress(OSError, sqlite3.Error):
             store.resolve_harness_native_approval_request(
@@ -402,6 +400,8 @@ def _persist_cursor_native_permission_after_shell(
         pending=pending,
         reason="Approved in Cursor native approval prompt.",
         now=now,
+        artifact_id=runtime_artifact.artifact_id,
+        artifact_hash=runtime_artifact_hash,
     )
     receipt = build_receipt(
         harness="cursor",

--- a/src/codex_plugin_scanner/guard/store_approval_facade.py
+++ b/src/codex_plugin_scanner/guard/store_approval_facade.py
@@ -118,6 +118,52 @@ class StoreApprovalsMixin:
         with self._connect() as connection:
             return load_next_pending_request(connection, exclude_ids=exclude_ids)
 
+    def resolve_harness_native_approval_request(
+        self,
+        request_id: str,
+        *,
+        reason: str | None,
+        resolved_at: str,
+        expected_harness: str,
+        expected_artifact_id: str | None = None,
+        expected_artifact_hash: str | None = None,
+    ) -> bool:
+        """Close an inbox request after a verified harness-native Accept.
+
+        Cursor (and similar) native prompts are the user's approval. Requiring
+        the local approval-gate password/MFA a second time left the request
+        inbox pending after Accept. This path is artifact-scoped allow-only.
+        """
+
+        if not request_id.strip():
+            return False
+        with self._connect() as connection:
+            connection.execute("begin immediate")
+            request = load_approval_request(connection, request_id)
+            if request is None:
+                return False
+            if str(request.get("status") or "") != "pending":
+                return False
+            if str(request.get("harness") or "") != expected_harness:
+                return False
+            if expected_artifact_id is not None and str(request.get("artifact_id") or "") != expected_artifact_id:
+                return False
+            if (
+                expected_artifact_hash is not None
+                and str(request.get("artifact_hash") or "") != expected_artifact_hash
+            ):
+                return False
+            require_resolvable_approval_request(request)
+            persist_approval_resolution(
+                connection,
+                request_id,
+                resolution_action="allow",
+                resolution_scope="artifact",
+                reason=reason,
+                resolved_at=resolved_at,
+            )
+        return True
+
     def resolve_approval_request(
         self,
         request_id: str,

--- a/src/codex_plugin_scanner/guard/store_approval_facade.py
+++ b/src/codex_plugin_scanner/guard/store_approval_facade.py
@@ -149,10 +149,8 @@ class StoreApprovalsMixin:
             request_artifact_id = str(request.get("artifact_id") or "")
             if expected_artifact_id is not None and request_artifact_id != expected_artifact_id:
                 return False
-            if (
-                expected_artifact_hash is not None
-                and str(request.get("artifact_hash") or "") != expected_artifact_hash
-            ):
+            request_artifact_hash = str(request.get("artifact_hash") or "")
+            if expected_artifact_hash is not None and request_artifact_hash != expected_artifact_hash:
                 return False
             require_resolvable_approval_request(request)
             persist_approval_resolution(

--- a/src/codex_plugin_scanner/guard/store_approval_facade.py
+++ b/src/codex_plugin_scanner/guard/store_approval_facade.py
@@ -146,7 +146,8 @@ class StoreApprovalsMixin:
                 return False
             if str(request.get("harness") or "") != expected_harness:
                 return False
-            if expected_artifact_id is not None and str(request.get("artifact_id") or "") != expected_artifact_id:
+            request_artifact_id = str(request.get("artifact_id") or "")
+            if expected_artifact_id is not None and request_artifact_id != expected_artifact_id:
                 return False
             if (
                 expected_artifact_hash is not None

--- a/src/codex_plugin_scanner/guard/store_approval_facade.py
+++ b/src/codex_plugin_scanner/guard/store_approval_facade.py
@@ -152,7 +152,10 @@ class StoreApprovalsMixin:
             request_artifact_hash = str(request.get("artifact_hash") or "")
             if expected_artifact_hash is not None and request_artifact_hash != expected_artifact_hash:
                 return False
-            require_resolvable_approval_request(request)
+            try:
+                require_resolvable_approval_request(request)
+            except ValueError:
+                return False
             persist_approval_resolution(
                 connection,
                 request_id,

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -1221,6 +1221,174 @@ def test_cursor_native_shell_session_allow_after_trusted_after_shell(tmp_path: P
     )
 
 
+def test_cursor_native_accept_resolves_inbox_when_approval_gate_enabled(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.adapters.cursor_hooks import prepare_cursor_hook_payload
+    from codex_plugin_scanner.guard.approval_gate import update_settings as update_approval_gate_settings
+    from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+    from codex_plugin_scanner.guard.models import GuardApprovalRequest
+    from codex_plugin_scanner.guard.store import GuardStore
+
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    update_approval_gate_settings(
+        store.guard_home,
+        {
+            "enabled": True,
+            "new_password": "cursor-native-accept-gate",
+            "confirm_password": "cursor-native-accept-gate",
+            "cooldown_seconds": 0,
+            "strict_all_decisions": False,
+        },
+    )
+    conversation_id = "conv-cursor-native-inbox"
+    command = "rm -rf ./hol-guard-cursor-native-test-marker"
+    generation_id = "gen-cursor-native-inbox"
+    request_id = "req-cursor-native-inbox"
+    artifact = _cursor_shell_artifact(workspace_dir=workspace_dir, command=command)
+    store.add_approval_request(
+        GuardApprovalRequest(
+            request_id=request_id,
+            harness="cursor",
+            artifact_id=artifact.artifact_id,
+            artifact_name=artifact.name,
+            artifact_hash="hash-cursor-shell",
+            policy_action="require-reapproval",
+            recommended_scope="artifact",
+            changed_fields=("tool_action_request",),
+            source_scope="project",
+            config_path=artifact.config_path,
+            review_command=f"hol-guard approvals approve {request_id}",
+            approval_url=f"http://127.0.0.1:5474/approvals/{request_id}",
+        ),
+        "2026-08-15T00:00:00+00:00",
+    )
+    _record_cursor_pending_for_test(
+        store=store,
+        guard_home=home_dir,
+        guard_commands_module=guard_commands_module,
+        conversation_id=conversation_id,
+        command=command,
+        workspace_dir=workspace_dir,
+        generation_id=generation_id,
+    )
+    guard_commands_module._attach_cursor_pending_approval_request_ids(
+        store=store,
+        payload={
+            "conversation_id": conversation_id,
+            "hook_event_name": "beforeShellExecution",
+            "command": command,
+            "cwd": str(workspace_dir),
+            "generation_id": generation_id,
+        },
+        response_payload={"approval_request_ids": [request_id]},
+    )
+    saved = guard_commands_module._persist_cursor_native_permission_after_shell(
+        store=store,
+        payload=prepare_cursor_hook_payload(
+            {
+                "conversation_id": conversation_id,
+                "generation_id": generation_id,
+                "hook_event_name": "afterShellExecution",
+                "command": command,
+                "cwd": str(workspace_dir),
+                "duration": 15,
+            }
+        ),
+        harness="cursor",
+        home_dir=home_dir,
+        guard_home=home_dir,
+        workspace=workspace_dir,
+        hook_env=_trusted_cursor_after_shell_env(
+            home_dir,
+            conversation_id=conversation_id,
+            command=command,
+            workspace_dir=workspace_dir,
+            approval_binding=generation_id,
+        ),
+    )
+    resolved = store.get_approval_request(request_id)
+
+    assert saved is True
+    assert resolved is not None
+    assert resolved.get("status") == "resolved"
+    assert resolved.get("resolution_action") == "allow"
+    assert store.list_approval_requests(status="pending", harness="cursor") == []
+
+
+def test_cursor_native_accept_resolves_inbox_by_artifact_when_ids_missing(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.adapters.cursor_hooks import prepare_cursor_hook_payload
+    from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+    from codex_plugin_scanner.guard.models import GuardApprovalRequest
+    from codex_plugin_scanner.guard.store import GuardStore
+
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    conversation_id = "conv-cursor-native-inbox-fallback"
+    command = "rm -rf ./hol-guard-cursor-native-test-marker"
+    generation_id = "gen-cursor-native-inbox-fallback"
+    request_id = "req-cursor-native-inbox-fallback"
+    artifact = _cursor_shell_artifact(workspace_dir=workspace_dir, command=command)
+    store.add_approval_request(
+        GuardApprovalRequest(
+            request_id=request_id,
+            harness="cursor",
+            artifact_id=artifact.artifact_id,
+            artifact_name=artifact.name,
+            artifact_hash="hash-cursor-shell",
+            policy_action="require-reapproval",
+            recommended_scope="artifact",
+            changed_fields=("tool_action_request",),
+            source_scope="project",
+            config_path=artifact.config_path,
+            review_command=f"hol-guard approvals approve {request_id}",
+            approval_url=f"http://127.0.0.1:5474/approvals/{request_id}",
+        ),
+        "2026-08-15T00:00:00+00:00",
+    )
+    _record_cursor_pending_for_test(
+        store=store,
+        guard_home=home_dir,
+        guard_commands_module=guard_commands_module,
+        conversation_id=conversation_id,
+        command=command,
+        workspace_dir=workspace_dir,
+        generation_id=generation_id,
+    )
+    saved = guard_commands_module._persist_cursor_native_permission_after_shell(
+        store=store,
+        payload=prepare_cursor_hook_payload(
+            {
+                "conversation_id": conversation_id,
+                "generation_id": generation_id,
+                "hook_event_name": "afterShellExecution",
+                "command": command,
+                "cwd": str(workspace_dir),
+                "duration": 15,
+            }
+        ),
+        harness="cursor",
+        home_dir=home_dir,
+        guard_home=home_dir,
+        workspace=workspace_dir,
+        hook_env=_trusted_cursor_after_shell_env(
+            home_dir,
+            conversation_id=conversation_id,
+            command=command,
+            workspace_dir=workspace_dir,
+            approval_binding=generation_id,
+        ),
+    )
+    resolved = store.get_approval_request(request_id)
+
+    assert saved is True
+    assert resolved is not None
+    assert resolved.get("status") == "resolved"
+
+
 def test_cursor_tampered_pending_shell_cannot_bootstrap_signed_native_allow(tmp_path: Path) -> None:
     from codex_plugin_scanner.guard.adapters.cursor_hooks import prepare_cursor_hook_payload
     from codex_plugin_scanner.guard.cli import commands as guard_commands_module


### PR DESCRIPTION
## Summary
- Accepting a native Cursor permission prompt now resolves the matching approval-center request automatically.
- Trusted after-shell observer proof is treated as the user's artifact-scoped approval, so the inbox no longer stays pending behind a second gate.
- Matching pending Cursor requests are also closed by artifact identity when request IDs were not attached.

## Testing
- `PYTHONPATH=src python3 -c` runner for `test_cursor_native_accept_resolves_inbox_when_approval_gate_enabled`
- `PYTHONPATH=src python3 -c` runner for `test_cursor_native_accept_resolves_inbox_by_artifact_when_ids_missing`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cursor-native approvals now automatically resolve the matching approval inbox item after verified shell or MCP execution.
  * Approval matching can use artifact identity when a request ID is unavailable.

* **Bug Fixes**
  * Prevented approvals from resolving when request, harness, or artifact details do not match.
  * A second inbox decision is no longer required after native Cursor approval.

* **Documentation**
  * Clarified the approval resolution workflow.

* **Tests**
  * Added coverage for approval resolution with approval gates enabled and disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->