### PR TITLE
fix(zcode): write current hooks.events schema in managed hook install

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 12631,
-  "maximum_test_source_lines": 289355,
+  "maximum_test_source_lines": 289358,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12629,
-  "maximum_test_source_lines": 289303,
+  "maximum_collected_cases": 12631,
+  "maximum_test_source_lines": 289355,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12620,
-  "maximum_test_source_lines": 289120,
+  "maximum_collected_cases": 12629,
+  "maximum_test_source_lines": 289303,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/adapters/zcode.py
+++ b/src/codex_plugin_scanner/guard/adapters/zcode.py
@@ -2,14 +2,16 @@
 
 ZCode is z.ai's local AI coding harness. Its CLI app config lives under
 ``~/.zcode/cli/config.json`` and is Claude-Code-shaped: an ``mcp`` section, a
-``plugins`` section, and an optional ``hooks`` section that follows Claude
-Code's hook group schema. Plugins are cached under
+``plugins`` section, and an optional ``hooks`` section whose event groups are
+nested under ``hooks.events`` (current ZCode rejects the legacy flat
+``hooks.<Event>`` layout and fails to load the entire config file, so Guard
+migrates legacy groups on install). Plugins are cached under
 ``~/.zcode/cli/plugins/cache/<marketplace>/<plugin>/<version>/``.
 
 This adapter discovers MCP servers, enabled plugins, plugin manifests and
 provenance, plugin hooks, skills, commands, and marketplaces; installs
 Guard-managed ``PreToolUse`` and ``UserPromptSubmit`` hooks into the CLI
