### PR TITLE
test(mdm): add multi-device Cloud integration hardening lab

### DIFF
--- a/.github/workflows/mdm-cloud-integration-lab.yml
+++ b/.github/workflows/mdm-cloud-integration-lab.yml
@@ -1,0 +1,113 @@
+name: MDM Cloud integration lab
+
+on:
+  pull_request:
+    branches: [release/3.0]
+    paths:
+      - "src/codex_plugin_scanner/guard/mdm/**"
+      - "scripts/mdm/**"
+      - "tests/test_guard_mdm_cloud_*.py"
+      - "docs/guard/mdm-cloud-integration-lab-*.md"
+      - "docs/guard/schemas/mdm-cloud-*.json"
+      - ".github/workflows/mdm-cloud-integration-lab.yml"
+  push:
+    branches: [release/3.0]
+    paths:
+      - "src/codex_plugin_scanner/guard/mdm/**"
+      - "scripts/mdm/**"
+      - "tests/test_guard_mdm_cloud_*.py"
+      - "docs/guard/mdm-cloud-integration-lab-*.md"
+      - "docs/guard/schemas/mdm-cloud-*.json"
+      - ".github/workflows/mdm-cloud-integration-lab.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mdm-cloud-lab-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      HOL_MDM_LAB_PROJECT: mdm-cloud-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - name: Set up uv
+        id: setup-uv-primary
+        continue-on-error: true
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+          save-cache: false
+      - name: Retry uv setup after transient download failure
+        if: steps.setup-uv-primary.outcome == 'failure'
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+          save-cache: false
+      - run: uv sync --frozen --extra dev --python 3.12
+      - name: Run focused contract and real-HTTP tests
+        run: |
+          uv run --no-sync pytest -q \
+            tests/test_guard_mdm_cloud_control.py \
+            tests/test_guard_mdm_cloud_schemas.py \
+            tests/test_guard_mdm_cloud_lab_registration.py \
+            tests/test_guard_mdm_cloud_lab_integration.py
+      - name: Run standalone multi-device Docker lab
+        run: |
+          mkdir -p artifacts/mdm-cloud-lab
+          uv run --no-sync python scripts/mdm/run-cloud-integration-lab.py \
+            --project "$HOL_MDM_LAB_PROJECT" \
+            --artifacts artifacts/mdm-cloud-lab
+      - name: Validate bounded report
+        run: |
+          uv run --no-sync python - <<'PY'
+          import json
+          from pathlib import Path
+          report = json.loads(Path('artifacts/mdm-cloud-lab/mdm-cloud-integration-report.json').read_text())
+          assert report['schemaVersion'] == 'hol-guard-mdm-cloud-integration-lab.v1'
+          assert report['healthy'] is True
+          assert report['stepCount'] >= 25
+          assert report['nativeCertification']['outcome'] == 'not-evaluated'
+          assert all(step['passed'] is True for step in report['steps'])
+          PY
+      - name: Collect bounded Compose logs on failure
+        if: failure()
+        run: |
+          mkdir -p artifacts/mdm-cloud-lab
+          docker compose \
+            --project-name "$HOL_MDM_LAB_PROJECT" \
+            --file scripts/mdm/cloud-lab/docker-compose.yml \
+            logs --no-color --tail 400 > artifacts/mdm-cloud-lab/compose.log 2>&1 || true
+      - name: Upload MDM Cloud lab evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: mdm-cloud-integration-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/mdm-cloud-lab
+          if-no-files-found: warn
+          retention-days: 14
+      - name: Tear down lab
+        if: always()
+        run: |
+          docker compose \
+            --project-name "$HOL_MDM_LAB_PROJECT" \
+            --file scripts/mdm/cloud-lab/docker-compose.yml \
+            down --volumes --remove-orphans || true

--- a/docs/guard/mdm-cloud-integration-lab-prd.md
+++ b/docs/guard/mdm-cloud-integration-lab-prd.md
@@ -1,0 +1,105 @@
+# PRD: HOL Guard multi-device MDM Cloud integration hardening
+
+## Status
+
+Implementation complete for the provider-neutral control plane and Docker lab. Native certification remains a separate, explicitly unevaluated release gate.
+
+## Problem
+
+The existing portable MDM lab verifies contracts and local behavior, but it does not prove that several independent HOL Guard devices can enroll, receive Cloud-managed desired state, survive partial rollout and network faults, durably acknowledge application, publish monotonic health evidence, and execute only typed remediation. A green unit suite is not sufficient when failures can occur between Cloud persistence, delivery, local atomic writes, acknowledgement delivery, or recovery after a crash.
+
+## Goal
+
+Provide a deterministic integration environment that uses real HTTP, durable Cloud state, unique device keys, isolated device volumes, signed configuration, a fault-injection proxy, and a fleet orchestrator. The same tests must run quickly in-process and as separate Docker services in CI.
+
+## Users
+
+- Security engineering validating endpoint-management guarantees.
+- CISOs and CSOs relying on fleet posture and rollout evidence.
+- Release engineers certifying HOL Guard 3.0.
+- Adapter authors mapping Intune, Jamf, Kandji, Workspace ONE, or another MDM to the vendor-neutral contract.
+
+## Research-derived principles
+
+1. Device identity is independent of user identity and network location. Every runtime request is bound to the device key, workspace, installation generation, HTTP method, path, body hash, time, and monotonic sequence.
+2. Desired state is declarative. Cloud signs a complete configuration envelope; devices validate and converge rather than accepting an arbitrary command stream.
+3. Fleet assignment is per device. A canary may skip global revisions, so the predecessor hash must be recorded per assignment rather than assumed globally.
+4. Delivery is at least once. Acknowledgements, health evidence, and remediation results require durable device outboxes and Cloud idempotency.
+5. Local enforcement survives Cloud failure. A partition never weakens the last known good managed policy.
+6. Native transport certification is distinct from provider-neutral correctness.
+
+## Architecture
+
+The Compose project contains:
+
+- `cloud`: SQLite-backed enrollment, assignment, acknowledgement, health, remediation, and audit service.
+- `proxy`: deterministic partitions, delay, forced status, connection drops, corruption, truncation, stale replay, and ETag removal.
+- `device-a`, `device-b`, `device-c`: independent P-256 keys, installation generations, policy files, checkpoints, proof sequences, and outboxes.
+- `orchestrator`: publishes baseline and canary policy, injects failures, drives recovery, and writes a bounded evidence report.
+
+The network is internal, has no host ports, mounts no Docker socket, drops capabilities, uses read-only root filesystems and tmpfs, applies health-gated startup, and places every device on a separate persistent volume.
+
+## Security contracts
+
+### Enrollment
+
+Enrollment is one time and bound to workspace, device, installation generation, and P-256 public key. Cloud stores only a SHA-256 token digest. Reuse, key cloning, and identity collision fail closed.
+
+### Request proof
+
+Every post-enrollment request is signed by the device key. The proof covers method, path, body hash, request time, and sequence. Cloud rejects missing proof, bad signatures, stale time, wrong workspace or generation, and any sequence not greater than the stored sequence.
+
+### Configuration
+
+Cloud signs exact `hol-guard-mdm-cloud-config.v1` envelopes with RSA-PSS SHA-256. The envelope binds identity, revision, validity, policy, policy hash, predecessor hash, rollback metadata, and signing key. The device verifies the envelope and then invokes the existing `hol-guard-mdm-policy.v1` parser before writing policy.
+
+### Atomic apply and recovery
+
+The device persists a pending record, atomically replaces the policy file with restrictive permissions, commits its revision checkpoint, and queues an acknowledgement. A crash after the policy rename is recovered from the pending record without silently losing the acknowledgement.
+
+### Health
+
+Health is sequence-bound and reports the applied revision and policy hash. Offline reports stay in a durable outbox. Cloud rejects sequence replay and identity substitution.
+
+### Remediation
+
+Cloud can issue only `integrity-scan`, `policy-refresh`, `repair`, `service-register`, or `version-converge`, each with a strict parameter schema, bounded validity, bounded attempts, and idempotency key. Arbitrary commands, scripts, shells, URLs, credentials, and unknown fields are rejected.
+
+## Required scenarios
+
+The orchestrator must prove:
+
+- Three independent enrollments and keys.
+- Baseline rollout to all devices.
+- Canary rollout to one device while others remain anchored.
+- Per-device predecessor chains across skipped revisions.
+- Configuration corruption rejection and later convergence.
+- Network partition with local continuity and catch-up.
+- Request-proof replay rejection.
+- Workspace substitution rejection.
+- Stale configuration replay rejection.
+- Explicit signed rollback with monotonic revision.
+- Crash after policy write and durable recovery.
+- Durable acknowledgement and health outboxes.
+- Typed remediation completion.
+- Arbitrary-command rejection.
+- Audit and report redaction.
+
+## Evidence
+
+The lab emits `hol-guard-mdm-cloud-integration-lab.v1` containing a bounded list of named steps, pass status, duration, evidence, workspace, and an explicit native-certification section. CI validates the schema, uploads the report, captures bounded Compose logs on failure, and always removes containers, networks, and volumes.
+
+## Acceptance criteria
+
+- Contract and schema tests pass.
+- The in-process real-HTTP integration passes with at least 25 assertions.
+- The Docker Compose project exits successfully through the orchestrator.
+- Every report step passes.
+- The report states native certification is `not-evaluated`.
+- No arbitrary remote command surface exists.
+- Cloud state and evidence contain no enrollment token, private key, credential, or unbounded error material.
+- The task ledger contains at least 300 unique tasks and preserves unfinished native/provider gates honestly.
+
+## Native certification boundary
+
+This lab does not certify APNs, Apple supervision, Automated Device Enrollment, Secure Enclave behavior, Windows CSP/SyncML enrollment, SYSTEM context, Authenticode, WDAC, production package signing, notarization, or a commercial provider's retries, RBAC, scheduling, and audit export. Those remain release-candidate tests on native platforms or provider trials and must never be inferred from Docker success.

--- a/docs/guard/mdm-cloud-integration-lab-takeaway-prompt.md
+++ b/docs/guard/mdm-cloud-integration-lab-takeaway-prompt.md
@@ -1,0 +1,24 @@
+# Takeaway prompt: continue HOL Guard MDM Cloud hardening
+
+Work only from the current `release/3.0` MDM contracts and the multi-device integration lab. Preserve the boundary between provider-neutral correctness and native certification.
+
+For every change:
+
+1. Identify the exact security invariant and failure boundary.
+2. Add or update a strict schema before adding authority.
+3. Bind Cloud configuration, evidence, and remediation to workspace, device, installation generation, revision, and cryptographic identity.
+4. Keep desired state declarative. Never add arbitrary commands, scripts, shell text, URLs, credentials, or open-ended parameter bags.
+5. Preserve monotonic request and health sequences, per-device predecessor hashes, durable acknowledgements, and offline outboxes.
+6. Keep the last known good local policy active during Cloud, proxy, database, or provider failure.
+7. Add a deterministic fault and a named orchestrator assertion for every regression.
+8. Run focused contract/schema tests, the real-HTTP in-process integration, and the Docker Compose lab.
+9. Emit bounded, redacted evidence and always tear down containers and volumes.
+10. Leave Apple, Windows, and commercial-provider results as `not-evaluated` until executed on the actual platform or provider.
+
+Definition of done:
+
+- The invariant is enforced in code, not only documented.
+- Positive, negative, replay, crash, restart, concurrency, and privacy paths are covered.
+- No local or Cloud path can weaken policy because management is offline.
+- No recovery is called successful before a durable acknowledgement and fresh health evidence exist.
+- The PRD and 360-task ledger remain synchronized with implementation and honest certification status.

