### PR TITLE
fix(update): verify daemon runtime handoff

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14739,
-  "maximum_test_source_lines": 319071,
+  "maximum_collected_cases": 14742,
+  "maximum_test_source_lines": 319247,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -161,6 +161,7 @@ from codex_plugin_scanner.guard.daemon.manager import (
     clear_guard_daemon_state,
     ensure_guard_daemon_after_update,
     guard_daemon_retirement_is_complete,
+    load_guard_daemon_url,
     repair_approval_center_locator,
     retire_all_guard_daemons_for_home,
 )
@@ -182,30 +183,58 @@ try:
 except (OSError, json.JSONDecodeError):
     state = {}
 preferred_port = state.get("port") if isinstance(state.get("port"), int) else None
-retired = []
-retirement_deadline = time.monotonic() + 5.0
-while True:
-    for pid in retire_all_guard_daemons_for_home(guard_home):
-        if pid not in retired:
-            retired.append(pid)
-    if guard_daemon_retirement_is_complete(guard_home):
-        break
-    if time.monotonic() >= retirement_deadline:
-        break
-    time.sleep(0.1)
-if not guard_daemon_retirement_is_complete(guard_home):
-    print(json.dumps({"status": "retirement_failed", "retired": retired}))
-    raise SystemExit(1)
-clear_guard_daemon_state(guard_home)
-repair_approval_center_locator(guard_home)
 refresh_parameters = inspect.signature(ensure_guard_daemon_after_update).parameters
 refresh_kwargs = {"preferred_port": preferred_port}
 if "home_dir" in refresh_parameters:
     refresh_kwargs["home_dir"] = home_dir
 if "allow_windows_job_breakaway" in refresh_parameters:
     refresh_kwargs["allow_windows_job_breakaway"] = True
-daemon_url = ensure_guard_daemon_after_update(guard_home, **refresh_kwargs)
-print(json.dumps({"status": "restarted", "retired": retired, "daemon_url": daemon_url}))
+retired = []
+last_failure_status = "runtime_replaced"
+for attempt in range(1, 4):
+    retirement_complete = False
+    retirement_deadline = time.monotonic() + 5.0
+    while True:
+        for pid in retire_all_guard_daemons_for_home(guard_home):
+            if pid not in retired:
+                retired.append(pid)
+        if guard_daemon_retirement_is_complete(guard_home):
+            retirement_complete = True
+            break
+        if time.monotonic() >= retirement_deadline:
+            last_failure_status = "retirement_failed"
+            break
+        time.sleep(0.1)
+    if not retirement_complete:
+        continue
+    clear_guard_daemon_state(guard_home)
+    repair_approval_center_locator(guard_home)
+    daemon_url = ensure_guard_daemon_after_update(guard_home, **refresh_kwargs)
+    # A separately installed desktop app can race the refresh and replace the
+    # just-started daemon with older bytes. Require the updated fingerprint to
+    # remain bound across a short stability window before reporting success.
+    verified_url = None
+    for _stability_check in range(3):
+        time.sleep(1.0)
+        verified_url = load_guard_daemon_url(guard_home)
+        if verified_url is None:
+            break
+    if verified_url is not None:
+        print(
+            json.dumps(
+                {
+                    "status": "restarted",
+                    "retired": retired,
+                    "daemon_url": verified_url,
+                    "attempts": attempt,
+                    "runtime_verified": True,
+                }
+            )
+        )
+        raise SystemExit(0)
+    last_failure_status = "runtime_replaced"
+print(json.dumps({"status": last_failure_status, "retired": retired, "attempts": 3}))
+raise SystemExit(1)
 """.strip()
 _DAEMON_REFRESH_CLEANUP_SCRIPT = """
 from __future__ import annotations
@@ -2107,10 +2136,10 @@ def refresh_guard_daemon_after_update(
             cleanup_verified=cleanup_verified,
         )
     status = payload.get("status")
