### PR TITLE
fix(release): publish matching plugin-scanner versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -766,24 +766,30 @@ jobs:
           name: distribution-sha256
       - name: Verify the TestPyPI-proven artifact
         run: sha256sum --check distribution-sha256.txt
-      - name: Keep only the Guard release distribution
-        run: rm -f dist/plugin_scanner-* dist/plugin-scanner-*
+      - name: Prepare project-specific distributions
+        run: |
+          shopt -s nullglob
+          guard_files=(dist/hol_guard-* dist/hol-guard-*)
+          scanner_files=(dist/plugin_scanner-* dist/plugin-scanner-*)
+          [[ "${#guard_files[@]}" == "2" && "${#scanner_files[@]}" == "2" ]]
+          mkdir dist-hol-guard dist-plugin-scanner
+          cp "${guard_files[@]}" dist-hol-guard/
+          cp "${scanner_files[@]}" dist-plugin-scanner/
       - name: Inspect PyPI release state
         id: pypi
         env:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
-          result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
-            verify-release --registry pypi --version "$VERSION" --dist-dir dist)
-          status=$(jq -r '.status' <<< "$result")
-          if [[ "$status" == "absent" ]]; then
-            echo "upload=true" >> "$GITHUB_OUTPUT"
-          elif [[ "$status" == "exact" ]]; then
-            echo "upload=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Unexpected PyPI status: $status" >&2
-            exit 1
-          fi
+          guard_result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
+            verify-release --registry pypi --project hol-guard --version "$VERSION" --dist-dir dist-hol-guard)
+          scanner_result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
+            verify-release --registry pypi --project plugin-scanner --version "$VERSION" --dist-dir dist-plugin-scanner)
+          guard_status=$(jq -r '.status' <<< "$guard_result")
+          scanner_status=$(jq -r '.status' <<< "$scanner_result")
+          [[ "$guard_status" == "absent" || "$guard_status" == "exact" ]]
+          [[ "$scanner_status" == "absent" || "$scanner_status" == "exact" ]]
+          [[ "$guard_status" == "absent" ]] && echo "hol_guard_upload=true" >> "$GITHUB_OUTPUT" || echo "hol_guard_upload=false" >> "$GITHUB_OUTPUT"
+          [[ "$scanner_status" == "absent" ]] && echo "plugin_scanner_upload=true" >> "$GITHUB_OUTPUT" || echo "plugin_scanner_upload=false" >> "$GITHUB_OUTPUT"
       - name: Revalidate alpha publication authorization
         env:
           ACTUAL_REF: ${{ github.ref }}
@@ -821,33 +827,51 @@ jobs:
             [[ -z "$existing_version" ]] || validator_args+=(--existing-version "$existing_version")
           done
           uv run --with packaging==25.0 python scripts/validate_alpha_release.py "${validator_args[@]}"
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
-        if: steps.pypi.outputs.upload == 'true'
+      - name: Publish HOL Guard to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+        if: steps.pypi.outputs.hol_guard_upload == 'true'
+        with:
+          packages-dir: dist-hol-guard/
+      - name: Publish plugin-scanner to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+        if: steps.pypi.outputs.plugin_scanner_upload == 'true'
+        with:
+          packages-dir: dist-plugin-scanner/
       - name: Remove generated upload attestations
