### PR TITLE
perf(hooks): backport verified native Desktop proxy to 3.0

### DIFF
--- a/.github/workflows/temporary-backport-native-desktop-hook-proxy.yml
+++ b/.github/workflows/temporary-backport-native-desktop-hook-proxy.yml
@@ -1,4 +1,4 @@
-name: Temporary backport native Desktop hook proxy
+name: Temporary analyze native Desktop hook proxy backport
 
 on:
   push:
@@ -6,64 +6,52 @@ on:
       - backport/native-desktop-hook-proxy-release-3.0
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: backport-native-desktop-hook-proxy-release-3.0
   cancel-in-progress: false
 
 jobs:
-  backport:
+  analyze:
     if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 10
     steps:
       - name: Check out release backport branch
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           ref: backport/native-desktop-hook-proxy-release-3.0
           fetch-depth: 0
-          persist-credentials: true
+          persist-credentials: false
 
-      - name: Apply reviewed mainline proxy commit
+      - name: Compare release and reviewed mainline tests
         shell: bash
         run: |
           set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch --no-tags origin d7386b7caa06499764f008d362949e7cae5527e4
-          git cherry-pick FETCH_HEAD
+          git show FETCH_HEAD:tests/test_bounded_cli_hook_bridge.py > "$RUNNER_TEMP/main-tests.py"
+          python3 - <<'PY'
+          import ast
+          from pathlib import Path
 
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
-        with:
-          python-version: "3.12"
+          release_path = Path('tests/test_bounded_cli_hook_bridge.py')
+          main_path = Path(__import__('os').environ['RUNNER_TEMP']) / 'main-tests.py'
+          release_tree = ast.parse(release_path.read_text(encoding='utf-8'))
+          main_tree = ast.parse(main_path.read_text(encoding='utf-8'))
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
-        with:
-          version: "0.9.26"
-          enable-cache: true
+          def names(tree):
+              return {
+                  node.name
+                  for node in tree.body
+                  if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+              }
 
-      - name: Install frozen release dependencies
-        run: uv sync --frozen --python 3.12
+          release_names = names(release_tree)
+          main_names = names(main_tree)
+          print('release_only=' + ','.join(sorted(release_names - main_names)))
+          print('main_only=' + ','.join(sorted(main_names - release_names)))
+          print(f'release_defs={len(release_names)} main_defs={len(main_names)}')
+          PY
 
-      - name: Validate focused proxy contracts
-        shell: bash
-        run: |
-          set -euo pipefail
-          uv run --no-sync ruff format --check \
-            src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py \
-            tests/test_bounded_cli_hook_bridge.py
-          uv run --no-sync ruff check \
-            src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py \
-            tests/test_bounded_cli_hook_bridge.py
-          uv run --no-sync pytest -q tests/test_bounded_cli_hook_bridge.py
-
-      - name: Remove one-shot workflow and publish backport branch
-        shell: bash
-        run: |
-          set -euo pipefail
-          git rm .github/workflows/temporary-backport-native-desktop-hook-proxy.yml
-          git commit -m "chore: remove temporary proxy backport workflow"
-          git push origin HEAD:backport/native-desktop-hook-proxy-release-3.0
+          git diff --no-index --stat tests/test_bounded_cli_hook_bridge.py "$RUNNER_TEMP/main-tests.py" || true

--- a/.github/workflows/temporary-backport-native-desktop-hook-proxy.yml
+++ b/.github/workflows/temporary-backport-native-desktop-hook-proxy.yml
@@ -1,4 +1,4 @@
-name: Temporary analyze native Desktop hook proxy backport
+name: Temporary apply native Desktop hook proxy backport
 
 on:
   push:
@@ -6,52 +6,122 @@ on:
       - backport/native-desktop-hook-proxy-release-3.0
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: backport-native-desktop-hook-proxy-release-3.0
   cancel-in-progress: false
 
 jobs:
-  analyze:
+  apply:
     if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 30
     steps:
       - name: Check out release backport branch
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           ref: backport/native-desktop-hook-proxy-release-3.0
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
 
-      - name: Compare release and reviewed mainline tests
+      - name: Apply reviewed source and preserve release-only security tests
         shell: bash
         run: |
           set -euo pipefail
           git fetch --no-tags origin d7386b7caa06499764f008d362949e7cae5527e4
+          git show FETCH_HEAD:src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py \
+            > src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
           git show FETCH_HEAD:tests/test_bounded_cli_hook_bridge.py > "$RUNNER_TEMP/main-tests.py"
           python3 - <<'PY'
           import ast
+          import os
           from pathlib import Path
 
           release_path = Path('tests/test_bounded_cli_hook_bridge.py')
-          main_path = Path(__import__('os').environ['RUNNER_TEMP']) / 'main-tests.py'
-          release_tree = ast.parse(release_path.read_text(encoding='utf-8'))
-          main_tree = ast.parse(main_path.read_text(encoding='utf-8'))
+          main_path = Path(os.environ['RUNNER_TEMP']) / 'main-tests.py'
+          release_source = release_path.read_text(encoding='utf-8')
+          main_source = main_path.read_text(encoding='utf-8')
+          release_tree = ast.parse(release_source)
+          main_tree = ast.parse(main_source)
 
