### PR TITLE
fix(dashboard): persist explicit protection posture on Settings save

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 15004,
-  "maximum_test_source_lines": 323381,
+  "maximum_test_source_lines": 323416,
   "schema_version": 1
 }

--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -924,18 +924,6 @@ export type GuardProtectionCapability = {
   limited: boolean;
 };
 
-export type GuardProtectionCapability = {
-  harness: string;
-  display_name: string;
-  can_pre_block: boolean;
-  can_ask_inline: boolean;
-  has_native_remember: boolean;
-  fail_open_on_hook_failure: boolean;
-  can_pre_block_limited: boolean;
-  honesty_sentence: string;
-  limited: boolean;
-};
-
 export type GuardSettingsPayload = {
   guard_home: string;
   config_path: string;

--- a/dashboard/src/settings-workspace.tsx
+++ b/dashboard/src/settings-workspace.tsx
@@ -392,12 +392,18 @@ function normalizeGuardSettings(settings: GuardSettings): GuardSettings {
 
 function applyProtectionPosture(settings: GuardSettings, posture: ProtectionPosture): GuardSettings {
   if (posture === "watch") {
-    return { ...settings, protection_posture: "watch", mode: "observe" };
+    return {
+      ...settings,
+      protection_posture: "watch",
+      protection_posture_explicit: true,
+      mode: "observe",
+    };
   }
   const securityLevel = posture === "extra_careful" ? "strict" : "balanced";
   return {
     ...settings,
     protection_posture: posture,
+    protection_posture_explicit: true,
     mode: "enforce",
     security_level: securityLevel,
     risk_actions: riskProfileActions[securityLevel],

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/settings-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/settings-workspace.js
@@ -2660,12 +2660,18 @@ function normalizeGuardSettings(settings) {
 }
 function applyProtectionPosture(settings, posture) {
   if (posture === "watch") {
-    return { ...settings, protection_posture: "watch", mode: "observe" };
+    return {
+      ...settings,
+      protection_posture: "watch",
+      protection_posture_explicit: true,
+      mode: "observe"
+    };
   }
   const securityLevel = posture === "extra_careful" ? "strict" : "balanced";
   return {
     ...settings,
     protection_posture: posture,
+    protection_posture_explicit: true,
     mode: "enforce",
     security_level: securityLevel,
     risk_actions: riskProfileActions[securityLevel],

--- a/tests/test_guard_protection_posture.py
+++ b/tests/test_guard_protection_posture.py
@@ -135,6 +135,41 @@ def test_settings_echo_does_not_persist_derived_posture(tmp_path: Path) -> None:
     assert resolve_risk_action(loaded, "network_egress", harness="codex") == "warn"
 
 
+def test_settings_save_blob_with_explicit_watch_stamps_entered_at(tmp_path: Path) -> None:
+    guard_home = tmp_path / ".hol-guard"
+    loaded = update_guard_settings(
+        guard_home,
+        {
+            "mode": "observe",
+            "security_level": "balanced",
+            "risk_actions": {},
+            "protection_posture": "watch",
+            "protection_posture_explicit": True,
+        },
+    )
+    assert loaded.protection_posture == "watch"
+    assert loaded.protection_posture_explicit is True
+    assert loaded.mode == "observe"
+    assert loaded.watch_entered_at is not None
+
+
+def test_settings_save_blob_with_explicit_protected_uses_posture_maps(tmp_path: Path) -> None:
+    guard_home = tmp_path / ".hol-guard"
+    loaded = update_guard_settings(
+        guard_home,
+        {
+            "mode": "enforce",
+            "security_level": "balanced",
+            "risk_actions": {},
+            "protection_posture": "protected",
+            "protection_posture_explicit": True,
+        },
+    )
+    assert loaded.protection_posture_explicit is True
+    assert resolve_risk_action(loaded, "network_egress", harness="codex") == "allow"
+    assert resolve_risk_action(loaded, "package_script", harness="codex") == "require-reapproval"
+
+
 def test_mode_prompt_does_not_clear_explicit_protected(tmp_path: Path) -> None:
     guard_home = tmp_path / ".hol-guard"
     update_guard_settings(guard_home, {"protection_posture": "protected"})


### PR DESCRIPTION
## Summary
- Mark a chosen Protection radio as an explicit posture so a full Settings save is not treated as a derived echo.
- Watch saves now record when Watch started so the 24-hour auto-revert can run.
- Protected and Extra careful saves now keep the posture risk maps.
- Remove a duplicate GuardProtectionCapability type alias.

## Testing
- uv run --no-sync pytest tests/test_guard_protection_posture.py -q
- bun run test in dashboard