-        run: rm -f dist/*.publish.attestation
+        run: rm -f dist-hol-guard/*.publish.attestation dist-plugin-scanner/*.publish.attestation
       - name: Download and verify exact PyPI artifacts
         env:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
           for attempt in {1..60}; do
-            if ! result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
-              verify-release --registry pypi --version "$VERSION" --dist-dir dist \
-              --download-dir verified-pypi); then
+            if ! guard_result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
+              verify-release --registry pypi --project hol-guard --version "$VERSION" \
+              --dist-dir dist-hol-guard --download-dir verified-pypi-hol-guard); then
               exit 1
             fi
-            status=$(jq -r '.status' <<< "$result")
-            if [[ "$status" == "exact" ]]; then
+            if ! scanner_result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
+              verify-release --registry pypi --project plugin-scanner --version "$VERSION" \
+              --dist-dir dist-plugin-scanner --download-dir verified-pypi-plugin-scanner); then
+              exit 1
+            fi
+            guard_status=$(jq -r '.status' <<< "$guard_result")
+            scanner_status=$(jq -r '.status' <<< "$scanner_result")
+            if [[ "$guard_status" == "exact" && "$scanner_status" == "exact" ]]; then
               break
             fi
-            if [[ "$status" != "absent" || "$attempt" == "60" ]]; then
+            if [[ "$guard_status" != "absent" && "$guard_status" != "exact" ]] || \
+              [[ "$scanner_status" != "absent" && "$scanner_status" != "exact" ]] || \
+              [[ "$attempt" == "60" ]]; then
               echo "PyPI did not expose the exact release artifacts" >&2
               exit 1
             fi
             sleep 5
           done
-          wheel=$(jq -r '.install_paths[] | select(endswith(".whl"))' <<< "$result")
-          [[ -n "$wheel" ]]
-          [[ "$(uv tool run --from "$wheel" hol-guard --version)" == "hol-guard $VERSION" ]]
+          guard_wheel=$(jq -r '.install_paths[] | select(endswith(".whl"))' <<< "$guard_result")
+          scanner_wheel=$(jq -r '.install_paths[] | select(endswith(".whl"))' <<< "$scanner_result")
+          [[ -n "$guard_wheel" && -n "$scanner_wheel" ]]
+          [[ "$(uv tool run --from "$guard_wheel" hol-guard --version)" == "hol-guard $VERSION" ]]
+          [[ "$(uv tool run --from "$scanner_wheel" plugin-scanner --version)" == "plugin-scanner $VERSION" ]]
 
   publish-main-testpypi:
     name: Verify main artifact on TestPyPI
@@ -973,8 +997,15 @@ jobs:
           name: distribution-sha256
       - name: Verify immutable build artifact
         run: sha256sum --check distribution-sha256.txt
-      - name: Keep only the Guard release distribution
-        run: rm -f dist/plugin_scanner-* dist/plugin-scanner-*
+      - name: Prepare project-specific distributions
+        run: |
+          shopt -s nullglob
+          guard_files=(dist/hol_guard-* dist/hol-guard-*)
+          scanner_files=(dist/plugin_scanner-* dist/plugin-scanner-*)
+          [[ "${#guard_files[@]}" == "2" && "${#scanner_files[@]}" == "2" ]]
+          mkdir dist-hol-guard dist-plugin-scanner
+          cp "${guard_files[@]}" dist-hol-guard/
+          cp "${scanner_files[@]}" dist-plugin-scanner/
       - name: Revalidate main publication
         env:
           SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
@@ -1017,44 +1048,61 @@ jobs:
         env:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
-          result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
-            verify-release --registry pypi --version "$VERSION" --dist-dir dist)
-          status=$(jq -r '.status' <<< "$result")
-          if [[ "$status" == "absent" ]]; then
-            echo "upload=true" >> "$GITHUB_OUTPUT"
-          elif [[ "$status" == "exact" ]]; then
-            echo "upload=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Unexpected PyPI status: $status" >&2
-            exit 1
-          fi
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
-        if: steps.pypi.outputs.upload == 'true'
+          guard_result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
+            verify-release --registry pypi --project hol-guard --version "$VERSION" --dist-dir dist-hol-guard)
+          scanner_result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
+            verify-release --registry pypi --project plugin-scanner --version "$VERSION" --dist-dir dist-plugin-scanner)
+          guard_status=$(jq -r '.status' <<< "$guard_result")
+          scanner_status=$(jq -r '.status' <<< "$scanner_result")
+          [[ "$guard_status" == "absent" || "$guard_status" == "exact" ]]
+          [[ "$scanner_status" == "absent" || "$scanner_status" == "exact" ]]
+          [[ "$guard_status" == "absent" ]] && echo "hol_guard_upload=true" >> "$GITHUB_OUTPUT" || echo "hol_guard_upload=false" >> "$GITHUB_OUTPUT"
+          [[ "$scanner_status" == "absent" ]] && echo "plugin_scanner_upload=true" >> "$GITHUB_OUTPUT" || echo "plugin_scanner_upload=false" >> "$GITHUB_OUTPUT"
+      - name: Publish HOL Guard to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+        if: steps.pypi.outputs.hol_guard_upload == 'true'
+        with:
+          packages-dir: dist-hol-guard/
+      - name: Publish plugin-scanner to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+        if: steps.pypi.outputs.plugin_scanner_upload == 'true'
+        with:
+          packages-dir: dist-plugin-scanner/
       - name: Remove generated upload attestations
-        run: rm -f dist/*.publish.attestation
+        run: rm -f dist-hol-guard/*.publish.attestation dist-plugin-scanner/*.publish.attestation
       - name: Download and verify exact PyPI artifacts
         env:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
           for attempt in {1..60}; do
-            if ! result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
-              verify-release --registry pypi --version "$VERSION" --dist-dir dist \
-              --download-dir verified-pypi); then
+            if ! guard_result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
+              verify-release --registry pypi --project hol-guard --version "$VERSION" \
+              --dist-dir dist-hol-guard --download-dir verified-pypi-hol-guard); then
               exit 1
             fi
-            status=$(jq -r '.status' <<< "$result")
-            if [[ "$status" == "exact" ]]; then
+            if ! scanner_result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
+              verify-release --registry pypi --project plugin-scanner --version "$VERSION" \
+              --dist-dir dist-plugin-scanner --download-dir verified-pypi-plugin-scanner); then
+              exit 1
+            fi
+            guard_status=$(jq -r '.status' <<< "$guard_result")
+            scanner_status=$(jq -r '.status' <<< "$scanner_result")
+            if [[ "$guard_status" == "exact" && "$scanner_status" == "exact" ]]; then
               break
             fi
-            if [[ "$status" != "absent" || "$attempt" == "60" ]]; then
+            if [[ "$guard_status" != "absent" && "$guard_status" != "exact" ]] || \
+              [[ "$scanner_status" != "absent" && "$scanner_status" != "exact" ]] || \
+              [[ "$attempt" == "60" ]]; then
               echo "PyPI did not expose the exact release artifacts" >&2
               exit 1
             fi
             sleep 5
           done
-          wheel=$(jq -r '.install_paths[] | select(endswith(".whl"))' <<< "$result")
-          [[ -n "$wheel" ]]
-          [[ "$(uv tool run --from "$wheel" hol-guard --version)" == "hol-guard $VERSION" ]]
+          guard_wheel=$(jq -r '.install_paths[] | select(endswith(".whl"))' <<< "$guard_result")
+          scanner_wheel=$(jq -r '.install_paths[] | select(endswith(".whl"))' <<< "$scanner_result")
+          [[ -n "$guard_wheel" && -n "$scanner_wheel" ]]
+          [[ "$(uv tool run --from "$guard_wheel" hol-guard --version)" == "hol-guard $VERSION" ]]
+          [[ "$(uv tool run --from "$scanner_wheel" plugin-scanner --version)" == "plugin-scanner $VERSION" ]]
 
   release-main:
     name: Create main GitHub release

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12642,
-  "maximum_test_source_lines": 289514,
+  "maximum_collected_cases": 12645,
+  "maximum_test_source_lines": 289601,
   "schema_version": 1
 }

--- a/scripts/verify_release_registry.py
+++ b/scripts/verify_release_registry.py
@@ -19,7 +19,8 @@ from typing import Final
 from packaging.utils import InvalidSdistFilename, InvalidWheelFilename, parse_sdist_filename, parse_wheel_filename
 from packaging.version import InvalidVersion, Version
 
-PROJECT_NAME: Final = "hol-guard"
+DEFAULT_PROJECT_NAME: Final = "hol-guard"
+SUPPORTED_PROJECT_NAMES: Final = ("hol-guard", "plugin-scanner")
 MAX_RESPONSE_BYTES: Final = 256 * 1024 * 1024
 _SHA256: Final[re.Pattern[str]] = re.compile(r"[0-9a-f]{64}")
 
@@ -101,13 +102,19 @@ def stdlib_fetch(url: str) -> bytes:
     return b"".join(chunks)
 
 
-def _project_url(registry: Registry) -> str:
-    return f"https://{registry.api_host}/pypi/{PROJECT_NAME}/json"
+def _validated_project_name(project_name: str) -> str:
+    if project_name not in SUPPORTED_PROJECT_NAMES:
+        raise RegistryVerificationError(f"Unsupported release project: {project_name}")
+    return project_name
 
 
-def _release_url(registry: Registry, version: str) -> str:
+def _project_url(registry: Registry, project_name: str) -> str:
+    return f"https://{registry.api_host}/pypi/{_validated_project_name(project_name)}/json"
+
+
+def _release_url(registry: Registry, project_name: str, version: str) -> str:
     quoted_version = urllib.parse.quote(version, safe="")
-    return f"https://{registry.api_host}/pypi/{PROJECT_NAME}/{quoted_version}/json"
+    return f"https://{registry.api_host}/pypi/{_validated_project_name(project_name)}/{quoted_version}/json"
 
 
 def _fetch_payload(
@@ -153,9 +160,10 @@ def _canonical_public_version(version_text: object, *, label: str) -> Version:
 def list_registry_versions(
     registry: Registry,
     *,
+    project_name: str = DEFAULT_PROJECT_NAME,
     fetcher: Fetcher = stdlib_fetch,
 ) -> tuple[str, ...]:
-    payload = _fetch_payload(_project_url(registry), fetcher=fetcher)
+    payload = _fetch_payload(_project_url(registry, project_name), fetcher=fetcher)
     if payload is None:
         raise RegistryVerificationError("Registry project response was unexpectedly absent")
     document = _decode_object(payload, label="Registry project response")
@@ -180,11 +188,11 @@ def _distribution_identity(filename: str) -> tuple[str, Version]:
         raise RegistryVerificationError(f"Invalid distribution filename: {filename}") from exc
 
 
-def _validate_distribution_filename(filename: object, version: Version) -> str:
+def _validate_distribution_filename(filename: object, version: Version, project_name: str) -> str:
     if not isinstance(filename, str) or not filename or Path(filename).name != filename:
         raise RegistryVerificationError("Registry distribution filename is invalid")
     name, file_version = _distribution_identity(filename)
-    if name != PROJECT_NAME or file_version != version:
+    if name != _validated_project_name(project_name) or file_version != version:
         raise RegistryVerificationError("Registry returned a distribution for the wrong project or version")
     return filename
 
@@ -216,11 +224,12 @@ def inspect_release(
     registry: Registry,
     version_text: str,
     *,
+    project_name: str = DEFAULT_PROJECT_NAME,
     fetcher: Fetcher = stdlib_fetch,
 ) -> ReleaseInspection:
     version = _canonical_public_version(version_text, label="Requested version")
     payload = _fetch_payload(
-        _release_url(registry, str(version)),
+        _release_url(registry, project_name, str(version)),
         fetcher=fetcher,
         allow_not_found=True,
     )
@@ -243,7 +252,7 @@ def inspect_release(
     for item in urls:
         if not isinstance(item, dict):
             raise RegistryVerificationError("Registry release file entry must be an object")
-        filename = _validate_distribution_filename(item.get("filename"), version)
+        filename = _validate_distribution_filename(item.get("filename"), version, project_name)
         if filename in seen:
             raise RegistryVerificationError(f"Registry release repeats distribution filename: {filename}")
         seen.add(filename)
@@ -274,8 +283,11 @@ def _sha256_file(path: Path) -> str:
 def compute_local_distribution_hashes(
     dist_dir: Path,
     version_text: str,
+    project_name: str = DEFAULT_PROJECT_NAME,
 ) -> dict[str, str]:
     version = _canonical_public_version(version_text, label="Requested version")
+    normalized_project_name = _validated_project_name(project_name)
+    project_prefixes = (normalized_project_name, normalized_project_name.replace("-", "_"))
     if not dist_dir.is_dir():
         raise RegistryVerificationError("Distribution directory does not exist")
 
@@ -284,29 +296,29 @@ def compute_local_distribution_hashes(
     found_sdist = False
     for path in sorted(dist_dir.iterdir()):
         if path.is_symlink():
-            if path.name.startswith(("hol_guard-", "hol-guard-")):
-                raise RegistryVerificationError("Local Guard distributions cannot be symbolic links")
+            if path.name.startswith(tuple(f"{prefix}-" for prefix in project_prefixes)):
+                raise RegistryVerificationError("Local project distributions cannot be symbolic links")
             continue
         if not path.is_file():
             continue
         try:
             name, file_version = _distribution_identity(path.name)
         except RegistryVerificationError:
-            if path.name.startswith(("hol_guard-", "hol-guard-")):
+            if path.name.startswith(tuple(f"{prefix}-" for prefix in project_prefixes)):
                 raise
             continue
-        if name != PROJECT_NAME:
+        if name != normalized_project_name:
             continue
         if file_version != version:
-            raise RegistryVerificationError("Local Guard distribution has the wrong version")
+            raise RegistryVerificationError("Local project distribution has the wrong version")
         if path.name in hashes:
-            raise RegistryVerificationError("Local Guard distribution filename is duplicated")
+            raise RegistryVerificationError("Local project distribution filename is duplicated")
         hashes[path.name] = _sha256_file(path)
         found_wheel = found_wheel or path.name.endswith(".whl")
         found_sdist = found_sdist or not path.name.endswith(".whl")
 
     if not hashes or not found_wheel or not found_sdist:
-        raise RegistryVerificationError("Local release requires both a Guard wheel and sdist")
+        raise RegistryVerificationError("Local release requires both a project wheel and sdist")
     return hashes
 
 
@@ -368,11 +380,12 @@ def verify_registry_release(
     version_text: str,
     dist_dir: Path,
     *,
+    project_name: str = DEFAULT_PROJECT_NAME,
     download_dir: Path | None = None,
     fetcher: Fetcher = stdlib_fetch,
 ) -> RegistryResult:
-    local_hashes = compute_local_distribution_hashes(dist_dir, version_text)
-    inspection = inspect_release(registry, version_text, fetcher=fetcher)
+    local_hashes = compute_local_distribution_hashes(dist_dir, version_text, project_name)
+    inspection = inspect_release(registry, version_text, project_name=project_name, fetcher=fetcher)
     if not inspection.exists:
         return RegistryResult(
             registry=registry,
@@ -397,6 +410,7 @@ def verify_testpypi_release(
     version_text: str,
     dist_dir: Path,
     *,
+    project_name: str = DEFAULT_PROJECT_NAME,
     download_dir: Path | None = None,
     fetcher: Fetcher = stdlib_fetch,
 ) -> TestPyPIResult:
@@ -406,6 +420,7 @@ def verify_testpypi_release(
         Registry.TESTPYPI,
         version_text,
         dist_dir,
+        project_name=project_name,
         download_dir=download_dir,
         fetcher=fetcher,
     )
@@ -414,9 +429,10 @@ def verify_testpypi_release(
 def assert_pypi_release_absent(
     version_text: str,
     *,
+    project_name: str = DEFAULT_PROJECT_NAME,
     fetcher: Fetcher = stdlib_fetch,
 ) -> None:
-    inspection = inspect_release(Registry.PYPI, version_text, fetcher=fetcher)
+    inspection = inspect_release(Registry.PYPI, version_text, project_name=project_name, fetcher=fetcher)
     if inspection.exists:
         raise RegistryVerificationError(f"PyPI release {inspection.version} already exists")
 
@@ -446,23 +462,28 @@ def _parser() -> argparse.ArgumentParser:
 
     list_parser = subparsers.add_parser("list-versions")
     _ = list_parser.add_argument("--registry", choices=[item.value for item in Registry], required=True)
+    _ = list_parser.add_argument("--project", choices=SUPPORTED_PROJECT_NAMES, default=DEFAULT_PROJECT_NAME)
 
     inspect_parser = subparsers.add_parser("inspect-release")
     _ = inspect_parser.add_argument("--registry", choices=[item.value for item in Registry], required=True)
+    _ = inspect_parser.add_argument("--project", choices=SUPPORTED_PROJECT_NAMES, default=DEFAULT_PROJECT_NAME)
     _ = inspect_parser.add_argument("--version", required=True)
 
     verify_parser = subparsers.add_parser("verify-testpypi")
+    _ = verify_parser.add_argument("--project", choices=SUPPORTED_PROJECT_NAMES, default=DEFAULT_PROJECT_NAME)
     _ = verify_parser.add_argument("--version", required=True)
     _ = verify_parser.add_argument("--dist-dir", type=Path, required=True)
     _ = verify_parser.add_argument("--download-dir", type=Path)
 
     generic_verify_parser = subparsers.add_parser("verify-release")
     _ = generic_verify_parser.add_argument("--registry", choices=[item.value for item in Registry], required=True)
+    _ = generic_verify_parser.add_argument("--project", choices=SUPPORTED_PROJECT_NAMES, default=DEFAULT_PROJECT_NAME)
     _ = generic_verify_parser.add_argument("--version", required=True)
     _ = generic_verify_parser.add_argument("--dist-dir", type=Path, required=True)
     _ = generic_verify_parser.add_argument("--download-dir", type=Path)
 
     absent_parser = subparsers.add_parser("assert-pypi-absent")
+    _ = absent_parser.add_argument("--project", choices=SUPPORTED_PROJECT_NAMES, default=DEFAULT_PROJECT_NAME)
     _ = absent_parser.add_argument("--version", required=True)
     return parser
 
@@ -473,12 +494,13 @@ def main(argv: Sequence[str] | None = None, *, fetcher: Fetcher = stdlib_fetch) 
     try:
         if command == "list-versions":
             registry = Registry(args.registry)
-            output: object = list_registry_versions(registry, fetcher=fetcher)
+            output: object = list_registry_versions(registry, project_name=args.project, fetcher=fetcher)
         elif command == "inspect-release":
             registry = Registry(args.registry)
             inspection = inspect_release(
                 registry,
                 args.version,
+                project_name=args.project,
                 fetcher=fetcher,
             )
             output = _inspection_output(inspection)
@@ -486,6 +508,7 @@ def main(argv: Sequence[str] | None = None, *, fetcher: Fetcher = stdlib_fetch) 
             result = verify_testpypi_release(
                 args.version,
                 args.dist_dir,
+                project_name=args.project,
                 download_dir=args.download_dir,
                 fetcher=fetcher,
             )
@@ -495,13 +518,14 @@ def main(argv: Sequence[str] | None = None, *, fetcher: Fetcher = stdlib_fetch) 
                 Registry(args.registry),
                 args.version,
                 args.dist_dir,
+                project_name=args.project,
                 download_dir=args.download_dir,
                 fetcher=fetcher,
             )
             output = _result_output(result)
         elif command == "assert-pypi-absent":
             version = args.version
-            assert_pypi_release_absent(version, fetcher=fetcher)
+            assert_pypi_release_absent(version, project_name=args.project, fetcher=fetcher)
             output = {"registry": Registry.PYPI.value, "version": version, "status": "absent"}
         else:
             raise RegistryVerificationError("Unsupported registry verification command")

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -191,18 +191,21 @@ def test_release_publication_reuses_one_hashed_build_artifact() -> None:
         "publish-alpha-testpypi",
     ]
     assert "needs.publish-alpha-testpypi.result == 'success'" in jobs["publish-alpha-pypi"]["if"]
-    for job_name in (
-        "publish-alpha-testpypi",
-        "publish-alpha-pypi",
-        "publish-main-testpypi",
-        "publish-main-pypi",
-    ):
+    for job_name in ("publish-alpha-testpypi", "publish-main-testpypi"):
         steps = jobs[job_name]["steps"]
         assert any(step.get("run") == "sha256sum --check distribution-sha256.txt" for step in steps)
         assert any(
             step.get("name") == "Keep only the Guard release distribution" and "plugin_scanner" in step.get("run", "")
             for step in steps
         )
+
+    for job_name in ("publish-alpha-pypi", "publish-main-pypi"):
+        steps = jobs[job_name]["steps"]
+        assert any(step.get("run") == "sha256sum --check distribution-sha256.txt" for step in steps)
+        prepare_step = next(step for step in steps if step.get("name") == "Prepare project-specific distributions")
+        assert "dist-hol-guard" in prepare_step["run"]
+        assert "dist-plugin-scanner" in prepare_step["run"]
+        assert not any(step.get("name") == "Keep only the Guard release distribution" for step in steps)
 
     workflow_text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
     assert "skip-existing" not in workflow_text and "pytest" not in workflow_text
@@ -310,19 +313,33 @@ def test_registry_state_is_revalidated_at_each_publication_boundary() -> None:
     for job_name in ("publish-alpha-pypi", "publish-main-pypi"):
         steps = jobs[job_name]["steps"]
         inspect_step = next(step for step in steps if step.get("name") == "Inspect PyPI release state")
-        publish_step = next(step for step in steps if str(step.get("uses", "")).startswith("pypa/"))
+        publish_steps = [step for step in steps if str(step.get("uses", "")).startswith("pypa/")]
         cleanup_step = next(step for step in steps if step.get("name") == "Remove generated upload attestations")
         verify_step = next(step for step in steps if step.get("name") == "Download and verify exact PyPI artifacts")
-        assert "verify-release --registry pypi" in inspect_step["run"]
-        assert publish_step["if"] == "steps.pypi.outputs.upload == 'true'"
-        assert cleanup_step["run"] == "rm -f dist/*.publish.attestation"
-        assert steps.index(publish_step) < steps.index(cleanup_step) < steps.index(verify_step)
+        assert "--project hol-guard" in inspect_step["run"]
+        assert "--project plugin-scanner" in inspect_step["run"]
+        assert len(publish_steps) == 2
+        assert {step["if"] for step in publish_steps} == {
+            "steps.pypi.outputs.hol_guard_upload == 'true'",
+            "steps.pypi.outputs.plugin_scanner_upload == 'true'",
+        }
+        assert {step["with"]["packages-dir"] for step in publish_steps} == {
+            "dist-hol-guard/",
+            "dist-plugin-scanner/",
+        }
+        assert "dist-hol-guard/*.publish.attestation" in cleanup_step["run"]
+        assert "dist-plugin-scanner/*.publish.attestation" in cleanup_step["run"]
+        assert all(steps.index(step) < steps.index(cleanup_step) for step in publish_steps)
+        assert steps.index(cleanup_step) < steps.index(verify_step)
         assert "--download-dir verified-pypi" in verify_step["run"]
-        assert 'status" == "exact"' in verify_step["run"]
-        assert 'status" != "absent"' in verify_step["run"]
+        assert "--project hol-guard" in verify_step["run"]
+        assert "--project plugin-scanner" in verify_step["run"]
+        assert 'guard_status" == "exact"' in verify_step["run"]
+        assert 'scanner_status" == "exact"' in verify_step["run"]
         assert "for attempt in {1..60}" in verify_step["run"]
         assert 'attempt" == "60"' in verify_step["run"]
         assert '== "hol-guard $VERSION"' in verify_step["run"]
+        assert '== "plugin-scanner $VERSION"' in verify_step["run"]
 
 
 def test_release_tags_are_bound_to_the_exact_published_source() -> None:

--- a/tests/test_verify_release_registry.py
+++ b/tests/test_verify_release_registry.py
@@ -41,6 +41,9 @@ class ChunkedResponse:
 VERSION = "2.2.0a1"
 WHEEL = f"hol_guard-{VERSION}-py3-none-any.whl"
 SDIST = f"hol_guard-{VERSION}.tar.gz"
+PLUGIN_PROJECT = "plugin-scanner"
+PLUGIN_WHEEL = f"plugin_scanner-{VERSION}-py3-none-any.whl"
+PLUGIN_SDIST = f"plugin_scanner-{VERSION}.tar.gz"
 WHEEL_BYTES = b"wheel-content"
 SDIST_BYTES = b"sdist-content"
 
@@ -60,12 +63,12 @@ class FakeFetcher:
         return response
 
 
-def _project_url(registry: Registry) -> str:
-    return f"https://{registry.api_host}/pypi/hol-guard/json"
+def _project_url(registry: Registry, project_name: str = "hol-guard") -> str:
+    return f"https://{registry.api_host}/pypi/{project_name}/json"
 
 
-def _release_url(registry: Registry, version: str = VERSION) -> str:
-    return f"https://{registry.api_host}/pypi/hol-guard/{version}/json"
+def _release_url(registry: Registry, version: str = VERSION, project_name: str = "hol-guard") -> str:
+    return f"https://{registry.api_host}/pypi/{project_name}/{version}/json"
 
 
 def _file_url(registry: Registry, filename: str) -> str:
@@ -106,6 +109,14 @@ def _local_dist(tmp_path: Path) -> Path:
     return dist
 
 
+def _local_plugin_dist(tmp_path: Path) -> Path:
+    dist = tmp_path / "plugin-dist"
+    dist.mkdir()
+    (dist / PLUGIN_WHEEL).write_bytes(WHEEL_BYTES)
+    (dist / PLUGIN_SDIST).write_bytes(SDIST_BYTES)
+    return dist
+
+
 def test_lists_sorted_canonical_registry_versions() -> None:
     fetcher = FakeFetcher(
         {_project_url(Registry.PYPI): json.dumps({"releases": {"2.2.0a2": [], "2.1.0": [], "2.2.0a1": []}}).encode()}
@@ -116,6 +127,65 @@ def test_lists_sorted_canonical_registry_versions() -> None:
         "2.2.0a1",
         "2.2.0a2",
     )
+
+
+def test_lists_plugin_scanner_registry_versions() -> None:
+    fetcher = FakeFetcher(
+        {_project_url(Registry.PYPI, PLUGIN_PROJECT): json.dumps({"releases": {"3.0.0a2": [], "3.0.0a1": []}}).encode()}
+    )
+
+    assert list_registry_versions(Registry.PYPI, project_name=PLUGIN_PROJECT, fetcher=fetcher) == (
+        "3.0.0a1",
+        "3.0.0a2",
+    )
+
+
+def test_verifies_plugin_scanner_release_independently(tmp_path: Path) -> None:
+    dist = _local_plugin_dist(tmp_path)
+    payload = _release_payload(
+        Registry.PYPI,
+        {PLUGIN_WHEEL: (WHEEL_BYTES, None), PLUGIN_SDIST: (SDIST_BYTES, None)},
+    )
+    fetcher = FakeFetcher({_release_url(Registry.PYPI, project_name=PLUGIN_PROJECT): payload})
+
+    result = verify_registry_release(
+        Registry.PYPI,
+        VERSION,
+        dist,
+        project_name=PLUGIN_PROJECT,
+        fetcher=fetcher,
+    )
+
+    assert result.status == "exact"
+    assert result.files == (PLUGIN_WHEEL, PLUGIN_SDIST)
+
+
+def test_verify_release_cli_accepts_plugin_scanner_project(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    dist = _local_plugin_dist(tmp_path)
+    payload = _release_payload(
+        Registry.PYPI,
+        {PLUGIN_WHEEL: (WHEEL_BYTES, None), PLUGIN_SDIST: (SDIST_BYTES, None)},
+    )
+    fetcher = FakeFetcher({_release_url(Registry.PYPI, project_name=PLUGIN_PROJECT): payload})
+
+    assert (
+        main(
+            [
+                "verify-release",
+                "--registry",
+                "pypi",
+                "--project",
+                PLUGIN_PROJECT,
+                "--version",
+                VERSION,
+                "--dist-dir",
+                str(dist),
+            ],
+            fetcher=fetcher,
+        )
+        == 0
+    )
+    assert json.loads(capsys.readouterr().out)["status"] == "exact"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- publish `hol-guard` and `plugin-scanner` independently from the same versioned, hashed build artifact
- verify exact registry bytes and CLI versions for both projects while allowing safe recovery when only one upload completed

## Testing
- `uv run pytest tests/test_compute_main_release_version.py tests/test_compute_alpha_release_version.py tests/test_validate_alpha_release.py tests/test_verify_release_registry.py tests/test_release_train_workflow.py -q`
- `uv run ruff check scripts/verify_release_registry.py tests/test_verify_release_registry.py tests/test_release_train_workflow.py`
- `uv run ruff format --check scripts/verify_release_registry.py tests/test_verify_release_registry.py tests/test_release_train_workflow.py`
- dual wheel/sdist build with `twine check`, followed by `hol-guard --version` and `plugin-scanner --version`