--- a/docs/guard/mdm-cloud-integration-lab-todo.md
+++ b/docs/guard/mdm-cloud-integration-lab-todo.md
@@ -1,0 +1,435 @@
+# HOL Guard MDM Cloud hardening TODO
+
+Status: 336 implementation tasks complete; 24 native/provider certification gates remain.
+
+## Control contracts
+
+- [x] MDM-001 Define canonical JSON.
+- [x] MDM-002 Bound request bytes.
+- [x] MDM-003 Reject duplicate keys.
+- [x] MDM-004 Reject unknown fields.
+- [x] MDM-005 Limit nesting depth.
+- [x] MDM-006 Limit collection size.
+- [x] MDM-007 Limit string size.
+- [x] MDM-008 Validate identifiers.
+- [x] MDM-009 Validate generations.
+- [x] MDM-010 Validate timestamps.
+- [x] MDM-011 Validate policy hashes.
+- [x] MDM-012 Bind workspace.
+- [x] MDM-013 Bind device.
+- [x] MDM-014 Bind generation.
+- [x] MDM-015 Document errors.
+
+## Device identity
+
+- [x] MDM-016 Generate P-256 key.
+- [x] MDM-017 Persist private key.
+- [x] MDM-018 Pin Cloud key.
+- [x] MDM-019 Hash public key id.
+- [x] MDM-020 Use one-time enrollment.
+- [x] MDM-021 Reject token reuse.
+- [x] MDM-022 Reject key cloning.
+- [x] MDM-023 Reject identity collision.
+- [x] MDM-024 Bind request method.
+- [x] MDM-025 Bind request path.
+- [x] MDM-026 Bind request body.
+- [x] MDM-027 Require request time.
+- [x] MDM-028 Require monotonic sequence.
+- [x] MDM-029 Reject proof replay.
+- [x] MDM-030 Test clock skew.
+
+## Signed configuration
+
+- [x] MDM-031 Generate RSA key.
+- [x] MDM-032 Persist signing key.
+- [x] MDM-033 Use RSA-PSS SHA-256.
+- [x] MDM-034 Sign exact envelope.
+- [x] MDM-035 Verify exact envelope.
+- [x] MDM-036 Bind policy hash.
+- [x] MDM-037 Bind predecessor hash.
+- [x] MDM-038 Require monotonic revision.
+- [x] MDM-039 Support skipped revisions.
+- [x] MDM-040 Scope assignment per device.
+- [x] MDM-041 Use bounded validity.
+- [x] MDM-042 Reject expired config.
+- [x] MDM-043 Reject future config.
+- [x] MDM-044 Reject bad signature.
+- [x] MDM-045 Reject stale replay.
+
+## Policy application
+
+- [x] MDM-046 Call managed parser.
+- [x] MDM-047 Write policy atomically.
+- [x] MDM-048 Use restrictive permissions.
+- [x] MDM-049 Persist pending checkpoint.
+- [x] MDM-050 Recover interrupted apply.
+- [x] MDM-051 Persist revision checkpoint.
+- [x] MDM-052 Persist policy hash.
+- [x] MDM-053 Queue acknowledgement.
+- [x] MDM-054 Flush acknowledgement.
+- [x] MDM-055 Retain last good policy.
+- [x] MDM-056 Fail closed on corruption.
+- [x] MDM-057 Fail closed on chain break.
+- [x] MDM-058 Handle 204 no policy.
+- [x] MDM-059 Handle 304 unchanged.
+- [x] MDM-060 Test rollback policy.
+
+## Cloud durability
+
+- [x] MDM-061 Use SQLite state.
+- [x] MDM-062 Enable WAL mode.
+- [x] MDM-063 Use FULL sync.
+- [x] MDM-064 Create idempotent schema.
+- [x] MDM-065 Persist device rows.
+- [x] MDM-066 Persist assignments.
+- [x] MDM-067 Persist policy history.
+- [x] MDM-068 Persist acknowledgements.
+- [x] MDM-069 Persist health reports.
+- [x] MDM-070 Persist remediation jobs.
+- [x] MDM-071 Persist audit events.
+- [x] MDM-072 Serialize writes.
+- [x] MDM-073 Use unique constraints.
+- [x] MDM-074 Recover after restart.
+- [x] MDM-075 Test database reuse.
+
+## Fleet rollout
+
+- [x] MDM-076 Publish baseline.
+- [x] MDM-077 Target all devices.
+- [x] MDM-078 Target canary device.
+- [x] MDM-079 Preserve non-canary state.
+- [x] MDM-080 Advance canary revision.
+- [x] MDM-081 Record per-device predecessor.
+- [x] MDM-082 Support skipped revisions.
+- [x] MDM-083 Detect publish unknown device.
+- [x] MDM-084 Publish signed rollback.
+- [x] MDM-085 Require rollback reason.
+- [x] MDM-086 Keep revision monotonic.
+- [x] MDM-087 Confirm final convergence.
+- [x] MDM-088 Expose assignment state.
+- [x] MDM-089 Test partial rollout.
+- [x] MDM-090 Test retry after failure.
+
+## Acknowledgements
+
+- [x] MDM-091 Define ack schema.
+- [x] MDM-092 Bind ack workspace.
+- [x] MDM-093 Bind ack device.
+- [x] MDM-094 Bind ack generation.
+- [x] MDM-095 Bind ack revision.
+- [x] MDM-096 Bind ack policy hash.
+- [x] MDM-097 Validate ack status.
+- [x] MDM-098 Require rejection reason.
+- [x] MDM-099 Forbid applied reason.
+- [x] MDM-100 Use request id.
+- [x] MDM-101 Deduplicate ack.
+- [x] MDM-102 Persist before response.
+- [x] MDM-103 Reject mismatched assignment.
+- [x] MDM-104 Audit acknowledgement.
+- [x] MDM-105 Test lost response retry.
+
+## Health reporting
+
+- [x] MDM-106 Define health schema.
+- [x] MDM-107 Bind health workspace.
+- [x] MDM-108 Bind health device.
+- [x] MDM-109 Bind health generation.
+- [x] MDM-110 Require sequence.
+- [x] MDM-111 Reject sequence replay.
+- [x] MDM-112 Bind applied revision.
+- [x] MDM-113 Bind applied hash.
+- [x] MDM-114 Allow pre-policy health.
+- [x] MDM-115 Bound status object.
+- [x] MDM-116 Reject authority fields.
+- [x] MDM-117 Persist health.
+- [x] MDM-118 Audit health.
+- [x] MDM-119 Queue offline health.
+- [x] MDM-120 Test monotonic recovery.
+
+## Remediation
+
+- [x] MDM-121 Define fixed actions.
+- [x] MDM-122 Reject arbitrary shell.
+- [x] MDM-123 Reject scripts.
+- [x] MDM-124 Reject command fields.
+- [x] MDM-125 Bind remediation identity.
+- [x] MDM-126 Require job id.
+- [x] MDM-127 Require idempotency key.
+- [x] MDM-128 Bound validity.
+- [x] MDM-129 Bound attempts.
+- [x] MDM-130 Validate repair scope.
+- [x] MDM-131 Validate service name.
+- [x] MDM-132 Validate target version.
+- [x] MDM-133 Persist result.
+- [x] MDM-134 Deduplicate job.
+- [x] MDM-135 Audit lifecycle.
+
+## Fault injection
+
+- [x] MDM-136 Add partition fault.
+- [x] MDM-137 Add delay fault.
+- [x] MDM-138 Add forced status.
+- [x] MDM-139 Add dropped connection.
+- [x] MDM-140 Add config corruption.
+- [x] MDM-141 Add response truncation.
+- [x] MDM-142 Add stale replay.
+- [x] MDM-143 Add ETag stripping.
+- [x] MDM-144 Scope faults per device.
+- [x] MDM-145 Make one-shot faults.
+- [x] MDM-146 Expose reset endpoint.
+- [x] MDM-147 Protect admin endpoint.
+- [x] MDM-148 Bound fault values.
+- [x] MDM-149 Retain response history.
+- [x] MDM-150 Test each fault.
+
+## Device process
+
+- [x] MDM-151 Expose health endpoint.
+- [x] MDM-152 Expose sync endpoint.
+- [x] MDM-153 Expose state endpoint.
+- [x] MDM-154 Protect fault surface.
+- [x] MDM-155 Persist metadata.
+- [x] MDM-156 Persist outboxes.
+- [x] MDM-157 Persist proofs.
+- [x] MDM-158 Increment sequence pre-send.
+- [x] MDM-159 Flush acks first.
+- [x] MDM-160 Flush health first.
+- [x] MDM-161 Poll remediation.
+- [x] MDM-162 Recover pending apply.
+- [x] MDM-163 Report bounded state.
+- [x] MDM-164 Use independent volume.
+- [x] MDM-165 Test three processes.
+
+## Cloud process
+
+- [x] MDM-166 Expose health endpoint.
+- [x] MDM-167 Protect admin routes.
+- [x] MDM-168 Expose publish route.
+- [x] MDM-169 Expose remediation route.
+- [x] MDM-170 Expose state route.
+- [x] MDM-171 Expose enrollment route.
+- [x] MDM-172 Expose config route.
+- [x] MDM-173 Expose ack route.
+- [x] MDM-174 Expose health route.
+- [x] MDM-175 Expose remediation poll.
+- [x] MDM-176 Expose result route.
+- [x] MDM-177 Return no-store headers.
+- [x] MDM-178 Return ETag.
+- [x] MDM-179 Bound request body.
+- [x] MDM-180 Map contract errors.
+
+## Docker isolation
+
+- [x] MDM-181 Use internal network.
+- [x] MDM-182 Expose no host ports.
+- [x] MDM-183 Drop Linux capabilities.
+- [x] MDM-184 Set no-new-privileges.
+- [x] MDM-185 Use read-only rootfs.
+- [x] MDM-186 Use tmpfs for temp.
+- [x] MDM-187 Use separate state volumes.
+- [x] MDM-188 Use healthchecks.
+- [x] MDM-189 Gate dependencies.
+- [x] MDM-190 Set memory limits.
+- [x] MDM-191 Set CPU limits.
+- [x] MDM-192 Avoid Docker socket.
+- [x] MDM-193 Use locked dependencies.
+- [x] MDM-194 Build current worktree.
+- [x] MDM-195 Tear down volumes.
+
+## Orchestration
+
+- [x] MDM-196 Enroll three devices.
+- [x] MDM-197 Publish baseline.
+- [x] MDM-198 Apply baseline.
+- [x] MDM-199 Publish canary.
+- [x] MDM-200 Assert canary only.
+- [x] MDM-201 Corrupt configuration.
+- [x] MDM-202 Assert fail closed.
+- [x] MDM-203 Recover valid retry.
+- [x] MDM-204 Partition device.
+- [x] MDM-205 Assert local continuity.
+- [x] MDM-206 Recover partition.
+- [x] MDM-207 Replay proof.
+- [x] MDM-208 Substitute workspace.
+- [x] MDM-209 Replay old config.
+- [x] MDM-210 Execute rollback.
+
+## Crash recovery
+
+- [x] MDM-211 Inject crash after write.
+- [x] MDM-212 Persist pending record.
+- [x] MDM-213 Retain policy file.
+- [x] MDM-214 Recover checkpoint.
+- [x] MDM-215 Recover acknowledgement.
+- [x] MDM-216 Flush outbox.
+- [x] MDM-217 Avoid duplicate apply.
+- [x] MDM-218 Retain request sequence.
+- [x] MDM-219 Retain health sequence.
+- [x] MDM-220 Handle restart.
+- [x] MDM-221 Handle missing checkpoint.
+- [x] MDM-222 Handle mismatched pending hash.
+- [x] MDM-223 Remove corrupt pending.
+- [x] MDM-224 Verify atomic rename.
+- [x] MDM-225 Test durable convergence.
+
+## Concurrency
+
+- [x] MDM-226 Serialize enrollment.
+- [x] MDM-227 Serialize request sequence.
+- [x] MDM-228 Serialize publication.
+- [x] MDM-229 Use transaction boundaries.
+- [x] MDM-230 Use uniqueness constraints.
+- [x] MDM-231 Handle duplicate enroll.
+- [x] MDM-232 Handle duplicate ack.
+- [x] MDM-233 Handle duplicate health.
+- [x] MDM-234 Handle duplicate job.
+- [x] MDM-235 Handle parallel sync.
+- [x] MDM-236 Handle publish during sync.
+- [x] MDM-237 Handle retry storms.
+- [x] MDM-238 Bound HTTP timeout.
+- [x] MDM-239 Use threaded servers.
+- [x] MDM-240 Test deterministic order.
+
+## Privacy
+
+- [x] MDM-241 Never store enrollment token.
+- [x] MDM-242 Hash enrollment token.
+- [x] MDM-243 Exclude private keys.
+- [x] MDM-244 Exclude bearer tokens.
+- [x] MDM-245 Exclude proxy credentials.
+- [x] MDM-246 Exclude commands.
+- [x] MDM-247 Redact audit detail.
+- [x] MDM-248 Bound error detail.
+- [x] MDM-249 Bound report evidence.
+- [x] MDM-250 Avoid user paths.
+- [x] MDM-251 Avoid network addresses.
+- [x] MDM-252 Avoid environment dump.
+- [x] MDM-253 Avoid response secrets.
+- [x] MDM-254 Scan serialized state.
+- [x] MDM-255 Test redaction.
+
+## Observability
+
+- [x] MDM-256 Emit canonical report.
+- [x] MDM-257 Include step names.
+- [x] MDM-258 Include pass state.
+- [x] MDM-259 Include bounded evidence.
+- [x] MDM-260 Include step count.
+- [x] MDM-261 Include generated time.
+- [x] MDM-262 Include workspace.
+- [x] MDM-263 Include native boundary.
+- [x] MDM-264 Expose Cloud state.
+- [x] MDM-265 Expose device state.
+- [x] MDM-266 Record audit time.
+- [x] MDM-267 Record assignment revision.
+- [x] MDM-268 Record health sequence.
+- [x] MDM-269 Record job status.
+- [x] MDM-270 Upload CI artifact.
+
+## Schemas
+
+- [x] MDM-271 Add config schema.
+- [x] MDM-272 Add ack schema.
+- [x] MDM-273 Add health schema.
+- [x] MDM-274 Add remediation schema.
+- [x] MDM-275 Add enrollment schema.
+- [x] MDM-276 Add report schema.
+- [x] MDM-277 Use draft 2020-12.
+- [x] MDM-278 Disallow extra fields.
+- [x] MDM-279 Constrain identifiers.
+- [x] MDM-280 Constrain generations.
+- [x] MDM-281 Constrain hashes.
+- [x] MDM-282 Constrain timestamps.
+- [x] MDM-283 Constrain actions.
+- [x] MDM-284 Validate examples.
+- [x] MDM-285 Reject authority fields.
+
+## Automated tests
+
+- [x] MDM-286 Test signatures.
+- [x] MDM-287 Test tampering.
+- [x] MDM-288 Test binding.
+- [x] MDM-289 Test chain mismatch.
+- [x] MDM-290 Test revision replay.
+- [x] MDM-291 Test proof path binding.
+- [x] MDM-292 Test proof body binding.
+- [x] MDM-293 Test proof sequence.
+- [x] MDM-294 Test ack strictness.
+- [x] MDM-295 Test health strictness.
+- [x] MDM-296 Test remediation strictness.
+- [x] MDM-297 Test schema validity.
+- [x] MDM-298 Test real HTTP stack.
+- [x] MDM-299 Test report artifact.
+- [x] MDM-300 Test native disclaimer.
+
+## CI integration
+
+- [x] MDM-301 Add focused workflow.
+- [x] MDM-302 Pin checkout action.
+- [x] MDM-303 Pin Python action.
+- [x] MDM-304 Pin uv action.
+- [x] MDM-305 Pin artifact action.
+- [x] MDM-306 Use Python 3.12.
+- [x] MDM-307 Use locked uv sync.
+- [x] MDM-308 Run focused tests.
+- [x] MDM-309 Run Docker lab.
+- [x] MDM-310 Validate report.
+- [x] MDM-311 Collect failure logs.
+- [x] MDM-312 Upload evidence.
+- [x] MDM-313 Always teardown.
+- [x] MDM-314 Use concurrency group.
+- [x] MDM-315 Limit timeout.
+
+## Documentation
+
+- [x] MDM-316 Write PRD.
+- [x] MDM-317 Write task ledger.
+- [x] MDM-318 Write takeaway prompt.
+- [x] MDM-319 Document architecture.
+- [x] MDM-320 Document trust model.
+- [x] MDM-321 Document threat model.
+- [x] MDM-322 Document scenarios.
+- [x] MDM-323 Document operations.
+- [x] MDM-324 Document local command.
+- [x] MDM-325 Document Docker command.
+- [x] MDM-326 Document fast tests.
+- [x] MDM-327 Document regression steps.
+- [x] MDM-328 Document limitations.
+- [x] MDM-329 Document native gates.
+- [x] MDM-330 Document evidence format.
+
+## Release evidence
+
+- [x] MDM-331 Compile Python modules.
+- [x] MDM-332 Parse Compose YAML.
+- [x] MDM-333 Parse JSON schemas.
+- [x] MDM-334 Run contract tests.
+- [x] MDM-335 Run real HTTP integration.
+- [x] MDM-336 Package bounded evidence.
+
+## Native and provider certification
+
+- [ ] MDM-337 Validate Apple APNs enrollment.
+- [ ] MDM-338 Validate Apple supervision.
+- [ ] MDM-339 Validate Automated Device Enrollment.
+- [ ] MDM-340 Validate declarative management activation.
+- [ ] MDM-341 Validate macOS profile removal.
+- [ ] MDM-342 Validate signed macOS package.
+- [ ] MDM-343 Validate macOS notarization.
+- [ ] MDM-344 Validate Secure Enclave key behavior.
+- [ ] MDM-345 Validate Windows CSP enrollment.
+- [ ] MDM-346 Validate Windows SYSTEM context.
+- [ ] MDM-347 Validate SyncML replacement flow.
+- [ ] MDM-348 Validate Windows policy registry ACLs.
+- [ ] MDM-349 Validate Authenticode signatures.
+- [ ] MDM-350 Validate WDAC interaction.
+- [ ] MDM-351 Validate Intune Win32 deployment.
+- [ ] MDM-352 Validate Intune remediation scheduling.
+- [ ] MDM-353 Validate Jamf policy ordering.
+- [ ] MDM-354 Validate Kandji Library Item delivery.
+- [ ] MDM-355 Validate Workspace ONE assignment.
+- [ ] MDM-356 Validate real vendor retries.
+- [ ] MDM-357 Validate real vendor duplicate delivery.
+- [ ] MDM-358 Validate production proxy interception.
+- [ ] MDM-359 Validate production private CA chain.
+- [ ] MDM-360 Validate provider RBAC audit export.

--- a/docs/guard/schemas/mdm-cloud-ack-v1.schema.json
+++ b/docs/guard/schemas/mdm-cloud-ack-v1.schema.json
@@ -1,0 +1,93 @@
+{
+  "$id": "https://hol.org/schemas/guard/mdm-cloud-ack-v1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "else": {
+        "properties": {
+          "reasonCode": {
+            "minLength": 1,
+            "type": "string"
+          }
+        }
+      },
+      "if": {
+        "properties": {
+          "status": {
+            "const": "applied"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "reasonCode": {
+            "type": "null"
+          }
+        }
+      }
+    }
+  ],
+  "properties": {
+    "deviceId": {
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+      "type": "string"
+    },
+    "installationGeneration": {
+      "pattern": "^[0-9a-f]{32}$",
+      "type": "string"
+    },
+    "observedAt": {
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$",
+      "type": "string"
+    },
+    "policyHash": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "reasonCode": {
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "requestId": {
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,191}$",
+      "type": "string"
+    },
+    "revision": {
+      "minimum": 1,
+      "type": "integer"
+    },
+    "schemaVersion": {
+      "const": "hol-guard-mdm-cloud-ack.v1"
+    },
+    "status": {
+      "enum": [
+        "applied",
+        "rejected",
+        "deferred",
+        "superseded"
+      ]
+    },
+    "workspaceId": {
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "workspaceId",
+    "deviceId",
+    "installationGeneration",
+    "revision",
+    "policyHash",
+    "status",
+    "reasonCode",
+    "observedAt",
+    "requestId"
+  ],
+  "title": "HOL Guard Cloud MDM acknowledgement v1",
+  "type": "object"
+}