-config ``hooks`` section (idempotently, without touching ``mcp`` or
+config ``hooks.events`` section (idempotently, without touching ``mcp`` or
 ``plugins``); and routes ZCode hook events through the shared Guard runtime.
 """
 
@@ -39,12 +41,16 @@ from .zcode_config import (
     ZCODE_CLI_DIR,
     ZCODE_DIR,
     ZCODE_ENV_HINTS,
+    ZCODE_HOOK_EVENT_NAMES,
+    ZCODE_HOOKS_EVENTS_KEY,
     ZCODE_MARKETPLACE_FILE,
     ZCODE_PLUGIN_CACHE_DIR,
     ZCODE_PLUGIN_MANIFEST_DIR,
     ZCODE_PLUGIN_MANIFEST_FILE,
     ZCODE_PLUGIN_MARKETPLACES_DIR,
     ZCODE_PRETOOL_MATCHERS,
+    ZCODE_V2_CONFIG_FILE,
+    ZCODE_V2_DIR,
     append_cli_config_artifacts,
     append_found_path,
     append_marketplace_artifacts,
@@ -145,6 +151,12 @@ class ZCodeHarnessAdapter(HarnessAdapter):
                     config_path=config_path,
                     scope=scope,
                 )
+
+        # Current ZCode desktop builds keep provider/app state under ~/.zcode/v2;
+        # its presence marks an install even before the CLI config exists.
+        v2_config = self._zcode_home_dir(context) / ZCODE_V2_DIR / ZCODE_V2_CONFIG_FILE
+        if v2_config.is_file():
+            append_found_path(found_paths, v2_config)
 
         for plugins_root, scope in self._plugins_candidates(context):
             if not plugins_root.is_dir():
@@ -254,6 +266,12 @@ class ZCodeHarnessAdapter(HarnessAdapter):
             guard_args.extend(["--home", str(context.home_dir)])
         if context.workspace_dir is not None:
             guard_args.extend(["--workspace", str(context.workspace_dir)])
+        if getattr(sys, "frozen", False):
+            # Frozen Guard builds parse their own CLI argv and cannot emulate
+            # interpreter flags like ``-c``, so the bounded-bridge bootstrap is
+            # unusable there. Invoke the Guard ``hook`` subcommand directly; it
+            # reads the same stdin payload and emits the same native response.
+            return (sys.executable, *guard_args)
         return bounded_cli_hook_command(
             python_executable=sys.executable,
             package_root=Path(__file__).resolve().parents[3],
@@ -323,8 +341,9 @@ class ZCodeHarnessAdapter(HarnessAdapter):
             "config_path": str(config_path),
             **shim_manifest,
             "notes": [
-                "Guard hook entries added to ~/.zcode/cli/config.json under the hooks section",
+                "Guard hook entries added to ~/.zcode/cli/config.json under the hooks.events section",
                 "User mcp, plugins, and any pre-existing hooks were preserved",
+                "Legacy flat hook groups were migrated into hooks.events for current ZCode",
                 *shim_notes,
             ],
         }
@@ -370,11 +389,18 @@ class ZCodeHarnessAdapter(HarnessAdapter):
         }
 
     def _sync_managed_hook_groups(self, hooks: dict[str, object], managed_command: str) -> None:
-        """Reconcile Guard-managed PreToolUse and UserPromptSubmit hook groups."""
+        """Reconcile Guard-managed PreToolUse and UserPromptSubmit hook groups.
 
-        pretool_raw = hooks.get("PreToolUse")
+        Guard only writes the ``hooks.events`` layout; legacy flat ``hooks.<Event>``
+        groups (whether Guard-managed leftovers or user entries written by older
+        ZCode builds) are folded into ``events`` first because current ZCode
+        rejects the legacy keys and fails to load the whole config file.
+        """
+
+        events = self._migrate_legacy_hook_events(hooks)
+        pretool_raw = events.get("PreToolUse")
         pretool_entries = self._prune_managed_entries(pretool_raw if isinstance(pretool_raw, list) else [])
-        prompt_raw = hooks.get("UserPromptSubmit")
+        prompt_raw = events.get("UserPromptSubmit")
         prompt_entries = self._prune_managed_entries(prompt_raw if isinstance(prompt_raw, list) else [])
         pretool_handler: dict[str, object] = {
             "type": "command",
@@ -389,13 +415,52 @@ class ZCodeHarnessAdapter(HarnessAdapter):
         for matcher in ZCODE_PRETOOL_MATCHERS:
             pretool_entries = _merge_hook_entry(pretool_entries, matcher, pretool_handler)
         prompt_entries = _merge_hook_entry(prompt_entries, None, prompt_handler)
-        hooks["PreToolUse"] = pretool_entries
-        hooks["UserPromptSubmit"] = prompt_entries
+        events["PreToolUse"] = pretool_entries
+        events["UserPromptSubmit"] = prompt_entries
+
+    @staticmethod
+    def _migrate_legacy_hook_events(hooks: dict[str, object]) -> dict[str, object]:
+        """Fold legacy flat ``hooks.<Event>`` groups into the ``events`` mapping.
+
+        User settings keys beside ``events`` (``enabled``, ``timeoutMs``,
+        ``maxOutputBytes``) are preserved untouched. Returns the events mapping,
+        stored back onto ``hooks`` by the caller.
+        """
+
+        events_value = hooks.get(ZCODE_HOOKS_EVENTS_KEY)
+        events: dict[str, object] = dict(events_value) if isinstance(events_value, dict) else {}
+        for event_name, entries in list(hooks.items()):
+            if event_name == ZCODE_HOOKS_EVENTS_KEY or event_name not in ZCODE_HOOK_EVENT_NAMES:
+                continue
+            if not isinstance(entries, list):
+                continue
+            existing = events.get(event_name)
+            merged = list(existing) if isinstance(existing, list) else []
+            merged.extend(entries)
+            events[event_name] = merged
+            hooks.pop(event_name, None)
+        hooks[ZCODE_HOOKS_EVENTS_KEY] = events
+        return events
 
     def _prune_managed_hook_groups(self, hooks: dict[str, object]) -> None:
-        for event_name in ("PreToolUse", "UserPromptSubmit"):
+        events_value = hooks.get(ZCODE_HOOKS_EVENTS_KEY)
+        if isinstance(events_value, dict):
+            for event_name in list(events_value):
+                entries = events_value.get(event_name)
+                remaining = self._prune_managed_entries(entries if isinstance(entries, list) else [])
+                if remaining:
+                    events_value[event_name] = remaining
+                else:
+                    events_value.pop(event_name, None)
+            if not events_value:
+                hooks.pop(ZCODE_HOOKS_EVENTS_KEY, None)
+        # Legacy flat groups from older Guard installs are pruned too, but user
+        # entries in them are left exactly where the user put them.
+        for event_name in list(hooks):
             entries = hooks.get(event_name)
-            remaining = self._prune_managed_entries(entries if isinstance(entries, list) else [])
+            if event_name == ZCODE_HOOKS_EVENTS_KEY or not isinstance(entries, list):
+                continue
+            remaining = self._prune_managed_entries(entries)
             if remaining:
                 hooks[event_name] = remaining
             else:

--- a/src/codex_plugin_scanner/guard/adapters/zcode.py
+++ b/src/codex_plugin_scanner/guard/adapters/zcode.py
@@ -55,6 +55,7 @@ from .zcode_config import (
     append_found_path,
     append_marketplace_artifacts,
     append_plugin_manifest_artifacts,
+    dedupe_hook_entries,
     is_guard_managed_hook_command,
 )
 
@@ -269,9 +270,11 @@ class ZCodeHarnessAdapter(HarnessAdapter):
         if getattr(sys, "frozen", False):
             # Frozen Guard builds parse their own CLI argv and cannot emulate
             # interpreter flags like ``-c``, so the bounded-bridge bootstrap is
-            # unusable there. Invoke the Guard ``hook`` subcommand directly; it
-            # reads the same stdin payload and emits the same native response.
-            return (sys.executable, *guard_args)
+            # unusable there. The frozen ``hol-guard`` entry point registers
+            # Guard subcommands at the root (no ``guard`` group token), so invoke
+            # the ``hook`` subcommand directly; it reads the same stdin payload
+            # and emits the same native response.
+            return (sys.executable, *guard_args[1:])
         return bounded_cli_hook_command(
             python_executable=sys.executable,
             package_root=Path(__file__).resolve().parents[3],
@@ -423,8 +426,9 @@ class ZCodeHarnessAdapter(HarnessAdapter):
         """Fold legacy flat ``hooks.<Event>`` groups into the ``events`` mapping.
 
         User settings keys beside ``events`` (``enabled``, ``timeoutMs``,
-        ``maxOutputBytes``) are preserved untouched. Returns the events mapping,
-        stored back onto ``hooks`` by the caller.
+        ``maxOutputBytes``) are preserved untouched, and legacy entries that
+        already exist in ``events`` are not duplicated. Returns the events
+        mapping, stored back onto ``hooks`` by the caller.
         """
 
         events_value = hooks.get(ZCODE_HOOKS_EVENTS_KEY)
@@ -437,7 +441,7 @@ class ZCodeHarnessAdapter(HarnessAdapter):
             existing = events.get(event_name)
             merged = list(existing) if isinstance(existing, list) else []
             merged.extend(entries)
-            events[event_name] = merged
+            events[event_name] = dedupe_hook_entries(merged)
             hooks.pop(event_name, None)
         hooks[ZCODE_HOOKS_EVENTS_KEY] = events
         return events

--- a/src/codex_plugin_scanner/guard/adapters/zcode_config.py
+++ b/src/codex_plugin_scanner/guard/adapters/zcode_config.py
@@ -3,7 +3,11 @@
 ZCode stores its CLI app config under ``~/.zcode/``. ``~/.zcode/cli/config.json``
 is Claude-Code-shaped: an ``mcp`` section (``mcp.servers.<name>``), a ``plugins``
 section (``plugins.enabledPlugins.<name@marketplace>``), and an optional
-``hooks`` section using Claude Code's hook group schema. Plugins are cached
+``hooks`` section. Current ZCode nests hook event groups under
+``hooks.events.<Event>`` (with optional ``enabled``/``timeoutMs``/
+``maxOutputBytes`` settings keys) and rejects the legacy flat
+``hooks.<Event>`` layout with a config load failure; both layouts are read for
+inventory while only the nested one is written. Plugins are cached
 under ``~/.zcode/cli/plugins/cache/<marketplace>/<plugin>/<version>/`` with a
 ``.zcode-plugin/plugin.json`` manifest, a ``.zcode-plugin-seed.json`` provenance
 file, ``hooks/hooks.json``, ``.mcp.json``, ``skills/`` and ``commands/`` trees.
@@ -11,6 +15,7 @@ file, ``hooks/hooks.json``, ``.mcp.json``, ``skills/`` and ``commands/`` trees.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
 
 from ..aibom_detection import enrich_mcp_server_metadata
@@ -20,6 +25,9 @@ from .base import _json_payload
 ZCODE_DIR = ".zcode"
 ZCODE_CLI_DIR = ".zcode/cli"
 ZCODE_CLI_CONFIG_FILE = "config.json"
+# Desktop app runtime state (provider config, app settings) written by current ZCode.
+ZCODE_V2_DIR = ".zcode/v2"
+ZCODE_V2_CONFIG_FILE = "config.json"
 ZCODE_PLUGINS_DIR = "plugins"
 ZCODE_PLUGIN_CACHE_DIR = "plugins/cache"
 ZCODE_PLUGIN_MARKETPLACES_DIR = "plugins/marketplaces"
@@ -34,6 +42,23 @@ ZCODE_PLUGIN_COMMANDS_DIR = "commands"
 ZCODE_MARKETPLACE_FILE = "marketplace.json"
 
 GUARD_MANAGED_MARKER = "HOL_GUARD_MANAGED_ZCODE"
+
+# Current ZCode nests hook event groups under ``hooks.events`` with optional
+# global settings (``enabled``, ``timeoutMs``, ``maxOutputBytes``) beside it.
+# Older ZCode builds placed the event arrays directly under ``hooks``; current
+# builds reject those legacy keys and fail to load the whole config file, so
+# Guard must only ever write the nested shape while still reading both.
+ZCODE_HOOKS_EVENTS_KEY = "events"
+ZCODE_HOOK_EVENT_NAMES = (
+    "SessionStart",
+    "UserPromptSubmit",
+    "PreToolUse",
+    "PermissionRequest",
+    "PostToolUse",
+    "PostToolUseFailure",
+    "Stop",
+)
+
 
 # Claude Code tool matchers ZCode surfaces. MCP tools arrive as mcp__<server>__<tool>;
 # the mcp__.* matcher must be present so the PreToolUse hook fires for MCP calls too,
@@ -87,6 +112,30 @@ def is_guard_managed_hook_command(command: object) -> bool:
     return GUARD_MANAGED_MARKER in command or (
         "codex_plugin_scanner.cli" in command and "'guard', 'hook'" in command and "--harness', 'zcode'" in command
     )
+
+
+def hook_event_groups(hooks_section: object) -> dict[str, list[object]]:
+    """Collect ``{event_name: entries}`` from both hooks schema generations.
+
+    Current ZCode stores event groups under ``hooks.events``; older builds put
+    them directly under ``hooks``. Both are read so inventories keep working
+    for configs written by either generation.
+    """
+
+    if not isinstance(hooks_section, dict):
+        return {}
+    groups: dict[str, list[object]] = {}
+    events = hooks_section.get(ZCODE_HOOKS_EVENTS_KEY)
+    if isinstance(events, dict):
+        for event_name, entries in events.items():
+            if isinstance(event_name, str) and isinstance(entries, list):
+                groups.setdefault(event_name, []).extend(entries)
+    for event_name, entries in hooks_section.items():
+        if event_name == ZCODE_HOOKS_EVENTS_KEY or event_name not in ZCODE_HOOK_EVENT_NAMES:
+            continue
+        if isinstance(entries, list):
+            groups.setdefault(event_name, []).extend(entries)
+    return groups
 
 
 def _string_args(server_config: dict[str, object]) -> tuple[str, ...]:
@@ -241,7 +290,7 @@ def append_cli_config_artifacts(
         _append_hook_groups(
             harness=harness,
             artifacts=artifacts,
-            hooks=hooks_section,
+            hooks=hook_event_groups(hooks_section),
             config_path=config_path,
             scope=scope,
         )
@@ -251,7 +300,7 @@ def _append_hook_groups(
     *,
     harness: str,
     artifacts: list[GuardArtifact],
-    hooks: dict[str, object],
+    hooks: Mapping[str, object],
     config_path: Path,
     scope: str,
 ) -> None:
@@ -540,6 +589,8 @@ __all__ = [
     "ZCODE_CLI_DIR",
     "ZCODE_DIR",
     "ZCODE_ENV_HINTS",
+    "ZCODE_HOOKS_EVENTS_KEY",
+    "ZCODE_HOOK_EVENT_NAMES",
     "ZCODE_MARKETPLACE_FILE",
     "ZCODE_PLUGINS_DIR",
     "ZCODE_PLUGIN_CACHE_DIR",
@@ -553,6 +604,8 @@ __all__ = [
     "ZCODE_PLUGIN_SEED_FILE",
     "ZCODE_PLUGIN_SKILLS_DIR",
     "ZCODE_PRETOOL_MATCHERS",
+    "ZCODE_V2_CONFIG_FILE",
+    "ZCODE_V2_DIR",
     "append_cli_config_artifacts",
     "append_command_artifacts",
     "append_found_path",
@@ -560,5 +613,6 @@ __all__ = [
     "append_marketplace_artifacts",
     "append_plugin_manifest_artifacts",
     "append_skill_artifacts",
+    "hook_event_groups",
     "is_guard_managed_hook_command",
 ]

--- a/src/codex_plugin_scanner/guard/adapters/zcode_config.py
+++ b/src/codex_plugin_scanner/guard/adapters/zcode_config.py
@@ -15,6 +15,7 @@ file, ``hooks/hooks.json``, ``.mcp.json``, ``skills/`` and ``commands/`` trees.
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping
 from pathlib import Path
 
@@ -114,12 +115,35 @@ def is_guard_managed_hook_command(command: object) -> bool:
     )
 
 
+def _entry_key(entry: object) -> str:
+    try:
+        return json.dumps(entry, sort_keys=True, ensure_ascii=True, separators=(",", ":"))
+    except (TypeError, ValueError):
+        return repr(entry)
+
+
+def dedupe_hook_entries(entries: list[object]) -> list[object]:
+    """Drop equal duplicate group entries so a handler listed in both schema
+    layouts is not inventoried or persisted twice (ZCode would run it twice)."""
+
+    seen: set[str] = set()
+    unique: list[object] = []
+    for entry in entries:
+        key = _entry_key(entry)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(entry)
+    return unique
+
+
 def hook_event_groups(hooks_section: object) -> dict[str, list[object]]:
     """Collect ``{event_name: entries}`` from both hooks schema generations.
 
     Current ZCode stores event groups under ``hooks.events``; older builds put
     them directly under ``hooks``. Both are read so inventories keep working
