### PR TITLE
fix(daemon): recover pre-request worker failures

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14735,
-  "maximum_test_source_lines": 318967,
+  "maximum_collected_cases": 14738,
+  "maximum_test_source_lines": 319042,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14738,
-  "maximum_test_source_lines": 319042,
+  "maximum_collected_cases": 14739,
+  "maximum_test_source_lines": 319071,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/daemon/hook_process_runner.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_process_runner.py
@@ -206,8 +206,8 @@ class HookProcessRunner:
             except queue.Empty:
                 return HookProcessReview(None, "daemon_hook_process_not_ready")
             try:
-                slot.request_exposed = True
                 slot.connection.send(("review", request))
+                slot.request_exposed = True
                 remaining_seconds = max(0.0, review_deadline - time.monotonic())
                 if not slot.connection.poll(remaining_seconds):
                     self._replace_slot_async(slot)
@@ -243,8 +243,8 @@ class HookProcessRunner:
                         return HookProcessReview(None, "daemon_hook_process_failed")
                 slot = retry_slot
                 try:
-                    slot.request_exposed = True
                     slot.connection.send(("review", request))
+                    slot.request_exposed = True
                     remaining_seconds = max(0.0, review_deadline - time.monotonic())
                     if not slot.connection.poll(remaining_seconds):
                         self._replace_slot_async(slot)

--- a/src/codex_plugin_scanner/guard/daemon/hook_process_runner.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_process_runner.py
@@ -206,6 +206,7 @@ class HookProcessRunner:
             except queue.Empty:
                 return HookProcessReview(None, "daemon_hook_process_not_ready")
             try:
+                slot.request_exposed = True
                 slot.connection.send(("review", request))
                 remaining_seconds = max(0.0, review_deadline - time.monotonic())
                 if not slot.connection.poll(remaining_seconds):
@@ -242,6 +243,7 @@ class HookProcessRunner:
                         return HookProcessReview(None, "daemon_hook_process_failed")
                 slot = retry_slot
                 try:
+                    slot.request_exposed = True
                     slot.connection.send(("review", request))
                     remaining_seconds = max(0.0, review_deadline - time.monotonic())
                     if not slot.connection.poll(remaining_seconds):

--- a/src/codex_plugin_scanner/guard/daemon/hook_process_worker.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_process_worker.py
@@ -43,6 +43,7 @@ class HookWorkerSlot:
     windows_job_contained: bool = False
     isolation_ready: bool = False
     pre_isolation_contained: bool = False
+    request_exposed: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -125,7 +126,10 @@ def retire_worker_slot(slot: HookWorkerSlot, *, graceful: bool = False) -> bool:
             slot.process.kill()
         tree_contained = False
     else:
-        tree_contained = slot.windows_job_contained
+        # A worker that died before the parent sent it a review request never
+        # handled untrusted input. Its dead bootstrap process cannot retain
+        # request-derived descendants, so the supervisor may safely replace it.
+        tree_contained = slot.windows_job_contained or not slot.request_exposed
     slot.process.join(timeout=_WORKER_RETIRE_JOIN_TIMEOUT_SECONDS)
     contained = (tree_contained or slot.windows_job_contained) and not slot.process.is_alive()
     if not contained:

--- a/tests/test_guard_hook_process_containment.py
+++ b/tests/test_guard_hook_process_containment.py
@@ -64,13 +64,14 @@ class _ProtocolConnection(_Connection):
         return True
 
 
