### PR TITLE
fix(release): ignore dev canaries in alpha history

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -152,7 +152,10 @@ jobs:
               fi
             fi
 
-            mapfile -t OTHER_VERSIONS < <(jq -r --arg version "$VERSION" '.[] | select(. != $version)' <<< "$EXISTING_VERSIONS")
+            mapfile -t OTHER_VERSIONS < <(
+              jq -r --arg version "$VERSION" \
+                '.[] | select(. != $version and (contains(".dev") | not))' <<< "$EXISTING_VERSIONS"
+            )
             VALIDATOR=(--channel alpha --version "$VERSION" --git-ref refs/heads/release/3.1 --actual-ref "$EVENT_REF" --github-sha "$SOURCE_SHA" --expected-sha "$SOURCE_SHA")
             for existing in "${OTHER_VERSIONS[@]}"; do
               VALIDATOR+=(--existing-version "$existing")

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -68,6 +68,7 @@ def test_push_resolves_to_alpha() -> None:
     assert "CHANNEL=alpha" in run
     assert 'EVENT_REF" != "refs/heads/release/3.1' in run
     assert "compute_alpha_release_version.py --release-train 3.1" in run
+    assert 'contains(".dev") | not' in run
 
 
 def test_source_must_remain_in_release_history() -> None:


### PR DESCRIPTION
## Summary
- exclude TestPyPI development canaries from public alpha validation history
- retain stable and public prerelease history when selecting the next 3.1 alpha

## Testing
- `uv run pytest tests/test_release_train_workflow.py tests/test_release_3_1_alpha_push.py -q`
- `uv run ruff check tests/test_release_train_workflow.py tests/test_release_3_1_alpha_push.py`
- `uv run ruff format --check tests/test_release_train_workflow.py tests/test_release_3_1_alpha_push.py`
- `uv run --no-sync python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory <inventory>`
