### PR TITLE
fix(guard): allow verified home-relative git fetches

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 15004,
-  "maximum_test_source_lines": 323132,
+  "maximum_test_source_lines": 323196,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/runtime/compound_git_inspection.py
+++ b/src/codex_plugin_scanner/guard/runtime/compound_git_inspection.py
@@ -27,6 +27,25 @@ _REPOSITORY_PATH_COMPONENT: Final = re.compile(r"[A-Za-z0-9_][A-Za-z0-9_.-]{0,12
 _BOUND: Final = 1000
 
 
+def canonical_home_git_c_path(command_text: str) -> str | None:
+    """Return an unquoted canonical current-user Git ``-C`` operand."""
+
+    match = re.match(r"\Agit[ \t]+-C[ \t]+(?P<path>~/[A-Za-z0-9_.\-/]+)(?=[ \t]+)", command_text)
+    if match is None:
+        return None
+    path = match.group("path")
+    tail = path[2:]
+    return (
+        path
+        if tail
+        and all(
+            component not in {"", ".", ".."} and _REPOSITORY_PATH_COMPONENT.fullmatch(component) is not None
+            for component in tail.split("/")
+        )
+        else None
+    )
+
+
 def is_low_risk_compound_git_inspection(context: ShellExecutionContext) -> bool:
     """Recognize a deterministic leading-cd Git routine."""
 
@@ -65,7 +84,11 @@ def _leading_literal_cd(segment: ShellExecutionSegment) -> bool:
     )
 
 
-def is_low_risk_git_inspection_segment(segment: ShellExecutionSegment) -> bool:
+def is_low_risk_git_inspection_segment(
+    segment: ShellExecutionSegment,
+    *,
+    home_dir: Path | None = None,
+) -> bool:
     """Recognize one bounded Git refresh or inspection segment."""
 
     tokens = _without_stderr_merge(segment.tokens)
@@ -74,11 +97,15 @@ def is_low_risk_git_inspection_segment(segment: ShellExecutionSegment) -> bool:
     operation_index = 1
     repository_path: str | None = None
     if tokens[1] == "-C":
-        if len(tokens) < 4 or not _safe_git_c_repository_path(tokens[2]):
+        if len(tokens) < 4 or not _safe_git_c_repository_path(tokens[2], home_dir=home_dir):
             return False
         repository_path = tokens[2]
         operation_index = 3
-    invocation_cwds = _git_invocation_cwds(segment, repository_path=repository_path)
+    invocation_cwds = _git_invocation_cwds(
+        segment,
+        repository_path=repository_path,
+        home_dir=home_dir,
+    )
     if invocation_cwds is None:
         return False
     execution_cwd, repository_cwd = invocation_cwds
@@ -175,7 +202,11 @@ def is_low_risk_git_push_segment(segment: ShellExecutionSegment) -> bool:
     )
 
 
-def is_low_risk_standalone_git_routine(context: ShellExecutionContext) -> bool:
+def is_low_risk_standalone_git_routine(
+    context: ShellExecutionContext,
+    *,
+    home_dir: Path | None = None,
+) -> bool:
     """Recognize one bounded Git read or configured-origin ref refresh."""
 
     if not context.complete or len(context.segments) != 1:
@@ -185,7 +216,7 @@ def is_low_risk_standalone_git_routine(context: ShellExecutionContext) -> bool:
         segment.tokens[:1] == ("git",)
         and not segment.control_before
         and not segment.control_after
-        and is_low_risk_git_inspection_segment(segment)
+        and is_low_risk_git_inspection_segment(segment, home_dir=home_dir)
     )
 
 
@@ -290,9 +321,20 @@ def _safe_repository_path(value: str) -> bool:
     )
 
 
-def _safe_git_c_repository_path(value: str) -> bool:
+def _safe_git_c_repository_path(value: str, *, home_dir: Path | None = None) -> bool:
     if _safe_repository_path(value):
         return True