-    if status != "restarted":
+    if status != "restarted" or payload.get("runtime_verified") is not True:
         cleanup_verified = _cleanup_failed_guard_daemon_refresh(active_context, context)
         return payload, _daemon_refresh_failure_note(
-            "Could not restart the Guard daemon after update: restart was not confirmed",
+            "Could not restart the Guard daemon after update: updated runtime was not confirmed",
             cleanup_verified=cleanup_verified,
         )
     return payload, "Restarted the Guard daemon to load the updated package."

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import io
 import json
 import os
 import subprocess
@@ -140,13 +141,18 @@ def test_daemon_refresh_after_update_uses_fresh_interpreter(tmp_path: Path, monk
             "guard_home": str(context.guard_home),
             "home_dir": str(context.home_dir),
         }
-        return subprocess.CompletedProcess(command, 0, '{"status":"restarted","retired":[123]}', "")
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            '{"status":"restarted","retired":[123],"runtime_verified":true}',
+            "",
+        )
 
     monkeypatch.setattr(update_commands.subprocess, "run", fake_run)
 
     payload, note = update_commands.refresh_guard_daemon_after_update(context)
 
-    assert payload == {"status": "restarted", "retired": [123]}
+    assert payload == {"status": "restarted", "retired": [123], "runtime_verified": True}
     assert note == "Restarted the Guard daemon to load the updated package."
 
 