-          def names(tree):
-              return {
-                  node.name
-                  for node in tree.body
-                  if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
-              }
+          definition_types = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+          release_names = {
+              node.name for node in release_tree.body if isinstance(node, definition_types)
+          }
+          lines = main_source.splitlines(keepends=True)
+          additions: list[str] = []
+          for node in main_tree.body:
+              if not isinstance(node, definition_types) or node.name in release_names:
+                  continue
+              starts = [node.lineno]
+              starts.extend(decorator.lineno for decorator in node.decorator_list)
+              start = min(starts) - 1
+              end = node.end_lineno
+              if end is None:
+                  raise SystemExit(f'missing end line for {node.name}')
+              additions.append(''.join(lines[start:end]).rstrip() + '\n')
 
-          release_names = names(release_tree)
-          main_names = names(main_tree)
-          print('release_only=' + ','.join(sorted(release_names - main_names)))
-          print('main_only=' + ','.join(sorted(main_names - release_names)))
-          print(f'release_defs={len(release_names)} main_defs={len(main_names)}')
+          expected = {
+              '_signed_bundle_fixture',
+              'test_desktop_proxy_rejects_writable_or_cross_bundle_paths',
+              'test_desktop_proxy_requires_one_real_team_and_same_bundle',
+              'test_frozen_hook_command_prefers_runtime_verified_signed_macos_proxy',
+              'test_linux_never_uses_caller_controlled_appimage_as_proxy_provenance',
+              'test_macos_launcher_reverifies_normal_paths_and_falls_back_by_status',
+              'test_untrusted_native_proxy_falls_back_to_internal_frozen_bridge',
+          }
+          added_names = {
+              node.name
+              for node in main_tree.body
+              if isinstance(node, definition_types) and node.name not in release_names
+          }
+          if added_names != expected:
+              raise SystemExit(
+                  f'unexpected main-only definitions: added={sorted(added_names)} expected={sorted(expected)}'
+              )
+          release_path.write_text(
+              release_source.rstrip() + '\n\n\n' + '\n\n'.join(additions),
+              encoding='utf-8',
+          )
           PY
 
-          git diff --no-index --stat tests/test_bounded_cli_hook_bridge.py "$RUNNER_TEMP/main-tests.py" || true
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+          enable-cache: true
+
+      - name: Install frozen release dependencies
+        run: uv sync --frozen --python 3.12
+
+      - name: Validate focused proxy contracts
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run --no-sync ruff format \
+            src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py \
+            tests/test_bounded_cli_hook_bridge.py
+          uv run --no-sync ruff check \
+            src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py \
+            tests/test_bounded_cli_hook_bridge.py
+          uv run --no-sync pytest -q tests/test_bounded_cli_hook_bridge.py
+
+      - name: Remove one-shot workflow and publish backport branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          git rm .github/workflows/temporary-backport-native-desktop-hook-proxy.yml
+          git diff --check
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add \
+            src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py \
+            tests/test_bounded_cli_hook_bridge.py
+          git commit -m "perf(hooks): prefer the verified native macOS Desktop proxy"
+          git push origin HEAD:backport/native-desktop-hook-proxy-release-3.0

--- a/.github/workflows/temporary-backport-native-desktop-hook-proxy.yml
+++ b/.github/workflows/temporary-backport-native-desktop-hook-proxy.yml
@@ -1,0 +1,69 @@
+name: Temporary backport native Desktop hook proxy
+
+on:
+  push:
+    branches:
+      - backport/native-desktop-hook-proxy-release-3.0
+
+permissions:
+  contents: write
+
+concurrency:
+  group: backport-native-desktop-hook-proxy-release-3.0
+  cancel-in-progress: false
+
+jobs:
+  backport:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out release backport branch
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          ref: backport/native-desktop-hook-proxy-release-3.0
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Apply reviewed mainline proxy commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch --no-tags origin d7386b7caa06499764f008d362949e7cae5527e4
+          git cherry-pick FETCH_HEAD
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          version: "0.9.26"
+          enable-cache: true
+
+      - name: Install frozen release dependencies
+        run: uv sync --frozen --python 3.12
+
+      - name: Validate focused proxy contracts
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run --no-sync ruff format --check \
+            src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py \
+            tests/test_bounded_cli_hook_bridge.py
+          uv run --no-sync ruff check \
+            src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py \
+            tests/test_bounded_cli_hook_bridge.py
+          uv run --no-sync pytest -q tests/test_bounded_cli_hook_bridge.py
+
+      - name: Remove one-shot workflow and publish backport branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          git rm .github/workflows/temporary-backport-native-desktop-hook-proxy.yml
+          git commit -m "chore: remove temporary proxy backport workflow"
+          git push origin HEAD:backport/native-desktop-hook-proxy-release-3.0


### PR DESCRIPTION
## Summary

Backports the reviewed native macOS Desktop hook proxy from `main` to `release/3.0` while preserving release-only coverage.

## Security model

- Uses the native Desktop proxy only after runtime verification of the signed macOS app bundle.
- Requires one real Team ID and the same bundle for the app and proxy.
- Rejects writable or cross-bundle proxy paths.
- Never treats caller-controlled Linux AppImage paths as provenance.
- Falls back to the internal frozen bridge whenever trust verification fails.

## Validation

- `ruff format` and `ruff check` on the touched implementation and tests
- `pytest -q tests/test_bounded_cli_hook_bridge.py`
- Python bytecode compilation
- `git diff --check`

Source implementation was taken from reviewed merge commit `d7386b7caa06499764f008d362949e7cae5527e4`.