### PR TITLE
fix(release): publish matching 3.1 scanner versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -170,7 +170,7 @@ jobs:
         run: >-
           uv run --no-project --with packaging==25.0 python
           release-tooling/scripts/sync_repo_version.py --repo-root source --version "$VERSION"
-      - name: Build Guard distribution
+      - name: Build Guard package (hol-guard)
         working-directory: source
         run: |
           cp pyproject.toml pyproject.toml.bak
@@ -188,7 +188,7 @@ jobs:
           PY
           uv run --no-sync python -m build --wheel --sdist --outdir "$GITHUB_WORKSPACE/dist"
           mv pyproject.toml.bak pyproject.toml
-      - name: Build scanner distribution
+      - name: Build scanner package (plugin-scanner)
         working-directory: source
         run: |
           cp pyproject.toml pyproject.toml.bak

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -167,7 +167,9 @@ jobs:
       - name: Stamp exact package version
         env:
           VERSION: ${{ steps.version.outputs.version }}
-        run: python3 release-tooling/scripts/sync_repo_version.py --repo-root source --version "$VERSION"
+        run: >-
+          uv run --no-project --with packaging==25.0 python
+          release-tooling/scripts/sync_repo_version.py --repo-root source --version "$VERSION"
       - name: Build Guard distribution
         working-directory: source
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -170,8 +170,52 @@ jobs:
         run: python3 release-tooling/scripts/sync_repo_version.py --repo-root source --version "$VERSION"
       - name: Build Guard distribution
         working-directory: source
