### PR TITLE
fix(release): checkout before prerelease verification

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -472,6 +472,11 @@ jobs:
       attestations: write
       id-token: write
     steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          ref: release/3.1
+          fetch-depth: 0
+          persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: distributions

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -239,6 +239,10 @@ def test_release_is_created_only_after_pypi() -> None:
     job = workflow()["jobs"]["release-alpha"]
     assert job["needs"] == ["build", "publish-alpha-pypi"]
     assert job["permissions"]["attestations"] == "write"
+    checkout = next(step for step in job["steps"] if str(step.get("uses", "")).startswith("actions/checkout@"))
+    assert checkout["with"]["ref"] == "release/3.1"
+    assert checkout["with"]["fetch-depth"] == 0
+    assert checkout["with"]["persist-credentials"] is False
 
 
 def test_release_notes_show_exact_alpha_install() -> None:


### PR DESCRIPTION
## Summary
- check out the release branch before verifying the reserved alpha tag
- keep prerelease asset creation bound to the exact release source

## Testing
- `uv run pytest tests/test_release_train_workflow.py tests/test_release_3_1_alpha_hardening.py -q`
- `uv run ruff check tests/test_release_train_workflow.py`
- `uv run ruff format --check tests/test_release_train_workflow.py`
- workflow YAML parsed with PyYAML
