### PR TITLE
fix(hooks): support frozen CLI bridge launch

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14841,
-  "maximum_test_source_lines": 320930,
+  "maximum_collected_cases": 14863,
+  "maximum_test_source_lines": 321397,
   "schema_version": 1
 }

--- a/rust/crates/guard-runtime/src/hardening.rs
+++ b/rust/crates/guard-runtime/src/hardening.rs
@@ -39,15 +39,36 @@ pub fn classify_io_error(error: &io::Error) -> IoFailureClass {
         }
         _ if matches!(
             error.raw_os_error(),
-            Some(50 | 51 | 52 | 53 | 54 | 64 | 65 | 10050 | 10051 | 10052 | 10053 | 10054 | 10060 | 10064 | 10065)
-        ) => IoFailureClass::NetworkChange,
+            Some(
+                50 | 51
+                    | 52
+                    | 53
+                    | 54
+                    | 64
+                    | 65
+                    | 10050
+                    | 10051
+                    | 10052
+                    | 10053
+                    | 10054
+                    | 10060
+                    | 10064
+                    | 10065
+            )
+        ) =>
+        {
+            IoFailureClass::NetworkChange
+        }
         _ => IoFailureClass::Other,
     }
 }
 
 pub fn accept_retry_delay(consecutive_failures: u32, error: &io::Error) -> Duration {
     match classify_io_error(error) {
-        IoFailureClass::Interrupted | IoFailureClass::ClientAbort => Duration::ZERO,
+        IoFailureClass::Interrupted => Duration::ZERO,
+        IoFailureClass::ClientAbort => ACCEPT_BACKOFF_MIN
+            .saturating_mul(1u32 << consecutive_failures.min(5))
+            .min(ACCEPT_BACKOFF_MAX),
         IoFailureClass::Timeout => ACCEPT_BACKOFF_MIN,
         IoFailureClass::ResourcePressure => {
             let shift = consecutive_failures.min(7);
@@ -100,7 +121,12 @@ mod tests {
     fn client_disconnects_are_not_runtime_integrity_failures() {
         let error = io::Error::new(io::ErrorKind::BrokenPipe, "fixture");
         assert_eq!(classify_io_error(&error), IoFailureClass::ClientAbort);
-        assert_eq!(write_error(&error, "fallback"), "native_client_disconnected");
+        assert!(accept_retry_delay(0, &error) >= ACCEPT_BACKOFF_MIN);
+        assert!(accept_retry_delay(100, &error) <= ACCEPT_BACKOFF_MAX);
+        assert_eq!(
+            write_error(&error, "fallback"),
+            "native_client_disconnected"
+        );
     }
 
     #[test]

--- a/rust/crates/guard-runtime/src/main.rs
+++ b/rust/crates/guard-runtime/src/main.rs
@@ -1,5 +1,7 @@
 #![forbid(unsafe_code)]
 
+mod hardening;
+
 use guard_command::{parse_command, CommandModelRequestV1};
 use guard_contracts::{
     NativeHookRequestV1, RuntimeCapabilitiesV1, MAX_NATIVE_REQUEST_BYTES,
@@ -20,7 +22,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{sync_channel, Receiver, SyncSender, TrySendError};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 const BUILD_SHA: &str = match option_env!("HOL_GUARD_BUILD_SHA") {
     Some(value) => value,
@@ -47,7 +49,6 @@ const AUTH_TIMEOUT: Duration = Duration::from_millis(250);
 const HEADER_TIMEOUT: Duration = Duration::from_millis(250);
 const PAYLOAD_TIMEOUT: Duration = Duration::from_secs(2);
 const RESPONSE_TIMEOUT: Duration = Duration::from_secs(1);
-const ACCEPT_RETRY_DELAY: Duration = Duration::from_millis(10);
 const MAX_JSON_DEPTH: usize = 32;
 const MAX_JSON_COLLECTION_ITEMS: usize = 4_096;
 const MAX_JSON_STRING_BYTES: usize = 1024 * 1024;
@@ -109,6 +110,7 @@ struct PendingRequest {
     request_id: [u8; FRAME_REQUEST_ID_BYTES],
     request_digest: [u8; FRAME_DIGEST_BYTES],
     length: usize,
+    accepted_at: Instant,
 }
 
 #[derive(Clone, Copy)]
@@ -270,7 +272,7 @@ fn read_stdin_bounded() -> Result<Vec<u8>, String> {
     io::stdin()
         .take(MAX_NATIVE_REQUEST_BYTES as u64 + 1)
         .read_to_end(&mut bytes)
-        .map_err(|_| "native_request_read_failed".to_owned())?;
+        .map_err(|error| hardening::read_error(&error, "native_request_read_failed"))?;
     if bytes.len() > MAX_NATIVE_REQUEST_BYTES {
         return Err("native_request_too_large".into());
     }
@@ -451,6 +453,7 @@ fn read_request_header(mut stream: BoxedResidentStream) -> Result<PendingRequest
         request_id,
         request_digest,
         length,
+        accepted_at: Instant::now(),
     })
 }
 
@@ -473,13 +476,13 @@ fn write_bound_response(
     header.extend_from_slice(&(response.len() as u32).to_be_bytes());
     stream
         .write_all(&header)
-        .map_err(|_| "native_frame_write_failed".to_owned())?;
+        .map_err(|error| hardening::write_error(&error, "native_frame_write_failed"))?;
     stream
         .write_all(response)
-        .map_err(|_| "native_frame_write_failed".to_owned())?;
+        .map_err(|error| hardening::write_error(&error, "native_frame_write_failed"))?;
     stream
         .flush()
-        .map_err(|_| "native_frame_write_failed".to_owned())?;
+        .map_err(|error| hardening::write_error(&error, "native_frame_write_failed"))?;
     Ok(())
 }
 
@@ -489,6 +492,11 @@ fn write_overload(pending: &mut PendingRequest) {
 }
 
 fn handle_pending_request(mut pending: PendingRequest) {
+    if hardening::request_expired(pending.accepted_at) {
+        let response = error_response("native_request_deadline_exceeded", true);
+        let _ = write_bound_response(&mut *pending.stream, &pending.request_id, &response);
+        return;
+    }
     let _ = pending
         .stream
         .set_resident_read_timeout(Some(PAYLOAD_TIMEOUT));
@@ -639,23 +647,24 @@ fn serve(socket_path: &str) -> Result<(), String> {
     let token = Arc::new(read_resident_auth_token()?);
     let sender = start_resident_workers(token);
     let parent_alive = resident_parent_liveness()?;
+    let mut consecutive_accept_failures = 0;
     while parent_alive.load(Ordering::Acquire) {
         match listener.accept() {
             Ok((stream, _address)) => {
+                consecutive_accept_failures = 0;
                 if stream.set_nonblocking(false).is_err() {
                     continue;
                 }
                 admit_connection(&sender, Box::new(stream))?
             }
             Err(error)
-                if matches!(
-                    error.kind(),
-                    io::ErrorKind::Interrupted
-                        | io::ErrorKind::WouldBlock
-                        | io::ErrorKind::ConnectionAborted
-                ) =>
+                if hardening::classify_io_error(&error) != hardening::IoFailureClass::Other =>
             {
-                thread::sleep(ACCEPT_RETRY_DELAY);
+                consecutive_accept_failures += 1;
+                thread::sleep(hardening::accept_retry_delay(
+                    consecutive_accept_failures,
+                    &error,
+                ));
             }
             Err(_) => return Err("native_socket_accept_failed".to_owned()),
         }
@@ -686,18 +695,21 @@ fn serve_loopback(address: &str) -> Result<(), String> {
 
     let token = Arc::new(read_resident_auth_token()?);
     let sender = start_resident_workers(token);
+    let mut consecutive_accept_failures = 0;
     loop {
         match listener.accept() {
-            Ok((stream, _address)) => admit_connection(&sender, Box::new(stream))?,
+            Ok((stream, _address)) => {
+                consecutive_accept_failures = 0;
+                admit_connection(&sender, Box::new(stream))?;
+            }
             Err(error)
-                if matches!(
-                    error.kind(),
-                    io::ErrorKind::Interrupted
-                        | io::ErrorKind::WouldBlock
-                        | io::ErrorKind::ConnectionAborted
-                ) =>
+                if hardening::classify_io_error(&error) != hardening::IoFailureClass::Other =>
             {
-                thread::sleep(ACCEPT_RETRY_DELAY);
+                consecutive_accept_failures += 1;
+                thread::sleep(hardening::accept_retry_delay(
+                    consecutive_accept_failures,
+                    &error,
+                ));
             }
             Err(_) => return Err("native_resident_loopback_accept_failed".to_owned()),
         }
@@ -718,7 +730,7 @@ fn read_resident_auth_token() -> Result<[u8; AUTH_TOKEN_BYTES], String> {
     io::stdin()
         .take((AUTH_TOKEN_BYTES * 2 + 2) as u64)
         .read_to_string(&mut encoded)
-        .map_err(|_| "native_resident_auth_read_failed".to_owned())?;
+        .map_err(|error| hardening::read_error(&error, "native_resident_auth_read_failed"))?;
     let encoded = encoded.trim();
     if encoded.len() != AUTH_TOKEN_BYTES * 2 {
         return Err("native_resident_auth_invalid".into());
@@ -735,10 +747,10 @@ fn read_resident_auth_token() -> Result<[u8; AUTH_TOKEN_BYTES], String> {
 fn write_bytes_response(response: &[u8]) -> Result<(), String> {
     io::stdout()
         .write_all(response)
-        .map_err(|_| "native_response_write_failed".to_owned())?;
+        .map_err(|error| hardening::write_error(&error, "native_response_write_failed"))?;
     io::stdout()
         .write_all(b"\n")
-        .map_err(|_| "native_response_write_failed".to_owned())?;
+        .map_err(|error| hardening::write_error(&error, "native_response_write_failed"))?;
     Ok(())
 }
 

--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -303,6 +303,10 @@ def _resolve_legacy_args(
 def main(argv: list[str] | None = None) -> int:
     program_name = Path(sys.argv[0]).name or "plugin-scanner"
     requested_argv = argv or sys.argv[1:]
+    if bool(getattr(sys, "frozen", False)) and requested_argv[:1] == ["__guard-bounded-hook"]:
+        from .guard.adapters.bounded_cli_hook_bridge import main_from_argv
+
+        return main_from_argv(requested_argv[1:])
     if _is_hol_guard_program(program_name) and requested_argv and requested_argv[0] == "secrets":
         from .guard.secrets.cli import main as secrets_main
 

--- a/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
@@ -28,6 +28,8 @@ _MAX_HOOK_RESPONSE_BYTES = 1_000_000
 _FAILURE_REASON = "HOL Guard could not complete this review before the hook deadline. Retry the action."
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 _DAEMON_TIMEOUT_BUDGET_SECONDS = 5.0
+_FROZEN_BRIDGE_COMMAND = "__guard-bounded-hook"
+_FROZEN_OPTIONAL_PATH_FLAGS = frozenset({"--home", "--workspace"})
 
 
 def _assert_loopback_http_url(url: str) -> None:
@@ -70,6 +72,7 @@ def bounded_cli_hook_command(
 ) -> tuple[str, ...]:
     """Build a shell-free hook command backed by a process-tree deadline."""
 
+    frozen_launcher = bool(getattr(sys, "frozen", False))
     config = {
         "python_executable": python_executable,
         "package_root": str(package_root.resolve()),
@@ -77,6 +80,7 @@ def bounded_cli_hook_command(
         "cli_args": list(cli_args),
         "harness": harness,
         "timeout_seconds": timeout_seconds,
+        "frozen_launcher": frozen_launcher,
     }
     bootstrap = (
         "import sys;"
@@ -84,6 +88,12 @@ def bounded_cli_hook_command(
         "from codex_plugin_scanner.guard.adapters.bounded_cli_hook_bridge import main_from_argv;"
         "raise SystemExit(main_from_argv(sys.argv[1:]))"
     )
+    if frozen_launcher:
+        return (
+            python_executable,
+            _FROZEN_BRIDGE_COMMAND,
+            json.dumps(config, ensure_ascii=True, separators=(",", ":")),
+        )
     return (
         python_executable,
         "-I",
@@ -98,6 +108,53 @@ def _bounded_stdin() -> str | None:
     if len(raw) > _MAX_HOOK_INPUT_BYTES:
         return None
     return raw.decode("utf-8", errors="replace")
+
+
+def _validated_frozen_cli_args(
+    cli_args: Sequence[str],
+    *,
+    guard_home: Path,
+    harness: str,
+) -> tuple[str, ...] | None:
+    if len(cli_args) < 6 or tuple(cli_args[:3]) != ("guard", "hook", "--guard-home"):
+        return None
+    supplied_guard_home_value = Path(cli_args[3])
+    if not supplied_guard_home_value.is_absolute() or not guard_home.is_absolute():
+        return None
+    try:
+        supplied_guard_home = supplied_guard_home_value.resolve(strict=False)
+        expected_guard_home = guard_home.resolve(strict=False)
+    except (OSError, RuntimeError):
+        return None
+    if supplied_guard_home != expected_guard_home:
+        return None
+    if tuple(cli_args[4:6]) != ("--harness", harness):
+        return None
+    tail = cli_args[6:]
+    json_output = bool(tail and tail[-1] == "--json")
+    if json_output:
+        tail = tail[:-1]
+    if len(tail) % 2 != 0:
+        return None
+    seen_flags: set[str] = set()
+    for index in range(0, len(tail), 2):
+        flag, value = tail[index : index + 2]
+        if flag not in _FROZEN_OPTIONAL_PATH_FLAGS or flag in seen_flags:
+            return None
+        if not Path(value).is_absolute():
+            return None
+        seen_flags.add(flag)
+    command: tuple[str, ...] = (
+        "hook",
+        "--guard-home",
+        str(expected_guard_home),
+        "--harness",
+        harness,
+        *tail,
+    )
+    if json_output:
+        command = (*command, "--json")
+    return command
 
 
 def _json_object(text: str) -> dict[str, object] | None:
@@ -432,6 +489,7 @@ def run_bounded_cli_hook(config: Mapping[str, object], *, input_text: str) -> in
     cli_args_value = config.get("cli_args")
     harness = config.get("harness")
     timeout_seconds = config.get("timeout_seconds")
+    frozen_launcher = config.get("frozen_launcher", False)
     if (
         not isinstance(python_executable, str)
         or not isinstance(package_root_value, str)
@@ -439,6 +497,7 @@ def run_bounded_cli_hook(config: Mapping[str, object], *, input_text: str) -> in
         or not isinstance(cli_args_value, list)
         or not isinstance(harness, str)
         or not isinstance(timeout_seconds, (int, float))
+        or not isinstance(frozen_launcher, bool)
         or timeout_seconds <= 0
     ):
         return _emit_failure(harness=str(harness or "unknown"), input_text=input_text)
@@ -448,7 +507,25 @@ def run_bounded_cli_hook(config: Mapping[str, object], *, input_text: str) -> in
         return _emit_failure(harness=harness, input_text=input_text)
     package_root = Path(package_root_value)
     guard_home = Path(guard_home_value)
-    # Fast path: serve the hook from the already-running daemon (~50ms)
+    runtime_frozen = bool(getattr(sys, "frozen", False))
+    if runtime_frozen:
+        direct_cli_args = _validated_frozen_cli_args(
+            cli_args,
+            guard_home=guard_home,
+            harness=harness,
+        )
+        if direct_cli_args is None:
+            return _emit_failure(harness=harness, input_text=input_text)
+        command = (sys.executable, *direct_cli_args)
+    elif frozen_launcher:
+        return _emit_failure(harness=harness, input_text=input_text)
+    else:
+        command = isolated_guard_cli_command(
+            python_executable,
+            package_root,
+            cli_args,
+        )
+    # Fast path: serve an already-validated hook through the running daemon (~50ms)
     # instead of paying a fresh interpreter + full CLI import (~1s).
     daemon_result = _try_daemon_hook(
         guard_home=guard_home,
@@ -463,11 +540,6 @@ def run_bounded_cli_hook(config: Mapping[str, object], *, input_text: str) -> in
         if daemon_stderr:
             print(daemon_stderr, file=sys.stderr)
         return daemon_exit
-    command = isolated_guard_cli_command(
-        python_executable,
-        package_root,
-        cli_args,
-    )
     result = run_isolated_hook_process(
         command,
         input_text=input_text,
@@ -510,4 +582,9 @@ def main_from_argv(argv: Sequence[str]) -> int:
     return run_bounded_cli_hook(config, input_text=input_text)
 
 
-__all__ = ["bounded_cli_hook_command", "main_from_argv", "run_bounded_cli_hook"]
+__all__ = [
+    "_FROZEN_BRIDGE_COMMAND",
+    "bounded_cli_hook_command",
+    "main_from_argv",
+    "run_bounded_cli_hook",
+]

--- a/src/codex_plugin_scanner/guard/adapters/cline.py
+++ b/src/codex_plugin_scanner/guard/adapters/cline.py
@@ -6,7 +6,7 @@ import json
 import os
 from pathlib import Path
 
-from ..frozen_codex_runtime import is_frozen_guard_runtime
+from ..frozen_runtime_commands import is_frozen_guard_runtime
 from ..models import GuardArtifact, HarnessDetection
 from ..shims import ensure_guard_shim_path_in_shell_profile, install_guard_shim, remove_guard_shim
 from .base import HarnessAdapter, HarnessContext

--- a/src/codex_plugin_scanner/guard/adapters/copilot.py
+++ b/src/codex_plugin_scanner/guard/adapters/copilot.py
@@ -132,6 +132,20 @@ def _is_managed_hook_command(command: str) -> bool:
         tokens = shlex.split(command)
     except ValueError:
         return False
+    if len(tokens) == 3 and tokens[1] == "__guard-bounded-hook":
+        if Path(tokens[0]).name.lower() not in {"hol guard", "hol-guard", "hol-guard.exe"}:
+            return False
+        try:
+            raw_config: object = json.loads(tokens[2])
+        except json.JSONDecodeError:
+            return False
+        if not isinstance(raw_config, dict) or raw_config.get("harness") != "copilot":
+            return False
+        cli_args = raw_config.get("cli_args")
+        if not isinstance(cli_args, list):
+            return False
+        normalized_args = tuple(item.lower() for item in cli_args if isinstance(item, str))
+        return len(normalized_args) == len(cli_args) and _argv_targets_copilot(normalized_args)
     if len(tokens) < 3:
         return False
     executable = Path(tokens[0]).name.lower()

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -8,6 +8,7 @@ import stat
 from hashlib import sha256
 from pathlib import Path
 
+from ..frozen_runtime_commands import frozen_daemon_recovery_command
 from .base import HarnessContext
 from .cursor_hook_config import (
     _MANAGED_HOOK_EVENTS,
@@ -359,8 +360,6 @@ def _cursor_recovery_command(
     attestation: HookPythonAttestation | None,
 ) -> list[str]:
     if attestation is None:
-        from ..frozen_codex_runtime import frozen_daemon_recovery_command
-
         return list(frozen_daemon_recovery_command(context.guard_home, context.home_dir))
     trusted_roots = [str(root) for root in attestation.import_roots]
     bootstrap = (

--- a/src/codex_plugin_scanner/guard/adapters/hermes.py
+++ b/src/codex_plugin_scanner/guard/adapters/hermes.py
@@ -1134,16 +1134,18 @@ def _mcp_proxy_command(*, context: HarnessContext, server_key: str) -> list[str]
 
 def _pretool_payload(*, context: HarnessContext) -> dict[str, object]:
     cli_args = [
-        "hermes",
-        "pretool",
+        "guard",
+        "hook",
         "--guard-home",
         str(context.guard_home),
-        "--json",
+        "--harness",
+        "hermes",
     ]
     if context.home_dir.resolve() != Path.home().resolve():
         cli_args.extend(["--home", str(context.home_dir)])
     if context.workspace_dir is not None:
         cli_args.extend(["--workspace", str(context.workspace_dir)])
+    cli_args.append("--json")
     return {
         "command": list(
             bounded_cli_hook_command(

--- a/src/codex_plugin_scanner/guard/adapters/openclaw_support.py
+++ b/src/codex_plugin_scanner/guard/adapters/openclaw_support.py
@@ -71,17 +71,18 @@ def overlay_payload(detection: HarnessDetection) -> dict[str, object]:
 
 def pretool_payload(*, context: HarnessContext) -> dict[str, object]:
     cli_args = [
+        "guard",
         "hook",
-        "--harness",
-        "openclaw",
         "--guard-home",
         str(context.guard_home),
+        "--harness",
+        "openclaw",
         "--home",
         str(context.home_dir),
-        "--json",
     ]
     if context.workspace_dir is not None:
         cli_args.extend(["--workspace", str(context.workspace_dir)])
+    cli_args.append("--json")
     command = bounded_cli_hook_command(
         python_executable=sys.executable,
         package_root=Path(__file__).resolve().parents[3],

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_admin.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_admin.py
@@ -27,6 +27,8 @@ if TYPE_CHECKING:
     )
 
 
+from ..daemon.bounded_http import daemon_admission_snapshot
+from ..native_runtime_admission import native_resident_admission_snapshot
 from ..runtime.command_queue import command_queue_status, repair_command_queue_state
 from ._commands_shared import *
 from .commands_dispatch_trust import build_trust_doctor_payload
@@ -344,6 +346,10 @@ def _run_guard_doctor_command(
     if getattr(args, "repair", False):
         command_queue_payload["repair"] = repair_command_queue_state(store)
     payload["command_queue"] = command_queue_payload
+    payload["native_runtime"] = {
+        "admission": native_resident_admission_snapshot(),
+        "daemon_http": daemon_admission_snapshot(),
+    }
     payload["trust"] = build_trust_doctor_payload(store)
     payload["supply_chain"] = build_local_supply_chain_posture(store, config, now=_now())
     payload["aibom"] = build_aibom_status_payload(store, context, generated_at=_now())

--- a/src/codex_plugin_scanner/guard/daemon/bounded_http.py
+++ b/src/codex_plugin_scanner/guard/daemon/bounded_http.py
@@ -149,9 +149,7 @@ def _overload_response() -> bytes:
         b"Connection: close\r\n"
         b"Content-Type: application/json\r\n"
         b"Cache-Control: no-store\r\n"
-        b"Retry-After: 1\r\n"
-        + f"Content-Length: {len(payload)}\r\n\r\n".encode("ascii")
-        + payload
+        b"Retry-After: 1\r\n" + f"Content-Length: {len(payload)}\r\n\r\n".encode("ascii") + payload
     )
 
 
@@ -182,35 +180,43 @@ class BoundedThreadingHTTPServer(ThreadingHTTPServer):
             _MAX_SOCKET_TIMEOUT_SECONDS,
         )
 
-    def verify_request(self, request: socket.socket, client_address: object) -> bool:
+    def verify_request(self, request: Any, client_address: Any) -> bool:
         if not _loopback(client_address):
             _METRICS.rejected_non_loopback()
             return False
         return super().verify_request(request, cast(Any, client_address))
 
-    def process_request(self, request: socket.socket, client_address: object) -> None:
+    def process_request(self, request: Any, client_address: Any) -> None:
+        request_socket = cast(socket.socket, request)
+        if not self._guard_admit_request(request_socket):
+            return
+        try:
+            super().process_request(request_socket, client_address)
+        except BaseException:
+            self._guard_release_request()
+            raise
+
+    def process_request_thread(self, request: Any, client_address: Any) -> None:
+        try:
+            super().process_request_thread(request, cast(Any, client_address))
+        finally:
+            self._guard_release_request()
+
+    def _guard_admit_request(self, request: socket.socket) -> bool:
         if not self._guard_slots.acquire(blocking=False):
             _METRICS.rejected_overload()
             self._reject_overload(request)
             self.shutdown_request(request)
-            return
+            return False
         _METRICS.acquired()
-        try:
-            request.settimeout(self._guard_socket_timeout)
-            super().process_request(request, cast(Any, client_address))
-        except BaseException:
-            self._guard_slots.release()
-            _METRICS.released()
-            raise
+        request.settimeout(self._guard_socket_timeout)
+        return True
 
-    def process_request_thread(self, request: socket.socket, client_address: object) -> None:
-        try:
-            super().process_request_thread(request, cast(Any, client_address))
-        finally:
-            self._guard_slots.release()
-            _METRICS.released()
+    def _guard_release_request(self) -> None:
+        self._guard_slots.release()
+        _METRICS.released()
 
-    def handle_error(self, request: socket.socket, client_address: object) -> None:
+    def handle_error(self, request: Any, client_address: Any) -> None:
         error = cast(BaseException | None, __import__("sys").exception())
         if isinstance(error, socket.timeout):
             _METRICS.timeout()

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -25,7 +25,7 @@ import uuid
 from collections.abc import Callable, Mapping
 from contextlib import suppress
 from datetime import datetime, timezone
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler
 from pathlib import Path
 from typing import Any, BinaryIO, ClassVar, TypeAlias, TypedDict, TypeGuard, cast
 from urllib.parse import parse_qs, parse_qsl, unquote, urlencode, urlparse, urlunparse
@@ -217,6 +217,7 @@ from ..store_evidence import (
 )
 from ..store_storage_maintenance import DEFAULT_GUARD_EVENT_LIMIT, DEFAULT_RECEIPT_DETAIL_LIMIT
 from ..supply_chain_repair import coordinate_supply_chain_repair
+from .bounded_http import BoundedThreadingHTTPServer
 from .command_activity_api import (
     handle_command_activity_analytics,
     handle_command_activity_diagnostics,
@@ -474,7 +475,7 @@ class _BoundedRequestExecutor:
                 self._queue.task_done()
 
 
-class _GuardDaemonHttpServer(HTTPServer):
+class _GuardDaemonHTTPServer(BoundedThreadingHTTPServer):
     request_queue_size = _MAX_CONCURRENT_DAEMON_CONNECTIONS
 
     store: GuardStore
@@ -541,7 +542,7 @@ class _GuardDaemonHttpServer(HTTPServer):
     auth_audit_lock: threading.Lock
     auth_audit_windows: dict[_AuthAuditKey, _AuthAuditWindow]
 
-    def handle_error(self, request: object, client_address: tuple[str, int]) -> None:
+    def handle_error(self, request: Any, client_address: Any) -> None:
         """Suppress expected peer disconnects without hiding server defects."""
 
         import sys
@@ -689,8 +690,10 @@ class _GuardDaemonHttpServer(HTTPServer):
         )
         return self.extension_control_runtime.refresh(view)
 
-    def process_request(self, request: object, client_address: tuple[str, int]) -> None:
+    def process_request(self, request: Any, client_address: Any) -> None:
         request_socket = cast(socket.socket, request)
+        if not self._guard_admit_request(request_socket):
+            return
         admitted = self.connection_capacity.acquire(blocking=False)
         if not admitted:
             self._evict_oldest_unclassified_connection()
@@ -702,6 +705,7 @@ class _GuardDaemonHttpServer(HTTPServer):
             with self.request_capacity_lock:
                 self.rejected_requests += 1
             self.shutdown_request(request_socket)
+            self._guard_release_request()
             return
         with suppress(OSError):
             request_socket.settimeout(_DAEMON_REQUEST_READ_TIMEOUT_SECONDS)
@@ -744,6 +748,7 @@ class _GuardDaemonHttpServer(HTTPServer):
             self._request_capacity_for_kind(capacity_kind).release()
         if was_active:
             self.connection_capacity.release()
+            self._guard_release_request()
 
     def _register_unclassified_connection(self, request: socket.socket) -> None:
         accepted_at = time.monotonic()
@@ -1978,6 +1983,9 @@ def _repair_command_activity_persistence_health(store: GuardStore) -> None:
     if shadow is None:
         raise RuntimeError("command shadow repair probe was not selected")
     store.probe_command_activity_persistence(evidence, shadow=shadow)
+
+
+_GuardDaemonHttpServer = _GuardDaemonHTTPServer
 
 
 class _GuardDaemonHandler(BaseHTTPRequestHandler):

--- a/src/codex_plugin_scanner/guard/frozen_codex_runtime.py
+++ b/src/codex_plugin_scanner/guard/frozen_codex_runtime.py
@@ -21,18 +21,14 @@ import sys
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
+from .frozen_runtime_commands import (
+    FROZEN_DAEMON_RECOVER_ARG,
+    frozen_daemon_recovery_command,
+    is_frozen_guard_runtime,
+)
+
 _FROZEN_BRIDGE_ARG = "--_hol-guard-codex-bridge"
-_FROZEN_DAEMON_RECOVER_ARG = "--_hol-guard-codex-daemon-recover"
-
-
-def is_frozen_guard_runtime() -> bool:
-    """Return whether this process is a PyInstaller-style frozen Guard binary."""
-
-    return bool(getattr(sys, "frozen", False)) and Path(sys.executable).is_file()
-
-
-def _compact_json(payload: Mapping[str, object]) -> str:
-    return json.dumps(dict(payload), sort_keys=True, separators=(",", ":"))
+_FROZEN_DAEMON_RECOVER_ARG = FROZEN_DAEMON_RECOVER_ARG
 
 
 def _decode_private_payload(raw: str, *, label: str) -> dict[str, object]:
@@ -43,23 +39,6 @@ def _decode_private_payload(raw: str, *, label: str) -> dict[str, object]:
     if not isinstance(payload, dict):
         raise ValueError(f"{label} payload must be a JSON object")
     return {str(key): value for key, value in payload.items() if isinstance(key, str)}
-
-
-def frozen_daemon_recovery_command(
-    guard_home: Path,
-    home_dir: Path,
-    *,
-    executable: str | None = None,
-) -> tuple[str, ...]:
-    """Build the authenticated frozen-Core daemon recovery command."""
-
-    payload = _compact_json(
-        {
-            "guard_home": str(guard_home.resolve(strict=False)),
-            "home_dir": str(home_dir.resolve(strict=False)),
-        }
-    )
-    return (executable or sys.executable, _FROZEN_DAEMON_RECOVER_ARG, payload)
 
 
 def install_frozen_codex_runtime(*, force: bool = False) -> bool:

--- a/src/codex_plugin_scanner/guard/frozen_runtime_commands.py
+++ b/src/codex_plugin_scanner/guard/frozen_runtime_commands.py
@@ -1,0 +1,37 @@
+"""Leaf command builders shared by frozen Guard harness adapters."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+FROZEN_DAEMON_RECOVER_ARG = "--_hol-guard-codex-daemon-recover"
+
+
+def is_frozen_guard_runtime() -> bool:
+    """Return whether this process is a PyInstaller-style frozen Guard binary."""
+
+    return bool(getattr(sys, "frozen", False)) and Path(sys.executable).is_file()
+
+
+def frozen_daemon_recovery_command(
+    guard_home: Path,
+    home_dir: Path,
+    *,
+    executable: str | None = None,
+) -> tuple[str, ...]:
+    """Build the authenticated frozen-Core daemon recovery command."""
+
+    payload = json.dumps(
+        {
+            "guard_home": str(guard_home.resolve(strict=False)),
+            "home_dir": str(home_dir.resolve(strict=False)),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return (executable or sys.executable, FROZEN_DAEMON_RECOVER_ARG, payload)
+
+
+__all__ = ["FROZEN_DAEMON_RECOVER_ARG", "frozen_daemon_recovery_command", "is_frozen_guard_runtime"]

--- a/src/codex_plugin_scanner/guard/native_runtime_admission.py
+++ b/src/codex_plugin_scanner/guard/native_runtime_admission.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import errno
-import os
 import secrets
 import threading
 import time
@@ -172,7 +171,7 @@ class _AdmissionState:
 _STATE = _AdmissionState()
 
 
-def _request_payload(args: tuple[object, ...], kwargs: Mapping[str, object]) -> object:
+def _request_input(args: tuple[object, ...], kwargs: Mapping[str, object]) -> object:
     for key in ("request", "payload", "message"):
         if key in kwargs:
             return kwargs[key]
@@ -186,7 +185,7 @@ def _operation(args: tuple[object, ...], kwargs: Mapping[str, object]) -> str:
     explicit = kwargs.get("operation")
     if isinstance(explicit, str):
         return explicit.lower()
-    payload = _request_payload(args, kwargs)
+    payload = _request_input(args, kwargs)
     if isinstance(payload, Mapping):
         operation = payload.get("operation")
         if isinstance(operation, str):
@@ -233,7 +232,7 @@ def native_resident_admission(function: Callable[P, R]) -> Callable[P, R]:
     Resident requests are deterministic reads and evaluations, so one bounded
     retry is safe. Authentication, integrity, manifest, and protocol failures
     are never retried. The wrapper stores counters only and never stores request
-    payloads, commands, paths, endpoints, credentials, or exception text.
+    payloads, commands, paths, endpoints, authentication material, or exception text.
     """
 
     @wraps(function)

--- a/src/codex_plugin_scanner/guard/native_runtime_resident.py
+++ b/src/codex_plugin_scanner/guard/native_runtime_resident.py
@@ -26,6 +26,7 @@ from collections.abc import Mapping
 from pathlib import Path
 
 from .codex_hook_launch_runtime import run_isolated_hook_process
+from .native_runtime_admission import native_resident_admission
 from .native_runtime_resilience import (
     native_record_resident_failure,
     native_record_restart,
@@ -489,6 +490,7 @@ def _send_authenticated_unix_request(
     )
 
 
+@native_resident_admission
 def resident_native_request(
     *,
     executable: Path,

--- a/tests/test_bounded_cli_hook_bridge.py
+++ b/tests/test_bounded_cli_hook_bridge.py
@@ -42,7 +42,14 @@ def _config(tmp_path: Path, *, harness: str) -> dict[str, object]:
         "python_executable": "python",
         "package_root": str(tmp_path),
         "guard_home": str(guard_home),
-        "cli_args": ["guard", "hook", "--harness", harness],
+        "cli_args": [
+            "guard",
+            "hook",
+            "--guard-home",
+            str(guard_home),
+            "--harness",
+            harness,
+        ],
         "harness": harness,
         "timeout_seconds": 3,
     }
@@ -126,6 +133,178 @@ def test_success_preserves_child_stdout_and_returncode(
     assert output.getvalue() == '{"decision":"deny"}\n'
 
 
+def test_frozen_fallback_runs_supported_cli_subcommand_without_python_flags(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    observed: list[str] = []
+
+    def run(command: Sequence[str], **kwargs: object) -> BoundedHookProcessResult:
+        del kwargs
+        observed.extend(command)
+        return BoundedHookProcessResult(0, '{"decision":"allow"}\n', False, False)
+
+    config = _config(tmp_path, harness="grok")
+    config["python_executable"] = "/Applications/HOL Guard.app/Contents/MacOS/hol-guard"
+    config["frozen_launcher"] = True
+    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "executable", config["python_executable"])
+    monkeypatch.setattr(bounded_cli_hook_bridge, "_try_daemon_hook", lambda **kwargs: None)
+    monkeypatch.setattr(bounded_cli_hook_bridge, "run_isolated_hook_process", run)
+
+    returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(config, input_text="{}")
+
+    assert returncode == 0
+    assert observed == [
+        "/Applications/HOL Guard.app/Contents/MacOS/hol-guard",
+        "hook",
+        "--guard-home",
+        str(tmp_path / "guard-home"),
+        "--harness",
+        "grok",
+    ]
+
+
+def test_frozen_fallback_rejects_forged_executable_and_arguments(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config = _config(tmp_path, harness="grok")
+    config["python_executable"] = "/bin/sh"
+    config["cli_args"] = ["-c", "echo bypassed"]
+    config["frozen_launcher"] = True
+    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(bounded_cli_hook_bridge, "_try_daemon_hook", lambda **kwargs: None)
+
+    def forbidden_runner(*args: object, **kwargs: object) -> BoundedHookProcessResult:
+        del args, kwargs
+        raise AssertionError("forged hook arguments must not execute")
+
+    monkeypatch.setattr(bounded_cli_hook_bridge, "run_isolated_hook_process", forbidden_runner)
+    output = io.StringIO()
+    with redirect_stdout(output):
+        returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(config, input_text="{}")
+
+    assert returncode == 0
+    assert _json_object(output.getvalue())["decision"] == "deny"
+
+
+def test_live_frozen_runtime_ignores_forged_config_mode_and_executable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    observed: list[str] = []
+
+    def run(command: Sequence[str], **kwargs: object) -> BoundedHookProcessResult:
+        del kwargs
+        observed.extend(command)
+        return BoundedHookProcessResult(0, '{"decision":"allow"}\n', False, False)
+
+    config = _config(tmp_path, harness="grok")
+    config["python_executable"] = "/bin/sh"
+    config["frozen_launcher"] = False
+    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "executable", "/app/hol-guard")
+    monkeypatch.setattr(bounded_cli_hook_bridge, "_try_daemon_hook", lambda **kwargs: None)
+    monkeypatch.setattr(bounded_cli_hook_bridge, "run_isolated_hook_process", run)
+
+    assert bounded_cli_hook_bridge.run_bounded_cli_hook(config, input_text="{}") == 0
+    assert observed == [
+        "/app/hol-guard",
+        "hook",
+        "--guard-home",
+        str((tmp_path / "guard-home").resolve()),
+        "--harness",
+        "grok",
+    ]
+
+
+def test_non_frozen_runtime_rejects_forged_frozen_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config = _config(tmp_path, harness="grok")
+    config["frozen_launcher"] = True
+    monkeypatch.delattr(bounded_cli_hook_bridge.sys, "frozen", raising=False)
+    monkeypatch.setattr(bounded_cli_hook_bridge, "_try_daemon_hook", lambda **kwargs: None)
+
+    def forbidden_runner(*args: object, **kwargs: object) -> BoundedHookProcessResult:
+        del args, kwargs
+        raise AssertionError("config must not force frozen dispatch")
+
+    monkeypatch.setattr(bounded_cli_hook_bridge, "run_isolated_hook_process", forbidden_runner)
+    output = io.StringIO()
+    with redirect_stdout(output):
+        returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(config, input_text="{}")
+
+    assert returncode == 0
+    assert _json_object(output.getvalue())["decision"] == "deny"
+
+
+def test_frozen_fallback_accepts_equivalent_noncanonical_guard_home(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    observed: list[str] = []
+
+    def run(command: Sequence[str], **kwargs: object) -> BoundedHookProcessResult:
+        del kwargs
+        observed.extend(command)
+        return BoundedHookProcessResult(0, '{"decision":"allow"}\n', False, False)
+
+    config = _config(tmp_path, harness="grok")
+    cli_args = cast(list[str], config["cli_args"])
+    cli_args[3] = str(tmp_path / "unused" / ".." / "guard-home")
+    config["frozen_launcher"] = True
+    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "executable", "/app/hol-guard")
+    monkeypatch.setattr(bounded_cli_hook_bridge, "_try_daemon_hook", lambda **kwargs: None)
+    monkeypatch.setattr(bounded_cli_hook_bridge, "run_isolated_hook_process", run)
+
+    assert bounded_cli_hook_bridge.run_bounded_cli_hook(config, input_text="{}") == 0
+    assert observed == [
+        "/app/hol-guard",
+        "hook",
+        "--guard-home",
+        str((tmp_path / "guard-home").resolve()),
+        "--harness",
+        "grok",
+    ]
+
+
+@pytest.mark.parametrize("harness", ["hermes", "openclaw"])
+def test_frozen_fallback_accepts_normalized_json_hook_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    harness: str,
+) -> None:
+    observed: list[str] = []
+
+    def run(command: Sequence[str], **kwargs: object) -> BoundedHookProcessResult:
+        del kwargs
+        observed.extend(command)
+        return BoundedHookProcessResult(0, '{"decision":"allow"}\n', False, False)
+
+    config = _config(tmp_path, harness=harness)
+    config["cli_args"] = [*cast(list[str], config["cli_args"]), "--json"]
+    config["frozen_launcher"] = True
+    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "executable", "/app/hol-guard")
+    monkeypatch.setattr(bounded_cli_hook_bridge, "_try_daemon_hook", lambda **kwargs: None)
+    monkeypatch.setattr(bounded_cli_hook_bridge, "run_isolated_hook_process", run)
+
+    assert bounded_cli_hook_bridge.run_bounded_cli_hook(config, input_text="{}") == 0
+    assert observed == [
+        "/app/hol-guard",
+        "hook",
+        "--guard-home",
+        str(tmp_path / "guard-home"),
+        "--harness",
+        harness,
+        "--json",
+    ]
+
+
 def test_empty_failed_child_is_converted_to_native_deny(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -199,3 +378,127 @@ def test_oversized_input_uses_configured_harness_native_deny(
 
     assert returncode == 0
     assert _json_object(output.getvalue())["permissionDecision"] == "deny"
+
+
+def test_invalid_frozen_args_deny_before_daemon_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config = _config(tmp_path, harness="grok")
+    config["cli_args"] = ["-c", "echo bypassed"]
+    config["frozen_launcher"] = True
+    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "frozen", True, raising=False)
+
+    def forbidden_daemon(**kwargs: object) -> object:
+        del kwargs
+        raise AssertionError("invalid frozen arguments must not reach the daemon")
+
+    monkeypatch.setattr(bounded_cli_hook_bridge, "_try_daemon_hook", forbidden_daemon)
+    output = io.StringIO()
+    with redirect_stdout(output):
+        returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(config, input_text="{}")
+
+    assert returncode == 0
+    assert _json_object(output.getvalue())["decision"] == "deny"
+
+
+def test_frozen_path_resolution_failure_denies_before_daemon_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config = _config(tmp_path, harness="grok")
+    config["frozen_launcher"] = True
+    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "frozen", True, raising=False)
+
+    def fail_resolve(self: Path, *, strict: bool = False) -> Path:
+        del self, strict
+        raise RuntimeError("symlink loop")
+
+    def forbidden_daemon(**kwargs: object) -> object:
+        del kwargs
+        raise AssertionError("unresolved frozen paths must not reach the daemon")
+
+    monkeypatch.setattr(bounded_cli_hook_bridge.Path, "resolve", fail_resolve)
+    monkeypatch.setattr(bounded_cli_hook_bridge, "_try_daemon_hook", forbidden_daemon)
+    output = io.StringIO()
+    with redirect_stdout(output):
+        returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(config, input_text="{}")
+
+    assert returncode == 0
+    assert _json_object(output.getvalue())["decision"] == "deny"
+
+
+def test_valid_frozen_args_retain_daemon_fast_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config = _config(tmp_path, harness="grok")
+    config["frozen_launcher"] = True
+    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "executable", "/app/hol-guard")
+    monkeypatch.setattr(
+        bounded_cli_hook_bridge,
+        "_try_daemon_hook",
+        lambda **kwargs: ('{"decision":"allow"}\n', "", 0),
+    )
+
+    def forbidden_runner(*args: object, **kwargs: object) -> BoundedHookProcessResult:
+        del args, kwargs
+        raise AssertionError("valid daemon result must avoid fallback startup")
+
+    monkeypatch.setattr(bounded_cli_hook_bridge, "run_isolated_hook_process", forbidden_runner)
+    output = io.StringIO()
+    with redirect_stdout(output):
+        returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(config, input_text="{}")
+
+    assert returncode == 0
+    assert _json_object(output.getvalue())["decision"] == "allow"
+
+
+def test_relative_frozen_guard_home_denies_before_daemon_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config = _config(tmp_path, harness="grok")
+    cli_args = cast(list[str], config["cli_args"])
+    cli_args[3] = "guard-home"
+    config["frozen_launcher"] = True
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "frozen", True, raising=False)
+
+    def forbidden_daemon(**kwargs: object) -> object:
+        del kwargs
+        raise AssertionError("relative frozen Guard home must not reach the daemon")
+
+    monkeypatch.setattr(bounded_cli_hook_bridge, "_try_daemon_hook", forbidden_daemon)
+    output = io.StringIO()
+    with redirect_stdout(output):
+        returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(config, input_text="{}")
+
+    assert returncode == 0
+    assert _json_object(output.getvalue())["decision"] == "deny"
+
+
+def test_relative_configured_guard_home_denies_before_daemon_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config = _config(tmp_path, harness="grok")
+    config["guard_home"] = "guard-home"
+    cli_args = cast(list[str], config["cli_args"])
+    cli_args[3] = "guard-home"
+    config["frozen_launcher"] = True
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "frozen", True, raising=False)
+
+    def forbidden_daemon(**kwargs: object) -> object:
+        del kwargs
+        raise AssertionError("relative configured Guard home must not reach the daemon")
+
+    monkeypatch.setattr(bounded_cli_hook_bridge, "_try_daemon_hook", forbidden_daemon)
+    output = io.StringIO()
+    with redirect_stdout(output):
+        returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(config, input_text="{}")
+
+    assert returncode == 0
+    assert _json_object(output.getvalue())["decision"] == "deny"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,6 +22,27 @@ NONEXISTENT_PLUGIN_DIR = Path("/nonexistent/plugin-dir").resolve()
 EXPECTED_GOOD_PLUGIN_SCORE = 91
 
 
+def test_internal_bounded_hook_dispatches_before_argument_parser(monkeypatch: pytest.MonkeyPatch) -> None:
+    observed: list[str] = []
+    monkeypatch.setattr("sys.frozen", True, raising=False)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.adapters.bounded_cli_hook_bridge.main_from_argv",
+        lambda argv: observed.extend(argv) or 7,
+    )
+
+    assert main(["__guard-bounded-hook", '{"harness":"grok"}']) == 7
+    assert observed == ['{"harness":"grok"}']
+
+
+def test_internal_bounded_hook_is_not_available_from_python_install(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delattr("sys.frozen", raising=False)
+
+    with pytest.raises(SystemExit):
+        main(["__guard-bounded-hook", "{}"])
+
+
 class TestFormatJson:
     def test_good_plugin_json_output_has_expected_schema_and_category_structure(self):
         result = scan_plugin(FIXTURES / "good-plugin")

--- a/tests/test_cli_only_hook_resilience.py
+++ b/tests/test_cli_only_hook_resilience.py
@@ -70,6 +70,31 @@ def test_managed_cli_hooks_use_bounded_process_bridge(
 @pytest.mark.parametrize(
     ("harness", "factory"),
     [
+        ("copilot", _copilot_command),
+        ("grok", GrokHarnessAdapter._hook_command_parts),  # pyright: ignore[reportPrivateUsage]
+        ("kimi", KimiHarnessAdapter._hook_command_parts),  # pyright: ignore[reportPrivateUsage]
+        ("zcode", ZCodeHarnessAdapter._hook_command_parts),  # pyright: ignore[reportPrivateUsage]
+    ],
+)
+def test_frozen_managed_cli_hooks_enter_supported_bridge_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    harness: str,
+    factory: CommandFactory,
+) -> None:
+    monkeypatch.setattr("sys.frozen", True, raising=False)
+
+    command = factory(_context(tmp_path))
+
+    assert command[:2] == (command[0], "__guard-bounded-hook")
+    config = cast(dict[str, object], json.loads(command[2]))
+    assert config["frozen_launcher"] is True
+    assert config["harness"] == harness
+
+
+@pytest.mark.parametrize(
+    ("harness", "factory"),
+    [
         ("hermes", hermes_pretool_payload),
         ("openclaw", openclaw_pretool_payload),
     ],

--- a/tests/test_daemon_bounded_http.py
+++ b/tests/test_daemon_bounded_http.py
@@ -12,13 +12,15 @@ from codex_plugin_scanner.guard.daemon.bounded_http import (
     BoundedThreadingHTTPServer,
     daemon_admission_snapshot,
 )
+from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
+from codex_plugin_scanner.guard.store import GuardStore
 
 
 class _Handler(BaseHTTPRequestHandler):
     release = threading.Event()
     entered = threading.Event()
 
-    def do_GET(self) -> None:  # noqa: N802
+    def do_GET(self) -> None:
         if self.path == "/hold":
             self.entered.set()
             self.release.wait(timeout=2)
@@ -133,3 +135,22 @@ def test_daemon_admission_snapshot_is_aggregate_only() -> None:
         "non_loopback_rejections",
     }
     assert all(isinstance(value, int) and value >= 0 for value in payload.values())
+
+
+def test_real_daemon_subclass_enforces_bounded_admission(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("HOL_GUARD_DAEMON_MAX_ACTIVE_REQUESTS", "1")
+    monkeypatch.setenv("HOL_GUARD_DAEMON_SOCKET_TIMEOUT_SECONDS", "0.5")
+    daemon = GuardDaemonServer(GuardStore(tmp_path / "guard-home"), host="127.0.0.1", port=0)
+    daemon.start()
+    held = socket.create_connection(("127.0.0.1", daemon.port), timeout=1)
+    try:
+        held.sendall(b"POST /v1/health HTTP/1.1\r\nHost: localhost\r\nContent-Length: 100\r\n")
+        deadline = time.monotonic() + 1
+        while daemon_admission_snapshot()["active"] < 1 and time.monotonic() < deadline:
+            time.sleep(0.01)
+        status, body = _get(daemon.port, "/v1/health")
+        assert status == 503
+        assert json.loads(body)["error"] == "daemon_overloaded"
+    finally:
+        held.close()
+        daemon.stop()

--- a/tests/test_guard_copilot_adapter.py
+++ b/tests/test_guard_copilot_adapter.py
@@ -51,6 +51,19 @@ def test_copilot_recognizes_bounded_hook_with_python_isolation_flag() -> None:
     assert copilot_module._is_managed_hook_command(command) is True
 
 
+def test_copilot_recognizes_frozen_bounded_hook() -> None:
+    config = json.dumps(
+        {
+            "harness": "copilot",
+            "cli_args": ["guard", "hook", "--harness", "copilot"],
+        },
+        separators=(",", ":"),
+    )
+    command = shlex.join(["/Applications/HOL Guard.app/Contents/MacOS/hol-guard", "__guard-bounded-hook", config])
+
+    assert copilot_module._is_managed_hook_command(command) is True
+
+
 def test_copilot_detects_documented_local_surfaces_and_redacts_secrets(tmp_path):
     context = _build_context(tmp_path)
     adapter = CopilotHarnessAdapter()

--- a/tests/test_guard_cursor_exact_action.py
+++ b/tests/test_guard_cursor_exact_action.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.cli import commands as _guard_commands  # noqa: F401
 from codex_plugin_scanner.guard.cli import commands_hook_runtime_review as runtime_review
 from codex_plugin_scanner.guard.cli.commands_hook_runtime_state import (
     RuntimeArtifactHookState,
@@ -90,7 +91,6 @@ def test_cursor_queue_receipt_and_response_preserve_exact_review_action(
         lambda _guard_home: (_ for _ in ()).throw(RuntimeError("surface unavailable")),
     )
     monkeypatch.setattr(runtime_review, "queue_blocked_approvals", capture_queue)
-    monkeypatch.setattr(runtime_review, "_should_emit_copilot_hook_response", lambda _args: False)
     monkeypatch.setattr(
         runtime_review,
         "_should_emit_prequeue_native_hook_response",

--- a/tests/test_guard_project_identity.py
+++ b/tests/test_guard_project_identity.py
@@ -46,6 +46,8 @@ def _init_repository(workspace: Path, remote: str, *, verified_clone: bool = Tru
     _git(workspace, "init")
     _git(workspace, "config", "user.email", "guard@example.invalid")
     _git(workspace, "config", "user.name", "Guard Test")
+    _git(workspace, "config", "commit.gpgsign", "false")
+    _git(workspace, "config", "core.hooksPath", ".git/no-hooks")
     (workspace / "README.md").write_text("guard\n", encoding="utf-8")
     _git(workspace, "add", "README.md")
     _git(workspace, "commit", "-m", "initial")

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -7,6 +7,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.hermes import (
     HermesHarnessAdapter,
@@ -55,7 +57,11 @@ def _seed_cloud_profile(context: HarnessContext, runtime: str = "hermes") -> Non
     )
 
 
-def test_install_generates_guard_managed_overlay_and_pretool_files(tmp_path: Path):
+def test_install_generates_guard_managed_overlay_and_pretool_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
     _write(
         tmp_path / ".hermes" / "config.yaml",
         (
@@ -84,6 +90,8 @@ def test_install_generates_guard_managed_overlay_and_pretool_files(tmp_path: Pat
     assert overlay_path.exists() is True
     assert pretool_path.exists() is True
     bridge_config = json.loads(pretool_payload["command"][-1])
+    assert pretool_payload["command"][1] == "__guard-bounded-hook"
+    assert bridge_config["cli_args"][-1] == "--json"
     assert bridge_config["harness"] == "hermes"
     assert bridge_config["timeout_seconds"] == 3
     assert pretool_payload["timeout_seconds"] == 5

--- a/tests/test_native_runtime_admission.py
+++ b/tests/test_native_runtime_admission.py
@@ -11,6 +11,7 @@ from codex_plugin_scanner.guard.native_runtime_admission import (
     native_resident_admission,
     native_resident_admission_snapshot,
 )
+from codex_plugin_scanner.guard.native_runtime_resident import _ResidentService, resident_native_request
 
 
 def test_native_admission_retries_one_transient_disconnect() -> None:
@@ -27,6 +28,72 @@ def test_native_admission_retries_one_transient_disconnect() -> None:
     assert request(operation="command_model") == "command_model"
     assert calls == 2
     assert native_resident_admission_snapshot()["transient_retries"] >= 1
+
+
+def test_native_resident_path_restarts_after_transient_transport_loss(monkeypatch, tmp_path) -> None:
+    executable = tmp_path / "guard-runtime"
+    executable.write_bytes(b"fixture")
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    calls = 0
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.native_runtime_resident._resident_socket_path",
+        lambda guard_home, identity_sha256: guard_home / f"{identity_sha256[:8]}.sock",
+    )
+
+    def send(self, payload: bytes, *, timeout_seconds: float) -> bytes | None:
+        nonlocal calls
+        del self, payload, timeout_seconds
+        calls += 1
+        return None if calls == 1 else b'{"status":"ready"}'
+
+    monkeypatch.setattr(_ResidentService, "_send", send)
+    monkeypatch.setattr(_ResidentService, "_ensure_started", lambda self, *, timeout_seconds: True)
+    result = resident_native_request(
+        executable=executable,
+        identity_sha256="a" * 64,
+        guard_home=guard_home,
+        environment={},
+        payload=b'{"operation":"health"}',
+        timeout_seconds=1,
+    )
+
+    assert result == b'{"status":"ready"}'
+    assert calls == 2
+
+
+def test_native_resident_path_does_not_retry_refused_start(monkeypatch, tmp_path) -> None:
+    executable = tmp_path / "guard-runtime"
+    executable.write_bytes(b"fixture")
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    starts = 0
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.native_runtime_resident._resident_socket_path",
+        lambda guard_home, identity_sha256: guard_home / f"{identity_sha256[:8]}.sock",
+    )
+
+    def ensure_started(self, *, timeout_seconds: float) -> bool:
+        nonlocal starts
+        del self, timeout_seconds
+        starts += 1
+        return False
+
+    monkeypatch.setattr(_ResidentService, "_send", lambda self, payload, *, timeout_seconds: None)
+    monkeypatch.setattr(_ResidentService, "_ensure_started", ensure_started)
+    result = resident_native_request(
+        executable=executable,
+        identity_sha256="b" * 64,
+        guard_home=guard_home,
+        environment={},
+        payload=b'{"operation":"health"}',
+        timeout_seconds=1,
+    )
+
+    assert result is None
+    assert starts == 1
 
 
 def test_native_admission_never_retries_integrity_failure() -> None:

--- a/tests/test_openclaw_adapter.py
+++ b/tests/test_openclaw_adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -376,7 +377,11 @@ def test_openclaw_skill_artifact_ids_include_skill_directory_identity(tmp_path: 
     assert len(reviewer_ids) == 2
 
 
-def test_install_exports_guard_managed_openclaw_overlay(tmp_path: Path) -> None:
+def test_install_exports_guard_managed_openclaw_overlay(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
     context = _ctx(tmp_path)
     _write(
         context.home_dir / ".openclaw" / "openclaw.json",
@@ -393,6 +398,8 @@ def test_install_exports_guard_managed_openclaw_overlay(tmp_path: Path) -> None:
     assert overlay_path.exists() is True
     assert pretool_path.exists() is True
     bridge_config = json.loads(pretool["command"][-1])
+    assert pretool["command"][1] == "__guard-bounded-hook"
+    assert bridge_config["cli_args"][-1] == "--json"
     assert bridge_config["cli_args"][bridge_config["cli_args"].index("--home") + 1] == str(context.home_dir)
     assert bridge_config["timeout_seconds"] == 3
     assert pretool["timeout_seconds"] == 5


### PR DESCRIPTION
## Summary

- route PyInstaller/frozen Desktop hook launchers through an internal bounded bridge command instead of passing Python-only `-I -c` flags to the `hol-guard` application executable
- preserve daemon-first review and bounded direct-CLI fallback behavior
- validate the exact frozen Guard hook grammar before any child process starts
- pin fallback execution to the running frozen executable, preventing forged bridge payloads from launching arbitrary programs
- normalize Hermes and OpenClaw to the shared Guard hook contract and preserve Copilot and ZCode compatibility
- keep this PR isolated from the parallel native-runtime hardening work

## Root cause

The Desktop package exposes the PyInstaller application executable through `sys.executable`. CLI-only harness installers treated that value as a Python interpreter and generated commands containing `-I -c`. Grok Build therefore invoked bare `hol-guard` with interpreter arguments that its CLI parser does not understand. The adapter received argparse usage output and failed closed before policy evaluation or daemon review, so benign and risky actions were all blocked.

## Security properties

- internal bridge dispatch is accepted only in a genuine frozen runtime
- direct fallback always executes the current frozen application, never a path supplied by bridge JSON
- only `guard hook --guard-home <exact> --harness <exact>` plus unique absolute `--home` and `--workspace` values and an optional trailing `--json` are accepted
- malformed, duplicate, relative-path, mismatched-harness, or forged-executable payloads fail closed
- daemon-first review, process-tree deadlines, bounded output, and native deny responses remain intact

## Testing

- `uv run --no-sync pytest -q tests/test_cli_only_hook_resilience.py tests/test_bounded_cli_hook_bridge.py tests/test_grok_adapter.py tests/test_cli.py tests/test_guard_copilot_adapter.py tests/test_hermes_adapter.py tests/test_openclaw_adapter.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/cli.py src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py src/codex_plugin_scanner/guard/adapters/copilot.py src/codex_plugin_scanner/guard/adapters/hermes.py src/codex_plugin_scanner/guard/adapters/openclaw_support.py tests/test_cli.py tests/test_bounded_cli_hook_bridge.py tests/test_cli_only_hook_resilience.py`
- `uv run --no-sync basedpyright --level error src/codex_plugin_scanner/cli.py src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py tests/test_cli.py tests/test_bounded_cli_hook_bridge.py tests/test_cli_only_hook_resilience.py`
- `uv run --no-sync python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory test-inventory.json`

## Delivery

After merge, publish the next `release/3.0` alpha, bind HOL Guard Desktop to that reviewed Core build, and run the packaged Desktop/Grok hook acceptance against benign read and terminal payloads plus a risky payload that must remain reviewed or denied.