@@ -172,7 +178,7 @@ def test_daemon_refresh_authorizes_breakaway_only_for_restart_child(tmp_path: Pa
             calls.append((script, dict(kwargs)))
             return SimpleNamespace(
                 returncode=0,
-                stdout='{"status":"restarted"}',
+                stdout='{"status":"restarted","runtime_verified":true}',
                 stderr="",
                 output_limited=False,
             )
@@ -182,7 +188,7 @@ def test_daemon_refresh_authorizes_breakaway_only_for_restart_child(tmp_path: Pa
         update_context=FakeUpdateContext(),  # type: ignore[arg-type]
     )
 
-    assert payload == {"status": "restarted"}
+    assert payload == {"status": "restarted", "runtime_verified": True}
     assert note == "Restarted the Guard daemon to load the updated package."
     assert calls == [
         (
@@ -199,6 +205,102 @@ def test_daemon_refresh_authorizes_breakaway_only_for_restart_child(tmp_path: Pa
             },
         )
     ]
+
+
+def test_daemon_refresh_rejects_unverified_runtime_handoff(tmp_path: Path) -> None:
+    context = _context(tmp_path)
+    context.guard_home.mkdir(parents=True)
+    (context.guard_home / "daemon-state.json").write_text("{}", encoding="utf-8")
+
+    class FakeUpdateContext:
+        def python_command(self, script: str, *_args: str) -> list[str]:
+            return ["/trusted/python", script]
+
+        def run(self, command: list[str], **_kwargs: object) -> SimpleNamespace:
+            if command[-1] == update_commands._DAEMON_REFRESH_SCRIPT:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout='{"status":"restarted"}',
+                    stderr="",
+                    output_limited=False,
+                )
+            return SimpleNamespace(
+                returncode=0,
+                stdout='{"status":"cleaned","retired":[],"remaining":[]}',
+                stderr="",
+                output_limited=False,
+            )
+
+    payload, note = update_commands.refresh_guard_daemon_after_update(
+        context,
+        update_context=FakeUpdateContext(),  # type: ignore[arg-type]
+    )
+
+    assert payload == {"status": "restarted"}
+    assert note == "Could not restart the Guard daemon after update: updated runtime was not confirmed"
+
+
+def test_daemon_refresh_script_retries_a_retirement_timeout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from codex_plugin_scanner.guard.daemon import manager
+
+    context = _context(tmp_path)
+    context.home_dir.mkdir(parents=True)
+    context.guard_home.mkdir(parents=True)
+    (context.guard_home / "daemon-state.json").write_text('{"port":5474}', encoding="utf-8")
+    retirement_checks = iter([False, True])
+    monotonic_values = iter([0.0, 6.0, 10.0])
+    retire_calls: list[Path] = []
+
+    def fake_retire(guard_home: Path) -> list[int]:
+        retire_calls.append(guard_home)
+        return [101]
+
+    def fake_ensure(
+        _guard_home: Path,
+        *,
+        home_dir: Path | None = None,
+        preferred_port: int | None = None,
+        allow_windows_job_breakaway: bool = False,
+    ) -> str:
+        assert home_dir == context.home_dir
+        assert preferred_port == 5474
+        assert allow_windows_job_breakaway
+        return "http://127.0.0.1:5474"
+
+    monkeypatch.setattr(manager, "retire_all_guard_daemons_for_home", fake_retire)
+    monkeypatch.setattr(manager, "guard_daemon_retirement_is_complete", lambda _home: next(retirement_checks))
+    monkeypatch.setattr(manager, "clear_guard_daemon_state", lambda _home: None)
+    monkeypatch.setattr(manager, "repair_approval_center_locator", lambda _home: None)
+    monkeypatch.setattr(manager, "ensure_guard_daemon_after_update", fake_ensure)
+    monkeypatch.setattr(manager, "load_guard_daemon_url", lambda _home: "http://127.0.0.1:5474")
+    monkeypatch.setattr(update_commands.time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(update_commands.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        update_commands.sys,
+        "stdin",
+        io.StringIO(
+            json.dumps(
+                {
+                    "guard_home": str(context.guard_home),
+                    "home_dir": str(context.home_dir),
+                }
+            )
+        ),
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        exec(update_commands._DAEMON_REFRESH_SCRIPT, {})
+
+    assert exit_info.value.code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "restarted"
+    assert payload["runtime_verified"] is True
+    assert payload["attempts"] == 2
+    assert retire_calls == [context.guard_home, context.guard_home]
 
 
 def test_daemon_refresh_failure_runs_contained_cleanup_without_breakaway(tmp_path: Path) -> None:

--- a/tests/test_guard_update_daemon_handoff.py
+++ b/tests/test_guard_update_daemon_handoff.py
@@ -58,6 +58,7 @@ def test_refresh_script_adapts_to_new_manager_signature(
         return home_dir
 
     monkeypatch.setattr(manager, "ensure_guard_daemon_after_update", require_new_parameters)
+    monkeypatch.setattr(manager, "load_guard_daemon_url", lambda _home: "http://127.0.0.1:8123")
     monkeypatch.setattr(Path, "home", classmethod(process_home))
     monkeypatch.setattr(
         sys,
@@ -66,7 +67,10 @@ def test_refresh_script_adapts_to_new_manager_signature(
     )
 
     refresh_script = cast(str, update_commands.__dict__["_DAEMON_REFRESH_SCRIPT"])
-    exec(refresh_script, {})
+    with pytest.raises(SystemExit) as exit_info:
+        exec(refresh_script, {})
+
+    assert exit_info.value.code == 0
 
     assert observed == {
         "guard_home": guard_home.resolve(),
@@ -78,6 +82,8 @@ def test_refresh_script_adapts_to_new_manager_signature(
         "status": "restarted",
         "retired": [17],
         "daemon_url": "http://127.0.0.1:8123",
+        "runtime_verified": True,
+        "attempts": 1,
     }
 
 
@@ -112,6 +118,7 @@ def test_refresh_script_converges_when_supervisor_respawns_daemon(
         "ensure_guard_daemon_after_update",
         lambda _guard_home, **_kwargs: "http://127.0.0.1:8125",
     )
+    monkeypatch.setattr(manager, "load_guard_daemon_url", lambda _home: "http://127.0.0.1:8125")
     monkeypatch.setattr(
         sys,
         "stdin",
@@ -119,13 +126,18 @@ def test_refresh_script_converges_when_supervisor_respawns_daemon(
     )
 
     refresh_script = cast(str, update_commands.__dict__["_DAEMON_REFRESH_SCRIPT"])
-    exec(refresh_script, {})
+    with pytest.raises(SystemExit) as exit_info:
+        exec(refresh_script, {})
+
+    assert exit_info.value.code == 0
 
     assert retirement_calls == 3
     assert json.loads(capsys.readouterr().out) == {
         "status": "restarted",
         "retired": [21, 22, 23],
         "daemon_url": "http://127.0.0.1:8125",
+        "runtime_verified": True,
+        "attempts": 1,
     }
 
 
@@ -158,6 +170,7 @@ def test_refresh_script_preserves_legacy_manager_signature(
     monkeypatch.setattr(manager, "clear_guard_daemon_state", no_op)
     monkeypatch.setattr(manager, "repair_approval_center_locator", no_op)
     monkeypatch.setattr(manager, "ensure_guard_daemon_after_update", legacy_parameters)
+    monkeypatch.setattr(manager, "load_guard_daemon_url", lambda _home: "http://127.0.0.1:8124")
     monkeypatch.setattr(
         sys,
         "stdin",
@@ -165,11 +178,72 @@ def test_refresh_script_preserves_legacy_manager_signature(
     )
 
     refresh_script = cast(str, update_commands.__dict__["_DAEMON_REFRESH_SCRIPT"])
-    exec(refresh_script, {})
+    with pytest.raises(SystemExit) as exit_info:
+        exec(refresh_script, {})
+
+    assert exit_info.value.code == 0
 
     assert observed == {"guard_home": guard_home.resolve(), "preferred_port": 8124}
     assert json.loads(capsys.readouterr().out) == {
         "status": "restarted",
         "retired": [18],
         "daemon_url": "http://127.0.0.1:8124",
+        "runtime_verified": True,
+        "attempts": 1,
+    }
+
+
+def test_refresh_script_retries_when_runtime_changes_during_stability_window(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    home_dir = tmp_path / "home"
+    guard_home = home_dir / ".hol-guard"
+    guard_home.mkdir(parents=True)
+    (guard_home / "daemon-state.json").write_text('{"port":8126}', encoding="utf-8")
+    verification = iter(
+        [
+            "http://127.0.0.1:8126",
+            None,
+            "http://127.0.0.1:8126",
+            "http://127.0.0.1:8126",
+            "http://127.0.0.1:8126",
+        ]
+    )
+    retire_calls = 0
+
+    def retire(_guard_home: Path) -> list[int]:
+        nonlocal retire_calls
+        retire_calls += 1
+        return [30 + retire_calls]
+
+    monkeypatch.setattr(manager, "retire_all_guard_daemons_for_home", retire)
+    monkeypatch.setattr(manager, "guard_daemon_retirement_is_complete", lambda _home: True)
+    monkeypatch.setattr(manager, "clear_guard_daemon_state", lambda _home: None)
+    monkeypatch.setattr(manager, "repair_approval_center_locator", lambda _home: None)
+    monkeypatch.setattr(
+        manager,
+        "ensure_guard_daemon_after_update",
+        lambda _guard_home, **_kwargs: "http://127.0.0.1:8126",
+    )
+    monkeypatch.setattr(manager, "load_guard_daemon_url", lambda _home: next(verification))
+    monkeypatch.setattr(update_commands.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(json.dumps({"guard_home": str(guard_home), "home_dir": str(home_dir)})),
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        exec(cast(str, update_commands.__dict__["_DAEMON_REFRESH_SCRIPT"]), {})
+
+    assert exit_info.value.code == 0
+    assert retire_calls == 2
+    assert json.loads(capsys.readouterr().out) == {
+        "status": "restarted",
+        "retired": [31, 32],
+        "daemon_url": "http://127.0.0.1:8126",
+        "runtime_verified": True,
+        "attempts": 2,
     }


### PR DESCRIPTION
## Summary
- verify that the post-update daemon remains bound to the updated runtime
- retry bounded daemon handoff races and fail explicitly when another runtime replaces it

## Testing
- `uv run --no-sync pytest -q tests/test_guard_phase03_local_install.py tests/test_guard_update_daemon_handoff.py tests/test_dashboard_update.py --tb=short`
- `uv run --no-sync basedpyright --level error`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/cli/update_commands.py tests/test_guard_phase03_local_install.py`
- `uv run --no-sync python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory test-inventory.json`
