### PR TITLE
fix(daemon): preserve frozen desktop launch context

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+SPDX-License-Identifier: Apache-2.0
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14744,
-  "maximum_test_source_lines": 319313,
+  "maximum_collected_cases": 14746,
+  "maximum_test_source_lines": 319341,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -186,6 +186,10 @@ def _daemon_launcher_env(
             "PYTHONSAFEPATH": "1",
         }
     )
+    if getattr(sys, "frozen", False) is True:
+        env["PYINSTALLER_RESET_ENVIRONMENT"] = "1"
+        if os.environ.get("HOL_GUARD_DESKTOP") == "1":
+            env["HOL_GUARD_DESKTOP"] = "1"
     if os.name == "nt":
         env["USERPROFILE"] = str(trusted_home)
     if guard_home is not None and not _guard_home_is_ephemeral(guard_home):

--- a/src/codex_plugin_scanner/guard/frozen_daemon_runtime.py
+++ b/src/codex_plugin_scanner/guard/frozen_daemon_runtime.py
@@ -125,10 +125,9 @@ def install_frozen_daemon_runtime() -> None:
     if not bool(getattr(sys, "frozen", False)):
         return
 
-    # A daemon is an independent invocation of the one-file executable. Force
-    # PyInstaller to create a fresh extraction root instead of treating it as a
-    # worker process that reuses the parent's private _MEI runtime directory.
-    os.environ["PYINSTALLER_RESET_ENVIRONMENT"] = "1"
+    # The detached daemon launcher supplies this only for the independent
+    # one-file relaunch. Do not leak it to the daemon's multiprocessing workers.
+    os.environ.pop("PYINSTALLER_RESET_ENVIRONMENT", None)
 
     if _frozen_runtime_installed:
         return

--- a/tests/test_guard_frozen_daemon_runtime.py
+++ b/tests/test_guard_frozen_daemon_runtime.py
@@ -137,16 +137,44 @@ def test_frozen_runtime_fingerprint_binds_exact_executable_bytes(
     assert frozen_daemon_runtime._frozen_runtime_fingerprint() == hashlib.sha256(payload).hexdigest()
 
 
-def test_frozen_runtime_forces_fresh_pyinstaller_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_frozen_runtime_consumes_pyinstaller_reset_environment(monkeypatch: pytest.MonkeyPatch) -> None:
     inventory = manager._guard_daemon_process_inventory_for_guard_home
     monkeypatch.setattr(frozen_daemon_runtime.sys, "frozen", True, raising=False)
     monkeypatch.setattr(frozen_daemon_runtime, "_frozen_runtime_installed", False)
-    monkeypatch.delenv("PYINSTALLER_RESET_ENVIRONMENT", raising=False)
+    monkeypatch.setenv("PYINSTALLER_RESET_ENVIRONMENT", "1")
 
     frozen_daemon_runtime.install_frozen_daemon_runtime()
 
-    assert frozen_daemon_runtime.os.environ["PYINSTALLER_RESET_ENVIRONMENT"] == "1"
+    assert "PYINSTALLER_RESET_ENVIRONMENT" not in frozen_daemon_runtime.os.environ
     monkeypatch.setattr(manager, "_guard_daemon_process_inventory_for_guard_home", inventory)
+
+
+def test_frozen_daemon_launcher_preserves_pyinstaller_reset(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(manager.sys, "frozen", True, raising=False)
+    monkeypatch.setenv("PYINSTALLER_RESET_ENVIRONMENT", "untrusted-parent-value")
+    monkeypatch.setenv("HOL_GUARD_DESKTOP", "1")
+
+    child_env = manager._daemon_launcher_env(home_dir=tmp_path)
+
+    assert child_env["PYINSTALLER_RESET_ENVIRONMENT"] == "1"
+    assert child_env["HOL_GUARD_DESKTOP"] == "1"
+
+
+def test_non_frozen_daemon_launcher_drops_pyinstaller_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(manager.sys, "frozen", False, raising=False)
+    monkeypatch.setenv("PYINSTALLER_RESET_ENVIRONMENT", "1")
+    monkeypatch.setenv("HOL_GUARD_DESKTOP", "1")
+
+    child_env = manager._daemon_launcher_env(home_dir=tmp_path)
+
+    assert "PYINSTALLER_RESET_ENVIRONMENT" not in child_env
+    assert "HOL_GUARD_DESKTOP" not in child_env
 
 
 def test_non_frozen_runtime_does_not_patch_daemon_inventory(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- give detached frozen daemons a fresh PyInstaller runtime
- consume the relaunch marker before multiprocessing workers start
- preserve Desktop-managed update identity across the hardened daemon boundary
- restore the license identifier required by the release metadata contract

## Testing
- `uv run --no-sync pytest -q tests/test_guard_frozen_daemon_runtime.py tests/test_guard_daemon_manager.py tests/test_dashboard_update.py -k 'frozen or pyinstaller or frozen_desktop_status' --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/daemon/manager.py src/codex_plugin_scanner/guard/frozen_daemon_runtime.py tests/test_guard_frozen_daemon_runtime.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/daemon/manager.py src/codex_plugin_scanner/guard/frozen_daemon_runtime.py tests/test_guard_frozen_daemon_runtime.py`
- `uv run --no-sync basedpyright --level error`
- built a one-file Core executable and verified Desktop bootstrap plus live update status
- `uv run --no-sync pytest -q tests/test_guard_docs.py::test_project_metadata_declares_apache_license --tb=short`
