### PR TITLE
fix(desktop): dispatch frozen daemon workers before cli

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14731,
-  "maximum_test_source_lines": 318868,
+  "maximum_collected_cases": 14733,
+  "maximum_test_source_lines": 318912,
   "schema_version": 1
 }

--- a/scripts/mdm/hol-guard-entry.py
+++ b/scripts/mdm/hol-guard-entry.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
-from codex_plugin_scanner.guard.frozen_daemon_runtime import install_frozen_daemon_runtime
+from multiprocessing import freeze_support
 
 if __name__ == "__main__":
+    # Dispatch PyInstaller multiprocessing children before importing Guard.
+    # Otherwise private resource-tracker argv is parsed as a public CLI command.
+    freeze_support()
+
+    from codex_plugin_scanner.guard.frozen_daemon_runtime import install_frozen_daemon_runtime
+
     install_frozen_daemon_runtime()
 
     from codex_plugin_scanner.guard.frozen_codex_runtime import (

--- a/tests/test_desktop_core_alpha_feed_security.py
+++ b/tests/test_desktop_core_alpha_feed_security.py
@@ -12,6 +12,7 @@ import yaml
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "desktop-core-alpha-feed.yml"
 TOOL = ROOT / "scripts" / "release" / "desktop_core_alpha_feed.py"
+FROZEN_ENTRYPOINT = ROOT / "scripts" / "mdm" / "hol-guard-entry.py"
 
 
 def workflow_text() -> str:
@@ -79,11 +80,11 @@ def test_feed_uses_apple_trust_and_no_redundant_manifest_key() -> None:
     helper = TOOL.read_text(encoding="utf-8")
     job = publish_job()
     steps = {step.get("name"): step for step in job["steps"]}
-    extraction_line = 'codesign --display --extract-certificates "$BINARY" >/dev/null 2> "$RUNNER_TEMP/codesign-certificates.txt"'
+    extraction_line = (
+        'codesign --display --extract-certificates "$BINARY" >/dev/null 2> "$RUNNER_TEMP/codesign-certificates.txt"'
+    )
     extraction_lines = [
-        line.strip()
-        for line in text.splitlines()
-        if "codesign --display --extract-certificates" in line
+        line.strip() for line in text.splitlines() if "codesign --display --extract-certificates" in line
     ]
     verify = steps["Verify exact Apple identity, notarization, and Core contract"]
     verify_run = verify["run"]
@@ -110,7 +111,15 @@ def test_feed_uses_apple_trust_and_no_redundant_manifest_key() -> None:
     assert verify["env"]["MODE"] == "${{ steps.existing.outputs.mode }}"
     assert "spctl --assess" not in verify_run
     assert 'test -s "$RUNNER_TEMP/notary-result.json"' in verify_run
-    assert ".status == \"Accepted\" and (.id | type == \"string\" and length > 0)" in verify_run
+    assert '.status == "Accepted" and (.id | type == "string" and length > 0)' in verify_run
+
+
+def test_feed_builds_core_with_multiprocessing_safe_entrypoint() -> None:
+    entrypoint = FROZEN_ENTRYPOINT.read_text(encoding="utf-8")
+    freeze_dispatch = entrypoint.index("freeze_support()")
+    guard_import = entrypoint.index("from codex_plugin_scanner.guard.frozen_daemon_runtime")
+    assert freeze_dispatch < guard_import
+    assert "scripts/mdm/hol-guard-entry.py" in workflow_text()
 
 
 def test_macos_feed_avoids_bash4_only_builtins_and_binds_mode() -> None:

--- a/tests/test_guard_frozen_daemon_runtime.py
+++ b/tests/test_guard_frozen_daemon_runtime.py
@@ -3,19 +3,54 @@
 from __future__ import annotations
 
 import hashlib
+import runpy
+import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
 from codex_plugin_scanner.guard import frozen_daemon_runtime
 from codex_plugin_scanner.guard.daemon import manager
 
+ROOT = Path(__file__).resolve().parents[1]
+FROZEN_ENTRYPOINT = ROOT / "scripts" / "mdm" / "hol-guard-entry.py"
+
 
 def _daemon_command(executable: Path, guard_home: Path, home: Path, *, port: int = 4781) -> str:
-    return (
-        f"{executable} daemon --serve --guard-home {guard_home} "
-        f"--home {home} --port {port}"
-    )
+    return f"{executable} daemon --serve --guard-home {guard_home} --home {home} --port {port}"
+
+
+def test_frozen_entrypoint_dispatches_multiprocessing_before_guard_imports(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    multiprocessing = ModuleType("multiprocessing")
+    daemon_runtime = ModuleType("codex_plugin_scanner.guard.frozen_daemon_runtime")
+    codex_runtime = ModuleType("codex_plugin_scanner.guard.frozen_codex_runtime")
+    cli = ModuleType("codex_plugin_scanner.cli")
+
+    multiprocessing.__dict__["freeze_support"] = lambda: events.append("freeze-support")
+    daemon_runtime.__dict__["install_frozen_daemon_runtime"] = lambda: events.append("daemon-runtime")
+    codex_runtime.__dict__["install_frozen_codex_runtime"] = lambda: events.append("codex-runtime")
+    codex_runtime.__dict__["run_frozen_internal_command"] = lambda: events.append("private-command")
+    cli.__dict__["main"] = lambda: events.append("public-cli") or 0
+    monkeypatch.setitem(sys.modules, "multiprocessing", multiprocessing)
+    monkeypatch.setitem(sys.modules, "codex_plugin_scanner.guard.frozen_daemon_runtime", daemon_runtime)
+    monkeypatch.setitem(sys.modules, "codex_plugin_scanner.guard.frozen_codex_runtime", codex_runtime)
+    monkeypatch.setitem(sys.modules, "codex_plugin_scanner.cli", cli)
+
+    with pytest.raises(SystemExit) as exit_info:
+        _ = runpy.run_path(str(FROZEN_ENTRYPOINT), run_name="__main__")
+
+    assert exit_info.value.code == 0
+    assert events == [
+        "freeze-support",
+        "daemon-runtime",
+        "codex-runtime",
+        "private-command",
+        "public-cli",
+    ]
 
 
 def test_frozen_runtime_proves_same_executable_bootloader_parent(


### PR DESCRIPTION
## Summary

- dispatch frozen multiprocessing workers before importing the Guard CLI
- cover the frozen entrypoint ordering with behavioral and release-contract tests
- keep the release test-suite ratchet exact

## Root cause

The one-file Core executable imported and entered the public CLI before Python's frozen multiprocessing dispatch ran. Daemon worker processes therefore parsed internal worker arguments as Guard commands, so Desktop timed out waiting for the daemon state file.

## Verification

- focused frozen runtime, daemon manager, and Desktop feed tests: 118 passed, 3 skipped
- Ruff check and format check
- basedpyright: 0 errors
- test-suite ratchet: exact
- unsigned one-file build: Desktop bootstrap completed and daemon reported ready