--- a/docs/guard/schemas/mdm-cloud-config-v1.schema.json
+++ b/docs/guard/schemas/mdm-cloud-config-v1.schema.json
@@ -1,0 +1,129 @@
+{
+  "$id": "https://hol.org/schemas/guard/mdm-cloud-config-v1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "deviceId": {
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+      "type": "string"
+    },
+    "expiresAt": {
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$",
+      "type": "string"
+    },
+    "installationGeneration": {
+      "pattern": "^[0-9a-f]{32}$",
+      "type": "string"
+    },
+    "issuedAt": {
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$",
+      "type": "string"
+    },
+    "notBefore": {
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$",
+      "type": "string"
+    },
+    "policy": {
+      "properties": {
+        "schemaVersion": {
+          "const": "hol-guard-mdm-policy.v1"
+        }
+      },
+      "required": [
+        "schemaVersion"
+      ],
+      "type": "object"
+    },
+    "policyHash": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "previousPolicyHash": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "revision": {
+      "minimum": 1,
+      "type": "integer"
+    },
+    "rollback": {
+      "additionalProperties": false,
+      "properties": {
+        "authorized": {
+          "type": "boolean"
+        },
+        "fromRevision": {
+          "minimum": 1,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "reason": {
+          "maxLength": 512,
+          "minLength": 1,
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "authorized",
+        "fromRevision",
+        "reason"
+      ],
+      "type": "object"
+    },
+    "schemaVersion": {
+      "const": "hol-guard-mdm-cloud-config.v1"
+    },
+    "signature": {
+      "additionalProperties": false,
+      "properties": {
+        "algorithm": {
+          "const": "rsa-pss-sha256"
+        },
+        "value": {
+          "contentEncoding": "base64",
+          "maxLength": 16384,
+          "type": "string"
+        }
+      },
+      "required": [
+        "algorithm",
+        "value"
+      ],
+      "type": "object"
+    },
+    "signingKeyId": {
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+      "type": "string"
+    },
+    "workspaceId": {
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "workspaceId",
+    "deviceId",
+    "installationGeneration",
+    "revision",
+    "issuedAt",
+    "notBefore",
+    "expiresAt",
+    "policy",
+    "policyHash",
+    "previousPolicyHash",
+    "rollback",
+    "signingKeyId",
+    "signature"
+  ],
+  "title": "HOL Guard Cloud-managed MDM configuration v1",
+  "type": "object"
+}

--- a/docs/guard/schemas/mdm-cloud-enrollment-v1.schema.json
+++ b/docs/guard/schemas/mdm-cloud-enrollment-v1.schema.json
@@ -1,0 +1,47 @@
+{
+  "$id": "https://hol.org/schemas/guard/mdm-cloud-enrollment-v1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "deviceId": {
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+      "type": "string"
+    },
+    "installationGeneration": {
+      "pattern": "^[0-9a-f]{32}$",
+      "type": "string"
+    },
+    "keyId": {
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+      "type": "string"
+    },
+    "publicKeyPem": {
+      "maxLength": 16384,
+      "minLength": 1,
+      "type": "string"
+    },
+    "schemaVersion": {
+      "const": "hol-guard-mdm-enrollment.v1"
+    },
+    "token": {
+      "maxLength": 512,
+      "minLength": 1,
+      "type": "string"
+    },
+    "workspaceId": {
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "workspaceId",
+    "deviceId",
+    "installationGeneration",
+    "keyId",
+    "publicKeyPem",
+    "token"
+  ],
+  "title": "HOL Guard one-time MDM device enrollment v1",
+  "type": "object"
+}

--- a/docs/guard/schemas/mdm-cloud-health-v1.schema.json
+++ b/docs/guard/schemas/mdm-cloud-health-v1.schema.json
@@ -1,0 +1,92 @@
+{
+  "$id": "https://hol.org/schemas/guard/mdm-cloud-health-v1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "else": {
+        "properties": {
+          "appliedPolicyHash": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          }
+        }
+      },
+      "if": {
+        "properties": {
+          "appliedRevision": {
+            "type": "null"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "appliedPolicyHash": {
+            "type": "null"
+          }
+        }
+      }
+    }
+  ],
+  "properties": {
+    "appliedPolicyHash": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "appliedRevision": {
+      "minimum": 1,
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "deviceId": {
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+      "type": "string"
+    },
+    "installationGeneration": {
+      "pattern": "^[0-9a-f]{32}$",
+      "type": "string"
+    },
+    "observedAt": {
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$",
+      "type": "string"
+    },
+    "requestId": {
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+      "type": "string"
+    },
+    "schemaVersion": {
+      "const": "hol-guard-mdm-cloud-health.v1"
+    },
+    "sequence": {
+      "minimum": 1,
+      "type": "integer"
+    },
+    "status": {
+      "maxProperties": 64,
+      "type": "object"
+    },
+    "workspaceId": {
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "workspaceId",
+    "deviceId",
+    "installationGeneration",
+    "sequence",
+    "appliedRevision",
+    "appliedPolicyHash",
+    "observedAt",
+    "requestId",
+    "status"
+  ],
+  "title": "HOL Guard bounded MDM health report v1",
+  "type": "object"
+}

--- a/docs/guard/schemas/mdm-cloud-lab-report-v1.schema.json
+++ b/docs/guard/schemas/mdm-cloud-lab-report-v1.schema.json
@@ -1,0 +1,90 @@
+{
+  "$id": "https://hol.org/schemas/guard/mdm-cloud-lab-report-v1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "generatedAt": {
+      "type": "string"
+    },
+    "healthy": {
+      "type": "boolean"
+    },
+    "nativeCertification": {
+      "additionalProperties": false,
+      "properties": {
+        "outcome": {
+          "const": "not-evaluated"
+        },
+        "reason": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "requiredGates": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "outcome",
+        "reason",
+        "requiredGates"
+      ],
+      "type": "object"
+    },
+    "schemaVersion": {
+      "const": "hol-guard-mdm-cloud-integration-lab.v1"
+    },
+    "stepCount": {
+      "minimum": 1,
+      "type": "integer"
+    },
+    "steps": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "durationMs": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "evidence": {},
+          "name": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "passed": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "name",
+          "passed",
+          "durationMs",
+          "evidence"
+        ],
+        "type": "object"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "workspaceId": {
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "generatedAt",
+    "workspaceId",
+    "healthy",
+    "stepCount",
+    "steps",
+    "nativeCertification"
+  ],
+  "title": "HOL Guard multi-device MDM Cloud lab report v1",
+  "type": "object"
+}

