### PR TITLE
fix(update): preserve managed install authority

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12653,
-  "maximum_test_source_lines": 289811,
+  "maximum_collected_cases": 12662,
+  "maximum_test_source_lines": 289976,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -25,6 +25,7 @@ from urllib.parse import ParseResult, urlparse
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
 
+from ... import version as package_version
 from ..adapters.base import HarnessContext
 from ..adapters.codex import CodexHarnessAdapter, codex_native_hook_state
 from ..adapters.cursor_hooks import cursor_native_hook_state
@@ -1007,6 +1008,16 @@ def _expected_script_dir(installer_binary: str, installer: str) -> Path | None:
 
 
 def build_guard_install_surface_payload() -> dict[str, object]:
+    if _is_desktop_managed_runtime():
+        return {
+            "installer": "desktop",
+            "binary_diagnostics": {
+                "resolved_hol_guard": str(Path(sys.executable).resolve()),
+                "installer_binary": None,
+                "expected_script_dir": None,
+                "path_status": "bundled",
+            },
+        }
     installer = _installer_kind()
     return {
         "installer": installer,
@@ -1505,7 +1516,29 @@ def _current_version() -> str:
     try:
         return importlib.metadata.version("hol-guard")
     except importlib.metadata.PackageNotFoundError:
-        return "unknown"
+        return package_version.__version__ if _is_frozen_runtime() else "unknown"
+
+
+def _is_frozen_runtime() -> bool:
+    return getattr(sys, "frozen", False) is True
+
+
+def _is_desktop_managed_runtime() -> bool:
+    return _is_frozen_runtime() and os.environ.get("HOL_GUARD_DESKTOP") == "1"
+
+
+def _runtime_package_path() -> Path:
+    return Path(__file__).resolve()
+
+
+def _runtime_installer_kind() -> str | None:
+    for parent in _runtime_package_path().parents:
+        normalized_parent = parent.as_posix().lower()
+        if "/pipx/venvs/" in normalized_parent and (parent / "pipx_metadata.json").is_file():
+            return "pipx"
+        if "/uv/tools/" in normalized_parent and (parent / "pyvenv.cfg").is_file():
+            return "uv"
+    return None
 
 
 def _installer_kind() -> str:
@@ -1517,7 +1550,7 @@ def _installer_kind() -> str:
         return "pipx"
     if "/pipx/venvs/" in normalized_prefix:
         return "pipx"
-    return "pip"
+    return _runtime_installer_kind() or "pip"
 
 
 def _should_upgrade_from_pypi(
@@ -2615,7 +2648,15 @@ def build_guard_update_status_payload(*, guard_home: Path | None = None) -> dict
     blocked_reason: str | None = None
     trusted_failure_reason: str | None = None
     recovery_reinstall_available = False
-    installed_distribution: InstalledDistribution | None = None
+    installed_distribution = (
+        InstalledDistribution(
+            name="hol-guard",
+            version=_current_version(),
+            root=Path(sys.executable).resolve().parent,
+        )
+        if installer == "desktop"
+        else None
+    )
 
     if managed_state.status != "absent" and managed_policy is None:
         auto_updatable = False
@@ -2630,6 +2671,9 @@ def build_guard_update_status_payload(*, guard_home: Path | None = None) -> dict
     ):
         auto_updatable = False
         blocked_reason = "An organization-configured package source is required."
+    elif installer == "desktop":
+        auto_updatable = False
+        blocked_reason = "Updates are managed by HOL Guard Desktop."
     else:
         try:
             installed_distribution = _status_installed_distribution(
@@ -2658,11 +2702,11 @@ def build_guard_update_status_payload(*, guard_home: Path | None = None) -> dict
             network_policy=(managed_policy.network if managed_policy is not None else ManagedNetworkPolicy()),
             include_alpha=include_alpha,
         )
-        if installed_distribution is not None
+        if installed_distribution is not None and installer != "desktop"
         else {
             "source": source_kind,
-            "status": "unavailable",
-            "current_version": None,
+            "status": "managed" if installer == "desktop" else "unavailable",
+            "current_version": current_version if installer == "desktop" else None,
             "latest_version": None,
             "update_available": None,
         }

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -186,6 +186,10 @@ def _daemon_launcher_env(
             "PYTHONSAFEPATH": "1",
         }
     )
+    if getattr(sys, "frozen", False) is True:
+        env["PYINSTALLER_RESET_ENVIRONMENT"] = "1"
+        if os.environ.get("HOL_GUARD_DESKTOP") == "1":
+            env["HOL_GUARD_DESKTOP"] = "1"
     if os.name == "nt":
         env["USERPROFILE"] = str(trusted_home)
     if guard_home is not None and not _guard_home_is_ephemeral(guard_home):

