### PR TITLE
fix(release): filter canaries before alpha allocation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -127,7 +127,13 @@ jobs:
             PYPI_VERSIONS=$(uv run --no-project --with packaging==25.0 python release-tooling/scripts/verify_release_registry.py list-versions --registry pypi)
             TESTPYPI_VERSIONS=$(uv run --no-project --with packaging==25.0 python release-tooling/scripts/verify_release_registry.py list-versions --registry testpypi)
             TAG_VERSIONS=$(git -C release-tooling tag --list 'alpha/v3.1.0a*' | sed 's#^alpha/v##' | jq -R -s 'split("\n") | map(select(length > 0))')
-            EXISTING_VERSIONS=$(jq -n --argjson pypi "$PYPI_VERSIONS" --argjson testpypi "$TESTPYPI_VERSIONS" --argjson tags "$TAG_VERSIONS" '$pypi + $testpypi + $tags | unique')
+            EXISTING_VERSIONS=$(
+              jq -n \
+                --argjson pypi "$PYPI_VERSIONS" \
+                --argjson testpypi "$TESTPYPI_VERSIONS" \
+                --argjson tags "$TAG_VERSIONS" \
+                '$pypi + $testpypi + $tags | unique | map(select(contains(".dev") | not))'
+            )
 
             if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
               if [[ "$RELEASE_CHANNEL" != "alpha" || "$RELEASE_TRAIN" != "3.1" ]]; then
@@ -152,10 +158,7 @@ jobs:
               fi
             fi
 
-            mapfile -t OTHER_VERSIONS < <(
-              jq -r --arg version "$VERSION" \
-                '.[] | select(. != $version and (contains(".dev") | not))' <<< "$EXISTING_VERSIONS"
-            )
+            mapfile -t OTHER_VERSIONS < <(jq -r --arg version "$VERSION" '.[] | select(. != $version)' <<< "$EXISTING_VERSIONS")
             VALIDATOR=(--channel alpha --version "$VERSION" --git-ref refs/heads/release/3.1 --actual-ref "$EVENT_REF" --github-sha "$SOURCE_SHA" --expected-sha "$SOURCE_SHA")
             for existing in "${OTHER_VERSIONS[@]}"; do
               VALIDATOR+=(--existing-version "$existing")

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -127,13 +127,14 @@ jobs:
             PYPI_VERSIONS=$(uv run --no-project --with packaging==25.0 python release-tooling/scripts/verify_release_registry.py list-versions --registry pypi)
             TESTPYPI_VERSIONS=$(uv run --no-project --with packaging==25.0 python release-tooling/scripts/verify_release_registry.py list-versions --registry testpypi)
             TAG_VERSIONS=$(git -C release-tooling tag --list 'alpha/v3.1.0a*' | sed 's#^alpha/v##' | jq -R -s 'split("\n") | map(select(length > 0))')
-            EXISTING_VERSIONS=$(
+            ALL_VERSIONS=$(
               jq -n \
                 --argjson pypi "$PYPI_VERSIONS" \
                 --argjson testpypi "$TESTPYPI_VERSIONS" \
                 --argjson tags "$TAG_VERSIONS" \
-                '$pypi + $testpypi + $tags | unique | map(select(contains(".dev") | not))'
+                '$pypi + $testpypi + $tags | unique'
             )
+            PUBLIC_VERSIONS=$(jq 'map(select(contains(".dev") | not))' <<< "$ALL_VERSIONS")
 
             if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
               if [[ "$RELEASE_CHANNEL" != "alpha" || "$RELEASE_TRAIN" != "3.1" ]]; then
@@ -154,11 +155,11 @@ jobs:
               if [[ "${#SOURCE_TAGS[@]}" -eq 1 ]]; then
                 VERSION="${SOURCE_TAGS[0]}"
               else
-                VERSION=$(uv run --no-project --with packaging==25.0 python release-tooling/scripts/compute_alpha_release_version.py --release-train 3.1 <<< "$EXISTING_VERSIONS")
+                VERSION=$(uv run --no-project --with packaging==25.0 python release-tooling/scripts/compute_alpha_release_version.py --release-train 3.1 <<< "$PUBLIC_VERSIONS")
               fi
             fi
 
-            mapfile -t OTHER_VERSIONS < <(jq -r --arg version "$VERSION" '.[] | select(. != $version)' <<< "$EXISTING_VERSIONS")
+            mapfile -t OTHER_VERSIONS < <(jq -r --arg version "$VERSION" '.[] | select(. != $version)' <<< "$ALL_VERSIONS")
             VALIDATOR=(--channel alpha --version "$VERSION" --git-ref refs/heads/release/3.1 --actual-ref "$EVENT_REF" --github-sha "$SOURCE_SHA" --expected-sha "$SOURCE_SHA")
             for existing in "${OTHER_VERSIONS[@]}"; do
               VALIDATOR+=(--existing-version "$existing")

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -68,8 +68,11 @@ def test_push_resolves_to_alpha() -> None:
     assert "CHANNEL=alpha" in run
     assert 'EVENT_REF" != "refs/heads/release/3.1' in run
     assert "compute_alpha_release_version.py --release-train 3.1" in run
-    assert '$pypi + $testpypi + $tags | unique | map(select(contains(".dev") | not))' in run
-    assert 'compute_alpha_release_version.py --release-train 3.1 <<< "$EXISTING_VERSIONS"' in run
+    assert "ALL_VERSIONS=" in run
+    assert "$pypi + $testpypi + $tags | unique" in run
+    assert "PUBLIC_VERSIONS=$(jq 'map(select(contains(\".dev\") | not))'" in run
+    assert 'compute_alpha_release_version.py --release-train 3.1 <<< "$PUBLIC_VERSIONS"' in run
+    assert '<<< "$ALL_VERSIONS"' in run
 
 
 def test_source_must_remain_in_release_history() -> None:

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -68,7 +68,8 @@ def test_push_resolves_to_alpha() -> None:
     assert "CHANNEL=alpha" in run
     assert 'EVENT_REF" != "refs/heads/release/3.1' in run
     assert "compute_alpha_release_version.py --release-train 3.1" in run
-    assert 'contains(".dev") | not' in run
+    assert '$pypi + $testpypi + $tags | unique | map(select(contains(".dev") | not))' in run
+    assert 'compute_alpha_release_version.py --release-train 3.1 <<< "$EXISTING_VERSIONS"' in run
 
 
 def test_source_must_remain_in_release_history() -> None:


### PR DESCRIPTION
## Summary
- filter TestPyPI development canaries before allocating the next public 3.1 alpha
- keep public registry and tag reservations in the collision history used by allocation and validation

## Testing
- `uv run pytest tests/test_release_train_workflow.py tests/test_compute_alpha_release_version.py tests/test_validate_alpha_release.py -q`
- `uv run ruff check tests/test_release_train_workflow.py`
- `uv run ruff format --check tests/test_release_train_workflow.py`
- workflow YAML parsed with PyYAML


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Release version discovery now combines package registry and Git tag data while excluding development (`.dev`) versions from automatic release selection.
  - Version conflict checks now account for all existing versions, including development releases, except the selected version.
  - Alpha version calculations now use the complete list of existing versions for more reliable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->