+    if value.startswith("~/"):
+        tail = value[2:]
+        return bool(
+            home_dir is not None
+            and tail
+            and not tail.startswith(("/", "\\"))
+            and all(
+                component not in {"", ".", ".."} and _REPOSITORY_PATH_COMPONENT.fullmatch(component) is not None
+                for component in tail.split("/")
+            )
+        )
     if not value or len(value) > 512 or not Path(value).is_absolute() or _dynamic(value):
         return False
     return all(
@@ -381,6 +423,7 @@ def _git_invocation_cwds(
     segment: ShellExecutionSegment,
     *,
     repository_path: str | None,
+    home_dir: Path | None = None,
 ) -> tuple[Path, Path] | None:
     if segment.effective_cwd is None:
         return None
@@ -389,16 +432,22 @@ def _git_invocation_cwds(
         if repository_path is None:
             repository_cwd = execution_cwd
         else:
-            requested_repository = Path(repository_path)
+            if repository_path.startswith("~/"):
+                if home_dir is None:
+                    return None
+                requested_repository = home_dir.resolve() / repository_path[2:]
+            else:
+                requested_repository = Path(repository_path)
             candidate = (
                 requested_repository if requested_repository.is_absolute() else execution_cwd / requested_repository
             )
             repository_cwd = candidate.resolve()
+        allowed_roots = (execution_cwd,) if home_dir is None else (execution_cwd, home_dir.resolve())
     except (OSError, RuntimeError):
         return None
     return (
         (execution_cwd, repository_cwd)
-        if repository_cwd.is_dir() and repository_cwd.is_relative_to(execution_cwd)
+        if repository_cwd.is_dir() and any(repository_cwd.is_relative_to(root) for root in allowed_roots)
         else None
     )
 
@@ -502,6 +551,7 @@ def _dynamic(value: str) -> bool:
 
 
 __all__ = (
+    "canonical_home_git_c_path",
     "is_low_risk_compound_git_inspection",
     "is_low_risk_git_inspection_segment",
     "is_low_risk_git_push_segment",

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/benign_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/benign_requests.py
@@ -169,7 +169,7 @@ def is_explicitly_benign_tool_action_request(
         if _looks_like_safe_git_status_command(stripped_command, parts, cwd=cwd):
             found_benign_candidate = True
             continue
-        if _looks_like_safe_standalone_git_routine(stripped_command, cwd=cwd):
+        if _looks_like_safe_standalone_git_routine(stripped_command, cwd=cwd, home_dir=home_dir):
             found_benign_candidate = True
             continue
         if home_dir is not None and is_safe_git_worktree_add(

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/git_routines.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/git_routines.py
@@ -8,6 +8,7 @@ import subprocess
 from pathlib import Path
 
 from ..compound_git_inspection import (
+    canonical_home_git_c_path,
     is_low_risk_standalone_git_routine,
     is_safe_standalone_git_object_existence_query,
 )
@@ -25,7 +26,12 @@ from .tool_action_requests import (
 )
 
 
-def _looks_like_safe_standalone_git_routine(command_text: str, *, cwd: Path | None) -> bool:
+def _looks_like_safe_standalone_git_routine(
+    command_text: str,
+    *,
+    cwd: Path | None,
+    home_dir: Path | None = None,
+) -> bool:
     if any(marker in command_text for marker in ("$(", "`", "<(", ">(", ";", "|", "\n")):
         return False
     if "&" in command_text:
@@ -43,7 +49,8 @@ def _looks_like_safe_standalone_git_routine(command_text: str, *, cwd: Path | No
         cwd=execution_cwd,
         workspace_root=execution_cwd,
     )
-    return is_low_risk_standalone_git_routine(context)
+    trusted_home = home_dir if canonical_home_git_c_path(command_text) is not None else None
+    return is_low_risk_standalone_git_routine(context, home_dir=trusted_home)
 
 
 def _looks_like_safe_git_status_command(

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/tool_action_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/tool_action_requests.py
@@ -8,7 +8,11 @@ from pathlib import Path
 from typing import cast
 
 from ..command_model import CanonicalCommand
-from ..compound_git_inspection import is_low_risk_git_inspection_segment, is_low_risk_standalone_git_routine
+from ..compound_git_inspection import (
+    canonical_home_git_c_path,
+    is_low_risk_git_inspection_segment,
+    is_low_risk_standalone_git_routine,
+)
 from ..git_execution_safety import git_status_args_are_read_only, git_status_has_execution_free_config
 from ..kubernetes_commands import kubernetes_secret_read_source
 from ..shell_command_wrappers import normalize_transparent_shell_command
@@ -275,12 +279,14 @@ def _unverified_git_fetch_request(
         workspace_root=parsing_cwd,
         home_dir=home_dir,
     )
+    trusted_home = home_dir if canonical_home_git_c_path(command_text) is not None else None
     if not any(_segment_invokes_git_fetch(segment.tokens) for segment in context.segments):
         return None
-    if cwd is not None and is_low_risk_standalone_git_routine(context):
+    if cwd is not None and is_low_risk_standalone_git_routine(context, home_dir=trusted_home):
         return None
     if context.complete and all(
-        not _segment_invokes_git_fetch(segment.tokens) or is_low_risk_git_inspection_segment(segment)
+        not _segment_invokes_git_fetch(segment.tokens)
+        or is_low_risk_git_inspection_segment(segment, home_dir=trusted_home)
         for segment in context.segments
     ):
         return None

--- a/tests/fixtures/guard-command-corpus/decision-diff-report.json
+++ b/tests/fixtures/guard-command-corpus/decision-diff-report.json
@@ -12,7 +12,7 @@
     },
     "sources_sha256": {
       "source-0181b7136f7bc07d3738def8": "198f5e851641f0efc2187c46877c61d6049d9aac53943f205febbcf8ef29c45a",
-      "source-01febcca4015bcd1b7aeebc7": "fca0e5de75cb02ce57efe129b228e352a3890f35c6698d339acb88317c57dc13",
+      "source-01febcca4015bcd1b7aeebc7": "a9a8ef9a75eec21ad377db812cffde0e8ab1d835c671f97b859db8506e591256",
       "source-02697a55adfb35c263740ec9": "70763bb670c4a0afaa87f9929dc77a66086fd70c5d6611525209754b710e2ce3",
       "source-02aeab3ad023a11ada3b7743": "82eb33d49c84e6d2b907b0de245fc1ff9bc991af96124cff3071e9bb02fa1e34",
       "source-02c7cfdf8b65ef460436b48e": "80c64da53cb971af074a04b493c12a5cc2c4ef7f3dda34d415ff7f2cdec553e2",

--- a/tests/test_guard_standalone_git_routine.py
+++ b/tests/test_guard_standalone_git_routine.py
@@ -446,6 +446,70 @@ def test_standalone_fetch_accepts_canonical_github_https_rewrite(tmp_path: Path)
         )
 
 
+def test_standalone_fetch_accepts_canonical_home_git_c_target(tmp_path: Path) -> None:
+    home, _repository_path = _repository(tmp_path)
+    workspace = home / "workspace"
+    workspace.mkdir()
+    command = "git -C ~/projects/example fetch origin release/3.0"
+
+    assert _is_benign(command, home=home, repository=workspace)
+    assert (
+        extract_sensitive_tool_action_request(
+            "Bash",
+            {"command": command},
+            cwd=workspace,
+            home_dir=home,
+        )
+        is None
+    )
+    assert (
+        _hook_runtime_artifact(
+            harness="codex",
+            payload={
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {"command": command},
+                "cwd": str(workspace),
+            },
+            action_envelope=None,
+            home_dir=home,
+            guard_home=home / ".guard",
+            workspace=workspace,
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    "repository_operand",
+    (
+        "~//projects/example",
+        "~/projects/../projects/example",
+        "'~/projects/example'",
+        '"~/projects/example"',
+        r"\~/projects/example",
+    ),
+)
+def test_standalone_fetch_rejects_ambiguous_home_git_c_target(
+    tmp_path: Path,
+    repository_operand: str,
+) -> None:
+    home, _repository_path = _repository(tmp_path)
+    workspace = home / "workspace"
+    workspace.mkdir()
+    command = f"git -C {repository_operand} fetch origin release/3.0"
+
+    assert not _is_benign(command, home=home, repository=workspace)
+    request = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": command},
+        cwd=workspace,
+        home_dir=home,
+    )
+    assert request is not None
+    assert request.action_class == "unverified Git remote refresh"
+
+
 def test_standalone_fetch_rejects_absolute_git_c_target_outside_execution_root(tmp_path: Path) -> None:
     home, repository = _repository(tmp_path)
     outside = tmp_path / "outside"


### PR DESCRIPTION
## Summary

- recognize canonical unquoted `~/...` repositories for bounded `git -C` fetches
- retain trusted Git, repository containment, GitHub origin, ref, and execution-config checks
- keep ambiguous paths, widened fetches, executable configuration, and symlink escapes gated

## Testing

- `uv run --no-sync pytest -q tests/test_guard_standalone_git_routine.py tests/test_guard_readonly_compound_false_positives.py tests/test_guard_command_extensions.py tests/test_guard_extension_control_hook.py --tb=short`
- `uv run --no-sync ruff check ...`
- `uv run --no-sync ruff format --check ...`
- `uv run --no-sync basedpyright --level error ...`
- `uv run --no-sync python tests/guard_command_decision_diff.py --check`
- test-suite inventory and ratchet validation

## Security boundary

Only a canonical, unquoted current-user home path is newly recognized. The resolved repository must remain inside the supplied home and pass the existing trusted-binary, origin, ref, routing, credential-helper, and hook checks. Quoted, escaped, doubled-separator, traversal, symlink-escape, alternate-remote, forced-refspec, and config-injection variants remain reviewable.