-def test_unknown_isolation_does_not_signal_group_without_live_guardian(
+def test_post_request_unknown_isolation_does_not_signal_group_without_live_guardian(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     slot = HookWorkerSlot(
         process=_DeadGuardian(),
         connection=_Connection(),
         retire_lock=threading.Lock(),
+        request_exposed=True,
     )
     monkeypatch.setattr(
         hook_worker_module.os,

--- a/tests/test_guard_hook_process_deadline_contract.py
+++ b/tests/test_guard_hook_process_deadline_contract.py
@@ -187,6 +187,37 @@ def test_windows_taskkill_failure_requires_job_containment_proof(
     assert retire_worker_slot(job_contained)
 
 
+def test_dead_pre_request_worker_can_be_replaced_without_isolation_proof() -> None:
+    process = _FakeProcess(3)
+    process.kill()
+    slot = HookWorkerSlot(
+        process=process,
+        connection=_SlowConnection(
+            entered=[0],
+            entered_lock=threading.Lock(),
+            all_entered=threading.Event(),
+        ),
+    )
+
+    assert retire_worker_slot(slot)
+
+
+def test_dead_post_request_worker_still_requires_containment_proof() -> None:
+    process = _FakeProcess(4)
+    process.kill()
+    slot = HookWorkerSlot(
+        process=process,
+        connection=_SlowConnection(
+            entered=[0],
+            entered_lock=threading.Lock(),
+            all_entered=threading.Event(),
+        ),
+        request_exposed=True,
+    )
+
+    assert not retire_worker_slot(slot)
+
+
 def test_slow_pi_reviews_release_every_slot_within_client_daemon_budget(
     tmp_path,
     monkeypatch,

--- a/tests/test_guard_hook_process_runner.py
+++ b/tests/test_guard_hook_process_runner.py
@@ -464,6 +464,35 @@ def test_non_idempotent_review_does_not_retry_transient_evaluator_not_ready(tmp_
     assert connection.send.call_count == 1
 
 
+def test_failed_send_does_not_mark_request_as_exposed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = HookProcessRunner(guard_home=tmp_path, process_limit=1, timeout_seconds=1)
+    runner._started = True  # pyright: ignore[reportPrivateUsage]
+    process = MagicMock()
+    process.pid = 4243
+    process.is_alive.return_value = False
+    connection = MagicMock()
+    connection.send.side_effect = BrokenPipeError
+    slot = HookWorkerSlot(process=process, connection=connection)
+    runner._slots.put_nowait(slot)  # pyright: ignore[reportPrivateUsage]
+    runner._ready_slot_ids.add(process.pid)  # pyright: ignore[reportPrivateUsage]
+    monkeypatch.setattr(runner, "_replace_slot_async", lambda _slot: None)
+
+    result = runner.review(
+        payload={"hook_event_name": "SessionStart"},
+        harness="pi",
+        home_dir=tmp_path,
+        guard_home=tmp_path,
+        workspace=tmp_path,
+        hook_env={},
+    )
+
+    assert result == HookProcessReview(None, "daemon_hook_process_failed")
+    assert not slot.request_exposed
+
+
 def test_idempotent_review_bounds_transient_not_ready_retries(tmp_path: Path) -> None:
     runner, connection = _transient_not_ready_test_runner(
         tmp_path,

--- a/tests/test_guard_hook_process_runner.py
+++ b/tests/test_guard_hook_process_runner.py
@@ -870,6 +870,49 @@ def test_transient_initial_worker_failure_replenishes_capacity(
     assert runner.stats()["workers"] == 0
 
 
+def test_pre_isolation_worker_death_replenishes_capacity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = HookProcessRunner(guard_home=tmp_path, process_limit=1)
+    original_start = runner._start_slot  # pyright: ignore[reportPrivateUsage]
+    attempts = 0
+    recovered_stats: dict[str, object] = {}
+
+    def transient_start(*, generation: int) -> HookWorkerSlot:
+        nonlocal attempts
+        attempts += 1
+        slot = original_start(generation=generation)
+        if attempts == 1:
+            slot.process.kill()
+            slot.process.join(timeout=1)
+        return slot
+
+    monkeypatch.setattr(runner, "_start_slot", transient_start)
+    try:
+        runner.start()
+        assert runner.wait_for_capacity(minimum_workers=1, timeout_seconds=10)
+        result = runner.review(
+            payload={"hook_event_name": "SessionStart"},
+            harness="pi",
+            home_dir=tmp_path,
+            guard_home=tmp_path,
+            workspace=tmp_path,
+            hook_env={},
+        )
+        recovered_stats = dict(runner.stats())
+    finally:
+        runner.close()
+
+    assert attempts >= 2
+    assert result.payload is not None
+    assert recovered_stats["workers"] == 1
+    assert recovered_stats["ready"] == 1
+    assert recovered_stats["failures"] == 1
+    assert recovered_stats["restarts"] == 0
+    assert runner.stats()["workers"] == 0
+
+
 def test_transient_worker_spawn_failure_replenishes_capacity(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- recover isolated hook worker capacity when a worker exits before receiving a review request
- preserve strict containment requirements after any request payload is exposed
- add regression coverage for startup recovery and post-request fail-closed behavior

## Verification

- focused hook containment, runner, OMP burst, and locked-storage tests
- Ruff check and format verification
- basedpyright
- release-branch test-suite ratchet