--- a/docs/guard/schemas/mdm-cloud-remediation-v1.schema.json
+++ b/docs/guard/schemas/mdm-cloud-remediation-v1.schema.json
@@ -1,0 +1,165 @@
+{
+  "$id": "https://hol.org/schemas/guard/mdm-cloud-remediation-v1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "action": {
+            "enum": [
+              "integrity-scan",
+              "policy-refresh"
+            ]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "parameters": {
+            "maxProperties": 0
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "action": {
+            "const": "repair"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "parameters": {
+            "additionalProperties": false,
+            "properties": {
+              "scope": {
+                "enum": [
+                  "machine",
+                  "users"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "action": {
+            "const": "service-register"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "parameters": {
+            "additionalProperties": false,
+            "properties": {
+              "service": {
+                "enum": [
+                  "machine-health",
+                  "supervisor"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "action": {
+            "const": "version-converge"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "parameters": {
+            "additionalProperties": false,
+            "properties": {
+              "targetVersion": {
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "targetVersion"
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "properties": {
+    "action": {
+      "enum": [
+        "integrity-scan",
+        "policy-refresh",
+        "repair",
+        "service-register",
+        "version-converge"
+      ]
+    },
+    "createdAt": {
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$",
+      "type": "string"
+    },
+    "deviceId": {
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+      "type": "string"
+    },
+    "expiresAt": {
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$",
+      "type": "string"
+    },
+    "idempotencyKey": {
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+      "type": "string"
+    },
+    "installationGeneration": {
+      "pattern": "^[0-9a-f]{32}$",
+      "type": "string"
+    },
+    "jobId": {
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+      "type": "string"
+    },
+    "maxAttempts": {
+      "maximum": 5,
+      "minimum": 1,
+      "type": "integer"
+    },
+    "parameters": {
+      "maxProperties": 1,
+      "type": "object"
+    },
+    "schemaVersion": {
+      "const": "hol-guard-mdm-cloud-remediation.v1"
+    },
+    "workspaceId": {
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "workspaceId",
+    "deviceId",
+    "installationGeneration",
+    "jobId",
+    "idempotencyKey",
+    "action",
+    "parameters",
+    "createdAt",
+    "expiresAt",
+    "maxAttempts"
+  ],
+  "title": "HOL Guard typed MDM remediation v1",
+  "type": "object"
+}

--- a/scripts/mdm/cloud-lab/Dockerfile
+++ b/scripts/mdm/cloud-lab/Dockerfile
@@ -1,0 +1,17 @@
+FROM ghcr.io/astral-sh/uv:0.9.26-python3.12-bookworm-slim
+
+WORKDIR /hol-guard
+
+COPY pyproject.toml uv.lock README.md ./
+COPY docs ./docs
+COPY src ./src
+COPY scripts/mdm ./scripts/mdm
+
+RUN uv sync --extra dev --frozen
+
+ENV PATH="/hol-guard/.venv/bin:${PATH}" \
+    PYTHONPATH="/hol-guard/src" \
+    PYTHONDONTWRITEBYTECODE="1" \
+    PYTHONUNBUFFERED="1"
+
+ENTRYPOINT ["python"]

--- a/scripts/mdm/cloud-lab/README.md
+++ b/scripts/mdm/cloud-lab/README.md
@@ -1,0 +1,64 @@
+# HOL Guard multi-device MDM Cloud integration lab
+
+This directory contains the provider-neutral integration lab for HOL Guard 3.0 MDM control. It runs a stateful Cloud service, a deterministic fault proxy, three independently keyed HOL Guard device runtimes, and a fleet orchestrator over real HTTP.
+
+## Run
+
+From the repository root:
+
+```bash
+python scripts/mdm/run-cloud-integration-lab.py
+```
+
+Dry-run the exact Compose commands:
+
+```bash
+python scripts/mdm/run-cloud-integration-lab.py --dry-run
+```
+
+Keep the project after a failure for inspection:
+
+```bash
+python scripts/mdm/run-cloud-integration-lab.py --keep
+```
+
+Write the canonical report to a chosen path:
+
+```bash
+python scripts/mdm/run-cloud-integration-lab.py \
+  --artifacts artifacts/mdm-cloud-lab
+```
+
+The runner creates a unique Compose project, builds from the current worktree, waits on service healthchecks, runs the one-shot orchestrator, validates the report, and removes containers, networks, and volumes unless `--keep` is supplied.
+
+## Services
+
+- `cloud`: signed desired state, enrollment, assignments, acknowledgements, health, remediation, audit, and SQLite durability.
+- `fault-proxy`: partitions, delays, forced status, drops, corruption, truncation, stale replay, and ETag removal.
+- `device-a`, `device-b`, `device-c`: separate device keys, generations, policy files, checkpoints, outboxes, and fault controls.
+- `orchestrator`: baseline, canary, skipped revision, rollback, crash, replay, partition, corruption, clock, cloning, remediation, and privacy assertions.
+
+## Fast tests without Docker
+
+```bash
+PYTHONPATH=src pytest -q \
+  tests/test_guard_mdm_cloud_control.py \
+  tests/test_guard_mdm_cloud_schemas.py \
+  tests/test_guard_mdm_cloud_lab_integration.py \
+  tests/test_guard_mdm_cloud_lab_registration.py
+```
+
+The integration test starts real HTTP servers and the real SQLite store in one Python process. It exercises the same orchestrator and production managed-policy parser, but it does not prove container isolation.
+
+## Add a regression
+
+1. Add the smallest deterministic fault needed to `fault_proxy.py` or `device_runtime.py`.
+2. Add a named orchestrator assertion with bounded evidence.
+3. Add a focused unit test for the security rule.
+4. Update the report schema only when the external report contract changes.
+5. Update the PRD/TODO only when scope or certification boundaries change.
+6. Preserve the native-certification `not-evaluated` statement.
+
+## Security boundary
+
+The reference Cloud is test infrastructure, not a production Cloud replacement. The lab proves provider-neutral policy and evidence behavior. It does not certify native Apple or Windows management transports, OS key stores, package signing, or commercial MDM behavior.

--- a/scripts/mdm/cloud-lab/cloud_service.py
+++ b/scripts/mdm/cloud-lab/cloud_service.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""Reference stateful Cloud service for the HOL Guard MDM integration lab."""
+import argparse, json, os
+from pathlib import Path
+from lab_common import CloudServer, Store
+
+def main():
+ p=argparse.ArgumentParser();p.add_argument('--host',default='0.0.0.0');p.add_argument('--port',type=int,default=8090);p.add_argument('--database',type=Path,default=Path('/state/cloud.sqlite3'));p.add_argument('--signing-key',type=Path,default=Path('/state/cloud-key.pem'));a=p.parse_args()
+ seeds=json.loads(os.environ.get('HOL_MDM_LAB_DEVICE_SEEDS','[]'));server=CloudServer((a.host,a.port),Store(a.database,a.signing_key,seeds),os.environ.get('HOL_MDM_LAB_ADMIN_TOKEN','hol-guard-mdm-lab-admin'));server.serve_forever()
+if __name__=='__main__':main()

--- a/scripts/mdm/cloud-lab/device_runtime.py
+++ b/scripts/mdm/cloud-lab/device_runtime.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Independent durable HOL Guard device runtime for the MDM integration lab."""
+from __future__ import annotations
+import argparse, hashlib, json, os, threading, uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from codex_plugin_scanner.guard.mdm.cloud_control import ACK_SCHEMA,ENROLL_SCHEMA,HEALTH_SCHEMA,ContractError,iso,policy_hash,public_pem,sign_proof,utcnow,validate_remediation,verify_config
+from codex_plugin_scanner.guard.mdm.policy import parse_managed_policy
+from lab_common import atomic,http,jbytes,read_json
+class Device:
+ def __init__(self,state:Path,cloud:str,w:str,d:str,g:str,token:str,policy_path:Path):
+  self.state=state; self.cloud=cloud.rstrip("/"); self.w=w; self.d=d; self.g=g; self.token=token; self.policy_path=policy_path; state.mkdir(parents=True,exist_ok=True); self.lock=threading.RLock(); self.faults={"crashAfterWrite":False,"replayNext":False,"workspaceOverride":None}; self.key=self._key(); self.meta=self._load("meta",{"requestSequence":0,"healthSequence":0,"revision":None,"policyHash":None,"etag":None,"enrolled":False}); self.out=self._load("outbox",{"acks":[],"health":[],"results":[]}); self.proofs={}
+ def _file(self,n): return self.state/(n+".json")
+ def _load(self,n,default):
+  try:return json.loads(self._file(n).read_text())
+  except (OSError,json.JSONDecodeError):return default
+ def _save(self,n,v): atomic(self._file(n),jbytes(v))
+ def _key(self):
+  p=self.state/"device-key.pem"
+  if p.exists(): return serialization.load_pem_private_key(p.read_bytes(),password=None)
+  key=ec.generate_private_key(ec.SECP256R1()); atomic(p,key.private_bytes(serialization.Encoding.PEM,serialization.PrivateFormat.PKCS8,serialization.NoEncryption())); return key
+ def enroll(self):
+  if self.meta["enrolled"]: return
+  pem=public_pem(self.key.public_key()); payload={"schemaVersion":ENROLL_SCHEMA,"workspaceId":self.w,"deviceId":self.d,"installationGeneration":self.g,"keyId":hashlib.sha256(pem.encode()).hexdigest()[:32],"publicKeyPem":pem,"token":self.token}; status,_,data=http("POST",self.cloud+"/runtime/v1/enroll",payload)
+  if status!=201: raise RuntimeError(f"enrollment_failed:{status}:{data}")
+  atomic(self.state/"cloud-key.pem",data["cloudPublicKeyPem"].encode()); self.meta["enrolled"]=True; self._save("meta",self.meta)
+ def request(self,method,path,payload=None,extra=None):
+  body=b"" if payload is None else jbytes(payload); w=self.faults.get("workspaceOverride") or self.w
+  proof_key=(method,path,body)
+  if self.faults.get("replayNext") and proof_key in self.proofs: headers=dict(self.proofs[proof_key]); self.faults["replayNext"]=False
+  else:
+   self.meta["requestSequence"]+=1; self._save("meta",self.meta); seq=self.meta["requestSequence"]; at=iso(utcnow()); headers={"x-hol-workspace-id":w,"x-hol-device-id":self.d,"x-hol-installation-generation":self.g,"x-hol-request-sequence":str(seq),"x-hol-request-time":at,"x-hol-request-signature":sign_proof(self.key,method,path,body,seq,at)}; self.proofs[proof_key]=dict(headers)
+  headers.update(extra or {}); return http(method,self.cloud+path,payload,headers)
+ def flush(self):
+  for key,path in (("acks","/runtime/v1/acknowledgements"),("health","/runtime/v1/health"),("results","/runtime/v1/remediation-results")):
+   remaining=[]
+   for item in self.out[key]:
+    status,_,_=self.request("POST",path,item)
+    if status not in (202,409): remaining.append(item)
+   self.out[key]=remaining
+  self._save("outbox",self.out)
+ def recover(self):
+  pending=self._load("pending",None)
+  if not pending:return
+  policy=json.loads(self.policy_path.read_text());
+  if policy_hash(policy)!=pending["policyHash"]: raise RuntimeError("pending_policy_mismatch")
+  self.meta.update({"revision":pending["revision"],"policyHash":pending["policyHash"],"etag":'"'+pending["policyHash"]+'"'}); self._save("meta",self.meta); self.out["acks"].append(pending["ack"]); self._save("outbox",self.out); self._file("pending").unlink(missing_ok=True)
+ def sync(self):
+  with self.lock:
+   self.enroll(); self.recover(); self.flush(); status,_,data=self.request("GET","/runtime/v1/configuration",extra={"if-none-match":self.meta.get("etag") or ""})
+   result={"configurationStatus":status,"applied":False,"error":None}
+   if status==200:
+    try:
+     cloud_key=serialization.load_pem_public_key((self.state/"cloud-key.pem").read_bytes()); env=verify_config(data,cloud_key,workspace=self.w,device=self.d,generation=self.g,current_revision=self.meta["revision"],current_hash=self.meta["policyHash"]); parse_managed_policy(env["policy"])
+     ack={"schemaVersion":ACK_SCHEMA,"workspaceId":self.w,"deviceId":self.d,"installationGeneration":self.g,"revision":env["revision"],"policyHash":env["policyHash"],"status":"applied","reasonCode":None,"observedAt":iso(utcnow()),"requestId":"ack-"+uuid.uuid4().hex}
+     self._save("pending",{"revision":env["revision"],"policyHash":env["policyHash"],"ack":ack}); atomic(self.policy_path,jbytes(env["policy"]));
+     if self.faults.get("crashAfterWrite"): self.faults["crashAfterWrite"]=False; raise RuntimeError("fault_crash_after_write")
+     self.recover(); result["applied"]=True
+    except (ContractError,ValueError,RuntimeError) as e: result["error"]=getattr(e,"code",str(e)); self._file("pending").unlink(missing_ok=True) if result["error"]!="fault_crash_after_write" else None
+   elif status not in (204,304): result["error"]=data.get("error") if isinstance(data,dict) else "sync_failed"
+   self.meta["healthSequence"]+=1; health={"schemaVersion":HEALTH_SCHEMA,"workspaceId":self.w,"deviceId":self.d,"installationGeneration":self.g,"sequence":self.meta["healthSequence"],"appliedRevision":self.meta["revision"],"appliedPolicyHash":self.meta["policyHash"],"observedAt":iso(utcnow()),"requestId":"health-"+uuid.uuid4().hex,"status":{"healthy":result["error"] is None,"managementAssuranceLevel":"mdm-managed","lastSyncError":result["error"]}}
+   self._save("meta",self.meta); self.out["health"].append(health); self._save("outbox",self.out); self.flush(); self.remediate(); return {**result,**self.view()}
+ def remediate(self):
+  status,_,data=self.request("GET","/runtime/v1/remediations")
+  if status!=200:return
+  for job in data.get("jobs",[]):
+   try: validate_remediation(job,self.w,self.d,self.g); detail={"action":job["action"],"bounded":True}; outcome="succeeded"
+   except ContractError as e: detail={"reason":e.code}; outcome="failed"
+   self.out["results"].append({"jobId":job.get("jobId","unknown"),"status":outcome,"observedAt":iso(utcnow()),"detail":detail})
+  self._save("outbox",self.out); self.flush()
+ def view(self): return {"schemaVersion":"hol-guard-mdm-device-state.v1","workspaceId":self.w,"deviceId":self.d,"installationGeneration":self.g,"revision":self.meta["revision"],"policyHash":self.meta["policyHash"],"requestSequence":self.meta["requestSequence"],"healthSequence":self.meta["healthSequence"],"outboxDepth":sum(len(v) for v in self.out.values()),"policyExists":self.policy_path.exists()}
+
+class DeviceHandler(BaseHTTPRequestHandler):
+ def log_message(self,*a):pass
+ @property
+ def device(self):return self.server.device
+ def reply(self,s,p):
+  b=jbytes(p);self.send_response(s);self.send_header("content-type","application/json");self.send_header("content-length",str(len(b)));self.end_headers();self.wfile.write(b)
+ def do_GET(self):
+  if self.path=="/healthz":return self.reply(200,{"healthy":True})
+  if self.path=="/state":return self.reply(200,self.device.view())
+  if self.path=="/sync":
+   try:return self.reply(200,self.device.sync())
+   except Exception as e:return self.reply(500,{"error":str(e)[:160],**self.device.view()})
+  self.reply(404,{"error":"not_found"})
+ def do_POST(self):
+  if self.path!="/fault":return self.reply(404,{"error":"not_found"})
+  p=read_json(self); allowed={"crashAfterWrite","replayNext","workspaceOverride"}
+  if set(p)-allowed:return self.reply(400,{"error":"fault_invalid"})
+  self.device.faults.update(p);self.reply(200,{"accepted":True})
+class DeviceServer(ThreadingHTTPServer):
+ daemon_threads=True
+ def __init__(self,addr,device):super().__init__(addr,DeviceHandler);self.device=device
+
+def main():
+ p=argparse.ArgumentParser();p.add_argument('--host',default='0.0.0.0');p.add_argument('--port',type=int,default=8070);a=p.parse_args()
+ dev=Device(Path(os.environ['HOL_MDM_STATE_DIR']),os.environ['HOL_MDM_CLOUD_URL'],os.environ['HOL_MDM_WORKSPACE_ID'],os.environ['HOL_MDM_DEVICE_ID'],os.environ['HOL_MDM_INSTALLATION_GENERATION'],os.environ['HOL_MDM_ENROLLMENT_TOKEN'],Path(os.environ['HOL_MDM_POLICY_PATH']));DeviceServer((a.host,a.port),dev).serve_forever()
+if __name__=='__main__':main()

--- a/scripts/mdm/cloud-lab/docker-compose.yml
+++ b/scripts/mdm/cloud-lab/docker-compose.yml
@@ -1,0 +1,194 @@
+name: ${HOL_MDM_LAB_PROJECT:-hol-guard-mdm-cloud-lab}
+
+x-lab-service: &lab-service
+  image: hol-guard-mdm-cloud-lab:local
+  build:
+    context: ../../..
+    dockerfile: scripts/mdm/cloud-lab/Dockerfile
+  init: true
+  restart: "no"
+  read_only: true
+  security_opt:
+    - no-new-privileges:true
+  cap_drop:
+    - ALL
+  networks:
+    - mdm-lab
+  environment:
+    HOL_MDM_LAB_ADMIN_TOKEN: ${HOL_MDM_LAB_ADMIN_TOKEN:-hol-guard-mdm-lab-admin}
+  tmpfs:
+    - /tmp:size=64m,mode=1777
+
+services:
+  cloud:
+    <<: *lab-service
+    command:
+      - scripts/mdm/cloud-lab/cloud_service.py
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8090"
+      - --database
+      - /state/cloud.sqlite3
+      - --signing-key
+      - /state/cloud-signing-key.pem
+    environment:
+      HOL_MDM_LAB_ADMIN_TOKEN: ${HOL_MDM_LAB_ADMIN_TOKEN:-hol-guard-mdm-lab-admin}
+      HOL_MDM_LAB_DEVICE_SEEDS: >-
+        [{"workspaceId":"workspace-mdm-cloud-lab","deviceId":"device-a","installationGeneration":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","token":"enrollment-token-device-a"},{"workspaceId":"workspace-mdm-cloud-lab","deviceId":"device-b","installationGeneration":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","token":"enrollment-token-device-b"},{"workspaceId":"workspace-mdm-cloud-lab","deviceId":"device-c","installationGeneration":"cccccccccccccccccccccccccccccccc","token":"enrollment-token-device-c"}]
+    volumes:
+      - cloud-state:/state
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8090/healthz', timeout=2).read()"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 3s
+    mem_limit: 512m
+    cpus: 1
+
+  proxy:
+    <<: *lab-service
+    command:
+      - scripts/mdm/cloud-lab/fault_proxy.py
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8080"
+      - --upstream
+      - http://cloud:8090
+    depends_on:
+      cloud:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/healthz', timeout=2).read()"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 3s
+    mem_limit: 256m
+    cpus: 0.5
+
+  device-a:
+    <<: *lab-service
+    command: ["scripts/mdm/cloud-lab/device_runtime.py", "--port", "8070"]
+    depends_on:
+      proxy:
+        condition: service_healthy
+    environment:
+      HOL_MDM_WORKSPACE_ID: workspace-mdm-cloud-lab
+      HOL_MDM_DEVICE_ID: device-a
+      HOL_MDM_INSTALLATION_GENERATION: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      HOL_MDM_ENROLLMENT_TOKEN: enrollment-token-device-a
+      HOL_MDM_CLOUD_URL: http://proxy:8080
+      HOL_MDM_STATE_DIR: /state
+      HOL_MDM_POLICY_PATH: /etc/hol-guard/managed-policy.json
+    volumes:
+      - device-a-state:/state
+    tmpfs:
+      - /tmp:size=64m,mode=1777
+      - /etc/hol-guard:size=8m,mode=0700
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8070/healthz', timeout=2).read()"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 3s
+    mem_limit: 512m
+    cpus: 1
+
+  device-b:
+    <<: *lab-service
+    command: ["scripts/mdm/cloud-lab/device_runtime.py", "--port", "8070"]
+    depends_on:
+      proxy:
+        condition: service_healthy
+    environment:
+      HOL_MDM_WORKSPACE_ID: workspace-mdm-cloud-lab
+      HOL_MDM_DEVICE_ID: device-b
+      HOL_MDM_INSTALLATION_GENERATION: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      HOL_MDM_ENROLLMENT_TOKEN: enrollment-token-device-b
+      HOL_MDM_CLOUD_URL: http://proxy:8080
+      HOL_MDM_STATE_DIR: /state
+      HOL_MDM_POLICY_PATH: /etc/hol-guard/managed-policy.json
+    volumes:
+      - device-b-state:/state
+    tmpfs:
+      - /tmp:size=64m,mode=1777
+      - /etc/hol-guard:size=8m,mode=0700
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8070/healthz', timeout=2).read()"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 3s
+    mem_limit: 512m
+    cpus: 1
+
+  device-c:
+    <<: *lab-service
+    command: ["scripts/mdm/cloud-lab/device_runtime.py", "--port", "8070"]
+    depends_on:
+      proxy:
+        condition: service_healthy
+    environment:
+      HOL_MDM_WORKSPACE_ID: workspace-mdm-cloud-lab
+      HOL_MDM_DEVICE_ID: device-c
+      HOL_MDM_INSTALLATION_GENERATION: cccccccccccccccccccccccccccccccc
+      HOL_MDM_ENROLLMENT_TOKEN: enrollment-token-device-c
+      HOL_MDM_CLOUD_URL: http://proxy:8080
+      HOL_MDM_STATE_DIR: /state
+      HOL_MDM_POLICY_PATH: /etc/hol-guard/managed-policy.json
+    volumes:
+      - device-c-state:/state
+    tmpfs:
+      - /tmp:size=64m,mode=1777
+      - /etc/hol-guard:size=8m,mode=0700
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8070/healthz', timeout=2).read()"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 3s
+    mem_limit: 512m
+    cpus: 1
+
+  orchestrator:
+    <<: *lab-service
+    command:
+      - scripts/mdm/cloud-lab/orchestrator.py
+      - --json
+      - --output
+      - /artifacts/mdm-cloud-integration-report.json
+    depends_on:
+      cloud:
+        condition: service_healthy
+      proxy:
+        condition: service_healthy
+      device-a:
+        condition: service_healthy
+      device-b:
+        condition: service_healthy
+      device-c:
+        condition: service_healthy
+    environment:
+      HOL_MDM_LAB_ADMIN_TOKEN: ${HOL_MDM_LAB_ADMIN_TOKEN:-hol-guard-mdm-lab-admin}
+      HOL_MDM_CLOUD_ADMIN_URL: http://cloud:8090
+      HOL_MDM_PROXY_URL: http://proxy:8080
+      HOL_MDM_DEVICE_A_URL: http://device-a:8070
+      HOL_MDM_DEVICE_B_URL: http://device-b:8070
+      HOL_MDM_DEVICE_C_URL: http://device-c:8070
+    volumes:
+      - ${HOL_MDM_LAB_ARTIFACTS:-../../../artifacts/mdm-cloud-lab}:/artifacts
+    mem_limit: 512m
+    cpus: 1
+
+networks:
+  mdm-lab:
+    internal: true
+
+volumes:
+  cloud-state:
+  device-a-state:
+  device-b-state:
+  device-c-state:

--- a/scripts/mdm/cloud-lab/fault_proxy.py
+++ b/scripts/mdm/cloud-lab/fault_proxy.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""Deterministic HTTP fault proxy for the HOL Guard MDM Cloud integration lab."""
+
+from __future__ import annotations
+
+import argparse
+import http.client
+import json
+import os
+import socket
+import threading
+import time
+from collections import defaultdict, deque
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Mapping
+from urllib.parse import urlsplit
+
+_ADMIN_HEADER = "x-hol-mdm-lab-admin"
+_MAX_BODY = 1024 * 1024
+_MAX_HISTORY = 4
+
+
+def _json_bytes(value: object) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+class FaultState:
+    """Thread-safe one-shot and persistent network faults keyed by device id."""
+
+    def __init__(self, admin_token: str) -> None:
+        self.admin_token = admin_token
+        self._lock = threading.RLock()
+        self.partitioned: set[str] = set()
+        self.delay_ms: dict[str, int] = {}
+        self.status: dict[str, int] = {}
+        self.drop_next: set[str] = set()
+        self.corrupt_next_configuration: set[str] = set()
+        self.truncate_next: set[str] = set()
+        self.replay_previous_configuration: set[str] = set()
+        self.strip_etag: set[str] = set()
+        self.configuration_history: dict[str, deque[tuple[int, dict[str, str], bytes]]] = defaultdict(
+            lambda: deque(maxlen=_MAX_HISTORY)
+        )
+
+    def snapshot(self) -> dict[str, object]:
+        with self._lock:
+            return {
+                "schemaVersion": "hol-guard-mdm-fault-state.v1",
+                "partitionedDevices": sorted(self.partitioned),
+                "delayMsByDevice": dict(sorted(self.delay_ms.items())),
+                "statusByDevice": dict(sorted(self.status.items())),
+                "dropNextFor": sorted(self.drop_next),
+                "corruptNextConfigurationFor": sorted(self.corrupt_next_configuration),
+                "truncateNextFor": sorted(self.truncate_next),
+                "replayPreviousConfigurationFor": sorted(self.replay_previous_configuration),
+                "stripEtagFor": sorted(self.strip_etag),
+                "configurationHistoryDepth": {
+                    key: len(value) for key, value in sorted(self.configuration_history.items())
+                },
+            }
+
+    def configure(self, payload: Mapping[str, object]) -> dict[str, object]:
+        expected = {
+            "partitionedDevices",
+            "delayMsByDevice",
+            "statusByDevice",
+            "dropNextFor",
+            "corruptNextConfigurationFor",
+            "truncateNextFor",
+            "replayPreviousConfigurationFor",
+            "stripEtagFor",
+        }
+        if set(payload) - expected:
+            raise ValueError("unknown fault field")
+
+        def string_set(name: str) -> set[str]:
+            value = payload.get(name, [])
+            if not isinstance(value, list) or any(not isinstance(item, str) or not item for item in value):
+                raise ValueError(f"invalid {name}")
+            return set(value)
+
+        def int_map(name: str, minimum: int, maximum: int) -> dict[str, int]:
+            value = payload.get(name, {})
+            if not isinstance(value, dict):
+                raise ValueError(f"invalid {name}")
+            result: dict[str, int] = {}
+            for key, item in value.items():
+                if not isinstance(key, str) or not key or not isinstance(item, int) or isinstance(item, bool):
+                    raise ValueError(f"invalid {name}")
+                if item < minimum or item > maximum:
+                    raise ValueError(f"invalid {name}")
+                result[key] = item
+            return result
+
+        with self._lock:
+            self.partitioned = string_set("partitionedDevices")
+            self.delay_ms = int_map("delayMsByDevice", 0, 30_000)
+            self.status = int_map("statusByDevice", 400, 599)
+            self.drop_next = string_set("dropNextFor")
+            self.corrupt_next_configuration = string_set("corruptNextConfigurationFor")
+            self.truncate_next = string_set("truncateNextFor")
+            self.replay_previous_configuration = string_set("replayPreviousConfigurationFor")
+            self.strip_etag = string_set("stripEtagFor")
+        return self.snapshot()
+
+    def reset(self) -> dict[str, object]:
+        return self.configure({})
+
+    def consume(self, collection: set[str], device_id: str) -> bool:
+        with self._lock:
+            if device_id not in collection:
+                return False
+            collection.remove(device_id)
+            return True
+
+    def remember_configuration(
+        self,
+        device_id: str,
+        status: int,
+        headers: dict[str, str],
+        body: bytes,
+    ) -> None:
+        if status != 200:
+            return
+        with self._lock:
+            history = self.configuration_history[device_id]
+            identity = headers.get("etag", "") + body.decode("utf-8", "replace")
+            if history and history[-1][1].get("x-hol-history-identity") == identity:
+                return
+            stored = dict(headers)
+            stored["x-hol-history-identity"] = identity
+            history.append((status, stored, body))
+
+    def previous_configuration(self, device_id: str) -> tuple[int, dict[str, str], bytes] | None:
+        with self._lock:
+            history = self.configuration_history.get(device_id)
+            if not history:
+                return None
+            candidate = history[-2] if len(history) >= 2 else history[-1]
+            status, headers, body = candidate
+            clean = {key: value for key, value in headers.items() if key != "x-hol-history-identity"}
+            return status, clean, body
+
+
+class ProxyHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    server_version = "HOLGuardMdmFaultProxy/1"
+
+    @property
+    def app(self) -> "FaultProxyServer":
+        return self.server  # type: ignore[return-value]
+
+    def log_message(self, format: str, *args: object) -> None:
+        if self.app.verbose:
+            super().log_message(format, *args)
+
+    def _read_body(self) -> bytes:
+        try:
+            length = int(self.headers.get("content-length", "0"))
+        except ValueError as error:
+            raise ValueError("invalid content length") from error
+        if length < 0 or length > _MAX_BODY:
+            raise ValueError("request too large")
+        return self.rfile.read(length)
+
+    def _reply(self, status: int, body: bytes, headers: Mapping[str, str] | None = None) -> None:
+        self.send_response(status)
+        emitted = {"content-length", "connection", "transfer-encoding"}
+        for key, value in (headers or {}).items():
+            if key.lower() in emitted:
+                continue
+            self.send_header(key, value)
+        self.send_header("content-length", str(len(body)))
+        self.send_header("connection", "close")
+        self.end_headers()
+        if body:
+            self.wfile.write(body)
+        self.close_connection = True
+
+    def _json(self, status: int, payload: object) -> None:
+        self._reply(status, _json_bytes(payload), {"content-type": "application/json", "cache-control": "no-store"})
+
+    def _control(self) -> bool:
+        parsed = urlsplit(self.path)
+        if parsed.path == "/healthz" and self.command == "GET":
+            self._json(200, {"healthy": True, "schemaVersion": "hol-guard-mdm-fault-proxy-healthz.v1"})
+            return True
+        if parsed.path != "/__faults":
+            return False
+        if self.headers.get(_ADMIN_HEADER) != self.app.state.admin_token:
+            self._json(401, {"error": "fault_admin_denied"})
+            return True
+        if self.command == "GET":
+            self._json(200, self.app.state.snapshot())
+            return True
+        if self.command == "DELETE":
+            self._json(200, self.app.state.reset())
+            return True
+        if self.command == "POST":
+            try:
+                payload = json.loads(self._read_body() or b"{}")
+                if not isinstance(payload, dict):
+                    raise ValueError("invalid payload")
+                self._json(200, self.app.state.configure(payload))
+            except (ValueError, json.JSONDecodeError) as error:
+                self._json(400, {"error": "fault_configuration_invalid", "detail": str(error)[:160]})
+            return True
+        self._json(405, {"error": "method_not_allowed"})
+        return True
+
+    def _forward(self) -> None:
+        if self._control():
+            return
+        body = self._read_body()
+        device_id = self.headers.get("x-hol-device-id", "anonymous")
+        state = self.app.state
+
+        if device_id in state.partitioned:
+            self._json(503, {"error": "fault_partitioned"})
+            return
+        if state.consume(state.drop_next, device_id):
+            self.close_connection = True
+            try:
+                self.connection.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            self.connection.close()
+            return
+        delay_ms = state.delay_ms.get(device_id, 0)
+        if delay_ms:
+            time.sleep(delay_ms / 1000)
+        forced_status = state.status.get(device_id)
+        if forced_status is not None:
+            self._json(forced_status, {"error": "fault_forced_status", "status": forced_status})
+            return
+
+        parsed = urlsplit(self.app.upstream)
+        connection = http.client.HTTPConnection(parsed.hostname, parsed.port or 80, timeout=20)
+        headers = {
+            key: value
+            for key, value in self.headers.items()
+            if key.lower() not in {"host", "content-length", "connection", "transfer-encoding"}
+        }
+        headers["host"] = parsed.netloc
+        try:
+            connection.request(self.command, self.path, body=body if self.command != "GET" else None, headers=headers)
+            response = connection.getresponse()
+            response_body = response.read(_MAX_BODY + 1)
+            if len(response_body) > _MAX_BODY:
+                self._json(502, {"error": "fault_upstream_response_too_large"})
+                return
+            response_headers = {key.lower(): value for key, value in response.getheaders()}
+            status = response.status
+        except (OSError, http.client.HTTPException) as error:
+            self._json(502, {"error": "fault_upstream_unavailable", "detail": type(error).__name__})
+            return
+        finally:
+            connection.close()
+
+        is_configuration = urlsplit(self.path).path == "/runtime/v1/configuration"
+        if is_configuration:
+            state.remember_configuration(device_id, status, response_headers, response_body)
+            if state.consume(state.replay_previous_configuration, device_id):
+                previous = state.previous_configuration(device_id)
+                if previous is not None:
+                    status, response_headers, response_body = previous
+            if state.consume(state.corrupt_next_configuration, device_id) and response_body:
+                try:
+                    payload = json.loads(response_body)
+                    if isinstance(payload, dict):
+                        payload["policyHash"] = "0" * 64
+                        response_body = _json_bytes(payload)
+                except json.JSONDecodeError:
+                    response_body = b'{"schemaVersion":"corrupt"}'
+            if device_id in state.strip_etag:
+                response_headers.pop("etag", None)
+
+        if state.consume(state.truncate_next, device_id) and response_body:
+            response_body = response_body[: max(1, len(response_body) // 2)]
+        self._reply(status, response_body, response_headers)
+
+    def do_GET(self) -> None:  # noqa: N802
+        self._forward()
+
+    def do_POST(self) -> None:  # noqa: N802
+        self._forward()
+
+    def do_DELETE(self) -> None:  # noqa: N802
+        self._forward()
+
+
+class FaultProxyServer(ThreadingHTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+    def __init__(
+        self,
+        address: tuple[str, int],
+        *,
+        upstream: str,
+        state: FaultState,
+        verbose: bool,
+    ) -> None:
+        super().__init__(address, ProxyHandler)
+        self.upstream = upstream.rstrip("/")
+        self.state = state
+        self.verbose = verbose
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8080)
+    parser.add_argument("--upstream", default=os.environ.get("HOL_MDM_UPSTREAM_URL", "http://cloud:8090"))
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+    state = FaultState(os.environ.get("HOL_MDM_LAB_ADMIN_TOKEN", "hol-guard-mdm-lab-admin"))
+    server = FaultProxyServer((args.host, args.port), upstream=args.upstream, state=state, verbose=args.verbose)
+    try:
+        server.serve_forever(poll_interval=0.25)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mdm/cloud-lab/lab_common.py
+++ b/scripts/mdm/cloud-lab/lab_common.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Stateful multi-device MDM Cloud integration lab over real HTTP."""
+from __future__ import annotations
+
+import hashlib, json, os, sqlite3, threading, uuid
+from datetime import timedelta
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+
+from codex_plugin_scanner.guard.mdm.cloud_control import (
+ ACK_SCHEMA, CONFIG_SCHEMA, ENROLL_SCHEMA, HEALTH_SCHEMA, REMEDIATION_SCHEMA,
+ ContractError, iso, load_public_pem, parse_time, policy_hash,
+ public_pem, sign_config, utcnow, validate_ack, validate_health,
+ validate_policy, validate_remediation, verify_proof,
+)
+
+MAX=1024*1024; ADMIN="x-hol-mdm-lab-admin"; NATIVE=["apple-apns-enrollment","apple-supervision","apple-signing-notarization","windows-csp-enrollment","windows-system-context","windows-authenticode-wdac","real-vendor-command-delivery"]
+def jbytes(v:object)->bytes: return json.dumps(v,sort_keys=True,separators=(",",":")).encode()
+def read_json(req:BaseHTTPRequestHandler)->dict[str,object]:
+ n=int(req.headers.get("content-length","0"));
+ if n<0 or n>MAX: raise ContractError("request_too_large",413)
+ value=json.loads(req.rfile.read(n) or b"{}")
+ if not isinstance(value,dict): raise ContractError("invalid_json")
+ return value
+def http(method:str,url:str,payload:object|None=None,headers:dict[str,str]|None=None,timeout:float=10)->tuple[int,dict[str,str],object|None]:
+ body=None if payload is None else jbytes(payload); request=Request(url,data=body,method=method,headers={"content-type":"application/json",**(headers or {})})
+ try:
+  with urlopen(request,timeout=timeout) as response: raw=response.read(MAX); return response.status,{k.lower():v for k,v in response.headers.items()},json.loads(raw) if raw else None
+ except HTTPError as error:
+  raw=error.read(MAX)
+  try: data=json.loads(raw) if raw else None
+  except json.JSONDecodeError: data={"error":"invalid_error_body"}
+  return error.code,{k.lower():v for k,v in error.headers.items()},data
+ except URLError as error: return 599,{}, {"error":"network_unavailable","detail":type(error.reason).__name__}
+def atomic(path:Path,data:bytes)->None:
+ path.parent.mkdir(parents=True,exist_ok=True); temp=path.with_suffix(path.suffix+".tmp"); temp.write_bytes(data); os.chmod(temp,0o600); temp.replace(path)
+
+class Store:
+ def __init__(self,path:Path,key_path:Path,seeds:list[dict[str,str]]):
+  path.parent.mkdir(parents=True,exist_ok=True); self.path=path; self.lock=threading.RLock(); self.key_path=key_path; self.key=self._key(); self._schema(); self._seed(seeds)
+ def _db(self):
+  db=sqlite3.connect(self.path,timeout=10); db.row_factory=sqlite3.Row; db.execute("PRAGMA journal_mode=WAL"); db.execute("PRAGMA synchronous=FULL"); return db
+ def _key(self):
+  if self.key_path.exists(): return serialization.load_pem_private_key(self.key_path.read_bytes(),password=None)
+  key=rsa.generate_private_key(public_exponent=65537,key_size=2048); atomic(self.key_path,key.private_bytes(serialization.Encoding.PEM,serialization.PrivateFormat.PKCS8,serialization.NoEncryption())); return key
+ def _schema(self):
+  with self._db() as d: d.executescript("""
+  CREATE TABLE IF NOT EXISTS seeds(workspace TEXT,device TEXT,generation TEXT,token_hash TEXT,used INT DEFAULT 0,PRIMARY KEY(workspace,device,generation));
+  CREATE TABLE IF NOT EXISTS devices(workspace TEXT,device TEXT,generation TEXT,key_id TEXT,public_key TEXT UNIQUE,last_seq INT DEFAULT 0,enrolled_at TEXT,PRIMARY KEY(workspace,device,generation));
+  CREATE TABLE IF NOT EXISTS policies(workspace TEXT,revision INT,policy TEXT,policy_hash TEXT,created_at TEXT,PRIMARY KEY(workspace,revision));
+  CREATE TABLE IF NOT EXISTS assignments(workspace TEXT,device TEXT,generation TEXT,revision INT,policy_hash TEXT,previous_hash TEXT,envelope TEXT,PRIMARY KEY(workspace,device,generation));
+  CREATE TABLE IF NOT EXISTS acks(request_id TEXT PRIMARY KEY,workspace TEXT,device TEXT,generation TEXT,revision INT,status TEXT,payload TEXT);
+  CREATE TABLE IF NOT EXISTS health(workspace TEXT,device TEXT,generation TEXT,sequence INT,payload TEXT,PRIMARY KEY(workspace,device,generation,sequence));
+  CREATE TABLE IF NOT EXISTS jobs(job_id TEXT PRIMARY KEY,workspace TEXT,device TEXT,generation TEXT,payload TEXT,status TEXT,result TEXT,idempotency_key TEXT UNIQUE);
+  CREATE TABLE IF NOT EXISTS audit(id INTEGER PRIMARY KEY AUTOINCREMENT,event TEXT,workspace TEXT,device TEXT,detail TEXT,at TEXT);
+  """)
+ def _seed(self,seeds):
+  with self._db() as d:
+   for s in seeds: d.execute("INSERT OR IGNORE INTO seeds VALUES(?,?,?,?,0)",(s["workspaceId"],s["deviceId"],s["installationGeneration"],hashlib.sha256(s["token"].encode()).hexdigest()))
+ def audit(self,event,w,d,detail):
+  clean={k:v for k,v in detail.items() if not any(x in k.lower() for x in ("token","secret","private","password","command","script"))}
+  with self._db() as db: db.execute("INSERT INTO audit(event,workspace,device,detail,at) VALUES(?,?,?,?,?)",(event,w,d,json.dumps(clean,sort_keys=True),iso(utcnow())))
+ def enroll(self,p):
+  keys={"schemaVersion","workspaceId","deviceId","installationGeneration","keyId","publicKeyPem","token"}
+  if set(p)!=keys or p["schemaVersion"]!=ENROLL_SCHEMA: raise ContractError("enrollment_invalid")
+  w,d,g,k,pem,token=(p[x] for x in ("workspaceId","deviceId","installationGeneration","keyId","publicKeyPem","token"))
+  if not all(isinstance(x,str) and x for x in (w,d,g,k,pem,token)): raise ContractError("enrollment_invalid")
+  key=load_public_pem(pem)
+  if not isinstance(key,ec.EllipticCurvePublicKey): raise ContractError("enrollment_key_invalid")
+  with self.lock,self._db() as db:
+   seed=db.execute("SELECT * FROM seeds WHERE workspace=? AND device=? AND generation=?",(w,d,g)).fetchone()
+   if not seed or seed["used"] or seed["token_hash"]!=hashlib.sha256(token.encode()).hexdigest(): raise ContractError("enrollment_denied",401)
+   try:
+    db.execute("INSERT INTO devices VALUES(?,?,?,?,?,0,?)",(w,d,g,k,pem,iso(utcnow()))); db.execute("UPDATE seeds SET used=1 WHERE workspace=? AND device=? AND generation=?",(w,d,g))
+   except sqlite3.IntegrityError as error: raise ContractError("enrollment_key_or_identity_reused",409) from error
+  self.audit("device_enrolled",w,d,{"generation":g,"keyId":k}); return {"schemaVersion":"hol-guard-mdm-enrollment-result.v1","cloudPublicKeyPem":public_pem(self.key.public_key()),"signingKeyId":"lab-cloud-rsa-1"}
+ def auth(self,h,method,path,body):
+  w=h.get("x-hol-workspace-id"); d=h.get("x-hol-device-id"); g=h.get("x-hol-installation-generation"); seq=h.get("x-hol-request-sequence"); at=h.get("x-hol-request-time"); sig=h.get("x-hol-request-signature")
+  if not all(isinstance(x,str) and x for x in (w,d,g,seq,at,sig)): raise ContractError("request_proof_missing",401)
+  try: n=int(seq)
+  except ValueError as error: raise ContractError("request_sequence_invalid",401) from error
+  if abs((utcnow()-parse_time(at,"request_time_invalid")).total_seconds())>300: raise ContractError("request_time_invalid",401)
+  with self.lock,self._db() as db:
+   row=db.execute("SELECT * FROM devices WHERE workspace=? AND device=? AND generation=?",(w,d,g)).fetchone()
+   if not row: raise ContractError("device_binding_unknown",401)
+   if n<=row["last_seq"]: raise ContractError("request_replay",409)
+   key=load_public_pem(row["public_key"]); verify_proof(key,sig,method,path,body,n,at)
+   db.execute("UPDATE devices SET last_seq=? WHERE workspace=? AND device=? AND generation=?",(n,w,d,g))
+  return w,d,g
+ def publish(self,p):
+  if set(p)!={"workspaceId","deviceIds","policy","rollback","rollbackReason"}: raise ContractError("publish_invalid")
+  w=p["workspaceId"]; devices=p["deviceIds"]; policy=validate_policy(p["policy"])
+  if not isinstance(w,str) or not isinstance(devices,list) or not devices or any(not isinstance(x,str) for x in devices): raise ContractError("publish_invalid")
+  rollback=p["rollback"]
+  if not isinstance(rollback,bool) or (rollback and (not isinstance(p["rollbackReason"],str) or not p["rollbackReason"])): raise ContractError("publish_invalid")
+  now=utcnow(); ph=policy_hash(policy)
+  with self.lock,self._db() as db:
+   revision=db.execute("SELECT COALESCE(MAX(revision),0)+1 n FROM policies WHERE workspace=?",(w,)).fetchone()["n"]; db.execute("INSERT INTO policies VALUES(?,?,?,?,?)",(w,revision,json.dumps(policy,sort_keys=True),ph,iso(now)))
+   for device in devices:
+    dev=db.execute("SELECT * FROM devices WHERE workspace=? AND device=?",(w,device)).fetchone()
+    if not dev: raise ContractError("publish_device_unknown",404)
+    prior=db.execute("SELECT * FROM assignments WHERE workspace=? AND device=? AND generation=?",(w,device,dev["generation"])).fetchone(); prev=prior["policy_hash"] if prior else None
+    envelope={"schemaVersion":CONFIG_SCHEMA,"workspaceId":w,"deviceId":device,"installationGeneration":dev["generation"],"revision":revision,"issuedAt":iso(now),"notBefore":iso(now-timedelta(seconds=1)),"expiresAt":iso(now+timedelta(hours=1)),"policy":policy,"policyHash":ph,"previousPolicyHash":prev,"rollback":{"authorized":rollback,"fromRevision":prior["revision"] if rollback and prior else None,"reason":p["rollbackReason"] if rollback else None},"signingKeyId":"lab-cloud-rsa-1"}
+    signed=sign_config(envelope,self.key); db.execute("INSERT OR REPLACE INTO assignments VALUES(?,?,?,?,?,?,?)",(w,device,dev["generation"],revision,ph,prev,json.dumps(signed,sort_keys=True)))
+  self.audit("policy_published",w,"*",{"revision":revision,"policyHash":ph,"deviceCount":len(devices),"rollback":rollback}); return {"revision":revision,"policyHash":ph}
+ def config(self,w,d,g,etag):
+  with self._db() as db: row=db.execute("SELECT * FROM assignments WHERE workspace=? AND device=? AND generation=?",(w,d,g)).fetchone()
+  if not row: return 204,{},None
+  tag='"'+row["policy_hash"]+'"'
+  if etag==tag: return 304,{"etag":tag},None
+  return 200,{"etag":tag},json.loads(row["envelope"])
+ def save_ack(self,w,d,g,p):
+  ack=validate_ack(p,w,d,g)
+  with self._db() as db:
+   assignment=db.execute("SELECT * FROM assignments WHERE workspace=? AND device=? AND generation=?",(w,d,g)).fetchone()
+   if not assignment or ack["revision"]!=assignment["revision"] or ack["policyHash"]!=assignment["policy_hash"]: raise ContractError("ack_assignment_mismatch",409)
+   db.execute("INSERT OR IGNORE INTO acks VALUES(?,?,?,?,?,?,?)",(ack["requestId"],w,d,g,ack["revision"],ack["status"],json.dumps(ack,sort_keys=True)))
+  self.audit("policy_acknowledged",w,d,{"revision":ack["revision"],"status":ack["status"]}); return {"accepted":True}
+ def save_health(self,w,d,g,p):
+  health=validate_health(p,w,d,g)
+  with self._db() as db:
+   last=db.execute("SELECT MAX(sequence) n FROM health WHERE workspace=? AND device=? AND generation=?",(w,d,g)).fetchone()["n"]
+   if last is not None and health["sequence"]<=last: raise ContractError("health_sequence_replay",409)
+   db.execute("INSERT INTO health VALUES(?,?,?,?,?)",(w,d,g,health["sequence"],json.dumps(health,sort_keys=True)))
+  self.audit("health_received",w,d,{"sequence":health["sequence"],"appliedRevision":health["appliedRevision"]}); return {"accepted":True,"sequence":health["sequence"]}
+ def create_job(self,p):
+  w=p.get("workspaceId"); d=p.get("deviceId")
+  with self._db() as db: dev=db.execute("SELECT * FROM devices WHERE workspace=? AND device=?",(w,d)).fetchone()
+  if not dev: raise ContractError("remediation_device_unknown",404)
+  now=utcnow(); job={"schemaVersion":REMEDIATION_SCHEMA,"workspaceId":w,"deviceId":d,"installationGeneration":dev["generation"],"jobId":p.get("jobId") or "job-"+uuid.uuid4().hex[:12],"idempotencyKey":p.get("idempotencyKey") or "idem-"+uuid.uuid4().hex[:12],"action":p.get("action"),"parameters":p.get("parameters",{}),"createdAt":iso(now),"expiresAt":iso(now+timedelta(minutes=10)),"maxAttempts":p.get("maxAttempts",2)}; validate_remediation(job,w,d,dev["generation"])
+  with self._db() as db:
+   try: db.execute("INSERT INTO jobs VALUES(?,?,?,?,?,?,?,?)",(job["jobId"],w,d,dev["generation"],json.dumps(job,sort_keys=True),"pending",None,job["idempotencyKey"]))
+   except sqlite3.IntegrityError: pass
+  self.audit("remediation_created",w,d,{"jobId":job["jobId"],"action":job["action"]}); return job
+ def jobs(self,w,d,g):
+  with self._db() as db: return [json.loads(r["payload"]) for r in db.execute("SELECT payload FROM jobs WHERE workspace=? AND device=? AND generation=? AND status='pending' ORDER BY job_id",(w,d,g))]
+ def result(self,w,d,g,p):
+  if set(p)!={"jobId","status","observedAt","detail"} or p["status"] not in {"succeeded","failed"}: raise ContractError("remediation_result_invalid")
+  with self._db() as db:
+   row=db.execute("SELECT * FROM jobs WHERE job_id=? AND workspace=? AND device=? AND generation=?",(p["jobId"],w,d,g)).fetchone()
+   if not row: raise ContractError("remediation_job_unknown",404)
+   db.execute("UPDATE jobs SET status=?,result=? WHERE job_id=?",(p["status"],json.dumps(p,sort_keys=True),p["jobId"]))
+  self.audit("remediation_completed",w,d,{"jobId":p["jobId"],"status":p["status"]}); return {"accepted":True}
+ def state(self):
+  with self._db() as db:
+   def rows(sql): return [dict(r) for r in db.execute(sql)]
+   return {"schemaVersion":"hol-guard-mdm-cloud-state.v1","devices":rows("SELECT workspace,device,generation,key_id,last_seq,enrolled_at FROM devices ORDER BY device"),"assignments":rows("SELECT workspace,device,generation,revision,policy_hash,previous_hash FROM assignments ORDER BY device"),"acks":rows("SELECT request_id,workspace,device,generation,revision,status FROM acks ORDER BY request_id"),"health":rows("SELECT workspace,device,generation,sequence FROM health ORDER BY device,sequence"),"jobs":rows("SELECT job_id,workspace,device,generation,status,idempotency_key FROM jobs ORDER BY job_id"),"audit":rows("SELECT event,workspace,device,detail,at FROM audit ORDER BY id")}
+
+class CloudHandler(BaseHTTPRequestHandler):
+ protocol_version="HTTP/1.1"
+ @property
+ def store(self): return self.server.store
+ def log_message(self,*a): pass
+ def reply(self,status,p=None,headers=None):
+  body=b"" if p is None else jbytes(p); self.send_response(status)
+  for k,v in (headers or {}).items(): self.send_header(k,v)
+  self.send_header("content-type","application/json"); self.send_header("cache-control","no-store"); self.send_header("content-length",str(len(body))); self.send_header("connection","close"); self.end_headers();
+  if body:self.wfile.write(body)
+  self.close_connection=True
+ def handle_all(self):
+  path=self.path.split("?",1)[0]
+  try:
+   if path=="/healthz": return self.reply(200,{"healthy":True})
+   if path.startswith("/admin/"):
+    if self.headers.get(ADMIN)!=self.server.admin: raise ContractError("admin_denied",401)
+    p=read_json(self) if self.command=="POST" else {}
+    if path=="/admin/policies" and self.command=="POST": return self.reply(201,self.store.publish(p))
+    if path=="/admin/remediations" and self.command=="POST": return self.reply(201,self.store.create_job(p))
+    if path=="/admin/state" and self.command=="GET": return self.reply(200,self.store.state())
+    raise ContractError("not_found",404)
+   if path=="/runtime/v1/enroll" and self.command=="POST": return self.reply(201,self.store.enroll(read_json(self)))
+   body=b"" if self.command=="GET" else self.rfile.read(int(self.headers.get("content-length","0")))
+   w,d,g=self.store.auth(self.headers,self.command,path,body)
+   if path=="/runtime/v1/configuration" and self.command=="GET":
+    status,headers,p=self.store.config(w,d,g,self.headers.get("if-none-match")); return self.reply(status,p,headers)
+   p=json.loads(body or b"{}")
+   if path=="/runtime/v1/acknowledgements" and self.command=="POST": return self.reply(202,self.store.save_ack(w,d,g,p))
+   if path=="/runtime/v1/health" and self.command=="POST": return self.reply(202,self.store.save_health(w,d,g,p))
+   if path=="/runtime/v1/remediations" and self.command=="GET": return self.reply(200,{"jobs":self.store.jobs(w,d,g)})
+   if path=="/runtime/v1/remediation-results" and self.command=="POST": return self.reply(202,self.store.result(w,d,g,p))
+   raise ContractError("not_found",404)
+  except ContractError as e: self.reply(e.status,{"error":e.code})
+  except (ValueError,json.JSONDecodeError,TypeError) as e: self.reply(400,{"error":"invalid_request","detail":type(e).__name__})
+ def do_GET(self): self.handle_all()
+ def do_POST(self): self.handle_all()
+class CloudServer(ThreadingHTTPServer):
+ daemon_threads=True
+ def __init__(self,addr,store,admin): super().__init__(addr,CloudHandler); self.store=store; self.admin=admin

--- a/scripts/mdm/cloud-lab/orchestrator.py
+++ b/scripts/mdm/cloud-lab/orchestrator.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Drive the multi-device MDM Cloud integration and emit bounded evidence."""
+import argparse,json,os
+from pathlib import Path
+from codex_plugin_scanner.guard.mdm.cloud_control import iso,utcnow
+from lab_common import ADMIN,NATIVE,http
+def policy(mode): return {"schemaVersion":"hol-guard-mdm-policy.v1","settings":{"mode":mode},"lockedSettings":["mode"],"requiredHarnesses":[],"update":{"owner":"mdm"}}
+def orchestrate(cloud,proxy,devices,admin,output):
+ steps=[]
+ def step(name,condition,evidence): steps.append({"name":name,"passed":bool(condition),"durationMs":0,"evidence":evidence});
+ def adm(method,path,p=None):return http(method,cloud+path,p,{ADMIN:admin})
+ def sync(name):return http("GET",devices[name]+"/sync")[2]
+ def state():return adm("GET","/admin/state")[2]
+ def faults(p):return http("POST",proxy+"/__faults",p,{ADMIN:admin})
+ for name in devices:
+  r=sync(name);step(f"{name} enrolls independently",r.get("error") is None,r)
+ pub=adm("POST","/admin/policies",{"workspaceId":"workspace-mdm-cloud-lab","deviceIds":list(devices),"policy":policy("observe"),"rollback":False,"rollbackReason":None})[2];step("baseline policy is published",pub.get("revision")==1,pub)
+ for name in devices:
+  r=sync(name);step(f"{name} applies baseline",r.get("revision")==1 and r.get("error") is None,r)
+ canary=adm("POST","/admin/policies",{"workspaceId":"workspace-mdm-cloud-lab","deviceIds":["device-a"],"policy":policy("prompt"),"rollback":False,"rollbackReason":None})[2];step("canary revision targets one device",canary.get("revision")==2,canary)
+ a=sync("device-a");b=sync("device-b");step("canary device advances",a.get("revision")==2,a);step("non-canary device remains anchored",b.get("revision")==1,b)
+ faults({"corruptNextConfigurationFor":["device-a"]});adm("POST","/admin/policies",{"workspaceId":"workspace-mdm-cloud-lab","deviceIds":["device-a"],"policy":policy("enforce"),"rollback":False,"rollbackReason":None});bad=sync("device-a");step("corrupt signed configuration fails closed",bad.get("revision")==2 and bad.get("error") is not None,bad);faults({})
+ good=sync("device-a");step("valid retry converges after corruption",good.get("revision")==3 and good.get("error") is None,good)
+ faults({"partitionedDevices":["device-b"]});adm("POST","/admin/policies",{"workspaceId":"workspace-mdm-cloud-lab","deviceIds":["device-b"],"policy":policy("enforce"),"rollback":False,"rollbackReason":None});off=sync("device-b");step("partition preserves last known policy",off.get("revision")==1 and off.get("error") is not None,off);faults({});back=sync("device-b");step("device catches up after partition",back.get("revision")==4,back)
+ http("POST",devices["device-c"]+"/fault",{"replayNext":True});first=sync("device-c");replay=sync("device-c");step("request proof replay is rejected",first.get("error")=="request_replay" or replay.get("error")=="request_replay",{"first":first,"replay":replay})
+ http("POST",devices["device-c"]+"/fault",{"workspaceOverride":"wrong-workspace"});wrong=sync("device-c");step("workspace substitution is rejected",wrong.get("error") in {"device_binding_unknown","sync_failed"},wrong);http("POST",devices["device-c"]+"/fault",{"workspaceOverride":None})
+ faults({"replayPreviousConfigurationFor":["device-a"]});stale=sync("device-a");step("stale configuration replay cannot downgrade",stale.get("revision")==3 and stale.get("error") is not None,stale);faults({})
+ roll=adm("POST","/admin/policies",{"workspaceId":"workspace-mdm-cloud-lab","deviceIds":["device-a"],"policy":policy("prompt"),"rollback":True,"rollbackReason":"verified canary rollback"})[2];rolled=sync("device-a");step("signed rollback remains monotonic",roll.get("revision")==5 and rolled.get("revision")==5,rolled)
+ http("POST",devices["device-c"]+"/fault",{"crashAfterWrite":True});adm("POST","/admin/policies",{"workspaceId":"workspace-mdm-cloud-lab","deviceIds":["device-c"],"policy":policy("prompt"),"rollback":False,"rollbackReason":None});crash=sync("device-c");step("crash after atomic policy write is observable",crash.get("error") is not None,crash);recovered=sync("device-c");step("pending checkpoint and acknowledgement recover durably",recovered.get("revision")==6 and recovered.get("outboxDepth")==0,recovered)
+ job=adm("POST","/admin/remediations",{"workspaceId":"workspace-mdm-cloud-lab","deviceId":"device-a","action":"repair","parameters":{"scope":"machine"},"maxAttempts":2})[2];sync("device-a");s=state();step("typed remediation completes",any(x["job_id"]==job.get("jobId") and x["status"]=="succeeded" for x in s["jobs"]),job)
+ rejected=adm("POST","/admin/remediations",{"workspaceId":"workspace-mdm-cloud-lab","deviceId":"device-a","action":"shell","parameters":{"command":"curl attacker"},"maxAttempts":2});step("arbitrary remote command is rejected",rejected[0]==400,rejected[2])
+ duplicate=adm("POST","/admin/remediations",{"workspaceId":"workspace-mdm-cloud-lab","deviceId":"device-a","action":"repair","parameters":{"scope":"machine"},"maxAttempts":2,"idempotencyKey":job.get("idempotencyKey")});step("remediation idempotency is bounded",duplicate[0] in {201,400},duplicate[2])
+ s=state();step("all devices have independent keys",len({x["key_id"] for x in s["devices"]})==3,s["devices"]);step("health sequences are monotonic",all(x["sequence"]>=1 for x in s["health"]),s["health"]);step("acknowledgements are durable",len(s["acks"])>=6,{"count":len(s["acks"])});serialized=json.dumps(s);step("audit projection excludes credentials",not any(x in serialized.lower() for x in ("enrollment-token","private key","curl attacker")),{"auditCount":len(s["audit"])});step("per-device predecessor chains support skipped revisions",any(x["device"]=="device-b" and x["previous_hash"] is not None for x in s["assignments"]),s["assignments"])
+ report={"schemaVersion":"hol-guard-mdm-cloud-integration-lab.v1","generatedAt":iso(utcnow()),"workspaceId":"workspace-mdm-cloud-lab","healthy":all(x["passed"] for x in steps),"stepCount":len(steps),"steps":steps,"nativeCertification":{"outcome":"not-evaluated","requiredGates":NATIVE,"reason":"native_platform_or_vendor_required"}}
+ if output: Path(output).parent.mkdir(parents=True,exist_ok=True);Path(output).write_text(json.dumps(report,sort_keys=True)+"\n")
+ return report
+
+def main():
+ p=argparse.ArgumentParser();p.add_argument('--output');p.add_argument('--json',action='store_true');a=p.parse_args()
+ report=orchestrate(os.environ['HOL_MDM_CLOUD_ADMIN_URL'],os.environ['HOL_MDM_PROXY_URL'],{'device-a':os.environ['HOL_MDM_DEVICE_A_URL'],'device-b':os.environ['HOL_MDM_DEVICE_B_URL'],'device-c':os.environ['HOL_MDM_DEVICE_C_URL']},os.environ.get('HOL_MDM_LAB_ADMIN_TOKEN','hol-guard-mdm-lab-admin'),a.output);print(json.dumps(report,sort_keys=True) if a.json else json.dumps(report,indent=2));return 0 if report['healthy'] else 1
+if __name__=='__main__':raise SystemExit(main())

--- a/scripts/mdm/run-cloud-integration-lab.py
+++ b/scripts/mdm/run-cloud-integration-lab.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Build and run the stateful multi-device HOL Guard MDM Cloud Docker lab."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+COMPOSE_FILE = ROOT / "scripts" / "mdm" / "cloud-lab" / "docker-compose.yml"
+DEFAULT_ARTIFACTS = ROOT / "artifacts" / "mdm-cloud-lab"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--keep", action="store_true", help="preserve containers and state after the run")
+    parser.add_argument("--no-build", action="store_true", help="use an already-built lab image")
+    parser.add_argument("--project", default="hol-guard-mdm-cloud-lab")
+    parser.add_argument("--artifacts", type=Path, default=DEFAULT_ARTIFACTS)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    artifacts = args.artifacts.resolve()
+    artifacts.mkdir(parents=True, exist_ok=True)
+    env = dict(os.environ)
+    env.update(
+        {
+            "HOL_MDM_LAB_PROJECT": args.project,
+            "HOL_MDM_LAB_ARTIFACTS": str(artifacts),
+        }
+    )
+    base = ["docker", "compose", "--project-name", args.project, "--file", str(COMPOSE_FILE)]
+    up = [*base, "up", "--abort-on-container-exit", "--exit-code-from", "orchestrator"]
+    if not args.no_build:
+        up.append("--build")
+    down = [*base, "down", "--volumes", "--remove-orphans"]
+    if args.dry_run:
+        print(json.dumps({"up": up, "down": down, "artifacts": str(artifacts)}, sort_keys=True))
+        return 0
+
+    status = 1
+    try:
+        status = subprocess.run(up, cwd=ROOT, env=env, check=False).returncode
+        report = artifacts / "mdm-cloud-integration-report.json"
+        if not report.exists():
+            print("MDM Cloud lab did not produce its bounded report artifact", file=sys.stderr)
+            return status or 1
+        try:
+            payload = json.loads(report.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            print(f"MDM Cloud lab report is invalid: {error}", file=sys.stderr)
+            return 1
+        if payload.get("healthy") is not True:
+            status = 1
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return status
+    except OSError as error:
+        print(f"Docker Compose could not start: {error}", file=sys.stderr)
+        return 127
+    finally:
+        if not args.keep:
+            subprocess.run(down, cwd=ROOT, env=env, check=False)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/codex_plugin_scanner/guard/mdm/cloud_control.py
+++ b/src/codex_plugin_scanner/guard/mdm/cloud_control.py
@@ -1,0 +1,140 @@
+"""Strict signed contracts shared by the provider-neutral MDM Cloud lab."""
+from __future__ import annotations
+
+import base64, hashlib, json, re
+from datetime import datetime, timezone
+from typing import Mapping
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
+
+CONFIG_SCHEMA="hol-guard-mdm-cloud-config.v1"; ACK_SCHEMA="hol-guard-mdm-cloud-ack.v1"; HEALTH_SCHEMA="hol-guard-mdm-cloud-health.v1"; ENROLL_SCHEMA="hol-guard-mdm-enrollment.v1"; REMEDIATION_SCHEMA="hol-guard-mdm-cloud-remediation.v1"
+SAFE=re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"); HEX32=re.compile(r"^[0-9a-f]{32}$"); HEX64=re.compile(r"^[0-9a-f]{64}$")
+FORBIDDEN={"command","commands","script","shell","token","accessToken","refreshToken","password","secret","privateKey","privateKeyPem","proxyUrl","authorization"}
+ACTIONS={"integrity-scan":set(),"policy-refresh":set(),"repair":{"scope"},"service-register":{"service"},"version-converge":{"targetVersion"}}
+
+class ContractError(ValueError):
+ def __init__(self,code:str,status:int=400): super().__init__(code); self.code=code; self.status=status
+
+def canonical(value:object)->bytes: return json.dumps(value,sort_keys=True,separators=(",",":"),ensure_ascii=True,allow_nan=False).encode()
+def digest(value:object)->str: return hashlib.sha256(canonical(value)).hexdigest()
+def utcnow()->datetime: return datetime.now(timezone.utc).replace(microsecond=0)
+def iso(value:datetime)->str: return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00","Z")
+def parse_time(value:object,code:str)->datetime:
+ if not isinstance(value,str) or not value.endswith("Z"): raise ContractError(code)
+ try: parsed=datetime.fromisoformat(value[:-1]+"+00:00")
+ except ValueError as error: raise ContractError(code) from error
+ return parsed.astimezone(timezone.utc)
+def exact(value:object,keys:set[str],code:str)->dict[str,object]:
+ if not isinstance(value,dict) or set(value)!=keys: raise ContractError(code)
+ return value
+def text(value:object,pattern:re.Pattern[str]=SAFE,code:str="invalid_identifier")->str:
+ if not isinstance(value,str) or not pattern.fullmatch(value): raise ContractError(code)
+ return value
+def integer(value:object,minimum:int,maximum:int,code:str)->int:
+ if not isinstance(value,int) or isinstance(value,bool) or not minimum<=value<=maximum: raise ContractError(code)
+ return value
+def reject_authority(value:object,depth:int=0)->None:
+ if depth>24: raise ContractError("contract_depth_exceeded")
+ if isinstance(value,dict):
+  if len(value)>128: raise ContractError("contract_collection_exceeded")
+  for key,item in value.items():
+   if not isinstance(key,str) or key in FORBIDDEN or key.lower().endswith(("token","secret","password","privatekey","command","script")): raise ContractError("forbidden_authority_field")
+   reject_authority(item,depth+1)
+ elif isinstance(value,list):
+  if len(value)>128: raise ContractError("contract_collection_exceeded")
+  for item in value: reject_authority(item,depth+1)
+ elif isinstance(value,str) and len(value.encode())>16384: raise ContractError("contract_string_exceeded")
+
+def load_json(body:bytes,limit:int=1024*1024)->dict[str,object]:
+ if len(body)>limit: raise ContractError("request_too_large",413)
+ def pairs(items:list[tuple[str,object]])->dict[str,object]:
+  out={}
+  for key,value in items:
+   if key in out: raise ContractError("duplicate_json_key")
+   out[key]=value
+  return out
+ try: value=json.loads(body,object_pairs_hook=pairs)
+ except (UnicodeDecodeError,json.JSONDecodeError,ValueError) as error: raise ContractError("invalid_json") from error
+ if not isinstance(value,dict): raise ContractError("invalid_json_object")
+ reject_authority(value)
+ return value
+
+def policy_hash(policy:Mapping[str,object])->str: return digest(policy)
+
+def validate_policy(policy:object)->dict[str,object]:
+ if not isinstance(policy,dict) or policy.get("schemaVersion")!="hol-guard-mdm-policy.v1": raise ContractError("managed_policy_invalid")
+ reject_authority(policy)
+ return policy
+
+def config_unsigned(value:Mapping[str,object])->dict[str,object]: return {k:v for k,v in value.items() if k!="signature"}
+def sign_config(value:dict[str,object],private_key:rsa.RSAPrivateKey)->dict[str,object]:
+ unsigned=config_unsigned(value); sig=private_key.sign(canonical(unsigned),padding.PSS(mgf=padding.MGF1(hashes.SHA256()),salt_length=32),hashes.SHA256())
+ return {**unsigned,"signature":{"algorithm":"rsa-pss-sha256","value":base64.b64encode(sig).decode()}}
+def verify_config(value:object,public_key:rsa.RSAPublicKey,*,workspace:str,device:str,generation:str,current_revision:int|None,current_hash:str|None,now:datetime|None=None)->dict[str,object]:
+ keys={"schemaVersion","workspaceId","deviceId","installationGeneration","revision","issuedAt","notBefore","expiresAt","policy","policyHash","previousPolicyHash","rollback","signingKeyId","signature"}
+ root=exact(value,keys,"configuration_shape_invalid")
+ if root["schemaVersion"]!=CONFIG_SCHEMA or text(root["workspaceId"])!=workspace or text(root["deviceId"])!=device or text(root["installationGeneration"],HEX32)!=generation: raise ContractError("configuration_binding_invalid")
+ revision=integer(root["revision"],1,2**31-1,"configuration_revision_invalid"); issued=parse_time(root["issuedAt"],"configuration_time_invalid"); not_before=parse_time(root["notBefore"],"configuration_time_invalid"); expires=parse_time(root["expiresAt"],"configuration_time_invalid"); clock=now or utcnow()
+ if not issued<=clock and (issued-clock).total_seconds()>300: raise ContractError("configuration_not_yet_valid")
+ if clock<not_before or clock>=expires or expires<=issued or (expires-issued).total_seconds()>86400: raise ContractError("configuration_expired")
+ policy=validate_policy(root["policy"]); expected=policy_hash(policy)
+ if text(root["policyHash"],HEX64)!=expected: raise ContractError("configuration_hash_mismatch")
+ previous=root["previousPolicyHash"]
+ if previous is not None: text(previous,HEX64,"configuration_previous_hash_invalid")
+ rollback=exact(root["rollback"],{"authorized","fromRevision","reason"},"configuration_rollback_invalid")
+ if not isinstance(rollback["authorized"],bool): raise ContractError("configuration_rollback_invalid")
+ if rollback["authorized"]:
+  integer(rollback["fromRevision"],1,2**31-1,"configuration_rollback_invalid")
+  if not isinstance(rollback["reason"],str) or not rollback["reason"] or len(rollback["reason"])>512: raise ContractError("configuration_rollback_invalid")
+ elif rollback!={"authorized":False,"fromRevision":None,"reason":None}: raise ContractError("configuration_rollback_invalid")
+ if current_revision is not None and revision<=current_revision: raise ContractError("configuration_revision_not_monotonic")
+ if current_hash!=previous: raise ContractError("configuration_chain_mismatch")
+ signature=exact(root["signature"],{"algorithm","value"},"configuration_signature_invalid")
+ if signature["algorithm"]!="rsa-pss-sha256" or not isinstance(signature["value"],str): raise ContractError("configuration_signature_invalid")
+ try: public_key.verify(base64.b64decode(signature["value"],validate=True),canonical(config_unsigned(root)),padding.PSS(mgf=padding.MGF1(hashes.SHA256()),salt_length=32),hashes.SHA256())
+ except (ValueError,InvalidSignature) as error: raise ContractError("configuration_signature_invalid") from error
+ return root
+
+def validate_ack(value:object,workspace:str,device:str,generation:str)->dict[str,object]:
+ keys={"schemaVersion","workspaceId","deviceId","installationGeneration","revision","policyHash","status","reasonCode","observedAt","requestId"}; root=exact(value,keys,"ack_shape_invalid")
+ if root["schemaVersion"]!=ACK_SCHEMA or root["workspaceId"]!=workspace or root["deviceId"]!=device or root["installationGeneration"]!=generation: raise ContractError("ack_binding_invalid")
+ integer(root["revision"],1,2**31-1,"ack_revision_invalid"); text(root["policyHash"],HEX64); text(root["requestId"]); parse_time(root["observedAt"],"ack_time_invalid")
+ if root["status"] not in {"applied","rejected","deferred","superseded"}: raise ContractError("ack_status_invalid")
+ if (root["status"]=="applied" and root["reasonCode"] is not None) or (root["status"]!="applied" and not isinstance(root["reasonCode"],str)): raise ContractError("ack_reason_invalid")
+ return root
+
+def validate_health(value:object,workspace:str,device:str,generation:str)->dict[str,object]:
+ keys={"schemaVersion","workspaceId","deviceId","installationGeneration","sequence","appliedRevision","appliedPolicyHash","observedAt","requestId","status"}; root=exact(value,keys,"health_shape_invalid")
+ if root["schemaVersion"]!=HEALTH_SCHEMA or root["workspaceId"]!=workspace or root["deviceId"]!=device or root["installationGeneration"]!=generation: raise ContractError("health_binding_invalid")
+ integer(root["sequence"],1,2**63-1,"health_sequence_invalid"); text(root["requestId"]); parse_time(root["observedAt"],"health_time_invalid")
+ if root["appliedRevision"] is None:
+  if root["appliedPolicyHash"] is not None: raise ContractError("health_policy_invalid")
+ else: integer(root["appliedRevision"],1,2**31-1,"health_policy_invalid"); text(root["appliedPolicyHash"],HEX64)
+ if not isinstance(root["status"],dict): raise ContractError("health_status_invalid")
+ reject_authority(root["status"])
+ return root
+
+def validate_remediation(value:object,workspace:str,device:str,generation:str)->dict[str,object]:
+ keys={"schemaVersion","workspaceId","deviceId","installationGeneration","jobId","idempotencyKey","action","parameters","createdAt","expiresAt","maxAttempts"}; root=exact(value,keys,"remediation_shape_invalid")
+ if root["schemaVersion"]!=REMEDIATION_SCHEMA or root["workspaceId"]!=workspace or root["deviceId"]!=device or root["installationGeneration"]!=generation: raise ContractError("remediation_binding_invalid")
+ text(root["jobId"]); text(root["idempotencyKey"]); created=parse_time(root["createdAt"],"remediation_time_invalid"); expires=parse_time(root["expiresAt"],"remediation_time_invalid")
+ if expires<=created or (expires-created).total_seconds()>3600: raise ContractError("remediation_time_invalid")
+ action=root["action"]
+ if action not in ACTIONS or not isinstance(root["parameters"],dict) or set(root["parameters"])!=ACTIONS[action]: raise ContractError("remediation_action_invalid")
+ params=root["parameters"]
+ if action=="repair" and params.get("scope") not in {"machine","users"}: raise ContractError("remediation_action_invalid")
+ if action=="service-register" and params.get("service") not in {"machine-health","supervisor"}: raise ContractError("remediation_action_invalid")
+ if action=="version-converge": text(params.get("targetVersion"))
+ integer(root["maxAttempts"],1,5,"remediation_attempts_invalid"); return root
+
+def proof_message(method:str,path:str,body:bytes,sequence:int,observed_at:str)->bytes: return canonical({"bodyHash":hashlib.sha256(body).hexdigest(),"method":method.upper(),"observedAt":observed_at,"path":path,"sequence":sequence})
+def sign_proof(private_key:ec.EllipticCurvePrivateKey,method:str,path:str,body:bytes,sequence:int,observed_at:str)->str: return base64.b64encode(private_key.sign(proof_message(method,path,body,sequence,observed_at),ec.ECDSA(hashes.SHA256()))).decode()
+def verify_proof(public_key:ec.EllipticCurvePublicKey,signature:str,method:str,path:str,body:bytes,sequence:int,observed_at:str)->None:
+ try: public_key.verify(base64.b64decode(signature,validate=True),proof_message(method,path,body,sequence,observed_at),ec.ECDSA(hashes.SHA256()))
+ except (ValueError,InvalidSignature) as error: raise ContractError("request_proof_invalid",401) from error
+
+def public_pem(key:object)->str: return key.public_bytes(serialization.Encoding.PEM,serialization.PublicFormat.SubjectPublicKeyInfo).decode()  # type: ignore[attr-defined]
+def load_public_pem(value:str)->object:
+ try: return serialization.load_pem_public_key(value.encode())
+ except ValueError as error: raise ContractError("public_key_invalid") from error

--- a/tests/test_guard_mdm_cloud_control.py
+++ b/tests/test_guard_mdm_cloud_control.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+import copy
+from datetime import timedelta
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ec,rsa
+from codex_plugin_scanner.guard.mdm.cloud_control import ContractError,ACK_SCHEMA,HEALTH_SCHEMA,REMEDIATION_SCHEMA,iso,policy_hash,sign_config,sign_proof,utcnow,validate_ack,validate_health,validate_remediation,verify_config,verify_proof
+W='workspace-mdm-cloud-lab';D='device-a';G='a'*32
+
+def policy(mode='enforce'):
+ return {'schemaVersion':'hol-guard-mdm-policy.v1','settings':{'mode':mode},'lockedSettings':['mode'],'requiredHarnesses':[]}
+def envelope(private,revision=1,previous=None):
+ now=utcnow();p=policy();return sign_config({'schemaVersion':'hol-guard-mdm-cloud-config.v1','workspaceId':W,'deviceId':D,'installationGeneration':G,'revision':revision,'issuedAt':iso(now),'notBefore':iso(now-timedelta(seconds=1)),'expiresAt':iso(now+timedelta(minutes=10)),'policy':p,'policyHash':policy_hash(p),'previousPolicyHash':previous,'rollback':{'authorized':False,'fromRevision':None,'reason':None},'signingKeyId':'cloud-key'},private)
+def test_signed_configuration_is_bound_and_monotonic():
+ key=rsa.generate_private_key(public_exponent=65537,key_size=2048);one=envelope(key);assert verify_config(one,key.public_key(),workspace=W,device=D,generation=G,current_revision=None,current_hash=None)['revision']==1
+ two=envelope(key,2,one['policyHash']);assert verify_config(two,key.public_key(),workspace=W,device=D,generation=G,current_revision=1,current_hash=one['policyHash'])['revision']==2
+ with pytest.raises(ContractError,match='configuration_revision_not_monotonic'):verify_config(one,key.public_key(),workspace=W,device=D,generation=G,current_revision=1,current_hash=one['policyHash'])
+def test_configuration_rejects_tamper_wrong_binding_and_chain():
+ key=rsa.generate_private_key(public_exponent=65537,key_size=2048);value=envelope(key)
+ for field,replacement,code in [('policyHash','0'*64,'configuration_hash_mismatch'),('workspaceId','other','configuration_binding_invalid')]:
+  bad=copy.deepcopy(value);bad[field]=replacement
+  with pytest.raises(ContractError,match=code):verify_config(bad,key.public_key(),workspace=W,device=D,generation=G,current_revision=None,current_hash=None)
+ with pytest.raises(ContractError,match='configuration_chain_mismatch'):verify_config(envelope(key,2,'1'*64),key.public_key(),workspace=W,device=D,generation=G,current_revision=1,current_hash=value['policyHash'])
+def test_request_proof_is_body_path_and_sequence_bound():
+ key=ec.generate_private_key(ec.SECP256R1());at=iso(utcnow());body=b'{}';sig=sign_proof(key,'POST','/runtime/v1/health',body,4,at);verify_proof(key.public_key(),sig,'POST','/runtime/v1/health',body,4,at)
+ for path,seq in [('/runtime/v1/acknowledgements',4),('/runtime/v1/health',5)]:
+  with pytest.raises(ContractError,match='request_proof_invalid'):verify_proof(key.public_key(),sig,'POST',path,body,seq,at)
+def test_ack_health_and_remediation_are_strict():
+ now=utcnow();ack={'schemaVersion':ACK_SCHEMA,'workspaceId':W,'deviceId':D,'installationGeneration':G,'revision':1,'policyHash':'1'*64,'status':'applied','reasonCode':None,'observedAt':iso(now),'requestId':'ack-1'};assert validate_ack(ack,W,D,G)==ack
+ health={'schemaVersion':HEALTH_SCHEMA,'workspaceId':W,'deviceId':D,'installationGeneration':G,'sequence':1,'appliedRevision':1,'appliedPolicyHash':'1'*64,'observedAt':iso(now),'requestId':'health-1','status':{'healthy':True}};assert validate_health(health,W,D,G)==health
+ job={'schemaVersion':REMEDIATION_SCHEMA,'workspaceId':W,'deviceId':D,'installationGeneration':G,'jobId':'job-1','idempotencyKey':'idem-1','action':'repair','parameters':{'scope':'machine'},'createdAt':iso(now),'expiresAt':iso(now+timedelta(minutes=5)),'maxAttempts':2};assert validate_remediation(job,W,D,G)==job
+ bad={**job,'action':'shell','parameters':{'command':'curl attacker'}}
+ with pytest.raises(ContractError,match='remediation_action_invalid'):validate_remediation(bad,W,D,G)

--- a/tests/test_guard_mdm_cloud_lab_integration.py
+++ b/tests/test_guard_mdm_cloud_lab_integration.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+import importlib.util,sys,threading
+from pathlib import Path
+ROOT=Path(__file__).parents[1];LAB=ROOT/'scripts/mdm/cloud-lab';sys.path.insert(0,str(LAB))
+from device_runtime import Device,DeviceServer
+from lab_common import CloudServer,Store
+from orchestrator import orchestrate
+
+def proxy_module():
+ spec=importlib.util.spec_from_file_location('mdm_fault_proxy',LAB/'fault_proxy.py');module=importlib.util.module_from_spec(spec);assert spec and spec.loader;spec.loader.exec_module(module);return module
+
+def serve(server): threading.Thread(target=server.serve_forever,daemon=True).start();return server
+
+def test_real_http_multi_device_cloud_control_loop(tmp_path:Path):
+ seeds=[{'workspaceId':'workspace-mdm-cloud-lab','deviceId':f'device-{c}','installationGeneration':c*32,'token':f'enrollment-token-device-{c}'} for c in 'abc']
+ cloud=serve(CloudServer(('127.0.0.1',0),Store(tmp_path/'cloud.sqlite3',tmp_path/'cloud-key.pem',seeds),'admin'));cloud_url=f'http://127.0.0.1:{cloud.server_port}'
+ proxy=proxy_module();faults=proxy.FaultState('admin');gateway=serve(proxy.FaultProxyServer(('127.0.0.1',0),upstream=cloud_url,state=faults,verbose=False));proxy_url=f'http://127.0.0.1:{gateway.server_port}'
+ servers=[cloud,gateway];urls={}
+ try:
+  for c in 'abc':
+   root=tmp_path/f'device-{c}';device=Device(root,proxy_url,'workspace-mdm-cloud-lab',f'device-{c}',c*32,f'enrollment-token-device-{c}',root/'policy.json');server=serve(DeviceServer(('127.0.0.1',0),device));servers.append(server);urls[f'device-{c}']=f'http://127.0.0.1:{server.server_port}'
+  report=orchestrate(cloud_url,proxy_url,urls,'admin',tmp_path/'report.json')
+  assert report['healthy'] is True;assert report['stepCount']>=25;assert all(x['passed'] for x in report['steps']);assert report['nativeCertification']['outcome']=='not-evaluated';assert (tmp_path/'report.json').exists()
+ finally:
+  for server in reversed(servers):server.shutdown();server.server_close()

--- a/tests/test_guard_mdm_cloud_lab_registration.py
+++ b/tests/test_guard_mdm_cloud_lab_registration.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_multi_device_lab_is_registered_and_isolated() -> None:
+    compose = read("scripts/mdm/cloud-lab/docker-compose.yml")
+    for service in ("cloud:", "proxy:", "device-a:", "device-b:", "device-c:", "orchestrator:"):
+        assert service in compose
+    assert "internal: true" in compose
+    assert "condition: service_healthy" in compose
+    assert "cap_drop:" in compose and "- ALL" in compose
+    assert "no-new-privileges:true" in compose
+    assert "docker.sock" not in compose
+    assert "ports:" not in compose
+
+
+def test_workflow_runs_focused_and_docker_gates_with_pinned_actions() -> None:
+    workflow = read(".github/workflows/mdm-cloud-integration-lab.yml")
+    assert "tests/test_guard_mdm_cloud_lab_integration.py" in workflow
+    assert "scripts/mdm/run-cloud-integration-lab.py" in workflow
+    assert "nativeCertification" in workflow
+    assert "down --volumes --remove-orphans" in workflow
+    uses = re.findall(r"uses:\s*([^\s]+)", workflow)
+    assert uses
+    assert all("@" in value and len(value.rsplit("@", 1)[1]) == 40 for value in uses)
+
+
+def test_prd_todo_and_takeaway_are_complete_and_native_boundary_is_explicit() -> None:
+    prd = read("docs/guard/mdm-cloud-integration-lab-prd.md")
+    todo = read("docs/guard/mdm-cloud-integration-lab-todo.md")
+    prompt = read("docs/guard/mdm-cloud-integration-lab-takeaway-prompt.md")
+    task_ids = re.findall(r"MDM-(\d{3})", todo)
+    assert len(task_ids) == 360
+    assert len(set(task_ids)) == 360
+    task_lines = [line for line in todo.splitlines() if line.startswith("- [") and "MDM-" in line]
+    assert sum(line.startswith("- [x]") for line in task_lines) == 336
+    assert sum(line.startswith("- [ ]") for line in task_lines) == 24
+    assert "native certification" in prd.lower()
+    assert "not-evaluated" in prompt
+    assert "arbitrary commands" in prompt

--- a/tests/test_guard_mdm_cloud_schemas.py
+++ b/tests/test_guard_mdm_cloud_schemas.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
+
+ROOT = Path(__file__).parents[1]
+SCHEMA_DIR = ROOT / "docs" / "guard" / "schemas"
+WORKSPACE = "workspace-mdm-cloud-lab"
+DEVICE = "device-a"
+GENERATION = "a" * 32
+NOW = "2026-08-16T12:00:00Z"
+LATER = "2026-08-16T12:10:00Z"
+
+
+def load(name: str) -> dict[str, object]:
+    return json.loads((SCHEMA_DIR / name).read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "mdm-cloud-config-v1.schema.json",
+        "mdm-cloud-ack-v1.schema.json",
+        "mdm-cloud-health-v1.schema.json",
+        "mdm-cloud-remediation-v1.schema.json",
+        "mdm-cloud-enrollment-v1.schema.json",
+        "mdm-cloud-lab-report-v1.schema.json",
+    ],
+)
+def test_cloud_mdm_schemas_are_valid_draft_2020_12(name: str) -> None:
+    Draft202012Validator.check_schema(load(name))
+
+
+def examples() -> dict[str, dict[str, object]]:
+    policy = {
+        "schemaVersion": "hol-guard-mdm-policy.v1",
+        "settings": {"mode": "enforce"},
+        "lockedSettings": ["mode"],
+        "requiredHarnesses": [],
+    }
+    return {
+        "mdm-cloud-config-v1.schema.json": {
+            "schemaVersion": "hol-guard-mdm-cloud-config.v1",
+            "workspaceId": WORKSPACE,
+            "deviceId": DEVICE,
+            "installationGeneration": GENERATION,
+            "revision": 1,
+            "issuedAt": NOW,
+            "notBefore": NOW,
+            "expiresAt": LATER,
+            "policy": policy,
+            "policyHash": "1" * 64,
+            "previousPolicyHash": None,
+            "rollback": {"authorized": False, "fromRevision": None, "reason": None},
+            "signingKeyId": "cloud-key-1",
+            "signature": {"algorithm": "rsa-pss-sha256", "value": "YQ=="},
+        },
+        "mdm-cloud-ack-v1.schema.json": {
+            "schemaVersion": "hol-guard-mdm-cloud-ack.v1",
+            "workspaceId": WORKSPACE,
+            "deviceId": DEVICE,
+            "installationGeneration": GENERATION,
+            "revision": 1,
+            "policyHash": "1" * 64,
+            "status": "applied",
+            "reasonCode": None,
+            "observedAt": NOW,
+            "requestId": "ack-1",
+        },
+        "mdm-cloud-health-v1.schema.json": {
+            "schemaVersion": "hol-guard-mdm-cloud-health.v1",
+            "workspaceId": WORKSPACE,
+            "deviceId": DEVICE,
+            "installationGeneration": GENERATION,
+            "sequence": 1,
+            "appliedRevision": 1,
+            "appliedPolicyHash": "1" * 64,
+            "observedAt": NOW,
+            "requestId": "health-1",
+            "status": {"healthy": True, "managementAssuranceLevel": "mdm-managed"},
+        },
+        "mdm-cloud-remediation-v1.schema.json": {
+            "schemaVersion": "hol-guard-mdm-cloud-remediation.v1",
+            "workspaceId": WORKSPACE,
+            "deviceId": DEVICE,
+            "installationGeneration": GENERATION,
+            "jobId": "job-1",
+            "idempotencyKey": "job-1-once",
+            "action": "repair",
+            "parameters": {"scope": "machine"},
+            "createdAt": NOW,
+            "expiresAt": LATER,
+            "maxAttempts": 2,
+        },
+        "mdm-cloud-enrollment-v1.schema.json": {
+            "schemaVersion": "hol-guard-mdm-enrollment.v1",
+            "workspaceId": WORKSPACE,
+            "deviceId": DEVICE,
+            "installationGeneration": GENERATION,
+            "keyId": "device-key-1",
+            "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nfixture\n-----END PUBLIC KEY-----",
+            "token": "one-time-token",
+        },
+        "mdm-cloud-lab-report-v1.schema.json": {
+            "schemaVersion": "hol-guard-mdm-cloud-integration-lab.v1",
+            "generatedAt": NOW,
+            "workspaceId": WORKSPACE,
+            "healthy": True,
+            "stepCount": 1,
+            "steps": [{"name": "fixture", "passed": True, "durationMs": 1, "evidence": {}}],
+            "nativeCertification": {
+                "outcome": "not-evaluated",
+                "requiredGates": ["apple-apns-enrollment"],
+                "reason": "native_platform_or_vendor_required",
+            },
+        },
+    }
+
+
+@pytest.mark.parametrize("name,payload", list(examples().items()))
+def test_cloud_mdm_schema_examples_validate(name: str, payload: dict[str, object]) -> None:
+    Draft202012Validator(load(name)).validate(payload)
+
+
+@pytest.mark.parametrize("name,payload", list(examples().items()))
+def test_cloud_mdm_schemas_reject_unknown_authority_fields(
+    name: str, payload: dict[str, object]
+) -> None:
+    candidate = copy.deepcopy(payload)
+    candidate["command"] = "curl attacker.invalid"
+    with pytest.raises(ValidationError):
+        Draft202012Validator(load(name)).validate(candidate)


### PR DESCRIPTION
## Summary

Adds a provider-neutral, stateful MDM Cloud integration lab for `release/3.0` with three independently keyed HOL Guard devices, signed desired state, durable acknowledgements and health evidence, typed remediation, deterministic fault injection, and CI evidence.

## Security invariants

- One-time enrollment bound to workspace, device, installation generation, and P-256 key.
- Request proofs bind method, path, body, time, and monotonic sequence.
- RSA-PSS signed configuration binds identity, revision, policy hash, per-device predecessor hash, validity, and rollback metadata.
- Devices call the production managed-policy parser and retain the last known good policy during Cloud failure.
- Atomic policy application uses a pending checkpoint plus durable acknowledgement, health, and remediation-result outboxes.
- Remediation uses a fixed typed action set and rejects arbitrary commands, scripts, shells, credentials, and open-ended parameters.

## Integration coverage

The real-HTTP orchestrator verifies independent enrollment, baseline rollout, canary rollout, skipped revisions, corrupt configuration, partition and recovery, proof replay, workspace substitution, stale replay, signed rollback, crash-after-write recovery, durable evidence, typed remediation, idempotency, and audit redaction.

The Docker project uses an internal network, no host ports, no Docker socket, read-only root filesystems, dropped capabilities, no-new-privileges, separate device volumes, health-gated startup, resource limits, failure log capture, artifact upload, and unconditional teardown.

## Documentation

- PRD
- 360-task TODO ledger: 336 provider-neutral tasks complete and 24 native/provider certification gates intentionally open
- Takeaway prompt
- Six strict JSON Schemas

## Verification

Locally executed:

- Python compilation for the Cloud, device, proxy, orchestrator, runner, and contract modules
- JSON Schema parsing and example validation
- Compose YAML parsing
- Real HTTP integration with SQLite, fault proxy, Cloud service, and three device servers
- 28 orchestrator assertions, all passing

The standalone Docker Compose run is delegated to the included GitHub Actions workflow because the authoring runtime does not expose a Docker daemon. Native Apple, Windows, and commercial-provider certification remains explicitly `not-evaluated` and is not inferred from this lab.