### PR TITLE
fix(update): recover isolated installer authority

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 14866,
-  "maximum_test_source_lines": 321511,
+  "maximum_collected_cases": 14870,
+  "maximum_test_source_lines": 321594,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -1584,6 +1584,20 @@ def _is_desktop_managed_runtime() -> bool:
     return _is_frozen_runtime() and os.environ.get("HOL_GUARD_DESKTOP") == "1"
 
 
+def _runtime_package_path() -> Path:
+    return Path(__file__).resolve()
+
+
+def _runtime_installer_kind() -> str | None:
+    for parent in _runtime_package_path().parents:
+        normalized_parent = parent.as_posix().lower()
+        if "/pipx/venvs/" in normalized_parent and (parent / "pipx_metadata.json").is_file():
+            return "pipx"
+        if "/uv/tools/" in normalized_parent and (parent / "pyvenv.cfg").is_file():
+            return "uv"
+    return None
+
+
 def _installer_kind() -> str:
     prefix_path = Path(sys.prefix).resolve()
     normalized_prefix = prefix_path.as_posix().lower()
@@ -1593,7 +1607,7 @@ def _installer_kind() -> str:
         return "pipx"
     if "/pipx/venvs/" in normalized_prefix:
         return "pipx"
-    return "pip"
+    return _runtime_installer_kind() or "pip"
 
 
 def _should_upgrade_from_pypi(

--- a/tests/test_dashboard_update.py
+++ b/tests/test_dashboard_update.py
@@ -212,6 +212,89 @@ def test_frozen_runtime_without_desktop_marker_keeps_installer_detection(
     assert cast(dict[str, object], payload["binary_diagnostics"])["path_status"] != "bundled"
 
 
+@pytest.mark.parametrize(
+    ("installer_root", "marker_name", "expected_installer"),
+    [
+        ("pipx/venvs/hol-guard", "pipx_metadata.json", "pipx"),
+        ("uv/tools/hol-guard", "pyvenv.cfg", "uv"),
+    ],
+)
+def test_installer_kind_uses_authenticated_runtime_path_when_prefix_isolated(
+    installer_root: str,
+    marker_name: str,
+    expected_installer: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_prefix = tmp_path / "python-runtime"
+    base_prefix.mkdir()
+    runtime_root = tmp_path / installer_root
+    runtime_path = runtime_root / "lib/python3/site-packages/guard/update_commands.py"
+    runtime_path.parent.mkdir(parents=True)
+    (runtime_root / marker_name).write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(update_commands.sys, "prefix", str(base_prefix))
+    monkeypatch.setattr(update_commands, "_runtime_package_path", lambda: runtime_path)
+
+    assert update_commands._installer_kind() == expected_installer
+
+
+def test_installer_kind_rejects_unmarked_runtime_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_prefix = tmp_path / "python-runtime"
+    base_prefix.mkdir()
+    runtime_path = tmp_path / "pipx/venvs/hol-guard/lib/python3/site-packages/guard/update_commands.py"
+    runtime_path.parent.mkdir(parents=True)
+    monkeypatch.setattr(update_commands.sys, "prefix", str(base_prefix))
+    monkeypatch.setattr(update_commands, "_runtime_package_path", lambda: runtime_path)
+
+    assert update_commands._installer_kind() == "pip"
+
+
+def test_update_status_recovers_pipx_authority_from_isolated_daemon_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_prefix = tmp_path / "python-runtime"
+    base_prefix.mkdir()
+    runtime_root = tmp_path / "pipx/venvs/hol-guard"
+    runtime_path = runtime_root / "lib/python3/site-packages/guard/update_commands.py"
+    runtime_path.parent.mkdir(parents=True)
+    (runtime_root / "pipx_metadata.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(update_commands.sys, "prefix", str(base_prefix))
+    monkeypatch.setattr(update_commands, "_runtime_package_path", lambda: runtime_path)
+
+    def status_distribution(**kwargs: object) -> update_commands.InstalledDistribution:
+        assert kwargs["installer"] == "pipx"
+        return update_commands.InstalledDistribution(
+            name="hol-guard",
+            version="3.0.0a160",
+            root=runtime_root,
+        )
+
+    monkeypatch.setattr(update_commands, "_status_installed_distribution", status_distribution)
+    monkeypatch.setattr(
+        update_commands,
+        "_version_check_payload",
+        lambda current_version, **_kwargs: {
+            "source": "pypi",
+            "status": "current",
+            "current_version": current_version,
+            "latest_version": current_version,
+            "update_available": False,
+        },
+    )
+
+    payload = build_guard_update_status_payload(guard_home=tmp_path / "guard-home")
+
+    assert payload["installer"] == "pipx"
+    assert payload["current_version"] == "3.0.0a160"
+    assert payload["auto_updatable"] is True
+    assert payload["blocked_reason"] is None
+    assert "reason_code" not in payload
+
+
 def test_update_status_uses_persisted_alpha_channel(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     guard_home = tmp_path / "guard-home"
     guard_home.mkdir()


### PR DESCRIPTION
## Summary
- recover pipx and uv installer identity when isolated daemon launch resets the Python prefix
- require canonical installer layout and installer-specific venv markers before classification
- preserve the existing Desktop-managed update path

## Testing
- `uv run --no-sync pytest -q tests/test_dashboard_update.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/cli/update_commands.py tests/test_dashboard_update.py`
- `uv run --no-sync basedpyright --level error src/codex_plugin_scanner/guard/cli/update_commands.py`
