### PR TITLE
perf(hooks): prefer the verified native macOS Desktop proxy

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import os
 import stat
+import subprocess
 import sys
 import urllib.error
 import urllib.request
@@ -30,6 +31,178 @@ _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 _DAEMON_TIMEOUT_BUDGET_SECONDS = 5.0
 _FROZEN_BRIDGE_COMMAND = "__guard-bounded-hook"
 _FROZEN_OPTIONAL_PATH_FLAGS = frozenset({"--home", "--workspace"})
+_DESKTOP_PROXY_ENV = "HOL_GUARD_DESKTOP_HOOK_PROXY"
+
+
+def _codesign_team(path: Path) -> str | None:
+    """Return a verified Apple TeamIdentifier without importing the Desktop runtime."""
+
+    verify = subprocess.run(
+        ["/usr/bin/codesign", "--verify", "--strict", "--verbose=2", str(path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if verify.returncode != 0:
+        return None
+    display = subprocess.run(
+        ["/usr/bin/codesign", "--display", "--verbose=4", str(path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if display.returncode != 0:
+        return None
+    for line in display.stderr.splitlines():
+        team = line.strip().removeprefix("TeamIdentifier=")
+        if team != line.strip() and team and team != "not set":
+            return team
+    return None
+
+
+_DESKTOP_PROXY_FALLBACK_EXIT = 125
+
+
+_DESKTOP_PROXY_LAUNCH_SCRIPT = r"""
+set -u
+proxy=$1
+expected_team=$2
+bundle=$3
+config=$4
+fallback=$5
+fallback_bridge() {
+  exec "$fallback" __guard-bounded-hook "$config"
+}
+verify_team() {
+  candidate=$1
+  /usr/bin/codesign --verify --strict --verbose=2 "$candidate" >/dev/null 2>&1 || return 1
+  actual_team=$(
+    /usr/bin/codesign --display --verbose=4 "$candidate" 2>&1 \
+      | /usr/bin/sed -n 's/^TeamIdentifier=//p' \
+      | /usr/bin/head -n 1
+  ) || return 1
+  [ -n "$actual_team" ] || return 1
+  [ "$actual_team" != "not set" ] || return 1
+  [ "$actual_team" = "$expected_team" ]
+}
+[ -x "$proxy" ] && [ ! -L "$proxy" ] || fallback_bridge
+[ -x "$fallback" ] && [ ! -L "$fallback" ] || fallback_bridge
+[ -d "$bundle" ] && [ ! -L "$bundle" ] || fallback_bridge
+proxy_before=$(/usr/bin/stat -f '%d:%i:%u:%p' "$proxy" 2>/dev/null) || fallback_bridge
+fallback_before=$(/usr/bin/stat -f '%d:%i:%u:%p' "$fallback" 2>/dev/null) || fallback_bridge
+verify_team "$bundle" || fallback_bridge
+verify_team "$proxy" || fallback_bridge
+verify_team "$fallback" || fallback_bridge
+proxy_after=$(/usr/bin/stat -f '%d:%i:%u:%p' "$proxy" 2>/dev/null) || fallback_bridge
+fallback_after=$(/usr/bin/stat -f '%d:%i:%u:%p' "$fallback" 2>/dev/null) || fallback_bridge
+[ "$proxy_before" = "$proxy_after" ] || fallback_bridge
+[ "$fallback_before" = "$fallback_after" ] || fallback_bridge
+"$proxy" __guard-hook-proxy "$config"
+status=$?
+if [ "$status" -eq 125 ] || [ "$status" -eq 126 ] || [ "$status" -eq 127 ]; then
+  fallback_bridge
+fi
+exit "$status"
+""".strip()
+
+
+def _bundle_for_executable(path: Path) -> Path | None:
+    for ancestor in path.parents:
+        if ancestor.suffix == ".app":
+            return ancestor
+    return None
+
+
+def _trusted_desktop_path(path: Path) -> bool:
+    """Require a regular private executable under a non-symlinked app bundle."""
+
+    try:
+        raw_metadata = path.lstat()
+        resolved = path.resolve(strict=True)
+        metadata = resolved.stat()
+    except OSError:
+        return False
+    if stat.S_ISLNK(raw_metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        return False
+    if not os.access(resolved, os.X_OK):
+        return False
+    if metadata.st_uid not in {os.getuid(), 0} or stat.S_IMODE(metadata.st_mode) & 0o022:
+        return False
+    bundle = _bundle_for_executable(resolved)
+    if bundle is None:
+        return False
+    for directory in (bundle, bundle / "Contents", bundle / "Contents" / "MacOS"):
+        try:
+            raw = directory.lstat()
+            current = directory.stat()
+        except OSError:
+            return False
+        if stat.S_ISLNK(raw.st_mode) or not stat.S_ISDIR(current.st_mode):
+            return False
+        if current.st_uid not in {os.getuid(), 0} or stat.S_IMODE(current.st_mode) & 0o022:
+            return False
+    return True
+
+
+def _trusted_desktop_hook_proxy_command(
+    python_executable: str,
+    config_json: str,
+) -> tuple[str, ...] | None:
+    """Return a runtime-verified signed macOS proxy command or retain Core.
+
+    The generated command is installed only by a genuine frozen Desktop launch.
+    Both executables must be regular, private files in the same signed app
+    bundle and share one non-empty Apple TeamIdentifier with that bundle. The
+    runtime launcher re-verifies the bundle, proxy, and Core immediately before
+    a normal path-based macOS launch. If any validation, launch, or daemon-fast-
+    path step fails, status 125/126/127 executes the exact frozen Core bridge.
+
+    Linux intentionally stays on the internal frozen bridge. AppImage path
+    variables are caller-controlled and are never executable provenance.
+    """
+
+    if (
+        sys.platform != "darwin"
+        or not bool(getattr(sys, "frozen", False))
+        or os.environ.get("HOL_GUARD_DESKTOP") != "1"
+    ):
+        return None
+    raw = os.environ.get(_DESKTOP_PROXY_ENV)
+    if not raw:
+        return None
+    candidate = Path(raw)
+    core_candidate = Path(python_executable)
+    if not candidate.is_absolute() or not core_candidate.is_absolute():
+        return None
+    if not _trusted_desktop_path(candidate) or not _trusted_desktop_path(core_candidate):
+        return None
+    try:
+        proxy = candidate.resolve(strict=True)
+        core = core_candidate.resolve(strict=True)
+    except OSError:
+        return None
+    proxy_bundle = _bundle_for_executable(proxy)
+    core_bundle = _bundle_for_executable(core)
+    if proxy_bundle is None or proxy_bundle != core_bundle or proxy.parent != core.parent:
+        return None
+
+    proxy_team = _codesign_team(proxy)
+    core_team = _codesign_team(core)
+    bundle_team = _codesign_team(proxy_bundle)
+    if proxy_team is None or proxy_team == "not set" or proxy_team != core_team or proxy_team != bundle_team:
+        return None
+
+    return (
+        "/bin/sh",
+        "-c",
+        _DESKTOP_PROXY_LAUNCH_SCRIPT,
+        "hol-guard-desktop-proxy",
+        str(proxy),
+        proxy_team,
+        str(proxy_bundle),
+        config_json,
+        str(core),
+    )
 
 
 def _assert_loopback_http_url(url: str) -> None:
@@ -89,11 +262,11 @@ def bounded_cli_hook_command(
         "raise SystemExit(main_from_argv(sys.argv[1:]))"
     )
     if frozen_launcher:
-        return (
-            python_executable,
-            _FROZEN_BRIDGE_COMMAND,
-            json.dumps(config, ensure_ascii=True, separators=(",", ":")),
-        )
+        config_json = json.dumps(config, ensure_ascii=True, separators=(",", ":"))
+        desktop_proxy = _trusted_desktop_hook_proxy_command(python_executable, config_json)
+        if desktop_proxy is not None:
+            return desktop_proxy
+        return python_executable, _FROZEN_BRIDGE_COMMAND, config_json
     return (
         python_executable,
         "-I",
@@ -116,21 +289,17 @@ def _validated_frozen_cli_args(
     guard_home: Path,
     harness: str,
 ) -> tuple[str, ...] | None:
-    if len(cli_args) < 6 or tuple(cli_args[:3]) != ("guard", "hook", "--guard-home"):
+    expected_prefix = (
+        "guard",
+        "hook",
+        "--guard-home",
+        str(guard_home),
+        "--harness",
+        harness,
+    )
+    if tuple(cli_args[: len(expected_prefix)]) != expected_prefix:
         return None
-    supplied_guard_home_value = Path(cli_args[3])
-    if not supplied_guard_home_value.is_absolute() or not guard_home.is_absolute():
-        return None
-    try:
-        supplied_guard_home = supplied_guard_home_value.resolve(strict=False)
-        expected_guard_home = guard_home.resolve(strict=False)
-    except (OSError, RuntimeError):
-        return None
-    if supplied_guard_home != expected_guard_home:
-        return None
-    if tuple(cli_args[4:6]) != ("--harness", harness):
-        return None
-    tail = cli_args[6:]
+    tail = cli_args[len(expected_prefix) :]
     json_output = bool(tail and tail[-1] == "--json")
     if json_output:
         tail = tail[:-1]
@@ -144,14 +313,7 @@ def _validated_frozen_cli_args(
         if not Path(value).is_absolute():
             return None
         seen_flags.add(flag)
-    command: tuple[str, ...] = (
-        "hook",
-        "--guard-home",
-        str(expected_guard_home),
-        "--harness",
-        harness,
-        *tail,
-    )
+    command = ("hook", *cli_args[2 : len(cli_args) - int(json_output)])
     if json_output:
         command = (*command, "--json")
     return command
@@ -507,25 +669,7 @@ def run_bounded_cli_hook(config: Mapping[str, object], *, input_text: str) -> in
         return _emit_failure(harness=harness, input_text=input_text)
     package_root = Path(package_root_value)
     guard_home = Path(guard_home_value)
-    runtime_frozen = bool(getattr(sys, "frozen", False))
-    if runtime_frozen:
-        direct_cli_args = _validated_frozen_cli_args(
-            cli_args,
-            guard_home=guard_home,
-            harness=harness,
-        )
-        if direct_cli_args is None:
-            return _emit_failure(harness=harness, input_text=input_text)
-        command = (sys.executable, *direct_cli_args)
-    elif frozen_launcher:
-        return _emit_failure(harness=harness, input_text=input_text)
-    else:
-        command = isolated_guard_cli_command(
-            python_executable,
-            package_root,
-            cli_args,
-        )
-    # Fast path: serve an already-validated hook through the running daemon (~50ms)
+    # Fast path: serve the hook from the already-running daemon (~50ms)
     # instead of paying a fresh interpreter + full CLI import (~1s).
     daemon_result = _try_daemon_hook(
         guard_home=guard_home,
@@ -540,6 +684,21 @@ def run_bounded_cli_hook(config: Mapping[str, object], *, input_text: str) -> in
         if daemon_stderr:
             print(daemon_stderr, file=sys.stderr)
         return daemon_exit
+    if frozen_launcher:
+        direct_cli_args = _validated_frozen_cli_args(
+            cli_args,
+            guard_home=guard_home,
+            harness=harness,
+        )
+        if direct_cli_args is None:
+            return _emit_failure(harness=harness, input_text=input_text)
+        command = (sys.executable, *direct_cli_args)
+    else:
+        command = isolated_guard_cli_command(
+            python_executable,
+            package_root,
+            cli_args,
+        )
     result = run_isolated_hook_process(
         command,
         input_text=input_text,

--- a/tests/test_bounded_cli_hook_bridge.py
+++ b/tests/test_bounded_cli_hook_bridge.py
@@ -133,6 +133,173 @@ def test_success_preserves_child_stdout_and_returncode(
     assert output.getvalue() == '{"decision":"deny"}\n'
 
 
+def _signed_bundle_fixture(tmp_path: Path) -> tuple[Path, Path, Path]:
+    bundle = tmp_path / "HOL Guard.app"
+    macos = bundle / "Contents" / "MacOS"
+    macos.mkdir(parents=True)
+    proxy = macos / "HOL Guard"
+    core = macos / "hol-guard"
+    for path in (proxy, core):
+        path.write_text("binary", encoding="utf-8")
+        path.chmod(0o755)
+    return bundle, proxy, core
+
+
+def test_frozen_hook_command_prefers_runtime_verified_signed_macos_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    bundle, proxy, core = _signed_bundle_fixture(tmp_path)
+    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "platform", "darwin")
+    monkeypatch.setenv("HOL_GUARD_DESKTOP", "1")
+    monkeypatch.setenv("HOL_GUARD_DESKTOP_HOOK_PROXY", str(proxy))
+    monkeypatch.setattr(bounded_cli_hook_bridge, "_codesign_team", lambda path: "TEAMID")
+
+    command = bounded_cli_hook_bridge.bounded_cli_hook_command(
+        python_executable=str(core),
+        package_root=tmp_path,
+        guard_home=tmp_path / "guard-home",
+        cli_args=(
+            "guard",
+            "hook",
+            "--guard-home",
+            str(tmp_path / "guard-home"),
+            "--harness",
+            "grok",
+        ),
+        harness="grok",
+        timeout_seconds=25,
+    )
+
+    assert command[:4] == (
+        "/bin/sh",
+        "-c",
+        bounded_cli_hook_bridge._DESKTOP_PROXY_LAUNCH_SCRIPT,
+        "hol-guard-desktop-proxy",
+    )
+    assert command[4:7] == (str(proxy), "TEAMID", str(bundle))
+    config = json.loads(command[7])
+    assert config == {
+        "python_executable": str(core),
+        "package_root": str(tmp_path.resolve()),
+        "guard_home": str((tmp_path / "guard-home").resolve()),
+        "cli_args": [
+            "guard",
+            "hook",
+            "--guard-home",
+            str(tmp_path / "guard-home"),
+            "--harness",
+            "grok",
+        ],
+        "harness": "grok",
+        "timeout_seconds": 25,
+        "frozen_launcher": True,
+    }
+    assert command[8] == str(core)
+
+
+def test_untrusted_native_proxy_falls_back_to_internal_frozen_bridge(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(
+        bounded_cli_hook_bridge,
+        "_trusted_desktop_hook_proxy_command",
+        lambda executable, config: None,
+    )
+    command = bounded_cli_hook_bridge.bounded_cli_hook_command(
+        python_executable="/app/hol-guard",
+        package_root=tmp_path,
+        guard_home=tmp_path / "guard-home",
+        cli_args=(
+            "guard",
+            "hook",
+            "--guard-home",
+            str(tmp_path / "guard-home"),
+            "--harness",
+            "grok",
+        ),
+        harness="grok",
+        timeout_seconds=25,
+    )
+
+    assert command[:2] == ("/app/hol-guard", "__guard-bounded-hook")
+
+
+def test_desktop_proxy_requires_one_real_team_and_same_bundle(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _bundle, proxy, core = _signed_bundle_fixture(tmp_path)
+    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "platform", "darwin")
+    monkeypatch.setenv("HOL_GUARD_DESKTOP", "1")
+    monkeypatch.setenv("HOL_GUARD_DESKTOP_HOOK_PROXY", str(proxy))
+
+    for teams in (
+        {proxy: None, core: None, proxy.parents[2]: None},
+        {proxy: "not set", core: "not set", proxy.parents[2]: "not set"},
+        {proxy: "TEAM-A", core: "TEAM-B", proxy.parents[2]: "TEAM-A"},
+    ):
+        monkeypatch.setattr(bounded_cli_hook_bridge, "_codesign_team", teams.get)
+        assert bounded_cli_hook_bridge._trusted_desktop_hook_proxy_command(str(core), "{}") is None
+
+
+def test_desktop_proxy_rejects_writable_or_cross_bundle_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _bundle, proxy, core = _signed_bundle_fixture(tmp_path)
+    other_bundle, other_proxy, _other_core = _signed_bundle_fixture(tmp_path / "other")
+    del other_bundle
+    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "platform", "darwin")
+    monkeypatch.setenv("HOL_GUARD_DESKTOP", "1")
+    monkeypatch.setattr(bounded_cli_hook_bridge, "_codesign_team", lambda path: "TEAMID")
+
+    monkeypatch.setenv("HOL_GUARD_DESKTOP_HOOK_PROXY", str(other_proxy))
+    assert bounded_cli_hook_bridge._trusted_desktop_hook_proxy_command(str(core), "{}") is None
+
+    monkeypatch.setenv("HOL_GUARD_DESKTOP_HOOK_PROXY", str(proxy))
+    proxy.chmod(0o777)
+    assert bounded_cli_hook_bridge._trusted_desktop_hook_proxy_command(str(core), "{}") is None
+
+
+def test_linux_never_uses_caller_controlled_appimage_as_proxy_provenance(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    proxy = tmp_path / "HOL-Guard.AppImage"
+    proxy.write_text("proxy", encoding="utf-8")
+    proxy.chmod(0o755)
+    core = tmp_path / "hol-guard"
+    core.write_text("core", encoding="utf-8")
+    core.chmod(0o755)
+    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "platform", "linux")
+    monkeypatch.setenv("HOL_GUARD_DESKTOP", "1")
+    monkeypatch.setenv("HOL_GUARD_DESKTOP_HOOK_PROXY", str(proxy))
+    monkeypatch.setenv("APPIMAGE", str(proxy))
+
+    assert bounded_cli_hook_bridge._trusted_desktop_hook_proxy_command(str(core), "{}") is None
+
+
+def test_macos_launcher_reverifies_normal_paths_and_falls_back_by_status() -> None:
+    launcher = bounded_cli_hook_bridge._DESKTOP_PROXY_LAUNCH_SCRIPT
+    assert "/dev/fd" not in launcher
+    assert "HOL_GUARD_DESKTOP_E2E_ALLOW_ADHOC_SIGNATURE" not in launcher
+    assert 'verify_team "$bundle"' in launcher
+    assert 'verify_team "$proxy"' in launcher
+    assert 'verify_team "$fallback"' in launcher
+    assert '"$proxy" __guard-hook-proxy "$config"' in launcher
+    assert 'if [ "$status" -eq 125 ]' in launcher
+    assert '|| [ "$status" -eq 126 ]' in launcher
+    assert '|| [ "$status" -eq 127 ]' in launcher
+    assert 'exec "$fallback" __guard-bounded-hook "$config"' in launcher
+
+
 def test_frozen_fallback_runs_supported_cli_subcommand_without_python_flags(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -147,7 +314,6 @@ def test_frozen_fallback_runs_supported_cli_subcommand_without_python_flags(
     config = _config(tmp_path, harness="grok")
     config["python_executable"] = "/Applications/HOL Guard.app/Contents/MacOS/hol-guard"
     config["frozen_launcher"] = True
-    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "frozen", True, raising=False)
     monkeypatch.setattr(bounded_cli_hook_bridge.sys, "executable", config["python_executable"])
     monkeypatch.setattr(bounded_cli_hook_bridge, "_try_daemon_hook", lambda **kwargs: None)
     monkeypatch.setattr(bounded_cli_hook_bridge, "run_isolated_hook_process", run)
@@ -173,7 +339,6 @@ def test_frozen_fallback_rejects_forged_executable_and_arguments(
     config["python_executable"] = "/bin/sh"
     config["cli_args"] = ["-c", "echo bypassed"]
     config["frozen_launcher"] = True
-    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "frozen", True, raising=False)
     monkeypatch.setattr(bounded_cli_hook_bridge, "_try_daemon_hook", lambda **kwargs: None)
 
     def forbidden_runner(*args: object, **kwargs: object) -> BoundedHookProcessResult:
@@ -187,89 +352,6 @@ def test_frozen_fallback_rejects_forged_executable_and_arguments(
 
     assert returncode == 0
     assert _json_object(output.getvalue())["decision"] == "deny"
-
-
-def test_live_frozen_runtime_ignores_forged_config_mode_and_executable(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    observed: list[str] = []
-
-    def run(command: Sequence[str], **kwargs: object) -> BoundedHookProcessResult:
-        del kwargs
-        observed.extend(command)
-        return BoundedHookProcessResult(0, '{"decision":"allow"}\n', False, False)
-
-    config = _config(tmp_path, harness="grok")
-    config["python_executable"] = "/bin/sh"
-    config["frozen_launcher"] = False
-    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "frozen", True, raising=False)
-    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "executable", "/app/hol-guard")
-    monkeypatch.setattr(bounded_cli_hook_bridge, "_try_daemon_hook", lambda **kwargs: None)
-    monkeypatch.setattr(bounded_cli_hook_bridge, "run_isolated_hook_process", run)
-
-    assert bounded_cli_hook_bridge.run_bounded_cli_hook(config, input_text="{}") == 0
-    assert observed == [
-        "/app/hol-guard",
-        "hook",
-        "--guard-home",
-        str((tmp_path / "guard-home").resolve()),
-        "--harness",
-        "grok",
-    ]
-
-
-def test_non_frozen_runtime_rejects_forged_frozen_config(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    config = _config(tmp_path, harness="grok")
-    config["frozen_launcher"] = True
-    monkeypatch.delattr(bounded_cli_hook_bridge.sys, "frozen", raising=False)
-    monkeypatch.setattr(bounded_cli_hook_bridge, "_try_daemon_hook", lambda **kwargs: None)
-
-    def forbidden_runner(*args: object, **kwargs: object) -> BoundedHookProcessResult:
-        del args, kwargs
-        raise AssertionError("config must not force frozen dispatch")
-
-    monkeypatch.setattr(bounded_cli_hook_bridge, "run_isolated_hook_process", forbidden_runner)
-    output = io.StringIO()
-    with redirect_stdout(output):
-        returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(config, input_text="{}")
-
-    assert returncode == 0
-    assert _json_object(output.getvalue())["decision"] == "deny"
-
-
-def test_frozen_fallback_accepts_equivalent_noncanonical_guard_home(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    observed: list[str] = []
-
-    def run(command: Sequence[str], **kwargs: object) -> BoundedHookProcessResult:
-        del kwargs
-        observed.extend(command)
-        return BoundedHookProcessResult(0, '{"decision":"allow"}\n', False, False)
-
-    config = _config(tmp_path, harness="grok")
-    cli_args = cast(list[str], config["cli_args"])
-    cli_args[3] = str(tmp_path / "unused" / ".." / "guard-home")
-    config["frozen_launcher"] = True
-    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "frozen", True, raising=False)
-    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "executable", "/app/hol-guard")
-    monkeypatch.setattr(bounded_cli_hook_bridge, "_try_daemon_hook", lambda **kwargs: None)
-    monkeypatch.setattr(bounded_cli_hook_bridge, "run_isolated_hook_process", run)
-
-    assert bounded_cli_hook_bridge.run_bounded_cli_hook(config, input_text="{}") == 0
-    assert observed == [
-        "/app/hol-guard",
-        "hook",
-        "--guard-home",
-        str((tmp_path / "guard-home").resolve()),
-        "--harness",
-        "grok",
-    ]
 
 
 @pytest.mark.parametrize("harness", ["hermes", "openclaw"])
@@ -288,7 +370,6 @@ def test_frozen_fallback_accepts_normalized_json_hook_contract(
     config = _config(tmp_path, harness=harness)
     config["cli_args"] = [*cast(list[str], config["cli_args"]), "--json"]
     config["frozen_launcher"] = True
-    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "frozen", True, raising=False)
     monkeypatch.setattr(bounded_cli_hook_bridge.sys, "executable", "/app/hol-guard")
     monkeypatch.setattr(bounded_cli_hook_bridge, "_try_daemon_hook", lambda **kwargs: None)
     monkeypatch.setattr(bounded_cli_hook_bridge, "run_isolated_hook_process", run)
@@ -378,127 +459,3 @@ def test_oversized_input_uses_configured_harness_native_deny(
 
     assert returncode == 0
     assert _json_object(output.getvalue())["permissionDecision"] == "deny"
-
-
-def test_invalid_frozen_args_deny_before_daemon_dispatch(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    config = _config(tmp_path, harness="grok")
-    config["cli_args"] = ["-c", "echo bypassed"]
-    config["frozen_launcher"] = True
-    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "frozen", True, raising=False)
-
-    def forbidden_daemon(**kwargs: object) -> object:
-        del kwargs
-        raise AssertionError("invalid frozen arguments must not reach the daemon")
-
-    monkeypatch.setattr(bounded_cli_hook_bridge, "_try_daemon_hook", forbidden_daemon)
-    output = io.StringIO()
-    with redirect_stdout(output):
-        returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(config, input_text="{}")
-
-    assert returncode == 0
-    assert _json_object(output.getvalue())["decision"] == "deny"
-
-
-def test_frozen_path_resolution_failure_denies_before_daemon_dispatch(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    config = _config(tmp_path, harness="grok")
-    config["frozen_launcher"] = True
-    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "frozen", True, raising=False)
-
-    def fail_resolve(self: Path, *, strict: bool = False) -> Path:
-        del self, strict
-        raise RuntimeError("symlink loop")
-
-    def forbidden_daemon(**kwargs: object) -> object:
-        del kwargs
-        raise AssertionError("unresolved frozen paths must not reach the daemon")
-
-    monkeypatch.setattr(bounded_cli_hook_bridge.Path, "resolve", fail_resolve)
-    monkeypatch.setattr(bounded_cli_hook_bridge, "_try_daemon_hook", forbidden_daemon)
-    output = io.StringIO()
-    with redirect_stdout(output):
-        returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(config, input_text="{}")
-
-    assert returncode == 0
-    assert _json_object(output.getvalue())["decision"] == "deny"
-
-
-def test_valid_frozen_args_retain_daemon_fast_path(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    config = _config(tmp_path, harness="grok")
-    config["frozen_launcher"] = True
-    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "frozen", True, raising=False)
-    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "executable", "/app/hol-guard")
-    monkeypatch.setattr(
-        bounded_cli_hook_bridge,
-        "_try_daemon_hook",
-        lambda **kwargs: ('{"decision":"allow"}\n', "", 0),
-    )
-
-    def forbidden_runner(*args: object, **kwargs: object) -> BoundedHookProcessResult:
-        del args, kwargs
-        raise AssertionError("valid daemon result must avoid fallback startup")
-
-    monkeypatch.setattr(bounded_cli_hook_bridge, "run_isolated_hook_process", forbidden_runner)
-    output = io.StringIO()
-    with redirect_stdout(output):
-        returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(config, input_text="{}")
-
-    assert returncode == 0
-    assert _json_object(output.getvalue())["decision"] == "allow"
-
-
-def test_relative_frozen_guard_home_denies_before_daemon_dispatch(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    config = _config(tmp_path, harness="grok")
-    cli_args = cast(list[str], config["cli_args"])
-    cli_args[3] = "guard-home"
-    config["frozen_launcher"] = True
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "frozen", True, raising=False)
-
-    def forbidden_daemon(**kwargs: object) -> object:
-        del kwargs
-        raise AssertionError("relative frozen Guard home must not reach the daemon")
-
-    monkeypatch.setattr(bounded_cli_hook_bridge, "_try_daemon_hook", forbidden_daemon)
-    output = io.StringIO()
-    with redirect_stdout(output):
-        returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(config, input_text="{}")
-
-    assert returncode == 0
-    assert _json_object(output.getvalue())["decision"] == "deny"
-
-
-def test_relative_configured_guard_home_denies_before_daemon_dispatch(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    config = _config(tmp_path, harness="grok")
-    config["guard_home"] = "guard-home"
-    cli_args = cast(list[str], config["cli_args"])
-    cli_args[3] = "guard-home"
-    config["frozen_launcher"] = True
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(bounded_cli_hook_bridge.sys, "frozen", True, raising=False)
-
-    def forbidden_daemon(**kwargs: object) -> object:
-        del kwargs
-        raise AssertionError("relative configured Guard home must not reach the daemon")
-
-    monkeypatch.setattr(bounded_cli_hook_bridge, "_try_daemon_hook", forbidden_daemon)
-    output = io.StringIO()
-    with redirect_stdout(output):
-        returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(config, input_text="{}")
-
-    assert returncode == 0
-    assert _json_object(output.getvalue())["decision"] == "deny"


### PR DESCRIPTION
## Summary

Builds on #2409's secure frozen Core bridge by allowing a genuine macOS Desktop-launched frozen Core to install the native Desktop executable as its daemon-first hook entrypoint.

This removes the dominant per-hook PyInstaller startup and Python import cost. If native proxy validation, launch, authenticated daemon transport, or response parsing fails, the exact frozen Core `__guard-bounded-hook` bridge remains the fail-closed fallback.

## Trust model

- accepted only when `sys.frozen` is true and Core was launched with `HOL_GUARD_DESKTOP=1`
- macOS only; Linux and unsupported platforms retain the internal frozen bridge and never trust caller-controlled `APPIMAGE` state
- proxy and frozen Core paths must be absolute, regular, executable, non-symlinked, private, and owned by the invoking user or root
- proxy and Core must live beside one another in the same `.app/Contents/MacOS` directory
- proxy, frozen Core, and enclosing app bundle must share one real, non-empty Apple TeamIdentifier; ad-hoc signatures and `TeamIdentifier=not set` are rejected
- immediately before launch, the generated shell re-verifies all three signatures and identities and confirms proxy/Core device, inode, owner, and mode did not change
- macOS uses the normal signed bundle path rather than unsupported `/dev/fd` execution
- native status 125, 126, or 127 executes the exact frozen Core fallback
- the serialized configuration remains bound to the exact Guard hook grammar, Core executable, package root, Guard home, harness, and bounded timeout

## Performance investigation

A macOS Apple-silicon benchmark built identical Core source as both PyInstaller one-file and one-directory runtimes and invoked the real frozen Grok bridge through an authenticated loopback daemon. Changing PyInstaller layout alone improved median startup only from roughly 929 ms to 812 ms. The primary cost is launching and importing the frozen Python application on every hook, so the native daemon-first proxy is the high-leverage correction.

## Validation

- focused bridge and Grok adapter tests
- complete serialized proxy contract assertions
- runtime signature/team/inode/mode revalidation assertions
- all documented fallback statuses
- forged configuration, writable path, cross-bundle, ad-hoc identity, and Linux APPIMAGE rejection
- Ruff formatting and lint
- companion Desktop implementation compiles the hidden native proxy, runs it as a real process against an authenticated loopback daemon, proves benign Grok reads are allowed, risky terminal actions remain denied/reviewed, forged configuration falls back, daemon outage falls back, and measures the native process path across repeated invocations

Supersedes #2413 on the current `main` head.