### PR TITLE
docs: make HOL Guard open-source status explicit

### DIFF
--- a/OPEN_SOURCE.md
+++ b/OPEN_SOURCE.md
@@ -1,0 +1,11 @@
+# Is HOL Guard open source?
+
+Yes. The HOL Guard source code distributed in this repository is open source under the Apache License 2.0. The repository's [`LICENSE`](./LICENSE) file is the authoritative license text.
+
+You can inspect the implementation, run HOL Guard locally, report issues, and contribute changes through this repository. The Python package published as `hol-guard` is built from this codebase.
+
+## Scope of this statement
+
+This statement applies to the source code and artifacts distributed from this repository under its Apache-2.0 license. HOL also operates hosted Guard Cloud services. The existence of hosted services does not change the license of the code in this repository, and this document does not make a licensing claim about code that is not distributed here.
+
+For security disclosures, use [`SECURITY.md`](./SECURITY.md). For contribution requirements, use [`CONTRIBUTING.md`](./CONTRIBUTING.md) where present and the repository's pull-request checks.


### PR DESCRIPTION
Clarifies a currently ambiguous branded discovery question with a dedicated repository-level source-of-truth document.

- States that code distributed from this repository is open source under Apache-2.0
- Points to `LICENSE` as authoritative
- Explains that the published `hol-guard` package is built from this codebase
- Avoids making an unsupported licensing claim about hosted Guard Cloud code that is not distributed here

This is documentation-only and targets `release/3.0`.