### PR TITLE
fix(update): report bundled desktop core version

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14742,
-  "maximum_test_source_lines": 319247,
+  "maximum_collected_cases": 14744,
+  "maximum_test_source_lines": 319313,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -25,6 +25,7 @@ from urllib.parse import ParseResult, urlparse
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
 
+from ... import version as package_version
 from ..adapters.base import HarnessContext
 from ..adapters.codex import CodexHarnessAdapter, codex_native_hook_state
 from ..adapters.cursor_hooks import cursor_native_hook_state
@@ -1067,6 +1068,16 @@ def _expected_script_dir(installer_binary: str, installer: str) -> Path | None:
 
 
 def build_guard_install_surface_payload() -> dict[str, object]:
+    if _is_desktop_managed_runtime():
+        return {
+            "installer": "desktop",
+            "binary_diagnostics": {
+                "resolved_hol_guard": str(Path(sys.executable).resolve()),
+                "installer_binary": None,
+                "expected_script_dir": None,
+                "path_status": "bundled",
+            },
+        }
     installer = _installer_kind()
     return {
         "installer": installer,
@@ -1562,7 +1573,15 @@ def _current_version() -> str:
     try:
         return importlib.metadata.version("hol-guard")
     except importlib.metadata.PackageNotFoundError:
-        return "unknown"
+        return package_version.__version__ if _is_frozen_runtime() else "unknown"
+
+
+def _is_frozen_runtime() -> bool:
+    return getattr(sys, "frozen", False) is True
+
+
+def _is_desktop_managed_runtime() -> bool:
+    return _is_frozen_runtime() and os.environ.get("HOL_GUARD_DESKTOP") == "1"
 
 
 def _installer_kind() -> str:
@@ -2648,7 +2667,15 @@ def build_guard_update_status_payload(*, guard_home: Path | None = None) -> dict
     blocked_reason: str | None = None
     trusted_failure_reason: str | None = None
     recovery_reinstall_available = False
-    installed_distribution: InstalledDistribution | None = None
+    installed_distribution = (
+        InstalledDistribution(
+            name="hol-guard",
+            version=_current_version(),
+            root=Path(sys.executable).resolve().parent,
+        )
+        if installer == "desktop"
+        else None
+    )
 
     if managed_state.status != "absent" and managed_policy is None:
         auto_updatable = False
@@ -2663,6 +2690,9 @@ def build_guard_update_status_payload(*, guard_home: Path | None = None) -> dict
     ):
         auto_updatable = False
         blocked_reason = "An organization-configured package source is required."
+    elif installer == "desktop":
+        auto_updatable = False
+        blocked_reason = "Updates are managed by HOL Guard Desktop."
     else:
         try:
             installed_distribution = _status_installed_distribution(
@@ -2691,11 +2721,11 @@ def build_guard_update_status_payload(*, guard_home: Path | None = None) -> dict
             network_policy=(managed_policy.network if managed_policy is not None else ManagedNetworkPolicy()),
             include_alpha=include_alpha,
         )
-        if installed_distribution is not None
+        if installed_distribution is not None and installer != "desktop"
         else {
             "source": source_kind,
-            "status": "unavailable",
-            "current_version": None,
+            "status": "managed" if installer == "desktop" else "unavailable",
+            "current_version": current_version if installer == "desktop" else None,
             "latest_version": None,
             "update_available": None,
         }

--- a/tests/test_dashboard_update.py
+++ b/tests/test_dashboard_update.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.metadata
 import json
 import os
 import stat
@@ -18,6 +19,7 @@ import pytest
 
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.approval_gate import update_settings as update_approval_gate_settings
+from codex_plugin_scanner.guard.cli import update_commands
 from codex_plugin_scanner.guard.cli.update_commands import build_guard_update_status_payload
 from codex_plugin_scanner.guard.config import load_guard_config
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
@@ -144,6 +146,70 @@ def test_build_guard_update_status_payload_shape(monkeypatch: pytest.MonkeyPatch
     assert payload["latest_version"] == "1.2.4"
     assert payload["auto_updatable"] is True
     assert payload["update_available"] is True
+
+
+def test_frozen_desktop_status_uses_embedded_version_without_package_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.update_commands._is_frozen_runtime",
+        lambda: True,
+    )
+    monkeypatch.setenv("HOL_GUARD_DESKTOP", "1")
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.update_commands.package_version.__version__",
+        "3.0.0a138",
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.update_commands.importlib.metadata.version",
+        MagicMock(side_effect=importlib.metadata.PackageNotFoundError),
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.update_commands._status_installed_distribution",
+        MagicMock(side_effect=AssertionError("frozen Desktop must not probe package metadata")),
+    )
+    version_check = MagicMock(side_effect=AssertionError("Desktop manages Core updates"))
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.update_commands._version_check_payload",
+        version_check,
+    )
+
+    payload = build_guard_update_status_payload()
+
+    assert payload["installer"] == "desktop"
+    assert payload["current_version"] == "3.0.0a138"
+    assert payload["latest_version"] is None
+    assert payload["auto_updatable"] is False
+    assert payload["update_available"] is False
+    assert payload["blocked_reason"] == "Updates are managed by HOL Guard Desktop."
+    assert "reason_code" not in payload
+    assert payload["version_check"] == {
+        "source": "pypi",
+        "status": "managed",
+        "current_version": "3.0.0a138",
+        "latest_version": None,
+        "update_available": None,
+    }
+    version_check.assert_not_called()
+
+
+def test_frozen_runtime_without_desktop_marker_keeps_installer_detection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.update_commands._is_frozen_runtime",
+        lambda: True,
+    )
+    monkeypatch.delenv("HOL_GUARD_DESKTOP", raising=False)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.update_commands._installer_kind",
+        lambda: "pip",
+    )
+
+    payload = update_commands.build_guard_install_surface_payload()
+
+    assert payload["installer"] == "pip"
+    assert cast(dict[str, object], payload["binary_diagnostics"])["path_status"] != "bundled"
 
 
 def test_update_status_uses_persisted_alpha_channel(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- report the embedded Core version when the frozen runtime has no package metadata
- identify Desktop-managed Core sessions without changing managed-package update behavior
- keep Core updates delegated to Desktop instead of probing a package installer

## Testing
- `uv run --no-sync pytest -q tests/test_dashboard_update.py tests/test_guard_update_isolation.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/cli/update_commands.py tests/test_dashboard_update.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/cli/update_commands.py tests/test_dashboard_update.py`
- `uv run --no-sync basedpyright --level error`