--- a/tests/test_dashboard_update.py
+++ b/tests/test_dashboard_update.py
@@ -18,6 +18,7 @@ import pytest
 
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.approval_gate import update_settings as update_approval_gate_settings
+from codex_plugin_scanner.guard.cli import update_commands
 from codex_plugin_scanner.guard.cli.update_commands import build_guard_update_status_payload
 from codex_plugin_scanner.guard.config import load_guard_config
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
@@ -140,6 +141,138 @@ def test_build_guard_update_status_payload_shape(monkeypatch: pytest.MonkeyPatch
     assert payload["latest_version"] == "1.2.4"
     assert payload["auto_updatable"] is True
     assert payload["update_available"] is True
+
+
+def test_frozen_desktop_status_uses_embedded_version_without_package_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(update_commands, "_is_frozen_runtime", lambda: True)
+    monkeypatch.setenv("HOL_GUARD_DESKTOP", "1")
+    monkeypatch.setattr(update_commands.package_version, "__version__", "3.0.0a160")
+    monkeypatch.setattr(
+        update_commands.importlib.metadata,
+        "version",
+        MagicMock(side_effect=update_commands.importlib.metadata.PackageNotFoundError),
+    )
+    status_probe = MagicMock(side_effect=AssertionError("Desktop must not probe package metadata"))
+    monkeypatch.setattr(update_commands, "_status_installed_distribution", status_probe)
+    version_check = MagicMock(side_effect=AssertionError("Desktop manages Core updates"))
+    monkeypatch.setattr(update_commands, "_version_check_payload", version_check)
+
+    payload = build_guard_update_status_payload()
+
+    assert payload["installer"] == "desktop"
+    assert payload["current_version"] == "3.0.0a160"
+    assert payload["latest_version"] is None
+    assert payload["auto_updatable"] is False
+    assert payload["update_available"] is False
+    assert payload["blocked_reason"] == "Updates are managed by HOL Guard Desktop."
+    assert "reason_code" not in payload
+    assert payload["version_check"] == {
+        "source": "pypi",
+        "status": "managed",
+        "current_version": "3.0.0a160",
+        "latest_version": None,
+        "update_available": None,
+    }
+    status_probe.assert_not_called()
+    version_check.assert_not_called()
+
+
+def test_frozen_runtime_without_desktop_marker_keeps_installer_detection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(update_commands, "_is_frozen_runtime", lambda: True)
+    monkeypatch.delenv("HOL_GUARD_DESKTOP", raising=False)
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pip")
+
+    payload = update_commands.build_guard_install_surface_payload()
+
+    assert payload["installer"] == "pip"
+    assert cast(dict[str, object], payload["binary_diagnostics"])["path_status"] != "bundled"
+
+
+@pytest.mark.parametrize(
+    ("installer_root", "marker_name", "expected_installer"),
+    [
+        ("pipx/venvs/hol-guard", "pipx_metadata.json", "pipx"),
+        ("uv/tools/hol-guard", "pyvenv.cfg", "uv"),
+    ],
+)
+def test_installer_kind_uses_authenticated_runtime_path_when_prefix_isolated(
+    installer_root: str,
+    marker_name: str,
+    expected_installer: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_prefix = tmp_path / "python-runtime"
+    base_prefix.mkdir()
+    runtime_root = tmp_path / installer_root
+    runtime_path = runtime_root / "lib/python3/site-packages/guard/update_commands.py"
+    runtime_path.parent.mkdir(parents=True)
+    (runtime_root / marker_name).write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(update_commands.sys, "prefix", str(base_prefix))
+    monkeypatch.setattr(update_commands, "_runtime_package_path", lambda: runtime_path)
+
+    assert update_commands._installer_kind() == expected_installer
+
+
+def test_installer_kind_rejects_unmarked_runtime_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_prefix = tmp_path / "python-runtime"
+    base_prefix.mkdir()
+    runtime_path = tmp_path / "pipx/venvs/hol-guard/lib/python3/site-packages/guard/update_commands.py"
+    runtime_path.parent.mkdir(parents=True)
+    monkeypatch.setattr(update_commands.sys, "prefix", str(base_prefix))
+    monkeypatch.setattr(update_commands, "_runtime_package_path", lambda: runtime_path)
+
+    assert update_commands._installer_kind() == "pip"
+
+
+def test_update_status_recovers_pipx_authority_from_isolated_daemon_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_prefix = tmp_path / "python-runtime"
+    base_prefix.mkdir()
+    runtime_root = tmp_path / "pipx/venvs/hol-guard"
+    runtime_path = runtime_root / "lib/python3/site-packages/guard/update_commands.py"
+    runtime_path.parent.mkdir(parents=True)
+    (runtime_root / "pipx_metadata.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(update_commands.sys, "prefix", str(base_prefix))
+    monkeypatch.setattr(update_commands, "_runtime_package_path", lambda: runtime_path)
+
+    def status_distribution(**kwargs: object) -> update_commands.InstalledDistribution:
+        assert kwargs["installer"] == "pipx"
+        return update_commands.InstalledDistribution(
+            name="hol-guard",
+            version="3.0.0a160",
+            root=runtime_root,
+        )
+
+    monkeypatch.setattr(update_commands, "_status_installed_distribution", status_distribution)
+    monkeypatch.setattr(
+        update_commands,
+        "_version_check_payload",
+        lambda current_version, **_kwargs: {
+            "source": "pypi",
+            "status": "current",
+            "current_version": current_version,
+            "latest_version": current_version,
+            "update_available": False,
+        },
+    )
+
+    payload = build_guard_update_status_payload(guard_home=tmp_path / "guard-home")
+
+    assert payload["installer"] == "pipx"
+    assert payload["current_version"] == "3.0.0a160"
+    assert payload["auto_updatable"] is True
+    assert payload["blocked_reason"] is None
+    assert "reason_code" not in payload
 
 
 def test_update_status_uses_persisted_alpha_channel(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_guard_daemon_manager.py
+++ b/tests/test_guard_daemon_manager.py
@@ -1591,6 +1591,38 @@ def test_isolated_daemon_bootstrap_ignores_python_startup_hooks(tmp_path, monkey
     assert all(key not in child_env for key in ("PYTHONPATH", "PYTHONHOME", "PYTHONSTARTUP", "VIRTUAL_ENV"))
 
 
+def test_frozen_desktop_daemon_launcher_preserves_managed_context(tmp_path, monkeypatch):
+    monkeypatch.setattr(daemon_manager_module.sys, "frozen", True, raising=False)
+    monkeypatch.setenv("PYINSTALLER_RESET_ENVIRONMENT", "untrusted-parent-value")
+    monkeypatch.setenv("HOL_GUARD_DESKTOP", "1")
+
+    child_env = daemon_manager_module._daemon_launcher_env(home_dir=tmp_path)
+
+    assert child_env["PYINSTALLER_RESET_ENVIRONMENT"] == "1"
+    assert child_env["HOL_GUARD_DESKTOP"] == "1"
+
+
+def test_frozen_non_desktop_daemon_launcher_does_not_gain_desktop_context(tmp_path, monkeypatch):
+    monkeypatch.setattr(daemon_manager_module.sys, "frozen", True, raising=False)
+    monkeypatch.delenv("HOL_GUARD_DESKTOP", raising=False)
+
+    child_env = daemon_manager_module._daemon_launcher_env(home_dir=tmp_path)
+
+    assert child_env["PYINSTALLER_RESET_ENVIRONMENT"] == "1"
+    assert "HOL_GUARD_DESKTOP" not in child_env
+
+
+def test_non_frozen_daemon_launcher_drops_desktop_context(tmp_path, monkeypatch):
+    monkeypatch.setattr(daemon_manager_module.sys, "frozen", False, raising=False)
+    monkeypatch.setenv("PYINSTALLER_RESET_ENVIRONMENT", "1")
+    monkeypatch.setenv("HOL_GUARD_DESKTOP", "1")
+
+    child_env = daemon_manager_module._daemon_launcher_env(home_dir=tmp_path)
+
+    assert "PYINSTALLER_RESET_ENVIRONMENT" not in child_env
+    assert "HOL_GUARD_DESKTOP" not in child_env
+
+
 @pytest.mark.parametrize(
     ("script", "timeout_seconds", "output_limit_bytes"),
     (


### PR DESCRIPTION
## Summary
- preserve Desktop-managed update identity across frozen daemon startup
- recover pipx and uv installer identity when isolated launch resets the Python prefix
- keep unmarked frozen and non-frozen runtimes outside the Desktop update path

## Testing
- `uv run --no-sync pytest -q tests/test_dashboard_update.py --tb=short`
- `uv run --no-sync pytest -q tests/test_guard_daemon_manager.py -k 'frozen_desktop_daemon_launcher or frozen_non_desktop_daemon_launcher or non_frozen_daemon_launcher_drops_desktop_context or isolated_daemon_bootstrap_ignores' --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/cli/update_commands.py src/codex_plugin_scanner/guard/daemon/manager.py tests/test_dashboard_update.py tests/test_guard_daemon_manager.py`
- `uv run --no-sync basedpyright --level error src/codex_plugin_scanner/guard/cli/update_commands.py src/codex_plugin_scanner/guard/daemon/manager.py`