-    for configs written by either generation.
+    for configs written by either generation. Entries that already exist in the
+    nested layout are not duplicated from the legacy one.
     """
 
     if not isinstance(hooks_section, dict):
@@ -135,7 +159,7 @@ def hook_event_groups(hooks_section: object) -> dict[str, list[object]]:
             continue
         if isinstance(entries, list):
             groups.setdefault(event_name, []).extend(entries)
-    return groups
+    return {event_name: dedupe_hook_entries(entries) for event_name, entries in groups.items()}
 
 
 def _string_args(server_config: dict[str, object]) -> tuple[str, ...]:
@@ -613,6 +637,7 @@ __all__ = [
     "append_marketplace_artifacts",
     "append_plugin_manifest_artifacts",
     "append_skill_artifacts",
+    "dedupe_hook_entries",
     "hook_event_groups",
     "is_guard_managed_hook_command",
 ]

--- a/src/codex_plugin_scanner/guard/adapters/zcode_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/zcode_hooks.py
@@ -45,6 +45,7 @@ def _canonical_zcode_event_name(raw_event: str) -> str:
         "pretooluse": "PreToolUse",
         "userpromptsubmit": "UserPromptSubmit",
         "posttooluse": "PostToolUse",
+        "posttoolusefailure": "PostToolUseFailure",
         "sessionstart": "SessionStart",
         "notification": "Notification",
         "permissionrequest": "PermissionRequest",

--- a/tests/test_guard_docs.py
+++ b/tests/test_guard_docs.py
@@ -156,7 +156,10 @@ def test_project_metadata_declares_apache_license() -> None:
     pyproject_text = _read_repo_file("pyproject.toml")
     readme_text = _read_repo_file("README.md")
 
-    assert "SPDX-License-Identifier: Apache-2.0" in license_text
+    # The canonical Apache License 2.0 text is kept verbatim (no SPDX banner)
+    # so GitHub classifies the repository license instead of NOASSERTION.
+    assert "Apache License" in license_text
+    assert "Version 2.0, January 2004" in license_text
     pyproject_data = tomllib.loads(pyproject_text)
     assert pyproject_data.get("project", {}).get("license") == "Apache-2.0"
     readme_parts = readme_text.split("## License", 1)

--- a/tests/test_zcode_adapter.py
+++ b/tests/test_zcode_adapter.py
@@ -252,6 +252,23 @@ class TestZCodeDetect:
         assert len(hooks) == 1
         assert hooks[0].command == "echo legacy-hook"
 
+    def test_detect_deduplicates_identical_handlers_across_layouts(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        user_handler = {"type": "command", "command": "echo both-layouts"}
+        group = {"matcher": "Bash", "hooks": [user_handler]}
+        _write_cli_config(
+            ctx.home_dir,
+            {
+                "hooks": {
+                    "events": {"PreToolUse": [dict(group)]},
+                    "PreToolUse": [dict(group)],
+                }
+            },
+        )
+        result = ZCodeHarnessAdapter().detect(ctx)
+        hooks = [a for a in result.artifacts if a.artifact_type == "hook" and a.command == "echo both-layouts"]
+        assert len(hooks) == 1
+
     def test_detect_uses_v2_config_as_install_signal(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path)
         v2_config = ctx.home_dir / ".zcode" / "v2" / "config.json"
@@ -336,10 +353,45 @@ class TestZCodeInstallUninstall:
         handler = payload["hooks"]["events"]["PreToolUse"][0]["hooks"][0]
         command = handler["command"]
         # Frozen Guard builds cannot emulate ``python -c``; the hook must call
-        # the Guard CLI hook subcommand directly instead.
-        assert "guard" in command and "hook" in command and "--harness" in command
+        # the Guard CLI hook subcommand directly instead. The frozen
+        # ``hol-guard`` entry point registers Guard subcommands at the root,
+        # so the command must not carry a standalone ``guard`` group token.
         assert "bounded_cli_hook_bridge" not in command
+        assert " hook " in command and "--harness" in command
+        import shlex
+
+        tokens = shlex.split(command.split(" # ", 1)[0])
+        assert tokens[1] == "hook", tokens[:3]
         assert GUARD_MANAGED_MARKER in command
+
+    def test_install_deduplicates_handlers_present_in_both_layouts(self, tmp_path: Path, monkeypatch) -> None:
+        ctx = _ctx(tmp_path)
+        user_handler = {"type": "command", "command": "echo user-pretool"}
+        _write_cli_config(
+            ctx.home_dir,
+            {
+                "hooks": {
+                    "events": {
+                        "PreToolUse": [
+                            {"matcher": "Bash", "hooks": [dict(user_handler)]},
+                        ]
+                    },
+                    "PreToolUse": [
+                        {"matcher": "Bash", "hooks": [dict(user_handler)]},
+                    ],
+                }
+            },
+        )
+        self._patch_shims(monkeypatch, ctx)
+        ZCodeHarnessAdapter().install(ctx)
+        payload = json.loads((ctx.home_dir / ".zcode" / "cli" / "config.json").read_text(encoding="utf-8"))
+        events = payload["hooks"]["events"]
+        assert "PreToolUse" not in payload["hooks"], "legacy keys must be migrated away"
+        bash_entry = next(e for e in events["PreToolUse"] if e.get("matcher") == "Bash")
+        user_commands = [
+            handler["command"] for handler in bash_entry["hooks"] if handler.get("command") == "echo user-pretool"
+        ]
+        assert user_commands == ["echo user-pretool"]
 
     def test_install_preserves_user_mcp_and_plugins(self, tmp_path: Path, monkeypatch) -> None:
         ctx = _ctx(tmp_path)

--- a/tests/test_zcode_adapter.py
+++ b/tests/test_zcode_adapter.py
@@ -207,6 +207,60 @@ class TestZCodeDetect:
         assert mcp[0].transport == "http"
         assert mcp[0].url == "https://example.com/mcp"
 
+    def test_detect_inventories_hooks_from_events_schema(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        _write_cli_config(
+            ctx.home_dir,
+            {
+                "hooks": {
+                    "enabled": True,
+                    "events": {
+                        "PreToolUse": [
+                            {
+                                "matcher": "Bash",
+                                "hooks": [{"type": "command", "command": "echo events-hook"}],
+                            }
+                        ]
+                    },
+                }
+            },
+        )
+        result = ZCodeHarnessAdapter().detect(ctx)
+        hooks = [a for a in result.artifacts if a.artifact_type == "hook"]
+        assert len(hooks) == 1
+        assert hooks[0].metadata.get("event") == "PreToolUse"
+        assert hooks[0].metadata.get("matcher") == "Bash"
+        assert hooks[0].command == "echo events-hook"
+
+    def test_detect_inventories_hooks_from_legacy_layout(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        _write_cli_config(
+            ctx.home_dir,
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash",
+                            "hooks": [{"type": "command", "command": "echo legacy-hook"}],
+                        }
+                    ]
+                }
+            },
+        )
+        result = ZCodeHarnessAdapter().detect(ctx)
+        hooks = [a for a in result.artifacts if a.artifact_type == "hook"]
+        assert len(hooks) == 1
+        assert hooks[0].command == "echo legacy-hook"
+
+    def test_detect_uses_v2_config_as_install_signal(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        v2_config = ctx.home_dir / ".zcode" / "v2" / "config.json"
+        v2_config.parent.mkdir(parents=True, exist_ok=True)
+        v2_config.write_text(json.dumps({"provider": {}}), encoding="utf-8")
+        result = ZCodeHarnessAdapter().detect(ctx)
+        assert result.installed is True
+        assert any(".zcode/v2/config.json" in path for path in result.config_paths)
+
     def test_project_scope_config_is_detected(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path, workspace=True)
         project_config = ctx.workspace_dir / ".zcode" / "cli" / "config.json"  # type: ignore[union-attr]
@@ -231,7 +285,7 @@ class TestZCodeInstallUninstall:
             lambda *args, **kwargs: {"shim_path": str(ctx.guard_home / "bin" / "guard-zcode"), "notes": []},
         )
 
-    def test_install_writes_managed_hooks(self, tmp_path: Path, monkeypatch) -> None:
+    def test_install_writes_managed_hooks_under_events(self, tmp_path: Path, monkeypatch) -> None:
         ctx = _ctx(tmp_path)
         self._patch_shims(monkeypatch, ctx)
         manifest = ZCodeHarnessAdapter().install(ctx)
@@ -240,21 +294,52 @@ class TestZCodeInstallUninstall:
         assert config_path.is_file()
         payload = json.loads(config_path.read_text(encoding="utf-8"))
         hooks = payload["hooks"]
+        # Current ZCode requires hook groups nested under hooks.events; the
+        # legacy flat layout makes ZCode reject the whole config file.
+        assert set(hooks.keys()) == {"events"}
+        events = hooks["events"]
+        assert set(events.keys()) == {"PreToolUse", "UserPromptSubmit"}
         pretool_matchers = {
             entry["matcher"]
-            for entry in hooks["PreToolUse"]
+            for entry in events["PreToolUse"]
             if isinstance(entry, dict) and isinstance(entry.get("matcher"), str)
         }
         assert set(ZCODE_PRETOOL_MATCHERS).issubset(pretool_matchers)
-        assert isinstance(hooks["UserPromptSubmit"], list)
+        assert isinstance(events["UserPromptSubmit"], list)
         managed_commands = [
             handler["command"]
-            for entry in hooks["PreToolUse"]
+            for entry in events["PreToolUse"]
             if isinstance(entry, dict)
             for handler in entry.get("hooks", [])
             if isinstance(handler, dict) and is_guard_managed_hook_command(handler.get("command"))
         ]
         assert managed_commands, "Guard-managed PreToolUse handlers must be present"
+
+    def test_install_hook_command_uses_bounded_bridge_for_interpreters(self, tmp_path: Path, monkeypatch) -> None:
+        ctx = _ctx(tmp_path)
+        self._patch_shims(monkeypatch, ctx)
+        monkeypatch.setattr("codex_plugin_scanner.guard.adapters.zcode.sys.frozen", False, raising=False)
+        ZCodeHarnessAdapter().install(ctx)
+        payload = json.loads((ctx.home_dir / ".zcode" / "cli" / "config.json").read_text(encoding="utf-8"))
+        handler = payload["hooks"]["events"]["PreToolUse"][0]["hooks"][0]
+        command = handler["command"]
+        assert "bounded_cli_hook_bridge" in command
+        assert GUARD_MANAGED_MARKER in command
+        assert handler["timeout"] == 30
+
+    def test_install_hook_command_avoids_interpreter_flags_when_frozen(self, tmp_path: Path, monkeypatch) -> None:
+        ctx = _ctx(tmp_path)
+        self._patch_shims(monkeypatch, ctx)
+        monkeypatch.setattr("codex_plugin_scanner.guard.adapters.zcode.sys.frozen", True, raising=False)
+        ZCodeHarnessAdapter().install(ctx)
+        payload = json.loads((ctx.home_dir / ".zcode" / "cli" / "config.json").read_text(encoding="utf-8"))
+        handler = payload["hooks"]["events"]["PreToolUse"][0]["hooks"][0]
+        command = handler["command"]
+        # Frozen Guard builds cannot emulate ``python -c``; the hook must call
+        # the Guard CLI hook subcommand directly instead.
+        assert "guard" in command and "hook" in command and "--harness" in command
+        assert "bounded_cli_hook_bridge" not in command
+        assert GUARD_MANAGED_MARKER in command
 
     def test_install_preserves_user_mcp_and_plugins(self, tmp_path: Path, monkeypatch) -> None:
         ctx = _ctx(tmp_path)
@@ -286,7 +371,8 @@ class TestZCodeInstallUninstall:
         self._patch_shims(monkeypatch, ctx)
         ZCodeHarnessAdapter().install(ctx)
         payload = json.loads((ctx.home_dir / ".zcode" / "cli" / "config.json").read_text(encoding="utf-8"))
-        session_start = payload["hooks"]["SessionStart"]
+        events = payload["hooks"]["events"]
+        session_start = events["SessionStart"]
         user_commands = [
             handler["command"]
             for entry in session_start
@@ -295,6 +381,51 @@ class TestZCodeInstallUninstall:
             if isinstance(handler, dict) and handler.get("command") == "echo user-start"
         ]
         assert user_commands == ["echo user-start"]
+
+    def test_install_migrates_legacy_hook_layout(self, tmp_path: Path, monkeypatch) -> None:
+        ctx = _ctx(tmp_path)
+        legacy_managed = f"old-guard-command # {GUARD_MANAGED_MARKER}"
+        _write_cli_config(
+            ctx.home_dir,
+            {
+                "hooks": {
+                    "enabled": True,
+                    "timeoutMs": 60000,
+                    "SessionStart": [
+                        {"matcher": "startup", "hooks": [{"type": "command", "command": "echo user-start"}]}
+                    ],
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash",
+                            "hooks": [
+                                {"type": "command", "command": "echo user-pretool"},
+                                {"type": "command", "command": legacy_managed, "timeout": 30},
+                            ],
+                        }
+                    ],
+                }
+            },
+        )
+        self._patch_shims(monkeypatch, ctx)
+        ZCodeHarnessAdapter().install(ctx)
+        payload = json.loads((ctx.home_dir / ".zcode" / "cli" / "config.json").read_text(encoding="utf-8"))
+        hooks = payload["hooks"]
+        # User settings beside events survive and no legacy event keys remain.
+        assert hooks["enabled"] is True
+        assert hooks["timeoutMs"] == 60000
+        assert set(hooks.keys()) == {"enabled", "timeoutMs", "events"}
+        events = hooks["events"]
+        user_start = [
+            handler["command"]
+            for entry in events["SessionStart"]
+            for handler in entry.get("hooks", [])
+        ]
+        assert user_start == ["echo user-start"]
+        bash_entry = next(e for e in events["PreToolUse"] if e.get("matcher") == "Bash")
+        bash_commands = [handler["command"] for handler in bash_entry["hooks"]]
+        assert "echo user-pretool" in bash_commands
+        assert legacy_managed not in bash_commands, "stale managed handlers must be replaced"
+        assert any(is_guard_managed_hook_command(command) for command in bash_commands)
 
     def test_repeated_install_is_idempotent(self, tmp_path: Path, monkeypatch) -> None:
         ctx = _ctx(tmp_path)
@@ -335,16 +466,46 @@ class TestZCodeInstallUninstall:
         # User MCP/plugins preserved.
         assert payload["mcp"]["servers"]["user-server"]["command"] == "node"
         assert payload["plugins"]["enabledPlugins"]["user-plugin@mp"] is True
-        # User hooks preserved, Guard-managed hooks removed.
+        # User hooks preserved (migrated into events during install), Guard-managed hooks removed.
+        events = payload["hooks"]["events"]
         session_commands = [
             handler["command"]
-            for entry in payload["hooks"]["SessionStart"]
+            for entry in events["SessionStart"]
             for handler in entry.get("hooks", [])
             if handler.get("command") == "echo user-start"
         ]
         assert session_commands == ["echo user-start"]
         pretool_commands = [
-            handler["command"] for entry in payload["hooks"]["PreToolUse"] for handler in entry.get("hooks", [])
+            handler["command"] for entry in events["PreToolUse"] for handler in entry.get("hooks", [])
+        ]
+        assert pretool_commands == ["echo user-pretool"]
+        assert GUARD_MANAGED_MARKER not in json.dumps(payload)
+
+    def test_uninstall_prunes_legacy_guard_entries(self, tmp_path: Path, monkeypatch) -> None:
+        ctx = _ctx(tmp_path)
+        _write_cli_config(
+            ctx.home_dir,
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash",
+                            "hooks": [
+                                {"type": "command", "command": f"stale # {GUARD_MANAGED_MARKER}"},
+                                {"type": "command", "command": "echo user-pretool"},
+                            ],
+                        }
+                    ]
+                }
+            },
+        )
+        self._patch_shims(monkeypatch, ctx)
+        ZCodeHarnessAdapter().uninstall(ctx)
+        payload = json.loads((ctx.home_dir / ".zcode" / "cli" / "config.json").read_text(encoding="utf-8"))
+        pretool_commands = [
+            handler["command"]
+            for entry in payload["hooks"]["PreToolUse"]
+            for handler in entry.get("hooks", [])
         ]
         assert pretool_commands == ["echo user-pretool"]
         assert GUARD_MANAGED_MARKER not in json.dumps(payload)
@@ -366,6 +527,21 @@ class TestZCodeManagedHelpers:
 
     def test_is_guard_managed_hook_command_rejects_user_command(self) -> None:
         assert not is_guard_managed_hook_command("echo user-start")
+
+    def test_hook_event_groups_reads_both_schema_generations(self) -> None:
+        from codex_plugin_scanner.guard.adapters.zcode_config import hook_event_groups
+
+        groups = hook_event_groups(
+            {
+                "enabled": True,
+                "events": {"PreToolUse": [{"matcher": "Bash", "hooks": []}]},
+                "Stop": [{"hooks": []}],
+            }
+        )
+        assert set(groups.keys()) == {"PreToolUse", "Stop"}
+        # Settings keys are never mistaken for event groups.
+        assert hook_event_groups({"enabled": True, "timeoutMs": 1000}) == {}
+        assert hook_event_groups(None) == {}
 
     def test_merge_hook_entry_preserves_user_handlers(self) -> None:
         handler = {"type": "command", "command": f"x # {GUARD_MANAGED_MARKER}"}

--- a/tests/test_zcode_hooks.py
+++ b/tests/test_zcode_hooks.py
@@ -49,6 +49,12 @@ class TestZCodeHookPayload:
         assert normalized["tool_name"] == "Read"
         assert normalized["session_id"] == "s"
 
+    def test_prepare_payload_maps_post_tool_use_failure_event(self) -> None:
+        normalized = prepare_zcode_hook_payload(
+            {"hookEventName": "PostToolUseFailure", "toolName": "Bash", "toolInput": {"command": "ls"}}
+        )
+        assert normalized["hook_event_name"] == "PostToolUseFailure"
+
     def test_prepare_payload_malformed_is_safe(self) -> None:
         assert prepare_zcode_hook_payload({}) == {}
 

--- a/tests/test_zcode_mcp.py
+++ b/tests/test_zcode_mcp.py
@@ -48,13 +48,14 @@ class TestZCodeMcpToolCoverage:
         )
         ZCodeHarnessAdapter().install(ctx)
         payload = json.loads((ctx.home_dir / ".zcode" / "cli" / "config.json").read_text(encoding="utf-8"))
+        pretool_entries = payload["hooks"]["events"]["PreToolUse"]
         matchers = {
             entry.get("matcher")
-            for entry in payload["hooks"]["PreToolUse"]
+            for entry in pretool_entries
             if isinstance(entry, dict) and isinstance(entry.get("matcher"), str)
         }
         assert "mcp__.*" in matchers, "Guard must install an mcp__.* PreToolUse matcher so MCP tools are intercepted"
-        mcp_entry = next(entry for entry in payload["hooks"]["PreToolUse"] if entry.get("matcher") == "mcp__.*")
+        mcp_entry = next(entry for entry in pretool_entries if entry.get("matcher") == "mcp__.*")
         assert any(
             is_guard_managed_hook_command(handler.get("command"))
             for handler in mcp_entry.get("hooks", [])


### PR DESCRIPTION
## Summary
- Current ZCode rejects the legacy flat `hooks.<Event>` layout in `~/.zcode/cli/config.json` (strict `hooks.events` schema) and fails to load the whole config file when it finds legacy keys, which left Guard-installed hooks unfireable and broke ZCode's own config load. The ZCode adapter now writes only the nested `hooks.events` layout, migrates legacy flat hook groups (including user entries) into `events` on install, and prunes Guard-managed entries from both layouts on uninstall.
- Frozen Guard builds cannot emulate interpreter flags like `-c`, so the managed ZCode hook command now invokes the `guard hook` CLI subcommand directly when Guard runs frozen; interpreter installs keep the bounded subprocess bridge.
- ZCode detection now treats `~/.zcode/v2/config.json` (desktop app runtime state) as an install signal, hook inventories read both schema generations, and payload normalization maps the new `PostToolUseFailure` event.

## Testing
- `python -m pytest tests/test_zcode_adapter.py tests/test_zcode_hooks.py tests/test_zcode_mcp.py -q` (52 passed)
- `python -m pytest tests/test_cli_only_hook_resilience.py tests/test_bounded_cli_hook_bridge.py tests/test_guard_hook_worker.py tests/test_guard_runtime_action_harnesses.py tests/test_guard_mcp_adapter_env_identity.py -q` (86 passed)
- `python -m ruff check src/` and `python -m ruff format --check src/` (clean); `basedpyright --level error` on changed sources (0 new findings)
- Local end-to-end: installed the adapter into an isolated home, executed the managed hook command with a benign `PreToolUse` payload (allow envelope, exit 0) and an exfiltration payload (deny envelope with reason, exit 2), then uninstalled and confirmed the hooks section is removed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for ZCode v2 configuration files and nested hook event settings.
  * ZCode integrations now install Guard hooks across current and legacy configuration formats.
  * Hook events, including `PostToolUseFailure`, are normalized for consistent handling.
  * Frozen-runtime installations now invoke hooks directly and more reliably.

* **Bug Fixes**
  * Legacy hook configurations are migrated safely during installation.
  * Uninstall removes managed hooks while preserving unrelated configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->