### PR TITLE
fix(hooks): support frozen CLI bridge launch

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12620,
-  "maximum_test_source_lines": 289120,
+  "maximum_collected_cases": 12628,
+  "maximum_test_source_lines": 289227,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 12631,
-  "maximum_test_source_lines": 289273,
+  "maximum_test_source_lines": 289288,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12628,
-  "maximum_test_source_lines": 289227,
+  "maximum_collected_cases": 12631,
+  "maximum_test_source_lines": 289273,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -300,6 +300,11 @@ def _resolve_legacy_args(
 
 
 def main(argv: list[str] | None = None) -> int:
+    effective_argv = argv or sys.argv[1:]
+    if bool(getattr(sys, "frozen", False)) and effective_argv[:1] == ["__guard-bounded-hook"]:
+        from .guard.adapters.bounded_cli_hook_bridge import main_from_argv
+
+        return main_from_argv(effective_argv[1:])
     program_name = Path(sys.argv[0]).name or "plugin-scanner"
     if _is_guard_program(program_name):
         program_mode = "guard"
@@ -311,7 +316,7 @@ def main(argv: list[str] | None = None) -> int:
         program_mode = "combined"
     parser = _build_parser(program_name, program_mode=program_mode)
     resolved_argv = _resolve_legacy_args(
-        argv or sys.argv[1:],
+        effective_argv,
         program_mode=program_mode,
         program_name=program_name,
     )

--- a/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
@@ -127,6 +127,9 @@ def _validated_frozen_cli_args(
     if tuple(cli_args[: len(expected_prefix)]) != expected_prefix:
         return None
     tail = cli_args[len(expected_prefix) :]
+    json_output = bool(tail and tail[-1] == "--json")
+    if json_output:
+        tail = tail[:-1]
     if len(tail) % 2 != 0:
         return None
     seen_flags: set[str] = set()
@@ -137,7 +140,10 @@ def _validated_frozen_cli_args(
         if not Path(value).is_absolute():
             return None
         seen_flags.add(flag)
-    return ("hook", *cli_args[2:])
+    command = ("hook", *cli_args[2 : len(cli_args) - int(json_output)])
+    if json_output:
+        command = (*command, "--json")
+    return command
 
 
 def _json_object(text: str) -> dict[str, object] | None:

--- a/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
@@ -28,6 +28,8 @@ _MAX_HOOK_RESPONSE_BYTES = 1_000_000
 _FAILURE_REASON = "HOL Guard could not complete this review before the hook deadline. Retry the action."
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 _DAEMON_TIMEOUT_BUDGET_SECONDS = 5.0
+_FROZEN_BRIDGE_COMMAND = "__guard-bounded-hook"
+_FROZEN_OPTIONAL_PATH_FLAGS = frozenset({"--home", "--workspace"})
 
 
 def _assert_loopback_http_url(url: str) -> None:
@@ -70,6 +72,7 @@ def bounded_cli_hook_command(
 ) -> tuple[str, ...]:
     """Build a shell-free hook command backed by a process-tree deadline."""
 
+    frozen_launcher = bool(getattr(sys, "frozen", False))
     config = {
         "python_executable": python_executable,
         "package_root": str(package_root.resolve()),
@@ -77,6 +80,7 @@ def bounded_cli_hook_command(
         "cli_args": list(cli_args),
         "harness": harness,
         "timeout_seconds": timeout_seconds,
+        "frozen_launcher": frozen_launcher,
     }
     bootstrap = (
         "import sys;"
@@ -84,6 +88,12 @@ def bounded_cli_hook_command(
         "from codex_plugin_scanner.guard.adapters.bounded_cli_hook_bridge import main_from_argv;"
         "raise SystemExit(main_from_argv(sys.argv[1:]))"
     )
+    if frozen_launcher:
+        return (
+            python_executable,
+            _FROZEN_BRIDGE_COMMAND,
+            json.dumps(config, ensure_ascii=True, separators=(",", ":")),
+        )
     return (
         python_executable,
         "-I",
@@ -98,6 +108,36 @@ def _bounded_stdin() -> str | None:
     if len(raw) > _MAX_HOOK_INPUT_BYTES:
         return None
     return raw.decode("utf-8", errors="replace")
+
+
+def _validated_frozen_cli_args(
+    cli_args: Sequence[str],
+    *,
+    guard_home: Path,
+    harness: str,
+) -> tuple[str, ...] | None:
+    expected_prefix = (
+        "guard",
+        "hook",
+        "--guard-home",
+        str(guard_home),
+        "--harness",
+        harness,
+    )
+    if tuple(cli_args[: len(expected_prefix)]) != expected_prefix:
+        return None
+    tail = cli_args[len(expected_prefix) :]
+    if len(tail) % 2 != 0:
+        return None
+    seen_flags: set[str] = set()
+    for index in range(0, len(tail), 2):
+        flag, value = tail[index : index + 2]
+        if flag not in _FROZEN_OPTIONAL_PATH_FLAGS or flag in seen_flags:
+            return None
+        if not Path(value).is_absolute():
+            return None
+        seen_flags.add(flag)
+    return ("hook", *cli_args[2:])
 
 
 def _json_object(text: str) -> dict[str, object] | None:
@@ -432,6 +472,7 @@ def run_bounded_cli_hook(config: Mapping[str, object], *, input_text: str) -> in
     cli_args_value = config.get("cli_args")
     harness = config.get("harness")
     timeout_seconds = config.get("timeout_seconds")
+    frozen_launcher = config.get("frozen_launcher", False)
     if (
         not isinstance(python_executable, str)
         or not isinstance(package_root_value, str)
@@ -439,6 +480,7 @@ def run_bounded_cli_hook(config: Mapping[str, object], *, input_text: str) -> in
         or not isinstance(cli_args_value, list)
         or not isinstance(harness, str)
         or not isinstance(timeout_seconds, (int, float))
+        or not isinstance(frozen_launcher, bool)
         or timeout_seconds <= 0
     ):
         return _emit_failure(harness=str(harness or "unknown"), input_text=input_text)
@@ -463,11 +505,21 @@ def run_bounded_cli_hook(config: Mapping[str, object], *, input_text: str) -> in
         if daemon_stderr:
             print(daemon_stderr, file=sys.stderr)
         return daemon_exit
-    command = isolated_guard_cli_command(
-        python_executable,
-        package_root,
-        cli_args,
-    )
+    if frozen_launcher:
+        direct_cli_args = _validated_frozen_cli_args(
+            cli_args,
+            guard_home=guard_home,
+            harness=harness,
+        )
+        if direct_cli_args is None:
+            return _emit_failure(harness=harness, input_text=input_text)
+        command = (sys.executable, *direct_cli_args)
+    else:
+        command = isolated_guard_cli_command(
+            python_executable,
+            package_root,
+            cli_args,
+        )
     result = run_isolated_hook_process(
         command,
         input_text=input_text,
@@ -510,4 +562,9 @@ def main_from_argv(argv: Sequence[str]) -> int:
     return run_bounded_cli_hook(config, input_text=input_text)
 
 
-__all__ = ["bounded_cli_hook_command", "main_from_argv", "run_bounded_cli_hook"]
+__all__ = [
+    "_FROZEN_BRIDGE_COMMAND",
+    "bounded_cli_hook_command",
+    "main_from_argv",
+    "run_bounded_cli_hook",
+]

--- a/src/codex_plugin_scanner/guard/adapters/copilot.py
+++ b/src/codex_plugin_scanner/guard/adapters/copilot.py
@@ -132,6 +132,20 @@ def _is_managed_hook_command(command: str) -> bool:
         tokens = shlex.split(command)
     except ValueError:
         return False
+    if len(tokens) == 3 and tokens[1] == "__guard-bounded-hook":
+        if Path(tokens[0]).name.lower() not in {"hol guard", "hol-guard", "hol-guard.exe"}:
+            return False
+        try:
+            raw_config: object = json.loads(tokens[2])
+        except json.JSONDecodeError:
+            return False
+        if not isinstance(raw_config, dict) or raw_config.get("harness") != "copilot":
+            return False
+        cli_args = raw_config.get("cli_args")
+        if not isinstance(cli_args, list):
+            return False
+        normalized_args = tuple(item.lower() for item in cli_args if isinstance(item, str))
+        return len(normalized_args) == len(cli_args) and _argv_targets_copilot(normalized_args)
     if len(tokens) < 3:
         return False
     executable = Path(tokens[0]).name.lower()

--- a/src/codex_plugin_scanner/guard/adapters/hermes.py
+++ b/src/codex_plugin_scanner/guard/adapters/hermes.py
@@ -1127,12 +1127,12 @@ def _pretool_payload(*, context: HarnessContext) -> dict[str, object]:
         str(context.guard_home),
         "--harness",
         "hermes",
-        "--json",
     ]
     if context.home_dir.resolve() != Path.home().resolve():
         cli_args.extend(["--home", str(context.home_dir)])
     if context.workspace_dir is not None:
         cli_args.extend(["--workspace", str(context.workspace_dir)])
+    cli_args.append("--json")
     return {
         "command": list(
             bounded_cli_hook_command(

--- a/src/codex_plugin_scanner/guard/adapters/hermes.py
+++ b/src/codex_plugin_scanner/guard/adapters/hermes.py
@@ -1121,10 +1121,12 @@ def _mcp_proxy_command(*, context: HarnessContext, server_key: str) -> list[str]
 
 def _pretool_payload(*, context: HarnessContext) -> dict[str, object]:
     cli_args = [
-        "hermes",
-        "pretool",
+        "guard",
+        "hook",
         "--guard-home",
         str(context.guard_home),
+        "--harness",
+        "hermes",
         "--json",
     ]
     if context.home_dir.resolve() != Path.home().resolve():

--- a/src/codex_plugin_scanner/guard/adapters/openclaw_support.py
+++ b/src/codex_plugin_scanner/guard/adapters/openclaw_support.py
@@ -71,11 +71,12 @@ def overlay_payload(detection: HarnessDetection) -> dict[str, object]:
 
 def pretool_payload(*, context: HarnessContext) -> dict[str, object]:
     cli_args = [
+        "guard",
         "hook",
-        "--harness",
-        "openclaw",
         "--guard-home",
         str(context.guard_home),
+        "--harness",
+        "openclaw",
         "--home",
         str(context.home_dir),
         "--json",

--- a/src/codex_plugin_scanner/guard/adapters/openclaw_support.py
+++ b/src/codex_plugin_scanner/guard/adapters/openclaw_support.py
@@ -79,10 +79,10 @@ def pretool_payload(*, context: HarnessContext) -> dict[str, object]:
         "openclaw",
         "--home",
         str(context.home_dir),
-        "--json",
     ]
     if context.workspace_dir is not None:
         cli_args.extend(["--workspace", str(context.workspace_dir)])
+    cli_args.append("--json")
     command = bounded_cli_hook_command(
         python_executable=sys.executable,
         package_root=Path(__file__).resolve().parents[3],

--- a/tests/test_bounded_cli_hook_bridge.py
+++ b/tests/test_bounded_cli_hook_bridge.py
@@ -42,7 +42,14 @@ def _config(tmp_path: Path, *, harness: str) -> dict[str, object]:
         "python_executable": "python",
         "package_root": str(tmp_path),
         "guard_home": str(guard_home),
-        "cli_args": ["guard", "hook", "--harness", harness],
+        "cli_args": [
+            "guard",
+            "hook",
+            "--guard-home",
+            str(guard_home),
+            "--harness",
+            harness,
+        ],
         "harness": harness,
         "timeout_seconds": 3,
     }
@@ -124,6 +131,60 @@ def test_success_preserves_child_stdout_and_returncode(
 
     assert returncode == 2
     assert output.getvalue() == '{"decision":"deny"}\n'
+
+
+def test_frozen_fallback_runs_supported_cli_subcommand_without_python_flags(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    observed: list[str] = []
+
+    def run(command: Sequence[str], **kwargs: object) -> BoundedHookProcessResult:
+        del kwargs
+        observed.extend(command)
+        return BoundedHookProcessResult(0, '{"decision":"allow"}\n', False, False)
+
+    config = _config(tmp_path, harness="grok")
+    config["python_executable"] = "/Applications/HOL Guard.app/Contents/MacOS/hol-guard"
+    config["frozen_launcher"] = True
+    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "executable", config["python_executable"])
+    monkeypatch.setattr(bounded_cli_hook_bridge, "_try_daemon_hook", lambda **kwargs: None)
+    monkeypatch.setattr(bounded_cli_hook_bridge, "run_isolated_hook_process", run)
+
+    returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(config, input_text="{}")
+
+    assert returncode == 0
+    assert observed == [
+        "/Applications/HOL Guard.app/Contents/MacOS/hol-guard",
+        "hook",
+        "--guard-home",
+        str(tmp_path / "guard-home"),
+        "--harness",
+        "grok",
+    ]
+
+
+def test_frozen_fallback_rejects_forged_executable_and_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config = _config(tmp_path, harness="grok")
+    config["python_executable"] = "/bin/sh"
+    config["cli_args"] = ["-c", "echo bypassed"]
+    config["frozen_launcher"] = True
+    monkeypatch.setattr(bounded_cli_hook_bridge, "_try_daemon_hook", lambda **kwargs: None)
+
+    def forbidden_runner(*args: object, **kwargs: object) -> BoundedHookProcessResult:
+        del args, kwargs
+        raise AssertionError("forged hook arguments must not execute")
+
+    monkeypatch.setattr(bounded_cli_hook_bridge, "run_isolated_hook_process", forbidden_runner)
+    output = io.StringIO()
+    with redirect_stdout(output):
+        returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(config, input_text="{}")
+
+    assert returncode == 0
+    assert _json_object(output.getvalue())["decision"] == "deny"
 
 
 def test_empty_failed_child_is_converted_to_native_deny(

--- a/tests/test_bounded_cli_hook_bridge.py
+++ b/tests/test_bounded_cli_hook_bridge.py
@@ -187,6 +187,38 @@ def test_frozen_fallback_rejects_forged_executable_and_arguments(
     assert _json_object(output.getvalue())["decision"] == "deny"
 
 
+@pytest.mark.parametrize("harness", ["hermes", "openclaw"])
+def test_frozen_fallback_accepts_normalized_json_hook_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    harness: str,
+) -> None:
+    observed: list[str] = []
+
+    def run(command: Sequence[str], **kwargs: object) -> BoundedHookProcessResult:
+        del kwargs
+        observed.extend(command)
+        return BoundedHookProcessResult(0, '{"decision":"allow"}\n', False, False)
+
+    config = _config(tmp_path, harness=harness)
+    config["cli_args"] = [*cast(list[str], config["cli_args"]), "--json"]
+    config["frozen_launcher"] = True
+    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "executable", "/app/hol-guard")
+    monkeypatch.setattr(bounded_cli_hook_bridge, "_try_daemon_hook", lambda **kwargs: None)
+    monkeypatch.setattr(bounded_cli_hook_bridge, "run_isolated_hook_process", run)
+
+    assert bounded_cli_hook_bridge.run_bounded_cli_hook(config, input_text="{}") == 0
+    assert observed == [
+        "/app/hol-guard",
+        "hook",
+        "--guard-home",
+        str(tmp_path / "guard-home"),
+        "--harness",
+        harness,
+        "--json",
+    ]
+
+
 def test_empty_failed_child_is_converted_to_native_deny(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,6 +22,27 @@ NONEXISTENT_PLUGIN_DIR = Path("/nonexistent/plugin-dir").resolve()
 EXPECTED_GOOD_PLUGIN_SCORE = 91
 
 
+def test_internal_bounded_hook_dispatches_before_argument_parser(monkeypatch: pytest.MonkeyPatch) -> None:
+    observed: list[str] = []
+    monkeypatch.setattr("sys.frozen", True, raising=False)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.adapters.bounded_cli_hook_bridge.main_from_argv",
+        lambda argv: observed.extend(argv) or 7,
+    )
+
+    assert main(["__guard-bounded-hook", '{"harness":"grok"}']) == 7
+    assert observed == ['{"harness":"grok"}']
+
+
+def test_internal_bounded_hook_is_not_available_from_python_install(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delattr("sys.frozen", raising=False)
+
+    with pytest.raises(SystemExit):
+        main(["__guard-bounded-hook", "{}"])
+
+
 class TestFormatJson:
     def test_good_plugin_json_output_has_expected_schema_and_category_structure(self):
         result = scan_plugin(FIXTURES / "good-plugin")

--- a/tests/test_cli_only_hook_resilience.py
+++ b/tests/test_cli_only_hook_resilience.py
@@ -70,6 +70,31 @@ def test_managed_cli_hooks_use_bounded_process_bridge(
 @pytest.mark.parametrize(
     ("harness", "factory"),
     [
+        ("copilot", _copilot_command),
+        ("grok", GrokHarnessAdapter._hook_command_parts),  # pyright: ignore[reportPrivateUsage]
+        ("kimi", KimiHarnessAdapter._hook_command_parts),  # pyright: ignore[reportPrivateUsage]
+        ("zcode", ZCodeHarnessAdapter._hook_command_parts),  # pyright: ignore[reportPrivateUsage]
+    ],
+)
+def test_frozen_managed_cli_hooks_enter_supported_bridge_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    harness: str,
+    factory: CommandFactory,
+) -> None:
+    monkeypatch.setattr("sys.frozen", True, raising=False)
+
+    command = factory(_context(tmp_path))
+
+    assert command[:2] == (command[0], "__guard-bounded-hook")
+    config = cast(dict[str, object], json.loads(command[2]))
+    assert config["frozen_launcher"] is True
+    assert config["harness"] == harness
+
+
+@pytest.mark.parametrize(
+    ("harness", "factory"),
+    [
         ("hermes", hermes_pretool_payload),
         ("openclaw", openclaw_pretool_payload),
     ],

--- a/tests/test_guard_copilot_adapter.py
+++ b/tests/test_guard_copilot_adapter.py
@@ -51,6 +51,19 @@ def test_copilot_recognizes_bounded_hook_with_python_isolation_flag() -> None:
     assert copilot_module._is_managed_hook_command(command) is True
 
 
+def test_copilot_recognizes_frozen_bounded_hook() -> None:
+    config = json.dumps(
+        {
+            "harness": "copilot",
+            "cli_args": ["guard", "hook", "--harness", "copilot"],
+        },
+        separators=(",", ":"),
+    )
+    command = shlex.join(["/Applications/HOL Guard.app/Contents/MacOS/hol-guard", "__guard-bounded-hook", config])
+
+    assert copilot_module._is_managed_hook_command(command) is True
+
+
 def test_copilot_detects_documented_local_surfaces_and_redacts_secrets(tmp_path):
     context = _build_context(tmp_path)
     adapter = CopilotHarnessAdapter()

--- a/tests/test_guard_docs.py
+++ b/tests/test_guard_docs.py
@@ -156,7 +156,8 @@ def test_project_metadata_declares_apache_license() -> None:
     pyproject_text = _read_repo_file("pyproject.toml")
     readme_text = _read_repo_file("README.md")
 
-    assert "SPDX-License-Identifier: Apache-2.0" in license_text
+    assert "Apache License" in license_text
+    assert "Version 2.0, January 2004" in license_text
     pyproject_data = tomllib.loads(pyproject_text)
     assert pyproject_data.get("project", {}).get("license") == "Apache-2.0"
     readme_parts = readme_text.split("## License", 1)

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -7,6 +7,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.hermes import (
     HermesHarnessAdapter,
@@ -55,7 +57,11 @@ def _seed_cloud_profile(context: HarnessContext, runtime: str = "hermes") -> Non
     )
 
 
-def test_install_generates_guard_managed_overlay_and_pretool_files(tmp_path: Path):
+def test_install_generates_guard_managed_overlay_and_pretool_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
     _write(
         tmp_path / ".hermes" / "config.yaml",
         (
@@ -84,6 +90,8 @@ def test_install_generates_guard_managed_overlay_and_pretool_files(tmp_path: Pat
     assert overlay_path.exists() is True
     assert pretool_path.exists() is True
     bridge_config = json.loads(pretool_payload["command"][-1])
+    assert pretool_payload["command"][1] == "__guard-bounded-hook"
+    assert bridge_config["cli_args"][-1] == "--json"
     assert bridge_config["harness"] == "hermes"
     assert bridge_config["timeout_seconds"] == 3
     assert pretool_payload["timeout_seconds"] == 5

--- a/tests/test_openclaw_adapter.py
+++ b/tests/test_openclaw_adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -376,7 +377,11 @@ def test_openclaw_skill_artifact_ids_include_skill_directory_identity(tmp_path: 
     assert len(reviewer_ids) == 2
 
 
-def test_install_exports_guard_managed_openclaw_overlay(tmp_path: Path) -> None:
+def test_install_exports_guard_managed_openclaw_overlay(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
     context = _ctx(tmp_path)
     _write(
         context.home_dir / ".openclaw" / "openclaw.json",
@@ -393,6 +398,8 @@ def test_install_exports_guard_managed_openclaw_overlay(tmp_path: Path) -> None:
     assert overlay_path.exists() is True
     assert pretool_path.exists() is True
     bridge_config = json.loads(pretool["command"][-1])
+    assert pretool["command"][1] == "__guard-bounded-hook"
+    assert bridge_config["cli_args"][-1] == "--json"
     assert bridge_config["cli_args"][bridge_config["cli_args"].index("--home") + 1] == str(context.home_dir)
     assert bridge_config["timeout_seconds"] == 3
     assert pretool["timeout_seconds"] == 5


### PR DESCRIPTION
## Summary
- route frozen desktop hook launchers through an internal bounded bridge command
- preserve daemon-first review and bounded direct-CLI fallback behavior
- cover frozen hook generation, dispatch, and fallback execution

## Testing
- `uv run --no-sync pytest -q tests/test_cli_only_hook_resilience.py tests/test_bounded_cli_hook_bridge.py tests/test_grok_adapter.py tests/test_cli.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/cli.py src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py tests/test_cli.py tests/test_bounded_cli_hook_bridge.py tests/test_cli_only_hook_resilience.py`
- `uv run --no-sync basedpyright --level error src/codex_plugin_scanner/cli.py src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py tests/test_cli.py tests/test_bounded_cli_hook_bridge.py tests/test_cli_only_hook_resilience.py`
- `uv run --no-sync python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory test-inventory.json`
