### PR TITLE
fix(release): tolerate TestPyPI capacity limits

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -312,28 +312,48 @@ jobs:
           [[ "$status" == "absent" || "$status" == "exact" ]]
           capacity_limited=false
           upload=false
+          current_bytes=0
+          artifact_bytes=0
           if [[ "$status" == "absent" ]]; then
             size_result=$(uv run --no-project --with packaging==25.0 python scripts/verify_release_registry.py project-size --registry testpypi)
             current_bytes=$(jq -r '.size_bytes' <<< "$size_result")
             artifact_bytes=$(python -c 'from pathlib import Path; print(sum(path.stat().st_size for path in Path("dist").iterdir() if path.is_file()))')
-            if (( current_bytes + artifact_bytes > 10000000000 )); then
+            if (( current_bytes + artifact_bytes >= 10000000000 )); then
               capacity_limited=true
             else
               upload=true
             fi
           fi
+          echo "artifact_bytes=$artifact_bytes" >> "$GITHUB_OUTPUT"
           echo "capacity_limited=$capacity_limited" >> "$GITHUB_OUTPUT"
+          echo "current_bytes=$current_bytes" >> "$GITHUB_OUTPUT"
           echo "upload=$upload" >> "$GITHUB_OUTPUT"
       - id: publish
+        continue-on-error: true
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         if: steps.state.outputs.upload == 'true'
         with:
           repository-url: https://test.pypi.org/legacy/
+      - name: Classify TestPyPI publish failure
+        id: classify
+        if: steps.publish.outcome == 'failure'
+        env:
+          ARTIFACT_BYTES: ${{ steps.state.outputs.artifact_bytes }}
+          CURRENT_BYTES: ${{ steps.state.outputs.current_bytes }}
+        run: |
+          size_result=$(uv run --no-project --with packaging==25.0 python scripts/verify_release_registry.py project-size --registry testpypi)
+          post_bytes=$(jq -r '.size_bytes' <<< "$size_result")
+          if (( post_bytes > CURRENT_BYTES && post_bytes + ARTIFACT_BYTES >= 10000000000 )); then
+            echo "capacity_limited=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "TestPyPI publish failed without a confirmed capacity race" >&2
+            exit 1
+          fi
       - name: Report unavailable TestPyPI canary
-        if: steps.state.outputs.capacity_limited == 'true'
+        if: steps.state.outputs.capacity_limited == 'true' || steps.classify.outputs.capacity_limited == 'true'
         run: echo "::warning::TestPyPI project capacity reached; continuing with immutable build hashes and independent PyPI verification"
       - name: Verify published TestPyPI bytes and CLI
-        if: steps.state.outputs.capacity_limited != 'true'
+        if: steps.state.outputs.capacity_limited != 'true' && steps.classify.outputs.capacity_limited != 'true'
         env:
           VERSION: ${{ needs.build.outputs.version }}
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -311,11 +311,17 @@ jobs:
           status=$(jq -r '.status' <<< "$result")
           [[ "$status" == "absent" || "$status" == "exact" ]]
           [[ "$status" == "absent" ]] && echo "upload=true" >> "$GITHUB_OUTPUT" || echo "upload=false" >> "$GITHUB_OUTPUT"
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
+      - id: publish
+        continue-on-error: true
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         if: steps.state.outputs.upload == 'true'
         with:
           repository-url: https://test.pypi.org/legacy/
+      - name: Report unavailable TestPyPI canary
+        if: steps.state.outputs.upload == 'true' && steps.publish.outcome == 'failure'
+        run: echo "::warning::TestPyPI upload unavailable; continuing with immutable build hashes and independent PyPI verification"
       - name: Verify published TestPyPI bytes and CLI
+        if: steps.state.outputs.upload != 'true' || steps.publish.outcome == 'success'
         env:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
@@ -354,7 +360,7 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: distribution-sha256
-      - name: Verify immutable TestPyPI-proven bytes
+      - name: Verify immutable build bytes
         run: sha256sum --check distribution-sha256.txt
       - name: Revalidate source and alpha reservation
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -310,18 +310,30 @@ jobs:
           result=$(uv run --no-project --with packaging==25.0 python scripts/verify_release_registry.py verify-release --registry testpypi --version "$VERSION" --dist-dir dist)
           status=$(jq -r '.status' <<< "$result")
           [[ "$status" == "absent" || "$status" == "exact" ]]
-          [[ "$status" == "absent" ]] && echo "upload=true" >> "$GITHUB_OUTPUT" || echo "upload=false" >> "$GITHUB_OUTPUT"
+          capacity_limited=false
+          upload=false
+          if [[ "$status" == "absent" ]]; then
+            size_result=$(uv run --no-project --with packaging==25.0 python scripts/verify_release_registry.py project-size --registry testpypi)
+            current_bytes=$(jq -r '.size_bytes' <<< "$size_result")
+            artifact_bytes=$(python -c 'from pathlib import Path; print(sum(path.stat().st_size for path in Path("dist").iterdir() if path.is_file()))')
+            if (( current_bytes + artifact_bytes > 10000000000 )); then
+              capacity_limited=true
+            else
+              upload=true
+            fi
+          fi
+          echo "capacity_limited=$capacity_limited" >> "$GITHUB_OUTPUT"
+          echo "upload=$upload" >> "$GITHUB_OUTPUT"
       - id: publish
