### PR TITLE
fix(dashboard): quiet sidebar alpha channel footer with deliberate link underline

### DIFF
--- a/dashboard/src/approval-center-primitives.tsx
+++ b/dashboard/src/approval-center-primitives.tsx
@@ -282,7 +282,7 @@ export function ShellSidebar(props: {
                 {props.queuedCount > 0 ? (
                   <a
                     href={guardAwareHref("/inbox")}
-                    className="block text-[11px] font-medium leading-relaxed text-brand-blue underline decoration-brand-blue/45 underline-offset-[3px] transition-colors hover:decoration-brand-blue"
+                    className="block text-[11px] font-medium leading-relaxed text-brand-blue guard-quiet-link"
                   >
                     {props.queuedCount} local {props.queuedCount === 1 ? "action needs" : "actions need"} a Guard decision. Open Inbox to review.
                   </a>

--- a/dashboard/src/approval-center-primitives.tsx
+++ b/dashboard/src/approval-center-primitives.tsx
@@ -282,7 +282,7 @@ export function ShellSidebar(props: {
                 {props.queuedCount > 0 ? (
                   <a
                     href={guardAwareHref("/inbox")}
-                    className="block text-[11px] font-medium leading-relaxed text-brand-blue underline underline-offset-2 hover:no-underline"
+                    className="block text-[11px] font-medium leading-relaxed text-brand-blue underline decoration-brand-blue/45 underline-offset-[3px] transition-colors hover:decoration-brand-blue"
                   >
                     {props.queuedCount} local {props.queuedCount === 1 ? "action needs" : "actions need"} a Guard decision. Open Inbox to review.
                   </a>

--- a/dashboard/src/guard-update-panel.tsx
+++ b/dashboard/src/guard-update-panel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type ChangeEvent } from "react";
-import { HiMiniAdjustmentsHorizontal, HiMiniArrowPath, HiMiniBeaker } from "react-icons/hi2";
+import { HiMiniArrowPath, HiMiniBeaker } from "react-icons/hi2";
 
 import {
   fetchGuardUpdateStatus,
@@ -168,8 +168,50 @@ export function GuardUpdatePanel(props: GuardUpdatePanelProps) {
 
   return (
     <div className={props.compact ? "space-y-1" : "space-y-2"}>
-      {version ? (
-        <p className="font-mono text-[10px] text-brand-dark/60" aria-label={`Guard version ${version}`}>
+      {props.onSetUpdateChannel ? (
+        <div className="flex items-center justify-between gap-2">
+          {version ? (
+            <p
+              className="min-w-0 truncate font-mono text-[10px] leading-4 text-brand-dark/70"
+              aria-label={`Guard version ${version}`}
+            >
+              v{version}
+            </p>
+          ) : (
+            <span className="min-w-0 flex-1" aria-hidden="true" />
+          )}
+          {useAlpha ? (
+            <div
+              className="inline-flex min-w-0 shrink-0 items-center gap-1.5"
+              role="status"
+              aria-label="Alpha updates enabled"
+            >
+              <HiMiniBeaker className="h-3 w-3 shrink-0 text-brand-blue" aria-hidden="true" />
+              <span className="text-[11px] font-semibold leading-4 text-brand-blue">Alpha updates</span>
+              <button
+                type="button"
+                onClick={handleOpenAlphaModal}
+                disabled={busy}
+                aria-label="Manage alpha updates"
+                title="Manage alpha updates"
+                className="rounded-sm text-[11px] font-medium leading-4 text-brand-blue underline decoration-brand-blue/45 underline-offset-[3px] transition-colors hover:decoration-brand-blue focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                Manage
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={handleOpenAlphaModal}
+              disabled={busy}
+              className="shrink-0 rounded-sm text-[11px] font-medium leading-4 text-brand-blue underline decoration-brand-blue/45 underline-offset-[3px] transition-colors hover:decoration-brand-blue focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              Try alpha updates
+            </button>
+          )}
+        </div>
+      ) : version ? (
+        <p className="font-mono text-[10px] text-brand-dark/70" aria-label={`Guard version ${version}`}>
           v{version}
         </p>
       ) : null}
@@ -178,37 +220,6 @@ export function GuardUpdatePanel(props: GuardUpdatePanelProps) {
       ) : null}
       {helpCopy ? (
         <p className="text-[11px] leading-relaxed text-brand-dark/70">{helpCopy}</p>
-      ) : null}
-      {props.onSetUpdateChannel && useAlpha ? (
-        <div
-          className="flex items-center justify-between gap-2 rounded-md border border-brand-blue/20 bg-brand-blue/[0.06] px-2 py-1.5"
-          role="status"
-          aria-label="Alpha updates enabled"
-        >
-          <span className="inline-flex min-w-0 items-center gap-1.5 text-[11px] font-semibold text-brand-blue">
-            <HiMiniBeaker className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-            Alpha updates
-          </span>
-          <button
-            type="button"
-            onClick={handleOpenAlphaModal}
-            disabled={busy}
-            aria-label="Manage alpha updates"
-            title="Manage alpha updates"
-            className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-brand-blue transition-colors hover:bg-brand-blue/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            <HiMiniAdjustmentsHorizontal className="h-4 w-4" aria-hidden="true" />
-          </button>
-        </div>
-      ) : props.onSetUpdateChannel ? (
-        <button
-          type="button"
-          onClick={handleOpenAlphaModal}
-          disabled={busy}
-          className="inline-flex min-h-9 w-full items-center justify-center rounded-lg border border-brand-blue/25 bg-white px-3 py-2 text-xs font-semibold text-brand-blue transition-colors hover:bg-brand-blue/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          Try alpha updates
-        </button>
       ) : null}
       {showUpdateButton && props.onUpdateGuard ? (
         <button

--- a/dashboard/src/guard-update-panel.tsx
+++ b/dashboard/src/guard-update-panel.tsx
@@ -194,7 +194,7 @@ export function GuardUpdatePanel(props: GuardUpdatePanelProps) {
                 disabled={busy}
                 aria-label="Manage alpha updates"
                 title="Manage alpha updates"
-                className="rounded-sm text-[11px] font-medium leading-4 text-brand-blue underline decoration-brand-blue/45 underline-offset-[3px] transition-colors hover:decoration-brand-blue focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60"
+                className="rounded-sm text-[11px] font-medium leading-4 text-brand-blue guard-quiet-link focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60"
               >
                 Manage
               </button>
@@ -204,7 +204,7 @@ export function GuardUpdatePanel(props: GuardUpdatePanelProps) {
               type="button"
               onClick={handleOpenAlphaModal}
               disabled={busy}
-              className="shrink-0 rounded-sm text-[11px] font-medium leading-4 text-brand-blue underline decoration-brand-blue/45 underline-offset-[3px] transition-colors hover:decoration-brand-blue focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60"
+              className="shrink-0 rounded-sm text-[11px] font-medium leading-4 text-brand-blue guard-quiet-link focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60"
             >
               Try alpha updates
             </button>

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -114,6 +114,26 @@ body {
   line-height: 1.4;
 }
 
+/* Quiet inline link treatment for the Local Guard card: a thin offset
+   underline in the text color that thickens on hover. Color-less by design —
+   the build's CSS prefixer duplicates any text-decoration-color declaration. */
+.guard-quiet-link {
+  text-decoration-line: underline;
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1px;
+  transition: text-decoration-thickness 150ms var(--ease-out-quart);
+}
+
+.guard-quiet-link:hover {
+  text-decoration-thickness: 1.5px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .guard-quiet-link {
+    transition: none;
+  }
+}
+
 .guard-tab-enter {
   animation: guard-tab-enter 220ms var(--ease-out-quart) both;
 }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -19395,7 +19395,7 @@ function GuardUpdatePanel(props) {
                 disabled: busy,
                 "aria-label": "Manage alpha updates",
                 title: "Manage alpha updates",
-                className: "rounded-sm text-[11px] font-medium leading-4 text-brand-blue underline decoration-brand-blue/45 underline-offset-[3px] transition-colors hover:decoration-brand-blue focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60",
+                className: "rounded-sm text-[11px] font-medium leading-4 text-brand-blue guard-quiet-link focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60",
                 children: "Manage"
               }
             )
@@ -19407,7 +19407,7 @@ function GuardUpdatePanel(props) {
           type: "button",
           onClick: handleOpenAlphaModal,
           disabled: busy,
-          className: "shrink-0 rounded-sm text-[11px] font-medium leading-4 text-brand-blue underline decoration-brand-blue/45 underline-offset-[3px] transition-colors hover:decoration-brand-blue focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60",
+          className: "shrink-0 rounded-sm text-[11px] font-medium leading-4 text-brand-blue guard-quiet-link focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60",
           children: "Try alpha updates"
         }
       )
@@ -20010,7 +20010,7 @@ function ShellSidebar(props) {
             "a",
             {
               href: guardAwareHref("/inbox"),
-              className: "block text-[11px] font-medium leading-relaxed text-brand-blue underline decoration-brand-blue/45 underline-offset-[3px] transition-colors hover:decoration-brand-blue",
+              className: "block text-[11px] font-medium leading-relaxed text-brand-blue guard-quiet-link",
               children: [
                 props.queuedCount,
                 " local ",

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -19366,47 +19366,57 @@ function GuardUpdatePanel(props) {
     setAlphaApprovalTotpCode(event.target.value);
   }, []);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: props.compact ? "space-y-1" : "space-y-2", children: [
-    version ? /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "font-mono text-[10px] text-brand-dark/60", "aria-label": `Guard version ${version}`, children: [
+    props.onSetUpdateChannel ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between gap-2", children: [
+      version ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
+        "p",
+        {
+          className: "min-w-0 truncate font-mono text-[10px] leading-4 text-brand-dark/70",
+          "aria-label": `Guard version ${version}`,
+          children: [
+            "v",
+            version
+          ]
+        }
+      ) : /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "min-w-0 flex-1", "aria-hidden": "true" }),
+      useAlpha ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
+        "div",
+        {
+          className: "inline-flex min-w-0 shrink-0 items-center gap-1.5",
+          role: "status",
+          "aria-label": "Alpha updates enabled",
+          children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniBeaker, { className: "h-3 w-3 shrink-0 text-brand-blue", "aria-hidden": "true" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-[11px] font-semibold leading-4 text-brand-blue", children: "Alpha updates" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "button",
+              {
+                type: "button",
+                onClick: handleOpenAlphaModal,
+                disabled: busy,
+                "aria-label": "Manage alpha updates",
+                title: "Manage alpha updates",
+                className: "rounded-sm text-[11px] font-medium leading-4 text-brand-blue underline decoration-brand-blue/45 underline-offset-[3px] transition-colors hover:decoration-brand-blue focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60",
+                children: "Manage"
+              }
+            )
+          ]
+        }
+      ) : /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "button",
+        {
+          type: "button",
+          onClick: handleOpenAlphaModal,
+          disabled: busy,
+          className: "shrink-0 rounded-sm text-[11px] font-medium leading-4 text-brand-blue underline decoration-brand-blue/45 underline-offset-[3px] transition-colors hover:decoration-brand-blue focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60",
+          children: "Try alpha updates"
+        }
+      )
+    ] }) : version ? /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "font-mono text-[10px] text-brand-dark/70", "aria-label": `Guard version ${version}`, children: [
       "v",
       version
     ] }) : null,
     props.updateStatus?.update_available ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] leading-relaxed text-brand-dark/75", children: updateStatusLabel(props.updateStatus) }) : null,
     helpCopy ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] leading-relaxed text-brand-dark/70", children: helpCopy }) : null,
-    props.onSetUpdateChannel && useAlpha ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
-      "div",
-      {
-        className: "flex items-center justify-between gap-2 rounded-md border border-brand-blue/20 bg-brand-blue/[0.06] px-2 py-1.5",
-        role: "status",
-        "aria-label": "Alpha updates enabled",
-        children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "inline-flex min-w-0 items-center gap-1.5 text-[11px] font-semibold text-brand-blue", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniBeaker, { className: "h-3.5 w-3.5 shrink-0", "aria-hidden": "true" }),
-            "Alpha updates"
-          ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "button",
-            {
-              type: "button",
-              onClick: handleOpenAlphaModal,
-              disabled: busy,
-              "aria-label": "Manage alpha updates",
-              title: "Manage alpha updates",
-              className: "inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-brand-blue transition-colors hover:bg-brand-blue/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60",
-              children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniAdjustmentsHorizontal, { className: "h-4 w-4", "aria-hidden": "true" })
-            }
-          )
-        ]
-      }
-    ) : props.onSetUpdateChannel ? /* @__PURE__ */ jsxRuntimeExports.jsx(
-      "button",
-      {
-        type: "button",
-        onClick: handleOpenAlphaModal,
-        disabled: busy,
-        className: "inline-flex min-h-9 w-full items-center justify-center rounded-lg border border-brand-blue/25 bg-white px-3 py-2 text-xs font-semibold text-brand-blue transition-colors hover:bg-brand-blue/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60",
-        children: "Try alpha updates"
-      }
-    ) : null,
     showUpdateButton && props.onUpdateGuard ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
       "button",
       {
@@ -20000,7 +20010,7 @@ function ShellSidebar(props) {
             "a",
             {
               href: guardAwareHref("/inbox"),
-              className: "block text-[11px] font-medium leading-relaxed text-brand-blue underline underline-offset-2 hover:no-underline",
+              className: "block text-[11px] font-medium leading-relaxed text-brand-blue underline decoration-brand-blue/45 underline-offset-[3px] transition-colors hover:decoration-brand-blue",
               children: [
                 props.queuedCount,
                 " local ",

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -4454,8 +4454,22 @@
     text-decoration-line: underline;
   }
 
-  .underline-offset-2 {
-    text-underline-offset: 2px;
+  .decoration-brand-blue\/45 {
+    -webkit-text-decoration-color: var(--brand-blue);
+    -webkit-text-decoration-color: var(--brand-blue);
+    text-decoration-color: var(--brand-blue);
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .decoration-brand-blue\/45 {
+      -webkit-text-decoration-color: color-mix(in oklab, var(--brand-blue) 45%, transparent);
+      -webkit-text-decoration-color: color-mix(in oklab, var(--brand-blue) 45%, transparent);
+      text-decoration-color: color-mix(in oklab, var(--brand-blue) 45%, transparent);
+    }
+  }
+
+  .underline-offset-\[3px\] {
+    text-underline-offset: 3px;
   }
 
   .accent-brand-blue {
@@ -5002,16 +5016,6 @@
       }
     }
 
-    .hover\:bg-brand-blue\/10:hover {
-      background-color: var(--brand-blue);
-    }
-
-    @supports (color: color-mix(in lab, red, red)) {
-      .hover\:bg-brand-blue\/10:hover {
-        background-color: color-mix(in oklab, var(--brand-blue) 10%, transparent);
-      }
-    }
-
     .hover\:bg-brand-blue\/20:hover {
       background-color: var(--brand-blue);
     }
@@ -5226,12 +5230,14 @@
       color: var(--color-white);
     }
 
-    .hover\:no-underline:hover {
-      text-decoration-line: none;
-    }
-
     .hover\:underline:hover {
       text-decoration-line: underline;
+    }
+
+    .hover\:decoration-brand-blue:hover {
+      -webkit-text-decoration-color: var(--brand-blue);
+      -webkit-text-decoration-color: var(--brand-blue);
+      text-decoration-color: var(--brand-blue);
     }
 
     .hover\:opacity-85:hover {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -4454,24 +4454,6 @@
     text-decoration-line: underline;
   }
 
-  .decoration-brand-blue\/45 {
-    -webkit-text-decoration-color: var(--brand-blue);
-    -webkit-text-decoration-color: var(--brand-blue);
-    text-decoration-color: var(--brand-blue);
-  }
-
-  @supports (color: color-mix(in lab, red, red)) {
-    .decoration-brand-blue\/45 {
-      -webkit-text-decoration-color: color-mix(in oklab, var(--brand-blue) 45%, transparent);
-      -webkit-text-decoration-color: color-mix(in oklab, var(--brand-blue) 45%, transparent);
-      text-decoration-color: color-mix(in oklab, var(--brand-blue) 45%, transparent);
-    }
-  }
-
-  .underline-offset-\[3px\] {
-    text-underline-offset: 3px;
-  }
-
   .accent-brand-blue {
     accent-color: var(--brand-blue);
   }
@@ -5232,12 +5214,6 @@
 
     .hover\:underline:hover {
       text-decoration-line: underline;
-    }
-
-    .hover\:decoration-brand-blue:hover {
-      -webkit-text-decoration-color: var(--brand-blue);
-      -webkit-text-decoration-color: var(--brand-blue);
-      text-decoration-color: var(--brand-blue);
     }
 
     .hover\:opacity-85:hover {
@@ -6310,7 +6286,22 @@ body {
   line-height: 1.4;
 }
 
+.guard-quiet-link {
+  text-underline-offset: 3px;
+  transition: text-decoration-thickness .15s var(--ease-out-quart);
+  text-decoration-line: underline;
+  text-decoration-thickness: 1px;
+}
+
+.guard-quiet-link:hover {
+  text-decoration-thickness: 1.5px;
+}
+
 @media (prefers-reduced-motion: reduce) {
+  .guard-quiet-link {
+    transition: none;
+  }
+
   .guard-tab-enter {
     animation: none;
   }


### PR DESCRIPTION
## Summary
- The sidebar's alpha channel control rendered as a full-width bordered white button that competed with the primary update action, with the version string orphaned below it. The footer now uses one quiet meta row: mono version on the left, channel control on the right.
- "Try alpha updates" is now a text link with a deliberately styled underline (soft brand-blue at rest, full-opacity on hover, 3px offset) so the affordance reads as designed rather than as rendering noise. The alpha-enabled state keeps the beaker status label and adds a "Manage" link in the same row geometry, replacing the cryptic icon-only settings button.
- The sidebar inbox link uses the same refined underline treatment so both link species in the Local Guard card match.

## Testing
- `npm test` in `dashboard/` (full suite, all passed)
- `npm run build` in `dashboard/` (clean; rebuilt daemon static assets included)
- Rendered the sidebar in all three states (stable idle, alpha enabled with queued approvals, update available) via `renderToStaticMarkup` and verified layout, underline placement, and baseline alignment in a headless-browser screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Refined the approval notice link with branded underline styling and improved hover behavior.
  * Updated Guard version and update-channel controls to use a more compact inline layout.
  * Added clearer inline actions for managing or trying alpha updates.
  * Refined version and alpha-status visual styling for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->