### PR TITLE
fix(release): verify nested alpha tag reservations

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -258,11 +258,16 @@ jobs:
         run: |
           set -euo pipefail
           tag="alpha/v${VERSION}"
-          encoded_tag=${tag//\//%2F}
-          existing=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${encoded_tag}" --jq '.object.sha' 2>/dev/null || true)
+          ref="refs/tags/${tag}"
+          exact_tag_sha() {
+            gh api "repos/${GITHUB_REPOSITORY}/git/matching-refs/tags/${tag}" \
+              | jq -r --arg ref "$ref" '.[] | select(.ref == $ref) | .object.sha'
+          }
+          existing=$(exact_tag_sha)
           if [[ -z "$existing" ]]; then
-            gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" -f ref="refs/tags/${tag}" -f sha="$SOURCE_SHA" >/dev/null
-            existing=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${encoded_tag}" --jq '.object.sha')
+            if ! existing=$(gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" -f ref="$ref" -f sha="$SOURCE_SHA" --jq '.object.sha'); then
+              existing=$(exact_tag_sha)
+            fi
           fi
           if [[ "$existing" != "$SOURCE_SHA" ]]; then
             echo "Alpha tag is already bound to a different source" >&2

--- a/tests/test_release_3_1_alpha_hardening.py
+++ b/tests/test_release_3_1_alpha_hardening.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-
 WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "publish.yml"
 
 
@@ -12,18 +11,20 @@ def test_alpha_version_selection_fetches_remote_tags() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
     assert "fetch-tags: true" in text
     assert "git -C release-tooling fetch --force --tags origin" in text
-    assert "tag --points-at \"$SOURCE_SHA\"" in text
+    assert 'tag --points-at "$SOURCE_SHA"' in text
 
 
-def test_hierarchical_alpha_tag_ref_is_encoded_for_lookup() -> None:
+def test_hierarchical_alpha_tag_ref_uses_exact_matching_ref_lookup() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
-    assert "encoded_tag=${tag//\\//%2F}" in text
-    assert "git/ref/tags/${encoded_tag}" in text
+    assert "git/matching-refs/tags/${tag}" in text
+    assert "select(.ref == $ref) | .object.sha" in text
+    assert "existing=$(exact_tag_sha)" in text
+    assert '-f ref="$ref"' in text
 
 
 def test_existing_github_prerelease_is_revalidated() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
     assert "--json targetCommitish,isDraft,isPrerelease" in text
     assert 'target" != "$SOURCE_SHA' in text
-    assert "gh release download \"$tag\"" in text
-    assert "cmp --silent \"$local_file\" \"$remote_file\"" in text
+    assert 'gh release download "$tag"' in text
+    assert 'cmp --silent "$local_file" "$remote_file"' in text

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -155,6 +155,8 @@ def test_alpha_tag_is_bound_to_source_sha() -> None:
         if step.get("name") == "Reserve version for source commit"
     )
     assert '-f sha="$SOURCE_SHA"' in run
+    assert "git/matching-refs/tags/${tag}" in run
+    assert "existing=$(exact_tag_sha)" in run
     assert '"$existing" != "$SOURCE_SHA"' in run
 
 


### PR DESCRIPTION
## Summary
- resolve nested alpha tag reservations through exact matching refs
- recover safely when concurrent tag creation wins the reservation race
- preserve fail-closed source binding without moving immutable tags

## Testing
- `uv run pytest tests/test_release_3_1_alpha_hardening.py tests/test_release_train_workflow.py -q`
- `uv run ruff check tests/test_release_3_1_alpha_hardening.py tests/test_release_train_workflow.py`
- `uv run ruff format --check tests/test_release_3_1_alpha_hardening.py tests/test_release_train_workflow.py`
- workflow YAML parsed with PyYAML
