### PR TITLE
fix(runtime): retire resident with supervisor

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+SPDX-License-Identifier: Apache-2.0
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14742,
-  "maximum_test_source_lines": 319247,
+  "maximum_collected_cases": 14743,
+  "maximum_test_source_lines": 319305,
   "schema_version": 1
 }

--- a/rust/crates/guard-runtime/src/main.rs
+++ b/rust/crates/guard-runtime/src/main.rs
@@ -16,7 +16,6 @@ use std::fmt;
 use std::io::{self, Read, Write};
 use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
 use std::panic::{catch_unwind, AssertUnwindSafe};
-use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{sync_channel, Receiver, SyncSender, TrySendError};
 use std::sync::{Arc, Mutex};
@@ -54,7 +53,7 @@ const MAX_JSON_COLLECTION_ITEMS: usize = 4_096;
 const MAX_JSON_STRING_BYTES: usize = 1024 * 1024;
 const SERVER_PROOF_LABEL: &[u8] = b"hol-guard-resident-server-v1\0";
 const CLIENT_PROOF_LABEL: &[u8] = b"hol-guard-resident-client-v1\0";
-const PARENT_LIVENESS_PATH_ENV: &str = "HOL_GUARD_PARENT_LIVENESS_PATH";
+const PARENT_LIVENESS_FD_ENV: &str = "HOL_GUARD_PARENT_LIVENESS_FD";
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "operation", content = "request", rename_all = "snake_case")]
@@ -581,14 +580,17 @@ fn admit_connection(
 #[cfg(unix)]
 fn resident_parent_liveness() -> Result<Arc<AtomicBool>, String> {
     let alive = Arc::new(AtomicBool::new(true));
-    let Ok(raw_path) = env::var(PARENT_LIVENESS_PATH_ENV) else {
+    let Ok(raw_descriptor) = env::var(PARENT_LIVENESS_FD_ENV) else {
         return Ok(alive);
     };
-    let path = Path::new(&raw_path);
-    let mut pipe = std::fs::File::open(path)
-        .map_err(|_| "native_parent_liveness_path_unavailable".to_owned())?;
-    std::fs::remove_file(path)
-        .map_err(|_| "native_parent_liveness_path_cleanup_failed".to_owned())?;
+    let descriptor = raw_descriptor
+        .parse::<u32>()
+        .map_err(|_| "native_parent_liveness_fd_invalid".to_owned())?;
+    let dev_path = format!("/dev/fd/{descriptor}");
+    let proc_path = format!("/proc/self/fd/{descriptor}");
+    let mut pipe = std::fs::File::open(dev_path)
+        .or_else(|_| std::fs::File::open(proc_path))
+        .map_err(|_| "native_parent_liveness_fd_unavailable".to_owned())?;
     let watcher_state = Arc::clone(&alive);
     thread::spawn(move || {
         let mut byte = [0u8; 1];

--- a/rust/crates/guard-runtime/src/main.rs
+++ b/rust/crates/guard-runtime/src/main.rs
@@ -16,6 +16,7 @@ use std::fmt;
 use std::io::{self, Read, Write};
 use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
 use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{sync_channel, Receiver, SyncSender, TrySendError};
 use std::sync::{Arc, Mutex};
@@ -53,7 +54,7 @@ const MAX_JSON_COLLECTION_ITEMS: usize = 4_096;
 const MAX_JSON_STRING_BYTES: usize = 1024 * 1024;
 const SERVER_PROOF_LABEL: &[u8] = b"hol-guard-resident-server-v1\0";
 const CLIENT_PROOF_LABEL: &[u8] = b"hol-guard-resident-client-v1\0";
-const PARENT_LIVENESS_FD_ENV: &str = "HOL_GUARD_PARENT_LIVENESS_FD";
+const PARENT_LIVENESS_PATH_ENV: &str = "HOL_GUARD_PARENT_LIVENESS_PATH";
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "operation", content = "request", rename_all = "snake_case")]
@@ -580,17 +581,14 @@ fn admit_connection(
 #[cfg(unix)]
 fn resident_parent_liveness() -> Result<Arc<AtomicBool>, String> {
     let alive = Arc::new(AtomicBool::new(true));
-    let Ok(raw_descriptor) = env::var(PARENT_LIVENESS_FD_ENV) else {
+    let Ok(raw_path) = env::var(PARENT_LIVENESS_PATH_ENV) else {
         return Ok(alive);
     };
-    let descriptor = raw_descriptor
-        .parse::<u32>()
-        .map_err(|_| "native_parent_liveness_fd_invalid".to_owned())?;
-    let dev_path = format!("/dev/fd/{descriptor}");
-    let proc_path = format!("/proc/self/fd/{descriptor}");
-    let mut pipe = std::fs::File::open(dev_path)
-        .or_else(|_| std::fs::File::open(proc_path))
-        .map_err(|_| "native_parent_liveness_fd_unavailable".to_owned())?;
+    let path = Path::new(&raw_path);
+    let mut pipe = std::fs::File::open(path)
+        .map_err(|_| "native_parent_liveness_path_unavailable".to_owned())?;
+    std::fs::remove_file(path)
+        .map_err(|_| "native_parent_liveness_path_cleanup_failed".to_owned())?;
     let watcher_state = Arc::clone(&alive);
     thread::spawn(move || {
         let mut byte = [0u8; 1];

--- a/rust/crates/guard-runtime/src/main.rs
+++ b/rust/crates/guard-runtime/src/main.rs
@@ -16,6 +16,7 @@ use std::fmt;
 use std::io::{self, Read, Write};
 use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
 use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{sync_channel, Receiver, SyncSender, TrySendError};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -52,6 +53,7 @@ const MAX_JSON_COLLECTION_ITEMS: usize = 4_096;
 const MAX_JSON_STRING_BYTES: usize = 1024 * 1024;
 const SERVER_PROOF_LABEL: &[u8] = b"hol-guard-resident-server-v1\0";
 const CLIENT_PROOF_LABEL: &[u8] = b"hol-guard-resident-client-v1\0";
+const PARENT_LIVENESS_FD_ENV: &str = "HOL_GUARD_PARENT_LIVENESS_FD";
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "operation", content = "request", rename_all = "snake_case")]
@@ -576,6 +578,29 @@ fn admit_connection(
 }
 
 #[cfg(unix)]
+fn resident_parent_liveness() -> Result<Arc<AtomicBool>, String> {
+    let alive = Arc::new(AtomicBool::new(true));
+    let Ok(raw_descriptor) = env::var(PARENT_LIVENESS_FD_ENV) else {
+        return Ok(alive);
+    };
+    let descriptor = raw_descriptor
+        .parse::<u32>()
+        .map_err(|_| "native_parent_liveness_fd_invalid".to_owned())?;
+    let dev_path = format!("/dev/fd/{descriptor}");
+    let proc_path = format!("/proc/self/fd/{descriptor}");
+    let mut pipe = std::fs::File::open(dev_path)
+        .or_else(|_| std::fs::File::open(proc_path))
+        .map_err(|_| "native_parent_liveness_fd_unavailable".to_owned())?;
+    let watcher_state = Arc::clone(&alive);
+    thread::spawn(move || {
+        let mut byte = [0u8; 1];
+        let _ = pipe.read(&mut byte);
+        watcher_state.store(false, Ordering::Release);
+    });
+    Ok(alive)
+}
+
+#[cfg(unix)]
 fn serve(socket_path: &str) -> Result<(), String> {
     use std::fs;
     use std::os::unix::fs::{FileTypeExt, PermissionsExt};
@@ -607,10 +632,14 @@ fn serve(socket_path: &str) -> Result<(), String> {
     let listener = UnixListener::bind(path).map_err(|_| "native_socket_bind_failed".to_owned())?;
     fs::set_permissions(path, fs::Permissions::from_mode(0o600))
         .map_err(|_| "native_socket_permissions_failed".to_owned())?;
+    listener
+        .set_nonblocking(true)
+        .map_err(|_| "native_socket_nonblocking_failed".to_owned())?;
 
     let token = Arc::new(read_resident_auth_token()?);
     let sender = start_resident_workers(token);
-    loop {
+    let parent_alive = resident_parent_liveness()?;
+    while parent_alive.load(Ordering::Acquire) {
         match listener.accept() {
             Ok((stream, _address)) => admit_connection(&sender, Box::new(stream))?,
             Err(error)
@@ -626,6 +655,7 @@ fn serve(socket_path: &str) -> Result<(), String> {
             Err(_) => return Err("native_socket_accept_failed".to_owned()),
         }
     }
+    Ok(())
 }
 
 #[cfg(not(unix))]

--- a/src/codex_plugin_scanner/guard/codex_hook_launch_runtime.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_launch_runtime.py
@@ -6,6 +6,7 @@ import os
 import signal
 import stat
 import subprocess
+import tempfile
 import threading
 import time
 from collections.abc import Mapping, Sequence
@@ -222,8 +223,8 @@ def run_isolated_hook_process(
     if _HOOK_PROCESS_CONTAINMENT_FAILED.is_set() and not _retry_quarantined_hook_processes():
         return BoundedHookProcessResult(None, "", False, False, containment_failed=True)
     windows_job: WindowsHookJob | None = None
-    liveness_read_fd: int | None = None
-    liveness_write_fd: int | None = None
+    liveness_path: Path | None = None
+    liveness_keeper_fd: int | None = None
     try:
         if os.name == "nt":
             process, windows_job = spawn_windows_hook_process(
@@ -234,12 +235,14 @@ def run_isolated_hook_process(
             )
         else:
             child_environment = dict(environment)
-            pass_fds: tuple[int, ...] = ()
             if parent_liveness:
-                liveness_read_fd, liveness_write_fd = os.pipe()
-                os.set_inheritable(liveness_read_fd, True)
-                child_environment["HOL_GUARD_PARENT_LIVENESS_FD"] = str(liveness_read_fd)
-                pass_fds = (liveness_read_fd,)
+                placeholder_fd, placeholder = tempfile.mkstemp(prefix=".guard-parent-", dir=cwd)
+                os.close(placeholder_fd)
+                liveness_path = Path(placeholder)
+                liveness_path.unlink()
+                os.mkfifo(liveness_path, mode=0o600)
+                liveness_keeper_fd = os.open(liveness_path, os.O_RDWR | os.O_NONBLOCK)
+                child_environment["HOL_GUARD_PARENT_LIVENESS_PATH"] = str(liveness_path)
             process = subprocess.Popen(
                 list(command),
                 cwd=cwd,
@@ -248,15 +251,14 @@ def run_isolated_hook_process(
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 start_new_session=True,
-                pass_fds=pass_fds,
             )
     except OSError:
-        for descriptor in (liveness_read_fd, liveness_write_fd):
-            if descriptor is not None:
-                os.close(descriptor)
+        if liveness_keeper_fd is not None:
+            os.close(liveness_keeper_fd)
+        if liveness_path is not None:
+            with suppress(FileNotFoundError):
+                liveness_path.unlink()
         return BoundedHookProcessResult(None, "", False, False)
-    if liveness_read_fd is not None:
-        os.close(liveness_read_fd)
 
     stdout_bytes = bytearray()
     output_bytes = 0
@@ -342,8 +344,11 @@ def run_isolated_hook_process(
             containment_confirmed = False
     if not containment_confirmed:
         _quarantine_hook_process(process, windows_job, io_threads)
-    if liveness_write_fd is not None:
-        os.close(liveness_write_fd)
+    if liveness_keeper_fd is not None:
+        os.close(liveness_keeper_fd)
+    if liveness_path is not None:
+        with suppress(FileNotFoundError):
+            liveness_path.unlink()
     with output_lock:
         stdout_decoded = stdout_bytes.decode("utf-8", errors="replace")
     return BoundedHookProcessResult(

--- a/src/codex_plugin_scanner/guard/codex_hook_launch_runtime.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_launch_runtime.py
@@ -210,6 +210,7 @@ def run_isolated_hook_process(
     output_limit: int = _HOOK_SUBPROCESS_OUTPUT_LIMIT,
     allow_windows_breakaway: bool = False,
     stop_event: threading.Event | None = None,
+    parent_liveness: bool = False,
 ) -> BoundedHookProcessResult:
     """Run one child with bounded input lifetime and combined output bytes.
 
@@ -221,6 +222,8 @@ def run_isolated_hook_process(
     if _HOOK_PROCESS_CONTAINMENT_FAILED.is_set() and not _retry_quarantined_hook_processes():
         return BoundedHookProcessResult(None, "", False, False, containment_failed=True)
     windows_job: WindowsHookJob | None = None
+    liveness_read_fd: int | None = None
+    liveness_write_fd: int | None = None
     try:
         if os.name == "nt":
             process, windows_job = spawn_windows_hook_process(
@@ -230,17 +233,30 @@ def run_isolated_hook_process(
                 allow_breakaway=allow_windows_breakaway,
             )
         else:
+            child_environment = dict(environment)
+            pass_fds: tuple[int, ...] = ()
+            if parent_liveness:
+                liveness_read_fd, liveness_write_fd = os.pipe()
+                os.set_inheritable(liveness_read_fd, True)
+                child_environment["HOL_GUARD_PARENT_LIVENESS_FD"] = str(liveness_read_fd)
+                pass_fds = (liveness_read_fd,)
             process = subprocess.Popen(
                 list(command),
                 cwd=cwd,
-                env=dict(environment),
+                env=child_environment,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 start_new_session=True,
+                pass_fds=pass_fds,
             )
     except OSError:
+        for descriptor in (liveness_read_fd, liveness_write_fd):
+            if descriptor is not None:
+                os.close(descriptor)
         return BoundedHookProcessResult(None, "", False, False)
+    if liveness_read_fd is not None:
+        os.close(liveness_read_fd)
 
     stdout_bytes = bytearray()
     output_bytes = 0
@@ -326,6 +342,8 @@ def run_isolated_hook_process(
             containment_confirmed = False
     if not containment_confirmed:
         _quarantine_hook_process(process, windows_job, io_threads)
+    if liveness_write_fd is not None:
+        os.close(liveness_write_fd)
     with output_lock:
         stdout_decoded = stdout_bytes.decode("utf-8", errors="replace")
     return BoundedHookProcessResult(

--- a/src/codex_plugin_scanner/guard/codex_hook_launch_runtime.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_launch_runtime.py
@@ -6,7 +6,6 @@ import os
 import signal
 import stat
 import subprocess
-import tempfile
 import threading
 import time
 from collections.abc import Mapping, Sequence
@@ -223,8 +222,8 @@ def run_isolated_hook_process(
     if _HOOK_PROCESS_CONTAINMENT_FAILED.is_set() and not _retry_quarantined_hook_processes():
         return BoundedHookProcessResult(None, "", False, False, containment_failed=True)
     windows_job: WindowsHookJob | None = None
-    liveness_path: Path | None = None
-    liveness_keeper_fd: int | None = None
+    liveness_read_fd: int | None = None
+    liveness_write_fd: int | None = None
     try:
         if os.name == "nt":
             process, windows_job = spawn_windows_hook_process(
@@ -235,14 +234,12 @@ def run_isolated_hook_process(
             )
         else:
             child_environment = dict(environment)
+            pass_fds: tuple[int, ...] = ()
             if parent_liveness:
-                placeholder_fd, placeholder = tempfile.mkstemp(prefix=".guard-parent-", dir=cwd)
-                os.close(placeholder_fd)
-                liveness_path = Path(placeholder)
-                liveness_path.unlink()
-                os.mkfifo(liveness_path, mode=0o600)
-                liveness_keeper_fd = os.open(liveness_path, os.O_RDWR | os.O_NONBLOCK)
-                child_environment["HOL_GUARD_PARENT_LIVENESS_PATH"] = str(liveness_path)
+                liveness_read_fd, liveness_write_fd = os.pipe()
+                os.set_inheritable(liveness_read_fd, True)
+                child_environment["HOL_GUARD_PARENT_LIVENESS_FD"] = str(liveness_read_fd)
+                pass_fds = (liveness_read_fd,)
             process = subprocess.Popen(
                 list(command),
                 cwd=cwd,
@@ -251,14 +248,15 @@ def run_isolated_hook_process(
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 start_new_session=True,
+                pass_fds=pass_fds,
             )
     except OSError:
-        if liveness_keeper_fd is not None:
-            os.close(liveness_keeper_fd)
-        if liveness_path is not None:
-            with suppress(FileNotFoundError):
-                liveness_path.unlink()
+        for descriptor in (liveness_read_fd, liveness_write_fd):
+            if descriptor is not None:
+                os.close(descriptor)
         return BoundedHookProcessResult(None, "", False, False)
+    if liveness_read_fd is not None:
+        os.close(liveness_read_fd)
 
     stdout_bytes = bytearray()
     output_bytes = 0
@@ -344,11 +342,8 @@ def run_isolated_hook_process(
             containment_confirmed = False
     if not containment_confirmed:
         _quarantine_hook_process(process, windows_job, io_threads)
-    if liveness_keeper_fd is not None:
-        os.close(liveness_keeper_fd)
-    if liveness_path is not None:
-        with suppress(FileNotFoundError):
-            liveness_path.unlink()
+    if liveness_write_fd is not None:
+        os.close(liveness_write_fd)
     with output_lock:
         stdout_decoded = stdout_bytes.decode("utf-8", errors="replace")
     return BoundedHookProcessResult(

--- a/src/codex_plugin_scanner/guard/native_runtime_resident.py
+++ b/src/codex_plugin_scanner/guard/native_runtime_resident.py
@@ -215,6 +215,7 @@ class _ResidentService:
             timeout_seconds=_SERVICE_LIFETIME_SECONDS,
             output_limit=_SERVICE_OUTPUT_LIMIT,
             stop_event=stop_event,
+            parent_liveness=True,
         )
         with self._lock:
             current_generation = generation == self._generation

--- a/tests/test_codex_hook_fallback_isolation.py
+++ b/tests/test_codex_hook_fallback_isolation.py
@@ -326,8 +326,8 @@ def test_parent_liveness_stops_child_after_supervisor_is_killed(tmp_path: Path) 
     child = (
         "import os;from pathlib import Path;"
         f"Path({str(child_pid_path)!r}).write_text(str(os.getpid()));"
-        "path=Path(os.environ['HOL_GUARD_PARENT_LIVENESS_PATH']);"
-        "stream=path.open('rb',buffering=0);path.unlink(missing_ok=True);stream.read(1)"
+        "descriptor=int(os.environ['HOL_GUARD_PARENT_LIVENESS_FD']);"
+        "os.fdopen(os.dup(descriptor),'rb',closefd=True).read(1)"
     )
     package_source = Path(launch_runtime.__file__).resolve().parents[2]
     supervisor_code = (

--- a/tests/test_codex_hook_fallback_isolation.py
+++ b/tests/test_codex_hook_fallback_isolation.py
@@ -326,8 +326,8 @@ def test_parent_liveness_stops_child_after_supervisor_is_killed(tmp_path: Path) 
     child = (
         "import os;from pathlib import Path;"
         f"Path({str(child_pid_path)!r}).write_text(str(os.getpid()));"
-        "descriptor=int(os.environ['HOL_GUARD_PARENT_LIVENESS_FD']);"
-        "os.fdopen(os.dup(descriptor),'rb',closefd=True).read(1)"
+        "path=Path(os.environ['HOL_GUARD_PARENT_LIVENESS_PATH']);"
+        "stream=path.open('rb',buffering=0);path.unlink(missing_ok=True);stream.read(1)"
     )
     package_source = Path(launch_runtime.__file__).resolve().parents[2]
     supervisor_code = (

--- a/tests/test_codex_hook_fallback_isolation.py
+++ b/tests/test_codex_hook_fallback_isolation.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import contextlib
 import io
 import json
 import os
+import signal
 import subprocess
 import sys
 import threading
@@ -314,6 +316,61 @@ def test_isolated_process_closes_descendant_held_pipes_after_parent_exit(tmp_pat
     assert result.returncode == 0
     assert elapsed < 1
     assert not marker.exists()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Unix resident runtimes use an inherited liveness pipe")
+def test_parent_liveness_stops_child_after_supervisor_is_killed(tmp_path: Path) -> None:
+    cwd = tmp_path / "neutral"
+    cwd.mkdir(mode=0o700)
+    child_pid_path = tmp_path / "child.pid"
+    child = (
+        "import os;from pathlib import Path;"
+        f"Path({str(child_pid_path)!r}).write_text(str(os.getpid()));"
+        "descriptor=int(os.environ['HOL_GUARD_PARENT_LIVENESS_FD']);"
+        "os.fdopen(os.dup(descriptor),'rb',closefd=True).read(1)"
+    )
+    package_source = Path(launch_runtime.__file__).resolve().parents[2]
+    supervisor_code = (
+        "import sys;from pathlib import Path;"
+        "from codex_plugin_scanner.guard.codex_hook_launch_runtime import "
+        "isolated_hook_environment,run_isolated_hook_process;"
+        f"run_isolated_hook_process([sys.executable,'-I','-c',{child!r}],"
+        f"input_text='',cwd=Path({str(cwd)!r}),environment=isolated_hook_environment(),"
+        "timeout_seconds=60,parent_liveness=True)"
+    )
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = str(package_source)
+    supervisor = subprocess.Popen(
+        [sys.executable, "-c", supervisor_code],
+        cwd=cwd,
+        env=environment,
+    )
+    child_pid: int | None = None
+    try:
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and not child_pid_path.exists():
+            time.sleep(0.02)
+        assert child_pid_path.exists()
+        child_pid = int(child_pid_path.read_text(encoding="utf-8"))
+
+        supervisor.kill()
+        supervisor.wait(timeout=5)
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            try:
+                os.kill(child_pid, 0)
+            except ProcessLookupError:
+                break
+            time.sleep(0.02)
+        else:
+            pytest.fail("child outlived its supervisor liveness pipe")
+    finally:
+        if supervisor.poll() is None:
+            supervisor.kill()
+            supervisor.wait(timeout=5)
+        if child_pid is not None:
+            with contextlib.suppress(ProcessLookupError):
+                os.kill(child_pid, signal.SIGKILL)
 
 
 def test_isolated_process_returns_when_tree_termination_cannot_be_confirmed(


### PR DESCRIPTION
## Summary
- bind the native resident evaluator lifetime to its Python supervisor
- stop orphaned resident processes after abrupt supervisor termination
- cover the parent-death contract with an isolated-process regression
- preserve the release branch's required SPDX license marker

## Testing
- `uv run pytest -q tests/test_codex_hook_fallback_isolation.py`
- `uv run ruff check src/codex_plugin_scanner/guard/codex_hook_launch_runtime.py src/codex_plugin_scanner/guard/native_runtime_resident.py tests/test_codex_hook_fallback_isolation.py`
- `uv run basedpyright src/codex_plugin_scanner/guard/codex_hook_launch_runtime.py src/codex_plugin_scanner/guard/native_runtime_resident.py`
- `cargo clippy -p hol-guard-runtime -- -D warnings`
- `cargo test -p hol-guard-runtime`
- `uv run pytest -q tests/test_guard_docs.py::test_project_metadata_declares_apache_license`