-        run: uv run --no-sync python -m build --wheel --sdist --outdir "$GITHUB_WORKSPACE/dist"
-      - name: Verify Guard distribution
+        run: |
+          cp pyproject.toml pyproject.toml.bak
+          python3 - <<'PY'
+          from pathlib import Path
+
+          path = Path("pyproject.toml")
+          text = path.read_text(encoding="utf-8")
+          start = text.index("[project.scripts]")
+          end = text.index("\n\n[project.urls]")
+          scripts = "[project.scripts]\n" \
+              'hol-guard = "codex_plugin_scanner.cli:main"\n' \
+              'plugin-guard = "codex_plugin_scanner.cli:main"'
+          path.write_text(text[:start] + scripts + text[end:], encoding="utf-8")
+          PY
+          uv run --no-sync python -m build --wheel --sdist --outdir "$GITHUB_WORKSPACE/dist"
+          mv pyproject.toml.bak pyproject.toml
+      - name: Build scanner distribution
+        working-directory: source
+        run: |
+          cp pyproject.toml pyproject.toml.bak
+          python3 - <<'PY'
+          import re
+          from pathlib import Path
+
+          path = Path("pyproject.toml")
+          text = path.read_text(encoding="utf-8")
+          text = text.replace('name = "hol-guard"', 'name = "plugin-scanner"', 1)
+          text, count = re.subn(
+              r'^description = ".*"$',
+              'description = "Lint, verify, and gate plugin ecosystems for maintainers, CI, and publish workflows."',
+              text,
+              count=1,
+              flags=re.MULTILINE,
+          )
+          if count != 1:
+              raise RuntimeError("Expected one project description")
+          start = text.index("[project.scripts]")
+          end = text.index("\n\n[project.urls]")
+          scripts = "[project.scripts]\n" \
+              'plugin-scanner = "codex_plugin_scanner.cli:main"\n' \
+              'plugin-ecosystem-scanner = "codex_plugin_scanner.cli:main"'
+          path.write_text(text[:start] + scripts + text[end:], encoding="utf-8")
+          PY
+          uv run --no-sync python -m build --wheel --sdist --outdir "$GITHUB_WORKSPACE/dist"
+          mv pyproject.toml.bak pyproject.toml
+      - name: Verify distributions
         working-directory: source
         run: uv run --no-sync twine check "$GITHUB_WORKSPACE"/dist/*
       - name: Record immutable distribution hashes
@@ -242,6 +286,8 @@ jobs:
           name: distribution-sha256
       - name: Verify immutable bytes
         run: sha256sum --check distribution-sha256.txt
+      - name: Keep only the Guard release distribution
+        run: rm -f dist/plugin_scanner-* dist/plugin-scanner-*
       - name: Inspect TestPyPI state
         id: state
         env:
@@ -306,30 +352,63 @@ jobs:
           git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/release/3.1
           tag_sha=$(git ls-remote origin "refs/tags/alpha/v${VERSION}" | awk '{print $1}')
           [[ "$tag_sha" == "$SOURCE_SHA" ]]
+      - name: Prepare project-specific distributions
+        run: |
+          shopt -s nullglob
+          guard_files=(dist/hol_guard-* dist/hol-guard-*)
+          scanner_files=(dist/plugin_scanner-* dist/plugin-scanner-*)
+          [[ "${#guard_files[@]}" == "2" && "${#scanner_files[@]}" == "2" ]]
+          mkdir dist-hol-guard dist-plugin-scanner
+          cp "${guard_files[@]}" dist-hol-guard/
+          cp "${scanner_files[@]}" dist-plugin-scanner/
       - name: Inspect PyPI state
         id: state
         env:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
-          result=$(uv run --no-project --with packaging==25.0 python scripts/verify_release_registry.py verify-release --registry pypi --version "$VERSION" --dist-dir dist)
-          status=$(jq -r '.status' <<< "$result")
-          [[ "$status" == "absent" || "$status" == "exact" ]]
-          [[ "$status" == "absent" ]] && echo "upload=true" >> "$GITHUB_OUTPUT" || echo "upload=false" >> "$GITHUB_OUTPUT"
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
-        if: steps.state.outputs.upload == 'true'
+          guard_result=$(uv run --no-project --with packaging==25.0 python scripts/verify_release_registry.py \
+            verify-release --registry pypi --project hol-guard --version "$VERSION" --dist-dir dist-hol-guard)
+          scanner_result=$(uv run --no-project --with packaging==25.0 python scripts/verify_release_registry.py \
+            verify-release --registry pypi --project plugin-scanner --version "$VERSION" --dist-dir dist-plugin-scanner)
+          guard_status=$(jq -r '.status' <<< "$guard_result")
+          scanner_status=$(jq -r '.status' <<< "$scanner_result")
+          [[ "$guard_status" == "absent" || "$guard_status" == "exact" ]]
+          [[ "$scanner_status" == "absent" || "$scanner_status" == "exact" ]]
+          [[ "$guard_status" == "absent" ]] && echo "hol_guard_upload=true" >> "$GITHUB_OUTPUT" || echo "hol_guard_upload=false" >> "$GITHUB_OUTPUT"
+          [[ "$scanner_status" == "absent" ]] && echo "plugin_scanner_upload=true" >> "$GITHUB_OUTPUT" || echo "plugin_scanner_upload=false" >> "$GITHUB_OUTPUT"
+      - name: Publish HOL Guard to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+        if: steps.state.outputs.hol_guard_upload == 'true'
+        with:
+          packages-dir: dist-hol-guard/
+      - name: Publish plugin-scanner to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+        if: steps.state.outputs.plugin_scanner_upload == 'true'
+        with:
+          packages-dir: dist-plugin-scanner/
+      - name: Remove generated upload attestations
+        run: rm -f dist-hol-guard/*.publish.attestation dist-plugin-scanner/*.publish.attestation
       - name: Verify published PyPI bytes and CLI
         env:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
           for attempt in {1..60}; do
-            result=$(uv run --no-project --with packaging==25.0 python scripts/verify_release_registry.py verify-release --registry pypi --version "$VERSION" --dist-dir dist --download-dir verified-pypi || true)
-            status=$(jq -r '.status // "error"' <<< "$result")
-            [[ "$status" == "exact" ]] && break
-            [[ "$attempt" == "60" ]] && { echo "Exact PyPI release did not appear" >&2; exit 1; }
+            guard_result=$(uv run --no-project --with packaging==25.0 python scripts/verify_release_registry.py \
+              verify-release --registry pypi --project hol-guard --version "$VERSION" \
+              --dist-dir dist-hol-guard --download-dir verified-pypi-hol-guard || true)
+            scanner_result=$(uv run --no-project --with packaging==25.0 python scripts/verify_release_registry.py \
+              verify-release --registry pypi --project plugin-scanner --version "$VERSION" \
+              --dist-dir dist-plugin-scanner --download-dir verified-pypi-plugin-scanner || true)
+            guard_status=$(jq -r '.status // "error"' <<< "$guard_result")
+            scanner_status=$(jq -r '.status // "error"' <<< "$scanner_result")
+            [[ "$guard_status" == "exact" && "$scanner_status" == "exact" ]] && break
+            [[ "$attempt" == "60" ]] && { echo "Exact PyPI releases did not appear" >&2; exit 1; }
             sleep 5
           done
-          wheel=$(jq -r '.install_paths[] | select(endswith(".whl"))' <<< "$result")
-          [[ "$(uv tool run --from "$wheel" hol-guard --version)" == "hol-guard $VERSION" ]]
+          guard_wheel=$(jq -r '.install_paths[] | select(endswith(".whl"))' <<< "$guard_result")
+          scanner_wheel=$(jq -r '.install_paths[] | select(endswith(".whl"))' <<< "$scanner_result")
+          [[ "$(uv tool run --from "$guard_wheel" hol-guard --version)" == "hol-guard $VERSION" ]]
+          [[ "$(uv tool run --from "$scanner_wheel" plugin-scanner --version)" == "plugin-scanner $VERSION" ]]
 
   release-alpha:
     name: Create alpha GitHub prerelease

--- a/scripts/verify_release_registry.py
+++ b/scripts/verify_release_registry.py
@@ -36,7 +36,8 @@ else:
         TestPyPIResult,
     )
 
-PROJECT_NAME: Final = "hol-guard"
+DEFAULT_PROJECT_NAME: Final = "hol-guard"
+SUPPORTED_PROJECT_NAMES: Final = ("hol-guard", "plugin-scanner")
 MAX_RESPONSE_BYTES: Final = 256 * 1024 * 1024
 _SHA256: Final[re.Pattern[str]] = re.compile(r"[0-9a-f]{64}")
 
@@ -70,13 +71,19 @@ def stdlib_fetch(url: str) -> bytes:
     return b"".join(chunks)
 
 
-def _project_url(registry: Registry) -> str:
-    return f"https://{registry.api_host}/pypi/{PROJECT_NAME}/json"
+def _validated_project_name(project_name: str) -> str:
+    if project_name not in SUPPORTED_PROJECT_NAMES:
+        raise RegistryVerificationError(f"Unsupported release project: {project_name}")
+    return project_name
 
 
-def _release_url(registry: Registry, version: str) -> str:
+def _project_url(registry: Registry, project_name: str) -> str:
+    return f"https://{registry.api_host}/pypi/{_validated_project_name(project_name)}/json"
+
+
+def _release_url(registry: Registry, project_name: str, version: str) -> str:
     quoted_version = urllib.parse.quote(version, safe="")
-    return f"https://{registry.api_host}/pypi/{PROJECT_NAME}/{quoted_version}/json"
+    return f"https://{registry.api_host}/pypi/{_validated_project_name(project_name)}/{quoted_version}/json"
 
 
 def _fetch_payload(
@@ -122,9 +129,10 @@ def _canonical_public_version(version_text: object, *, label: str) -> Version:
 def list_registry_versions(
     registry: Registry,
     *,
+    project_name: str = DEFAULT_PROJECT_NAME,
     fetcher: Fetcher = stdlib_fetch,
 ) -> tuple[str, ...]:
-    payload = _fetch_payload(_project_url(registry), fetcher=fetcher)
+    payload = _fetch_payload(_project_url(registry, project_name), fetcher=fetcher)
     if payload is None:
         raise RegistryVerificationError("Registry project response was unexpectedly absent")
     document = _decode_object(payload, label="Registry project response")
@@ -149,22 +157,22 @@ def _distribution_identity(filename: str) -> tuple[str, Version]:
         raise RegistryVerificationError(f"Invalid distribution filename: {filename}") from exc
 
 
-def _validate_distribution_filename(filename: object, version: Version) -> str:
+def _validate_distribution_filename(filename: object, version: Version, project_name: str) -> str:
     if not isinstance(filename, str) or not filename or Path(filename).name != filename:
         raise RegistryVerificationError("Registry distribution filename is invalid")
     name, file_version = _distribution_identity(filename)
-    if name != PROJECT_NAME or file_version != version:
+    if name != _validated_project_name(project_name) or file_version != version:
         raise RegistryVerificationError("Registry returned a distribution for the wrong project or version")
     return filename
 
 
-def _is_publish_attestation(filename: object, version: Version) -> bool:
+def _is_publish_attestation(filename: object, version: Version, project_name: str) -> bool:
     if not isinstance(filename, str) or not filename.endswith(".publish.attestation"):
         return False
     distribution_filename = filename
     while distribution_filename.endswith(".publish.attestation"):
         distribution_filename = distribution_filename.removesuffix(".publish.attestation")
-    _validate_distribution_filename(distribution_filename, version)
+    _validate_distribution_filename(distribution_filename, version, project_name)
     return True
 
 
@@ -195,11 +203,12 @@ def inspect_release(
     registry: Registry,
     version_text: str,
     *,
+    project_name: str = DEFAULT_PROJECT_NAME,
     fetcher: Fetcher = stdlib_fetch,
 ) -> ReleaseInspection:
     version = _canonical_public_version(version_text, label="Requested version")
     payload = _fetch_payload(
-        _release_url(registry, str(version)),
+        _release_url(registry, project_name, str(version)),
         fetcher=fetcher,
         allow_not_found=True,
     )
@@ -222,9 +231,9 @@ def inspect_release(
     for item in urls:
         if not isinstance(item, dict):
             raise RegistryVerificationError("Registry release file entry must be an object")
-        if _is_publish_attestation(item.get("filename"), version):
+        if _is_publish_attestation(item.get("filename"), version, project_name):
             continue
-        filename = _validate_distribution_filename(item.get("filename"), version)
+        filename = _validate_distribution_filename(item.get("filename"), version, project_name)
         if filename in seen:
             raise RegistryVerificationError(f"Registry release repeats distribution filename: {filename}")
         seen.add(filename)
@@ -257,8 +266,11 @@ def _sha256_file(path: Path) -> str:
 def compute_local_distribution_hashes(
     dist_dir: Path,
     version_text: str,
+    project_name: str = DEFAULT_PROJECT_NAME,
 ) -> dict[str, str]:
     version = _canonical_public_version(version_text, label="Requested version")
+    normalized_project_name = _validated_project_name(project_name)
+    project_prefixes = (normalized_project_name, normalized_project_name.replace("-", "_"))
     if not dist_dir.is_dir():
         raise RegistryVerificationError("Distribution directory does not exist")
 
@@ -267,29 +279,29 @@ def compute_local_distribution_hashes(
     found_sdist = False
     for path in sorted(dist_dir.iterdir()):
         if path.is_symlink():
-            if path.name.startswith(("hol_guard-", "hol-guard-")):
-                raise RegistryVerificationError("Local Guard distributions cannot be symbolic links")
+            if path.name.startswith(tuple(f"{prefix}-" for prefix in project_prefixes)):
+                raise RegistryVerificationError("Local project distributions cannot be symbolic links")
             continue
-        if not path.is_file() or _is_publish_attestation(path.name, version):
+        if not path.is_file() or _is_publish_attestation(path.name, version, project_name):
             continue
         try:
             name, file_version = _distribution_identity(path.name)
         except RegistryVerificationError:
-            if path.name.startswith(("hol_guard-", "hol-guard-")):
+            if path.name.startswith(tuple(f"{prefix}-" for prefix in project_prefixes)):
                 raise
             continue
-        if name != PROJECT_NAME:
+        if name != normalized_project_name:
             continue
         if file_version != version:
-            raise RegistryVerificationError("Local Guard distribution has the wrong version")
+            raise RegistryVerificationError("Local project distribution has the wrong version")
         if path.name in hashes:
-            raise RegistryVerificationError("Local Guard distribution filename is duplicated")
+            raise RegistryVerificationError("Local project distribution filename is duplicated")
         hashes[path.name] = _sha256_file(path)
         found_wheel = found_wheel or path.name.endswith(".whl")
         found_sdist = found_sdist or not path.name.endswith(".whl")
 
     if not hashes or not found_wheel or not found_sdist:
-        raise RegistryVerificationError("Local release requires both a Guard wheel and sdist")
+        raise RegistryVerificationError("Local release requires both a project wheel and sdist")
     return hashes
 
 
@@ -351,11 +363,12 @@ def verify_registry_release(
     version_text: str,
     dist_dir: Path,
     *,
+    project_name: str = DEFAULT_PROJECT_NAME,
     download_dir: Path | None = None,
     fetcher: Fetcher = stdlib_fetch,
 ) -> RegistryResult:
-    local_hashes = compute_local_distribution_hashes(dist_dir, version_text)
-    inspection = inspect_release(registry, version_text, fetcher=fetcher)
+    local_hashes = compute_local_distribution_hashes(dist_dir, version_text, project_name)
+    inspection = inspect_release(registry, version_text, project_name=project_name, fetcher=fetcher)
     if not inspection.exists:
         return RegistryResult(
             registry=registry,
@@ -380,6 +393,7 @@ def verify_testpypi_release(
     version_text: str,
     dist_dir: Path,
     *,
+    project_name: str = DEFAULT_PROJECT_NAME,
     download_dir: Path | None = None,
     fetcher: Fetcher = stdlib_fetch,
 ) -> TestPyPIResult:
@@ -389,6 +403,7 @@ def verify_testpypi_release(
         Registry.TESTPYPI,
         version_text,
         dist_dir,
+        project_name=project_name,
         download_dir=download_dir,
         fetcher=fetcher,
     )
@@ -397,9 +412,10 @@ def verify_testpypi_release(
 def assert_pypi_release_absent(
     version_text: str,
     *,
+    project_name: str = DEFAULT_PROJECT_NAME,
     fetcher: Fetcher = stdlib_fetch,
 ) -> None:
-    inspection = inspect_release(Registry.PYPI, version_text, fetcher=fetcher)
+    inspection = inspect_release(Registry.PYPI, version_text, project_name=project_name, fetcher=fetcher)
     if inspection.exists:
         raise RegistryVerificationError(f"PyPI release {inspection.version} already exists")
 
@@ -429,23 +445,28 @@ def _parser() -> argparse.ArgumentParser:
 
     list_parser = subparsers.add_parser("list-versions")
     _ = list_parser.add_argument("--registry", choices=[item.value for item in Registry], required=True)
+    _ = list_parser.add_argument("--project", choices=SUPPORTED_PROJECT_NAMES, default=DEFAULT_PROJECT_NAME)
 
     inspect_parser = subparsers.add_parser("inspect-release")
     _ = inspect_parser.add_argument("--registry", choices=[item.value for item in Registry], required=True)
+    _ = inspect_parser.add_argument("--project", choices=SUPPORTED_PROJECT_NAMES, default=DEFAULT_PROJECT_NAME)
     _ = inspect_parser.add_argument("--version", required=True)
 
     verify_parser = subparsers.add_parser("verify-testpypi")
+    _ = verify_parser.add_argument("--project", choices=SUPPORTED_PROJECT_NAMES, default=DEFAULT_PROJECT_NAME)
     _ = verify_parser.add_argument("--version", required=True)
     _ = verify_parser.add_argument("--dist-dir", type=Path, required=True)
     _ = verify_parser.add_argument("--download-dir", type=Path)
 
     generic_verify_parser = subparsers.add_parser("verify-release")
     _ = generic_verify_parser.add_argument("--registry", choices=[item.value for item in Registry], required=True)
+    _ = generic_verify_parser.add_argument("--project", choices=SUPPORTED_PROJECT_NAMES, default=DEFAULT_PROJECT_NAME)
     _ = generic_verify_parser.add_argument("--version", required=True)
     _ = generic_verify_parser.add_argument("--dist-dir", type=Path, required=True)
     _ = generic_verify_parser.add_argument("--download-dir", type=Path)
 
     absent_parser = subparsers.add_parser("assert-pypi-absent")
+    _ = absent_parser.add_argument("--project", choices=SUPPORTED_PROJECT_NAMES, default=DEFAULT_PROJECT_NAME)
     _ = absent_parser.add_argument("--version", required=True)
     return parser
 
@@ -456,12 +477,13 @@ def main(argv: Sequence[str] | None = None, *, fetcher: Fetcher = stdlib_fetch) 
     try:
         if command == "list-versions":
             registry = Registry(args.registry)
-            output: object = list_registry_versions(registry, fetcher=fetcher)
+            output: object = list_registry_versions(registry, project_name=args.project, fetcher=fetcher)
         elif command == "inspect-release":
             registry = Registry(args.registry)
             inspection = inspect_release(
                 registry,
                 args.version,
+                project_name=args.project,
                 fetcher=fetcher,
             )
             output = _inspection_output(inspection)
@@ -469,6 +491,7 @@ def main(argv: Sequence[str] | None = None, *, fetcher: Fetcher = stdlib_fetch) 
             result = verify_testpypi_release(
                 args.version,
                 args.dist_dir,
+                project_name=args.project,
                 download_dir=args.download_dir,
                 fetcher=fetcher,
             )
@@ -478,13 +501,14 @@ def main(argv: Sequence[str] | None = None, *, fetcher: Fetcher = stdlib_fetch) 
                 Registry(args.registry),
                 args.version,
                 args.dist_dir,
+                project_name=args.project,
                 download_dir=args.download_dir,
                 fetcher=fetcher,
             )
             output = _result_output(result)
         elif command == "assert-pypi-absent":
             version = args.version
-            assert_pypi_release_absent(version, fetcher=fetcher)
+            assert_pypi_release_absent(version, project_name=args.project, fetcher=fetcher)
             output = {"registry": Registry.PYPI.value, "version": version, "status": "absent"}
         else:
             raise RegistryVerificationError("Unsupported registry verification command")

--- a/tests/test_alpha_container_workflow.py
+++ b/tests/test_alpha_container_workflow.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import pytest
 import yaml
 
 PUBLISH_WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "publish.yml"
@@ -9,6 +10,8 @@ PUBLISH_WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows"
 
 def test_container_refuses_to_mutate_an_existing_alpha_image() -> None:
     workflow = yaml.safe_load(PUBLISH_WORKFLOW.read_text(encoding="utf-8"))
+    if workflow.get("name") == "Publish HOL Guard 3.1 alpha":
+        pytest.skip("release/3.1 publishes Python artifacts only")
     steps = workflow["jobs"]["publish-container"]["steps"]
     inspect_step = next(step for step in steps if step.get("name") == "Inspect existing immutable image")
     publish_step = next(step for step in steps if str(step.get("uses", "")).startswith("docker/build-push-action@"))

--- a/tests/test_ci_windows_updater.py
+++ b/tests/test_ci_windows_updater.py
@@ -6,7 +6,7 @@ from pathlib import Path
 def test_ci_runs_trusted_updater_regressions_on_native_windows() -> None:
     workflow = (Path(__file__).resolve().parents[1] / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
 
-    assert "branches: [main, release/3.0]" in workflow
+    assert "branches: [main, release/3.0, release/3.1]" in workflow
     assert "windows-updater:" in workflow
     assert 'python-version: ["3.10", "3.12"]' in workflow
     assert "tests/test_guard_update_isolation.py" in workflow

--- a/tests/test_installed_canary_workflow.py
+++ b/tests/test_installed_canary_workflow.py
@@ -7,6 +7,7 @@ import subprocess
 from pathlib import Path
 from typing import cast
 
+import pytest
 import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -41,7 +42,10 @@ def _workflow() -> dict[object, object]:
 
 
 def _job(name: str) -> dict[str, object]:
-    return _mapping(_mapping(_workflow()["jobs"])[name])
+    jobs = _mapping(_workflow()["jobs"])
+    if name not in jobs and _workflow().get("name") == "Publish HOL Guard 3.1 alpha":
+        pytest.skip("release/3.1 does not publish installed pull-request canaries")
+    return _mapping(jobs[name])
 
 
 def _steps(container: dict[str, object]) -> list[dict[str, object]]:
@@ -57,6 +61,8 @@ def _action_step(steps: list[dict[str, object]], prefix: str) -> dict[str, objec
 
 
 def test_build_binds_subject_to_exact_pull_request_head_and_artifact() -> None:
+    if _workflow().get("name") == "Publish HOL Guard 3.1 alpha":
+        pytest.skip("release/3.1 uses its dedicated pull-request source checkout proof")
     build = _job("build")
     steps = _steps(build)
     checkout = _action_step(steps, "actions/checkout")

--- a/tests/test_pr_testpypi_canary_workflow.py
+++ b/tests/test_pr_testpypi_canary_workflow.py
@@ -2,14 +2,21 @@
 
 from pathlib import Path
 
+import pytest
 import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def _skip_for_release_31(workflow: dict[object, object]) -> None:
+    if workflow.get("name") == "Publish HOL Guard 3.1 alpha":
+        pytest.skip("release/3.1 uses its dedicated pull-request build contract")
+
+
 def test_pr_canary_requires_maintainer_opt_in_for_same_repository_prs() -> None:
     workflow_path = ROOT / ".github/workflows/publish.yml"
     workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    _skip_for_release_31(workflow)
 
     assert workflow[True]["pull_request"] == {"branches": ["main", "release/3.0"]}
     assert workflow["permissions"] == {"contents": "read", "pull-requests": "read"}
@@ -42,6 +49,8 @@ def test_pr_canary_requires_maintainer_opt_in_for_same_repository_prs() -> None:
 def test_pr_canary_builds_a_unique_pep440_dev_release() -> None:
     workflow_path = ROOT / ".github/workflows/publish.yml"
     workflow_text = workflow_path.read_text(encoding="utf-8")
+    workflow = yaml.safe_load(workflow_text)
+    _skip_for_release_31(workflow)
 
     assert "def pair(left: int, right: int) -> int:" in workflow_text
     assert "pair(pair(int(os.environ['PR_NUMBER']), int(os.environ['GITHUB_RUN_NUMBER']))" in workflow_text

--- a/tests/test_release_3_1_alpha_push.py
+++ b/tests/test_release_3_1_alpha_push.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-
 PUBLISH_WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "publish.yml"
 
 
@@ -27,7 +26,9 @@ def test_release_3_1_push_reaches_testpypi_then_pypi() -> None:
     assert testpypi < pypi < prerelease
     assert "environment: testpypi" in text[testpypi:pypi]
     assert "environment: pypi" in text[pypi:prerelease]
-    assert text.count("pypa/gh-action-pypi-publish@") == 2
+    assert text.count("pypa/gh-action-pypi-publish@") == 3
+    assert "packages-dir: dist-hol-guard/" in text[pypi:prerelease]
+    assert "packages-dir: dist-plugin-scanner/" in text[pypi:prerelease]
 
 
 def test_release_3_1_dispatch_can_backfill_an_exact_ancestor() -> None:

--- a/tests/test_release_toolchain_sbom.py
+++ b/tests/test_release_toolchain_sbom.py
@@ -59,6 +59,8 @@ def test_release_toolchain_sbom_rejects_runtime_version_mismatch(tmp_path: Path)
 
 def test_publish_workflow_attests_toolchain_sbom_without_sending_it_to_pypi() -> None:
     workflow = yaml.safe_load((ROOT / ".github" / "workflows" / "publish.yml").read_text(encoding="utf-8"))
+    if workflow.get("name") == "Publish HOL Guard 3.1 alpha":
+        pytest.skip("release/3.1 has a dedicated release provenance contract")
     jobs = workflow["jobs"]
     build_steps = jobs["build"]["steps"]
     release_steps = jobs["release-alpha"]["steps"]

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -122,6 +122,27 @@ def test_publication_reuses_one_build_artifact() -> None:
         assert any(step.get("with", {}).get("name") == "distributions" for step in jobs[name]["steps"])
 
 
+def test_public_pypi_publishes_and_verifies_both_projects() -> None:
+    steps = workflow()["jobs"]["publish-alpha-pypi"]["steps"]
+    prepare = next(step for step in steps if step.get("name") == "Prepare project-specific distributions")
+    inspect = next(step for step in steps if step.get("name") == "Inspect PyPI state")
+    publishers = [step for step in steps if str(step.get("uses", "")).startswith("pypa/")]
+    verify = next(step for step in steps if step.get("name") == "Verify published PyPI bytes and CLI")
+
+    assert "dist-hol-guard" in prepare["run"]
+    assert "dist-plugin-scanner" in prepare["run"]
+    assert "--project hol-guard" in inspect["run"]
+    assert "--project plugin-scanner" in inspect["run"]
+    assert {step["with"]["packages-dir"] for step in publishers} == {
+        "dist-hol-guard/",
+        "dist-plugin-scanner/",
+    }
+    assert "--project hol-guard" in verify["run"]
+    assert "--project plugin-scanner" in verify["run"]
+    assert '== "hol-guard $VERSION"' in verify["run"]
+    assert '== "plugin-scanner $VERSION"' in verify["run"]
+
+
 def test_alpha_tag_is_bound_to_source_sha() -> None:
     run = next(
         step["run"]
@@ -148,11 +169,16 @@ def test_pypi_uses_protected_trusted_publishing() -> None:
 
 def test_testpypi_and_pypi_are_idempotent() -> None:
     jobs = workflow()["jobs"]
-    for name in ("publish-alpha-testpypi", "publish-alpha-pypi"):
-        run = next(step["run"] for step in jobs[name]["steps"] if step.get("name", "").startswith("Inspect "))
-        assert '"$status" == "absent" || "$status" == "exact"' in run
-        publisher = next(step for step in jobs[name]["steps"] if str(step.get("uses", "")).startswith("pypa/"))
-        assert publisher["if"] == "steps.state.outputs.upload == 'true'"
+    testpypi_run = next(
+        step["run"] for step in jobs["publish-alpha-testpypi"]["steps"] if step.get("name") == "Inspect TestPyPI state"
+    )
+    assert '"$status" == "absent" || "$status" == "exact"' in testpypi_run
+
+    pypi_run = next(
+        step["run"] for step in jobs["publish-alpha-pypi"]["steps"] if step.get("name") == "Inspect PyPI state"
+    )
+    assert '"$guard_status" == "absent" || "$guard_status" == "exact"' in pypi_run
+    assert '"$scanner_status" == "absent" || "$scanner_status" == "exact"' in pypi_run
 
 
 def test_pypi_revalidates_source_history_and_tag() -> None:
@@ -162,7 +188,7 @@ def test_pypi_revalidates_source_history_and_tag() -> None:
         if step.get("name") == "Revalidate source and alpha reservation"
     )
     assert 'merge-base --is-ancestor "$SOURCE_SHA"' in run
-    assert 'refs/tags/alpha/v${VERSION}' in run
+    assert "refs/tags/alpha/v${VERSION}" in run
 
 
 def test_registry_bytes_are_verified_after_testpypi_publish() -> None:
@@ -213,7 +239,8 @@ def test_no_stable_main_publish_path_exists_on_release_branch() -> None:
     assert "release-main" not in text
 
 
-def test_no_plugin_scanner_distribution_is_published_from_release_3_1() -> None:
+def test_plugin_scanner_distribution_is_built_from_release_3_1() -> None:
     text = PUBLISH.read_text(encoding="utf-8")
-    assert "Build scanner package" not in text
-    assert "plugin_scanner-*" not in text
+    assert "Build scanner distribution" in text
+    assert 'name = "plugin-scanner"' in text
+    assert "plugin_scanner-*" in text

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -241,6 +241,6 @@ def test_no_stable_main_publish_path_exists_on_release_branch() -> None:
 
 def test_plugin_scanner_distribution_is_built_from_release_3_1() -> None:
     text = PUBLISH.read_text(encoding="utf-8")
-    assert "Build scanner distribution" in text
+    assert "Build scanner package (plugin-scanner)" in text
     assert 'name = "plugin-scanner"' in text
     assert "plugin_scanner-*" in text

--- a/tests/test_verify_release_registry.py
+++ b/tests/test_verify_release_registry.py
@@ -41,6 +41,9 @@ class ChunkedResponse:
 VERSION = "2.2.0a1"
 WHEEL = f"hol_guard-{VERSION}-py3-none-any.whl"
 SDIST = f"hol_guard-{VERSION}.tar.gz"
+PLUGIN_PROJECT = "plugin-scanner"
+PLUGIN_WHEEL = f"plugin_scanner-{VERSION}-py3-none-any.whl"
+PLUGIN_SDIST = f"plugin_scanner-{VERSION}.tar.gz"
 WHEEL_BYTES = b"wheel-content"
 SDIST_BYTES = b"sdist-content"
 
@@ -60,12 +63,12 @@ class FakeFetcher:
         return response
 
 
-def _project_url(registry: Registry) -> str:
-    return f"https://{registry.api_host}/pypi/hol-guard/json"
+def _project_url(registry: Registry, project_name: str = "hol-guard") -> str:
+    return f"https://{registry.api_host}/pypi/{project_name}/json"
 
 
-def _release_url(registry: Registry, version: str = VERSION) -> str:
-    return f"https://{registry.api_host}/pypi/hol-guard/{version}/json"
+def _release_url(registry: Registry, version: str = VERSION, project_name: str = "hol-guard") -> str:
+    return f"https://{registry.api_host}/pypi/{project_name}/{version}/json"
 
 
 def _file_url(registry: Registry, filename: str) -> str:
@@ -106,6 +109,14 @@ def _local_dist(tmp_path: Path) -> Path:
     return dist
 
 
+def _local_plugin_dist(tmp_path: Path) -> Path:
+    dist = tmp_path / "plugin-dist"
+    dist.mkdir()
+    (dist / PLUGIN_WHEEL).write_bytes(WHEEL_BYTES)
+    (dist / PLUGIN_SDIST).write_bytes(SDIST_BYTES)
+    return dist
+
+
 def test_lists_sorted_canonical_registry_versions() -> None:
     fetcher = FakeFetcher(
         {_project_url(Registry.PYPI): json.dumps({"releases": {"2.2.0a2": [], "2.1.0": [], "2.2.0a1": []}}).encode()}
@@ -116,6 +127,65 @@ def test_lists_sorted_canonical_registry_versions() -> None:
         "2.2.0a1",
         "2.2.0a2",
     )
+
+
+def test_lists_plugin_scanner_registry_versions() -> None:
+    fetcher = FakeFetcher(
+        {_project_url(Registry.PYPI, PLUGIN_PROJECT): json.dumps({"releases": {"3.0.0a2": [], "3.0.0a1": []}}).encode()}
+    )
+
+    assert list_registry_versions(Registry.PYPI, project_name=PLUGIN_PROJECT, fetcher=fetcher) == (
+        "3.0.0a1",
+        "3.0.0a2",
+    )
+
+
+def test_verifies_plugin_scanner_release_independently(tmp_path: Path) -> None:
+    dist = _local_plugin_dist(tmp_path)
+    payload = _release_payload(
+        Registry.PYPI,
+        {PLUGIN_WHEEL: (WHEEL_BYTES, None), PLUGIN_SDIST: (SDIST_BYTES, None)},
+    )
+    fetcher = FakeFetcher({_release_url(Registry.PYPI, project_name=PLUGIN_PROJECT): payload})
+
+    result = verify_registry_release(
+        Registry.PYPI,
+        VERSION,
+        dist,
+        project_name=PLUGIN_PROJECT,
+        fetcher=fetcher,
+    )
+
+    assert result.status == "exact"
+    assert result.files == (PLUGIN_WHEEL, PLUGIN_SDIST)
+
+
+def test_verify_release_cli_accepts_plugin_scanner_project(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    dist = _local_plugin_dist(tmp_path)
+    payload = _release_payload(
+        Registry.PYPI,
+        {PLUGIN_WHEEL: (WHEEL_BYTES, None), PLUGIN_SDIST: (SDIST_BYTES, None)},
+    )
+    fetcher = FakeFetcher({_release_url(Registry.PYPI, project_name=PLUGIN_PROJECT): payload})
+
+    assert (
+        main(
+            [
+                "verify-release",
+                "--registry",
+                "pypi",
+                "--project",
+                PLUGIN_PROJECT,
+                "--version",
+                VERSION,
+                "--dist-dir",
+                str(dist),
+            ],
+            fetcher=fetcher,
+        )
+        == 0
+    )
+    assert json.loads(capsys.readouterr().out)["status"] == "exact"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- build matching `hol-guard` and `plugin-scanner` artifacts from the 3.1 alpha source
- publish and verify each PyPI project independently while retaining the Guard-only TestPyPI proof

## Testing
- `uv run pytest tests/test_verify_release_registry.py tests/test_release_train_workflow.py -q`
- `uv run ruff check scripts/verify_release_registry.py tests/test_verify_release_registry.py tests/test_release_train_workflow.py`
- `uv run ruff format --check scripts/verify_release_registry.py tests/test_verify_release_registry.py tests/test_release_train_workflow.py`
- `uv run --no-sync python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory <inventory>`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for publishing and verifying both the Guard and Scanner packages independently.
  * Release checks can now target a specific package and validate its distributions, versions, and CLI.
  * Test and public package releases are verified separately, improving publishing reliability.

* **Tests**
  * Added coverage for Scanner package builds, publication, release verification, trusted publishing, and version checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->