-        continue-on-error: true
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         if: steps.state.outputs.upload == 'true'
         with:
           repository-url: https://test.pypi.org/legacy/
       - name: Report unavailable TestPyPI canary
-        if: steps.state.outputs.upload == 'true' && steps.publish.outcome == 'failure'
-        run: echo "::warning::TestPyPI upload unavailable; continuing with immutable build hashes and independent PyPI verification"
+        if: steps.state.outputs.capacity_limited == 'true'
+        run: echo "::warning::TestPyPI project capacity reached; continuing with immutable build hashes and independent PyPI verification"
       - name: Verify published TestPyPI bytes and CLI
-        if: steps.state.outputs.upload != 'true' || steps.publish.outcome == 'success'
+        if: steps.state.outputs.capacity_limited != 'true'
         env:
           VERSION: ${{ needs.build.outputs.version }}
         run: |

--- a/scripts/verify_release_registry.py
+++ b/scripts/verify_release_registry.py
@@ -146,6 +146,34 @@ def list_registry_versions(
     return tuple(str(version) for version in sorted(versions))
 
 
+def registry_project_size_bytes(
+    registry: Registry,
+    *,
+    project_name: str = DEFAULT_PROJECT_NAME,
+    fetcher: Fetcher = stdlib_fetch,
+) -> int:
+    payload = _fetch_payload(_project_url(registry, project_name), fetcher=fetcher)
+    if payload is None:
+        raise RegistryVerificationError("Registry project response was unexpectedly absent")
+    document = _decode_object(payload, label="Registry project response")
+    releases = document.get("releases")
+    if not isinstance(releases, dict):
+        raise RegistryVerificationError("Registry project response is missing the releases object")
+
+    total = 0
+    for files in releases.values():
+        if not isinstance(files, list):
+            raise RegistryVerificationError("Registry release file list is invalid")
+        for item in files:
+            if not isinstance(item, dict):
+                raise RegistryVerificationError("Registry release file entry must be an object")
+            size = item.get("size")
+            if not isinstance(size, int) or isinstance(size, bool) or size < 0:
+                raise RegistryVerificationError("Registry release file size is invalid")
+            total += size
+    return total
+
+
 def _distribution_identity(filename: str) -> tuple[str, Version]:
     try:
         if filename.endswith(".whl"):
@@ -447,6 +475,10 @@ def _parser() -> argparse.ArgumentParser:
     _ = list_parser.add_argument("--registry", choices=[item.value for item in Registry], required=True)
     _ = list_parser.add_argument("--project", choices=SUPPORTED_PROJECT_NAMES, default=DEFAULT_PROJECT_NAME)
 
+    size_parser = subparsers.add_parser("project-size")
+    _ = size_parser.add_argument("--registry", choices=[item.value for item in Registry], required=True)
+    _ = size_parser.add_argument("--project", choices=SUPPORTED_PROJECT_NAMES, default=DEFAULT_PROJECT_NAME)
+
     inspect_parser = subparsers.add_parser("inspect-release")
     _ = inspect_parser.add_argument("--registry", choices=[item.value for item in Registry], required=True)
     _ = inspect_parser.add_argument("--project", choices=SUPPORTED_PROJECT_NAMES, default=DEFAULT_PROJECT_NAME)
@@ -478,6 +510,13 @@ def main(argv: Sequence[str] | None = None, *, fetcher: Fetcher = stdlib_fetch) 
         if command == "list-versions":
             registry = Registry(args.registry)
             output: object = list_registry_versions(registry, project_name=args.project, fetcher=fetcher)
+        elif command == "project-size":
+            registry = Registry(args.registry)
+            output = {
+                "project": args.project,
+                "registry": registry.value,
+                "size_bytes": registry_project_size_bytes(registry, project_name=args.project, fetcher=fetcher),
+            }
         elif command == "inspect-release":
             registry = Registry(args.registry)
             inspection = inspect_release(

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -166,14 +166,22 @@ def test_testpypi_uses_protected_trusted_publishing() -> None:
     assert job["permissions"]["id-token"] == "write"
     publish = next(step for step in job["steps"] if step.get("id") == "publish")
     assert str(publish["uses"]).startswith("pypa/gh-action-pypi-publish@")
-    assert "continue-on-error" not in publish
+    assert publish["continue-on-error"] is True
 
     verify = next(step for step in job["steps"] if step.get("name") == "Verify published TestPyPI bytes and CLI")
-    assert verify["if"] == "steps.state.outputs.capacity_limited != 'true'"
+    assert "steps.state.outputs.capacity_limited != 'true'" in verify["if"]
+    assert "steps.classify.outputs.capacity_limited != 'true'" in verify["if"]
 
     warning = next(step for step in job["steps"] if step.get("name") == "Report unavailable TestPyPI canary")
-    assert warning["if"] == "steps.state.outputs.capacity_limited == 'true'"
+    assert "steps.state.outputs.capacity_limited == 'true'" in warning["if"]
+    assert "steps.classify.outputs.capacity_limited == 'true'" in warning["if"]
     assert "project capacity reached" in warning["run"]
+
+    classify = next(step for step in job["steps"] if step.get("name") == "Classify TestPyPI publish failure")
+    assert classify["if"] == "steps.publish.outcome == 'failure'"
+    assert "post_bytes > CURRENT_BYTES" in classify["run"]
+    assert "post_bytes + ARTIFACT_BYTES >= 10000000000" in classify["run"]
+    assert "exit 1" in classify["run"]
 
 
 def test_pypi_uses_protected_trusted_publishing() -> None:

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -166,10 +166,14 @@ def test_testpypi_uses_protected_trusted_publishing() -> None:
     assert job["permissions"]["id-token"] == "write"
     publish = next(step for step in job["steps"] if step.get("id") == "publish")
     assert str(publish["uses"]).startswith("pypa/gh-action-pypi-publish@")
-    assert publish["continue-on-error"] is True
+    assert "continue-on-error" not in publish
 
     verify = next(step for step in job["steps"] if step.get("name") == "Verify published TestPyPI bytes and CLI")
-    assert verify["if"] == "steps.state.outputs.upload != 'true' || steps.publish.outcome == 'success'"
+    assert verify["if"] == "steps.state.outputs.capacity_limited != 'true'"
+
+    warning = next(step for step in job["steps"] if step.get("name") == "Report unavailable TestPyPI canary")
+    assert warning["if"] == "steps.state.outputs.capacity_limited == 'true'"
+    assert "project capacity reached" in warning["run"]
 
 
 def test_pypi_uses_protected_trusted_publishing() -> None:

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -164,7 +164,12 @@ def test_testpypi_uses_protected_trusted_publishing() -> None:
     job = workflow()["jobs"]["publish-alpha-testpypi"]
     assert job["environment"] == "testpypi"
     assert job["permissions"]["id-token"] == "write"
-    assert any(str(step.get("uses", "")).startswith("pypa/gh-action-pypi-publish@") for step in job["steps"])
+    publish = next(step for step in job["steps"] if step.get("id") == "publish")
+    assert str(publish["uses"]).startswith("pypa/gh-action-pypi-publish@")
+    assert publish["continue-on-error"] is True
+
+    verify = next(step for step in job["steps"] if step.get("name") == "Verify published TestPyPI bytes and CLI")
+    assert verify["if"] == "steps.state.outputs.upload != 'true' || steps.publish.outcome == 'success'"
 
 
 def test_pypi_uses_protected_trusted_publishing() -> None:

--- a/tests/test_verify_release_registry.py
+++ b/tests/test_verify_release_registry.py
@@ -18,6 +18,7 @@ from scripts.verify_release_registry import (
     inspect_release,
     list_registry_versions,
     main,
+    registry_project_size_bytes,
     verify_registry_release,
     verify_testpypi_release,
 )
@@ -138,6 +139,29 @@ def test_lists_plugin_scanner_registry_versions() -> None:
         "3.0.0a1",
         "3.0.0a2",
     )
+
+
+def test_sums_registry_project_file_sizes() -> None:
+    payload = json.dumps(
+        {
+            "releases": {
+                "3.1.0a1": [{"size": 11}, {"size": 17}],
+                "3.1.0a2": [{"size": 23}],
+            }
+        }
+    ).encode()
+    fetcher = FakeFetcher({_project_url(Registry.TESTPYPI): payload})
+
+    assert registry_project_size_bytes(Registry.TESTPYPI, fetcher=fetcher) == 51
+
+
+@pytest.mark.parametrize("size", [-1, True, "10", None])
+def test_rejects_invalid_registry_project_file_size(size: object) -> None:
+    payload = json.dumps({"releases": {"3.1.0a1": [{"size": size}]}}).encode()
+    fetcher = FakeFetcher({_project_url(Registry.TESTPYPI): payload})
+
+    with pytest.raises(RegistryVerificationError, match="file size is invalid"):
+        _ = registry_project_size_bytes(Registry.TESTPYPI, fetcher=fetcher)
 
 
 def test_verifies_plugin_scanner_release_independently(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- keep release publishing available when the TestPyPI project cannot accept more files
- retain strict build hash, source reservation, public registry byte, and CLI verification gates
- report unavailable TestPyPI uploads as workflow warnings

## Testing
- `uv run pytest tests/test_release_train_workflow.py tests/test_release_3_1_alpha_hardening.py -q`
- `uv run ruff check tests/test_release_train_workflow.py`
- `uv run ruff format --check tests/test_release_train_workflow.py`
- workflow YAML parsed with PyYAML


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project storage-size reporting from the package registry.
  * TestPyPI publishing now checks available capacity before uploading and skips uploads that would exceed the 10 GB limit.
  * Capacity-limited publishing displays a warning and skips unnecessary byte verification.

* **Bug Fixes**
  * Improved release verification behavior and clarified immutable build-byte hash verification.

* **Tests**
  * Added coverage for storage calculations, invalid registry data, and capacity-limited publishing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->