### PR TITLE
fix(daemon): recover pre-request worker failures

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12613,
-  "maximum_test_source_lines": 288844,
+  "maximum_collected_cases": 12616,
+  "maximum_test_source_lines": 288919,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/daemon/hook_process_runner.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_process_runner.py
@@ -206,6 +206,7 @@ class HookProcessRunner:
             except queue.Empty:
                 return HookProcessReview(None, "daemon_hook_process_not_ready")
             try:
+                slot.request_exposed = True
                 slot.connection.send(("review", request))
                 remaining_seconds = max(0.0, review_deadline - time.monotonic())
                 if not slot.connection.poll(remaining_seconds):
@@ -242,6 +243,7 @@ class HookProcessRunner:
                         return HookProcessReview(None, "daemon_hook_process_failed")
                 slot = retry_slot
                 try:
+                    slot.request_exposed = True
                     slot.connection.send(("review", request))
                     remaining_seconds = max(0.0, review_deadline - time.monotonic())
                     if not slot.connection.poll(remaining_seconds):

--- a/src/codex_plugin_scanner/guard/daemon/hook_process_worker.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_process_worker.py
@@ -42,6 +42,7 @@ class HookWorkerSlot:
     windows_job_contained: bool = False
     isolation_ready: bool = False
     pre_isolation_contained: bool = False
+    request_exposed: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -124,7 +125,10 @@ def retire_worker_slot(slot: HookWorkerSlot, *, graceful: bool = False) -> bool:
             slot.process.kill()
         tree_contained = False
     else:
-        tree_contained = slot.windows_job_contained
+        # A worker that died before the parent sent it a review request never
+        # handled untrusted input. Its dead bootstrap process cannot retain
+        # request-derived descendants, so the supervisor may safely replace it.
+        tree_contained = slot.windows_job_contained or not slot.request_exposed
     slot.process.join(timeout=_WORKER_RETIRE_JOIN_TIMEOUT_SECONDS)
     contained = (tree_contained or slot.windows_job_contained) and not slot.process.is_alive()
     if not contained:

--- a/tests/test_guard_hook_process_containment.py
+++ b/tests/test_guard_hook_process_containment.py
@@ -64,13 +64,14 @@ class _ProtocolConnection(_Connection):
         return True
 
 
-def test_unknown_isolation_does_not_signal_group_without_live_guardian(
+def test_post_request_unknown_isolation_does_not_signal_group_without_live_guardian(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     slot = HookWorkerSlot(
         process=_DeadGuardian(),
         connection=_Connection(),
         retire_lock=threading.Lock(),
+        request_exposed=True,
     )
     monkeypatch.setattr(
         hook_worker_module.os,

--- a/tests/test_guard_hook_process_deadline_contract.py
+++ b/tests/test_guard_hook_process_deadline_contract.py
@@ -204,6 +204,37 @@ def test_windows_taskkill_failure_requires_job_containment_proof(
     assert retire_worker_slot(job_contained)
 
 
+def test_dead_pre_request_worker_can_be_replaced_without_isolation_proof() -> None:
+    process = _FakeProcess(3)
+    process.kill()
+    slot = HookWorkerSlot(
+        process=process,
+        connection=_SlowConnection(
+            entered=[0],
+            entered_lock=threading.Lock(),
+            all_entered=threading.Event(),
+        ),
+    )
+
+    assert retire_worker_slot(slot)
+
+
+def test_dead_post_request_worker_still_requires_containment_proof() -> None:
+    process = _FakeProcess(4)
+    process.kill()
+    slot = HookWorkerSlot(
+        process=process,
+        connection=_SlowConnection(
+            entered=[0],
+            entered_lock=threading.Lock(),
+            all_entered=threading.Event(),
+        ),
+        request_exposed=True,
+    )
+
+    assert not retire_worker_slot(slot)
+
+
 def test_slow_pi_reviews_release_every_slot_within_client_daemon_budget(
     tmp_path,
     monkeypatch,

--- a/tests/test_guard_hook_process_runner.py
+++ b/tests/test_guard_hook_process_runner.py
@@ -871,6 +871,49 @@ def test_transient_initial_worker_failure_replenishes_capacity(
     assert runner.stats()["workers"] == 0
 
 
+def test_pre_isolation_worker_death_replenishes_capacity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = HookProcessRunner(guard_home=tmp_path, process_limit=1)
+    original_start = runner._start_slot  # pyright: ignore[reportPrivateUsage]
+    attempts = 0
+    recovered_stats: dict[str, object] = {}
+
+    def transient_start(*, generation: int) -> HookWorkerSlot:
+        nonlocal attempts
+        attempts += 1
+        slot = original_start(generation=generation)
+        if attempts == 1:
+            slot.process.kill()
+            slot.process.join(timeout=1)
+        return slot
+
+    monkeypatch.setattr(runner, "_start_slot", transient_start)
+    try:
+        runner.start()
+        assert runner.wait_for_capacity(minimum_workers=1, timeout_seconds=10)
+        result = runner.review(
+            payload={"hook_event_name": "SessionStart"},
+            harness="pi",
+            home_dir=tmp_path,
+            guard_home=tmp_path,
+            workspace=tmp_path,
+            hook_env={},
+        )
+        recovered_stats = dict(runner.stats())
+    finally:
+        runner.close()
+
+    assert attempts >= 2
+    assert result.payload is not None
+    assert recovered_stats["workers"] == 1
+    assert recovered_stats["ready"] == 1
+    assert recovered_stats["failures"] == 1
+    assert recovered_stats["restarts"] == 0
+    assert runner.stats()["workers"] == 0
+
+
 def test_transient_worker_spawn_failure_replenishes_capacity(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- recover isolated hook worker capacity when a worker exits before receiving a review request
- preserve strict containment requirements after any request payload is exposed
- add regression coverage for startup recovery and post-request fail-closed behavior

## Verification

- 58 focused hook containment and runner tests
- 87 daemon transport, storage, containment, and runner tests
- OMP fast-path burst and locked-storage liveness tests
- Ruff check and format verification
- basedpyright
- test-suite ratchet


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved review worker recovery when a worker stops before receiving request data.
  - Strengthened process isolation safeguards after review requests are sent.
  - Prevented unsafe process-group signaling when containment cannot be verified.
  - Ensured review capacity is restored and subsequent reviews can proceed after early worker failures.

- **Tests**
  - Added coverage for worker replacement, isolation checks, failure tracking, and clean shutdown behavior.

- **Chores**
  - Updated automated test-suite capacity thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->