### PR TITLE
fix(ci): satisfy MCP Registry description limit

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -99,6 +99,14 @@ jobs:
             '.version = $version | .packages[0].version = $version' \
             server.json > server.json.tmp
           mv server.json.tmp server.json
+          jq -e '
+            (.description | type) == "string" and
+            (.description | length) >= 1 and
+            (.description | length) <= 100
+          ' server.json >/dev/null || {
+            echo "server.json description must be a non-empty string no longer than 100 characters" >&2
+            exit 1
+          }
           jq -e --arg version "$VERSION" \
             '.name == "io.github.hashgraph-online/hol-guard" and
              .repository.url == "https://github.com/hashgraph-online/hol-guard" and

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.hashgraph-online/hol-guard",
   "title": "HOL Guard",
-  "description": "Local-first security evidence and approval workflows for AI agents, exposed through HOL Guard's stdio MCP server.",
+  "description": "Local-first AI agent security evidence and approval workflows through HOL Guard's stdio MCP server.",
   "websiteUrl": "https://hol.org/guard",
   "repository": {
     "url": "https://github.com/hashgraph-online/hol-guard",


### PR DESCRIPTION
## Summary

- shorten the MCP Registry description from 113 to 99 characters so it satisfies the Registry's 100-character schema limit
- add an explicit pre-publish validation that rejects empty or overlong descriptions before authentication and publication

## Root cause

The `Publish to MCP Registry` workflow reached the publisher successfully, but the Registry returned HTTP 422 because `server.json` used a 113-character `description`; the Registry accepts at most 100 characters.

## Verification

- `server.json` remains valid JSON and retains the canonical server/package metadata
- the new description is 99 characters
- the release workflow now validates the Registry constraint before invoking `mcp-publisher publish`

Signed-off-by: Michael Kantor <6068672+kantorcodes@users.noreply.github.com>