### PR TITLE
fix(guard): recover stuck local protection hooks and evidence

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12730,
-  "maximum_test_source_lines": 290450,
+  "maximum_collected_cases": 12737,
+  "maximum_test_source_lines": 290523,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12737,
-  "maximum_test_source_lines": 290523,
+  "maximum_collected_cases": 12738,
+  "maximum_test_source_lines": 290547,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 12738,
-  "maximum_test_source_lines": 290749,
+  "maximum_test_source_lines": 290887,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 12738,
-  "maximum_test_source_lines": 290997,
+  "maximum_test_source_lines": 291020,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 12738,
-  "maximum_test_source_lines": 290887,
+  "maximum_test_source_lines": 290997,
   "schema_version": 1
 }

--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -28,7 +28,7 @@ import type { AppView } from "./approval-center-primitives";
 import { buildClearPayload } from "./clear-policy-payload";
 import { harnessDisplayName, normalizeHarnessSlug } from "./approval-center-utils";
 import { ErrorBoundary } from "./error-boundary";
-import { protectionHealthFor } from "./protection-health";
+import { protectionHealthFor, remainingProtectionRepairParts } from "./protection-health";
 import { selectNextAfterResolution } from "./queue-state";
 import { useRouteFocus } from "./use-route-focus";
 
@@ -793,11 +793,19 @@ export function App() {
     }
     const remainingHealth = protectionHealthFor(refreshedSnapshot);
     if (remainingHealth.state !== "protected") {
-      const failedApps = remainingHealth.apps
-        .filter((app) => app.checks.some((check) => check.status === "fail"))
-        .map((app) => harnessDisplayName(app.harness));
-      const remaining = failedApps.length > 0
-        ? `${failedApps.join(", ")} still ${failedApps.length === 1 ? "needs" : "need"} repair.`
+      const remainingParts = remainingProtectionRepairParts(remainingHealth);
+      const failedHookApps = remainingParts.failedHookHarnesses.map((harness) => harnessDisplayName(harness));
+      const remainingMessages: string[] = [];
+      if (failedHookApps.length > 0) {
+        remainingMessages.push(
+          `${failedHookApps.join(", ")} still ${failedHookApps.length === 1 ? "needs" : "need"} hook repair.`,
+        );
+      }
+      if (remainingParts.evidenceFailed) {
+        remainingMessages.push("Command evidence still needs repair.");
+      }
+      const remaining = remainingMessages.length > 0
+        ? remainingMessages.join(" ")
         : "A local protection check still needs attention.";
       throw new Error(`${remaining} Open the repair details below for the exact check.`);
     }

--- a/dashboard/src/protection-health.test.ts
+++ b/dashboard/src/protection-health.test.ts
@@ -146,6 +146,17 @@ assert.deepEqual(remainingProtectionRepairParts(evidenceOnlyHealth), {
   evidenceFailed: true,
 });
 
+const evidenceUnknown = checks();
+evidenceUnknown[PROTECTION_CHECK_IDS.indexOf("decision_stream")] = {
+  check_id: "decision_stream",
+  status: "unknown",
+  reason_code: "decision_stream_gap",
+};
+assert.equal(
+  remainingProtectionRepairParts(normalizeProtectionHealth(payload(evidenceUnknown))).evidenceFailed,
+  true,
+);
+
 const hookFailureChecks = checks();
 hookFailureChecks[PROTECTION_CHECK_IDS.indexOf("harness_hooks")] = {
   check_id: "harness_hooks",

--- a/dashboard/src/protection-health.test.ts
+++ b/dashboard/src/protection-health.test.ts
@@ -6,6 +6,7 @@ import {
   PROTECTION_CHECK_IDS,
   protectionHeadlineFor,
   protectionHealthFor,
+  remainingProtectionRepairParts,
 } from "./protection-health";
 import type { GuardProtectionCheck, GuardRuntimeSnapshot } from "./guard-types";
 
@@ -118,6 +119,57 @@ const fleetSource = readFileSync(new URL("./fleet-workspace.tsx", import.meta.ur
 const reviewStatesSource = readFileSync(new URL("./review-states.tsx", import.meta.url), "utf8");
 assert.match(appSource, /const handleRepairProtection = useCallback/);
 assert.match(appSource, /onRepairProtection=\{handleRepairProtection\}/);
+assert.match(appSource, /remainingProtectionRepairParts\(remainingHealth\)/);
+assert.match(appSource, /Command evidence still needs repair/);
+assert.doesNotMatch(appSource, /app\.checks\.some\(\(check\) => check\.status === "fail"\)/);
+
+const evidenceOnlyHealth = normalizeProtectionHealth({
+  ...payload(decisionFailure),
+  apps: [
+    {
+      harness: "grok",
+      state: "degraded",
+      label: "Degraded",
+      detail: "Shared evidence failed.",
+      evidence_gap: false,
+      reason_codes: ["hooks_verified"],
+      checks: checks().map((check) => (
+        check.check_id === "decision_stream"
+          ? { check_id: "decision_stream", status: "fail", reason_code: "decision_stream_failed" }
+          : check
+      )),
+    },
+  ],
+});
+assert.deepEqual(remainingProtectionRepairParts(evidenceOnlyHealth), {
+  failedHookHarnesses: [],
+  evidenceFailed: true,
+});
+
+const hookFailureChecks = checks();
+hookFailureChecks[PROTECTION_CHECK_IDS.indexOf("harness_hooks")] = {
+  check_id: "harness_hooks",
+  status: "fail",
+  reason_code: "hook_verification_failed",
+};
+const hookFailureHealth = normalizeProtectionHealth({
+  ...payload(hookFailureChecks),
+  apps: [
+    {
+      harness: "grok",
+      state: "degraded",
+      label: "Degraded",
+      detail: "Hooks failed.",
+      evidence_gap: false,
+      reason_codes: ["hook_verification_failed"],
+      checks: hookFailureChecks,
+    },
+  ],
+});
+assert.deepEqual(remainingProtectionRepairParts(hookFailureHealth), {
+  failedHookHarnesses: ["grok"],
+  evidenceFailed: false,
+});
 assert.match(appDetailSource, /Install state" value=\{active \? "Installed"/);
 assert.match(appDetailSource, /protectionHealthFor\(runtime, harness\)/);
 assert.match(fleetSource, /resolveAppStatus\(install, appProtection,/);

--- a/dashboard/src/protection-health.ts
+++ b/dashboard/src/protection-health.ts
@@ -172,3 +172,15 @@ export function protectionHealthFor(
   const fallback = healthFromChecks(fallbackChecks());
   return { harness: STABLE_ID.test(harness) && harness.length <= 64 ? harness : "unknown", ...fallback };
 }
+
+export function remainingProtectionRepairParts(health: GuardProtectionHealth): {
+  failedHookHarnesses: string[];
+  evidenceFailed: boolean;
+} {
+  return {
+    failedHookHarnesses: health.apps
+      .filter((app) => app.checks.some((check) => check.check_id === "harness_hooks" && check.status === "fail"))
+      .map((app) => app.harness),
+    evidenceFailed: health.checks.some((check) => check.check_id === "decision_stream" && check.status === "fail"),
+  };
+}

--- a/dashboard/src/protection-health.ts
+++ b/dashboard/src/protection-health.ts
@@ -181,6 +181,6 @@ export function remainingProtectionRepairParts(health: GuardProtectionHealth): {
     failedHookHarnesses: health.apps
       .filter((app) => app.checks.some((check) => check.check_id === "harness_hooks" && check.status === "fail"))
       .map((app) => app.harness),
-    evidenceFailed: health.checks.some((check) => check.check_id === "decision_stream" && check.status === "fail"),
+    evidenceFailed: health.checks.some((check) => check.check_id === "decision_stream" && check.status !== "pass"),
   };
 }

--- a/src/codex_plugin_scanner/guard/adapters/grok.py
+++ b/src/codex_plugin_scanner/guard/adapters/grok.py
@@ -384,7 +384,7 @@ class GrokHarnessAdapter(HarnessAdapter):
         grok_root = self._grok_root(context)
         managed_config_path = self._managed_config_path(context)
         hooks_dir = self._hooks_dir(context)
-        _ensure_path_within_root(context.home_dir, managed_config_path, label="Grok")
+        _ensure_path_within_root(self._grok_home_dir(context), managed_config_path, label="Grok")
         grok_root.mkdir(parents=True, exist_ok=True)
         hooks_dir.mkdir(parents=True, exist_ok=True)
         state_dir = self._managed_state_dir(context)
@@ -429,8 +429,12 @@ class GrokHarnessAdapter(HarnessAdapter):
         return {
             "harness": self.harness,
             "active": True,
-            "config_path": str(managed_config_path),
             **shim_manifest,
+            "config_path": str(managed_config_path),
+            "managed_config_path": str(managed_config_path),
+            "managed_hooks_path": str(pretool_path),
+            "pretool_hook_path": str(pretool_path),
+            "prompt_hook_path": str(prompt_path),
             "notes": [
                 "Guard catch-all PreToolUse hook installed in .grok/hooks/hol-guard-pretooluse.json",
                 "Guard observe hooks installed for prompts, session start, and subagent start",
@@ -449,7 +453,7 @@ class GrokHarnessAdapter(HarnessAdapter):
         managed_config_path = self._managed_config_path(context)
         hooks_dir = self._hooks_dir(context)
         if managed_config_path.is_file():
-            _ensure_path_within_root(context.home_dir, managed_config_path, label="Grok")
+            _ensure_path_within_root(self._grok_home_dir(context), managed_config_path, label="Grok")
             existing_text = managed_config_path.read_text(encoding="utf-8")
             managed_config_path.write_text(remove_managed_block(existing_text).rstrip() + "\n", encoding="utf-8")
 

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -1460,6 +1460,11 @@ def _live_hook_verification(
 
                 verified[harness] = cursor_native_hook_state(context).get("protection_active") is True
                 continue
+            if harness == "grok":
+                from .cli.install_commands import grok_hooks_protection_ready
+
+                verified[harness] = grok_hooks_protection_ready(context)
+                continue
             verified[harness] = verify_managed_install_proof(install.get("manifest"), context) is True
         except (ImportError, OSError, RuntimeError, TypeError, ValueError):
             continue

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -351,8 +351,15 @@ def _grok_pretool_is_catchall(pretool_hook: Path) -> bool:
 
 def _grok_hook_command_is_guard(command: str) -> bool:
     lowered = command.lower()
+    tokens = lowered.replace("=", " ").replace(",", " ").split()
+    if not tokens:
+        return False
+    first = tokens[0].rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+    if first in {"echo", "true", "false", "printf", ":"}:
+        return False
     return "hook" in lowered and (
-        "hol-guard" in lowered
+        "hol-guard" in tokens
+        or any(token.endswith("/hol-guard") or token.endswith("\\hol-guard") for token in tokens)
         or "__guard-bounded-hook" in lowered
         or "bounded_cli_hook_bridge" in lowered
         or "codex_plugin_scanner.guard" in lowered
@@ -391,7 +398,7 @@ def _grok_event_has_command_hook(entries: object) -> bool:
             if not isinstance(hook_entry, dict) or hook_entry.get("type") != "command":
                 continue
             command = hook_entry.get("command")
-            if isinstance(command, str) and command.strip():
+            if isinstance(command, str) and _grok_hook_command_is_guard(command):
                 return True
     return False
 
@@ -404,10 +411,8 @@ def _grok_managed_config_is_active(managed_text: str) -> bool:
     if start < 0 or stop <= start:
         return False
     for line in managed_text[start:stop].splitlines():
-        stripped = line.strip()
-        if stripped.startswith("#"):
-            continue
-        if "Read(**/.grok/auth/**)" in stripped:
+        active = line.split("#", 1)[0].strip()
+        if "Read(**/.grok/auth/**)" in active:
             return True
     return False
 

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -379,10 +379,7 @@ def _grok_prompt_hook_is_observe(prompt_hook: Path) -> bool:
     if not isinstance(hooks, dict):
         return False
     required = ("UserPromptSubmit", "SubagentStart", "SessionStart")
-    for event_name in required:
-        if not _grok_event_has_command_hook(hooks.get(event_name)):
-            return False
-    return True
+    return all(_grok_event_has_command_hook(hooks.get(event_name)) for event_name in required)
 
 
 def _grok_event_has_command_hook(entries: object) -> bool:

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -349,6 +349,23 @@ def _grok_pretool_is_catchall(pretool_hook: Path) -> bool:
     return nested[0].get("type") == "command" and isinstance(command, str) and bool(command.strip())
 
 
+def grok_hooks_protection_ready(context: HarnessContext) -> bool:
+    """Return whether live Grok hook files and managed permission rules are active."""
+
+    checks = _grok_protection_checks(context)
+    hook_warnings = [
+        warning
+        for warning in checks.get("warnings", [])
+        if isinstance(warning, str) and "shim" not in warning.lower() and "launcher" not in warning.lower()
+    ]
+    return (
+        checks.get("pretool_catchall_installed") is True
+        and checks.get("prompt_hook_installed") is True
+        and checks.get("managed_config_installed") is True
+        and not hook_warnings
+    )
+
+
 def _grok_protection_checks(context: HarnessContext) -> dict[str, object]:
     from ..adapters.grok import GrokHarnessAdapter
 

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -371,12 +371,45 @@ def _grok_prompt_hook_is_observe(prompt_hook: Path) -> bool:
     hooks = payload.get("hooks")
     if not isinstance(hooks, dict):
         return False
-    required = {"UserPromptSubmit", "SubagentStart", "SessionStart"}
-    return required.issubset({name for name in hooks if isinstance(name, str)})
+    required = ("UserPromptSubmit", "SubagentStart", "SessionStart")
+    for event_name in required:
+        if not _grok_event_has_command_hook(hooks.get(event_name)):
+            return False
+    return True
+
+
+def _grok_event_has_command_hook(entries: object) -> bool:
+    if not isinstance(entries, list) or not entries:
+        return False
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        nested = entry.get("hooks")
+        if not isinstance(nested, list):
+            continue
+        for hook_entry in nested:
+            if not isinstance(hook_entry, dict) or hook_entry.get("type") != "command":
+                continue
+            command = hook_entry.get("command")
+            if isinstance(command, str) and command.strip():
+                return True
+    return False
 
 
 def _grok_managed_config_is_active(managed_text: str) -> bool:
-    return "BEGIN HOL GUARD MANAGED GROK" in managed_text and "Read(**/.grok/auth/**)" in managed_text
+    from ..adapters.grok_config import GUARD_MANAGED_BEGIN, GUARD_MANAGED_END
+
+    start = managed_text.find(GUARD_MANAGED_BEGIN)
+    stop = managed_text.find(GUARD_MANAGED_END)
+    if start < 0 or stop <= start:
+        return False
+    for line in managed_text[start:stop].splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        if "Read(**/.grok/auth/**)" in stripped:
+            return True
+    return False
 
 
 def grok_hooks_protection_ready(context: HarnessContext) -> bool:

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -346,11 +346,7 @@ def _grok_pretool_is_catchall(pretool_hook: Path) -> bool:
     if not isinstance(nested, list) or len(nested) != 1 or not isinstance(nested[0], dict):
         return False
     command = nested[0].get("command")
-    return (
-        nested[0].get("type") == "command"
-        and isinstance(command, str)
-        and _grok_hook_command_is_guard(command)
-    )
+    return nested[0].get("type") == "command" and isinstance(command, str) and _grok_hook_command_is_guard(command)
 
 
 def _grok_hook_command_is_guard(command: str) -> bool:

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -357,6 +357,7 @@ def _grok_hook_command_is_guard(command: str) -> bool:
     lowered = command.lower()
     return "hook" in lowered and (
         "hol-guard" in lowered
+        or "__guard-bounded-hook" in lowered
         or "bounded_cli_hook_bridge" in lowered
         or "codex_plugin_scanner.guard" in lowered
     )

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -346,16 +346,51 @@ def _grok_pretool_is_catchall(pretool_hook: Path) -> bool:
     if not isinstance(nested, list) or len(nested) != 1 or not isinstance(nested[0], dict):
         return False
     command = nested[0].get("command")
-    return nested[0].get("type") == "command" and isinstance(command, str) and bool(command.strip())
+    return (
+        nested[0].get("type") == "command"
+        and isinstance(command, str)
+        and _grok_hook_command_is_guard(command)
+    )
+
+
+def _grok_hook_command_is_guard(command: str) -> bool:
+    lowered = command.lower()
+    return "hook" in lowered and (
+        "hol-guard" in lowered
+        or "bounded_cli_hook_bridge" in lowered
+        or "codex_plugin_scanner.guard" in lowered
+    )
+
+
+def _grok_prompt_hook_is_observe(prompt_hook: Path) -> bool:
+    if not prompt_hook.is_file():
+        return False
+    try:
+        payload = json.loads(prompt_hook.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    hooks = payload.get("hooks")
+    if not isinstance(hooks, dict):
+        return False
+    required = {"UserPromptSubmit", "SubagentStart", "SessionStart"}
+    return required.issubset({name for name in hooks if isinstance(name, str)})
+
+
+def _grok_managed_config_is_active(managed_text: str) -> bool:
+    return "BEGIN HOL GUARD MANAGED GROK" in managed_text and "Read(**/.grok/auth/**)" in managed_text
 
 
 def grok_hooks_protection_ready(context: HarnessContext) -> bool:
     """Return whether live Grok hook files and managed permission rules are active."""
 
     checks = _grok_protection_checks(context)
+    warnings = checks.get("warnings")
+    warning_items = warnings if isinstance(warnings, list) else []
     hook_warnings = [
         warning
-        for warning in checks.get("warnings", [])
+        for warning in warning_items
         if isinstance(warning, str) and "shim" not in warning.lower() and "launcher" not in warning.lower()
     ]
     return (
@@ -381,8 +416,13 @@ def _grok_protection_checks(context: HarnessContext) -> dict[str, object]:
         warnings.append(
             "Grok Guard pre-tool hook still uses a stale per-tool matcher list. Re-run `hol-guard apps repair grok`."
         )
+    elif not _grok_prompt_hook_is_observe(prompt_hook):
+        warnings.append(
+            "Grok Guard observe hooks are missing prompt, session, or subagent events. "
+            "Re-run `hol-guard apps repair grok`."
+        )
     managed_text = managed_config.read_text(encoding="utf-8") if managed_config.is_file() else ""
-    if not managed_config.is_file() or "BEGIN HOL GUARD MANAGED GROK" not in managed_text:
+    if not managed_config.is_file() or not _grok_managed_config_is_active(managed_text):
         warnings.append(
             "Grok managed permission rules are missing from ~/.grok/managed_config.toml. "
             "Re-run `hol-guard apps connect grok`."

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1917,9 +1917,7 @@ def _repair_command_activity_persistence_health(store: GuardStore) -> None:
     evaluation = evaluate_command(_PROTECTION_REPAIR_PROBE_COMMAND)
     occurred_at = datetime.now(timezone.utc)
     activity_id = f"activity:protection-repair-probe:{uuid.uuid4().hex}"
-    decision_reason = (
-        ActivityDecisionReason.EXTENSION_MATCH if evaluation.matches else ActivityDecisionReason.NO_MATCH
-    )
+    decision_reason = ActivityDecisionReason.EXTENSION_MATCH if evaluation.matches else ActivityDecisionReason.NO_MATCH
     evidence = build_pre_hook_evidence(
         evaluation,
         CommandActivityDecisionFacts(

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1933,6 +1933,7 @@ def _repair_command_activity_persistence_health(store: GuardStore) -> None:
         request_correlation=None,
     )
     shadow = None
+    shadow_evaluation_succeeded = True
     try:
         shadow = build_command_shadow_observation(
             evaluation,
@@ -1950,10 +1951,11 @@ def _repair_command_activity_persistence_health(store: GuardStore) -> None:
         )
     except (RuntimeError, TypeError, ValueError):
         shadow = None
+        shadow_evaluation_succeeded = False
     store.probe_command_activity_persistence(
         evidence,
         shadow=shadow,
-        shadow_evaluation_succeeded=True,
+        shadow_evaluation_succeeded=shadow_evaluation_succeeded,
     )
 
 

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1910,41 +1910,81 @@ def _finalize_daemon_guard_connect_payload(
     return payload
 
 
+_PROTECTION_REPAIR_PROBE_COMMAND = "git status --porcelain=v1"
+
+
 def _repair_command_activity_persistence_health(store: GuardStore) -> None:
-    shadow_evaluation = evaluate_command("git push origin release/2.1 --force")
-    shadow_proposal = baseline_command_shadow_proposal(shadow_evaluation)
+    evaluation = evaluate_command(_PROTECTION_REPAIR_PROBE_COMMAND)
     occurred_at = datetime.now(timezone.utc)
+    activity_id = f"activity:protection-repair-probe:{uuid.uuid4().hex}"
+    decision_reason = (
+        ActivityDecisionReason.EXTENSION_MATCH if evaluation.matches else ActivityDecisionReason.NO_MATCH
+    )
     evidence = build_pre_hook_evidence(
-        shadow_evaluation,
+        evaluation,
         CommandActivityDecisionFacts(
             policy_action="allow",
-            decision_reason_code=ActivityDecisionReason.EXTENSION_MATCH,
+            decision_reason_code=decision_reason,
             prompted=False,
             approval_reuse_status=ActivityApprovalReuseStatus.NOT_APPLICABLE,
             receipt_id=None,
         ),
-        activity_id="activity:protection-repair-probe",
+        activity_id=activity_id,
         occurred_at=occurred_at,
         harness="codex",
         request_correlation=None,
     )
-    shadow = build_command_shadow_observation(
-        shadow_evaluation,
-        authoritative_action="allow",
-        proposal=shadow_proposal,
-        activity_id="activity:protection-repair-probe",
-        occurred_at=occurred_at,
-        control=CommandShadowControl(
-            enabled=True,
-            kill_switch=False,
-            release_cohorts=frozenset({CommandShadowCohort.BASELINE}),
-            disabled_cohorts=frozenset(),
-            sample_basis_points=10_000,
-        ),
+    shadow = None
+    try:
+        shadow = build_command_shadow_observation(
+            evaluation,
+            authoritative_action="allow",
+            proposal=baseline_command_shadow_proposal(evaluation),
+            activity_id=activity_id,
+            occurred_at=occurred_at,
+            control=CommandShadowControl(
+                enabled=True,
+                kill_switch=False,
+                release_cohorts=frozenset({CommandShadowCohort.BASELINE}),
+                disabled_cohorts=frozenset(),
+                sample_basis_points=10_000,
+            ),
+        )
+    except (RuntimeError, TypeError, ValueError):
+        shadow = None
+    store.probe_command_activity_persistence(
+        evidence,
+        shadow=shadow,
+        shadow_evaluation_succeeded=True,
     )
-    if shadow is None:
-        raise RuntimeError("command shadow repair probe was not selected")
-    store.probe_command_activity_persistence(evidence, shadow=shadow)
+
+
+def _repair_failing_managed_harness_hooks(store: GuardStore) -> list[str]:
+    from ..approvals import _live_hook_verification
+
+    installs = store.list_managed_installs()
+    context = HarnessContext(
+        home_dir=Path.home().resolve(),
+        workspace_dir=None,
+        guard_home=store.guard_home,
+    )
+    verified = _live_hook_verification(installs, store)
+    failed: list[str] = []
+    for install in installs:
+        harness = install.get("harness")
+        if not isinstance(harness, str) or install.get("active") is not True:
+            continue
+        if verified.get(harness) is True:
+            continue
+        try:
+            apply_managed_install("install", harness, False, context, store, None, _now())
+        except (OSError, RuntimeError, TypeError, ValueError):
+            failed.append(harness)
+            continue
+        refreshed = store.get_managed_install(harness)
+        if refreshed is None or _live_hook_verification([refreshed], store).get(harness) is not True:
+            failed.append(harness)
+    return failed
 
 
 class _GuardDaemonHandler(BaseHTTPRequestHandler):
@@ -4776,39 +4816,54 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             reason_count = len(degraded_reasons) if isinstance(degraded_reasons, list) else 0
             repaired_check_ids = ["policy_engine", "rule_packs", "tamper_checks"]
             pending_check_ids: list[str] = []
-            if check_id == "all" and repaired:
-                failed_check_ids: list[str] = []
+            failed_check_ids: list[str] = []
+            if check_id == "all":
                 try:
-                    containment_health = self._containment_health_payload(force_refresh=True)
-                    refreshed_signals = containment_health_signals(
-                        containment_health,
-                        now=datetime.now(timezone.utc),
-                    )
-                    for containment_check_id in (
-                        "decision_plane_compatibility",
-                        "containment_compatibility",
-                        "sandbox",
-                    ):
-                        if refreshed_signals[containment_check_id].status is ProtectionCheckStatus.PASS:
-                            repaired_check_ids.append(containment_check_id)
-                        else:
-                            failed_check_ids.append(containment_check_id)
+                    hook_failures = _repair_failing_managed_harness_hooks(store)
                 except (OSError, RuntimeError, TypeError, ValueError, sqlite3.Error):
-                    failed_check_ids.extend(["decision_plane_compatibility", "containment_compatibility", "sandbox"])
-                try:
-                    config = load_guard_config(store.guard_home)
-                    _repair_command_activity_persistence_health(store)
-                    store.maintain_command_activity(
-                        now=datetime.now(timezone.utc),
-                        detail_retain_days=config.evidence_retain_days,
-                    )
-                    evidence_health = store.get_command_activity_persistence_health()
-                    if evidence_health.active_error_count > 0:
+                    hook_failures = ["harness_hooks"]
+                has_active_hooks = any(
+                    isinstance(install.get("harness"), str) and install.get("active") is True
+                    for install in store.list_managed_installs()
+                )
+                if hook_failures:
+                    failed_check_ids.append("harness_hooks")
+                elif has_active_hooks:
+                    repaired_check_ids.append("harness_hooks")
+                if repaired:
+                    try:
+                        containment_health = self._containment_health_payload(force_refresh=True)
+                        refreshed_signals = containment_health_signals(
+                            containment_health,
+                            now=datetime.now(timezone.utc),
+                        )
+                        for containment_check_id in (
+                            "decision_plane_compatibility",
+                            "containment_compatibility",
+                            "sandbox",
+                        ):
+                            if refreshed_signals[containment_check_id].status is ProtectionCheckStatus.PASS:
+                                repaired_check_ids.append(containment_check_id)
+                            else:
+                                failed_check_ids.append(containment_check_id)
+                    except (OSError, RuntimeError, TypeError, ValueError, sqlite3.Error):
+                        failed_check_ids.extend(
+                            ["decision_plane_compatibility", "containment_compatibility", "sandbox"]
+                        )
+                    try:
+                        config = load_guard_config(store.guard_home)
+                        _repair_command_activity_persistence_health(store)
+                        store.maintain_command_activity(
+                            now=datetime.now(timezone.utc),
+                            detail_retain_days=config.evidence_retain_days,
+                        )
+                        evidence_health = store.get_command_activity_persistence_health()
+                        if evidence_health.active_error_count > 0:
+                            failed_check_ids.append("decision_stream")
+                        else:
+                            repaired_check_ids.append("decision_stream")
+                    except (OSError, RuntimeError, TypeError, ValueError, sqlite3.Error):
                         failed_check_ids.append("decision_stream")
-                    else:
-                        repaired_check_ids.append("decision_stream")
-                except (OSError, RuntimeError, TypeError, ValueError):
-                    failed_check_ids.append("decision_stream")
                 if failed_check_ids or pending_check_ids:
                     self._write_json(
                         {
@@ -4867,6 +4922,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._write_json(
                 {
                     "repaired": repaired,
+                    "repair_scope": "local_integrity",
                     "check_ids": ["decision_stream"],
                     "message": (
                         "Command evidence is healthy."

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -15446,6 +15446,12 @@ function protectionHealthFor(snapshot, harness = null) {
   const fallback = healthFromChecks(fallbackChecks());
   return { harness: STABLE_ID$1.test(harness) && harness.length <= 64 ? harness : "unknown", ...fallback };
 }
+function remainingProtectionRepairParts(health) {
+  return {
+    failedHookHarnesses: health.apps.filter((app) => app.checks.some((check) => check.check_id === "harness_hooks" && check.status === "fail")).map((app) => app.harness),
+    evidenceFailed: health.checks.some((check) => check.check_id === "decision_stream" && check.status === "fail")
+  };
+}
 const TARGETS$1 = /* @__PURE__ */ new Set(["exact", "category", "server"]);
 const DURATIONS$1 = /* @__PURE__ */ new Set(["once", "15m", "1h", "5h"]);
 const ROUTINE_BROWSER_OPERATIONS = /* @__PURE__ */ new Set([
@@ -31082,8 +31088,18 @@ function App() {
     }
     const remainingHealth = protectionHealthFor(refreshedSnapshot);
     if (remainingHealth.state !== "protected") {
-      const failedApps = remainingHealth.apps.filter((app) => app.checks.some((check) => check.status === "fail")).map((app) => harnessDisplayName(app.harness));
-      const remaining = failedApps.length > 0 ? `${failedApps.join(", ")} still ${failedApps.length === 1 ? "needs" : "need"} repair.` : "A local protection check still needs attention.";
+      const remainingParts = remainingProtectionRepairParts(remainingHealth);
+      const failedHookApps = remainingParts.failedHookHarnesses.map((harness) => harnessDisplayName(harness));
+      const remainingMessages = [];
+      if (failedHookApps.length > 0) {
+        remainingMessages.push(
+          `${failedHookApps.join(", ")} still ${failedHookApps.length === 1 ? "needs" : "need"} hook repair.`
+        );
+      }
+      if (remainingParts.evidenceFailed) {
+        remainingMessages.push("Command evidence still needs repair.");
+      }
+      const remaining = remainingMessages.length > 0 ? remainingMessages.join(" ") : "A local protection check still needs attention.";
       throw new Error(`${remaining} Open the repair details below for the exact check.`);
     }
     return "Automatic repairs completed. Guard rechecked every protection layer below.";

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -15449,7 +15449,7 @@ function protectionHealthFor(snapshot, harness = null) {
 function remainingProtectionRepairParts(health) {
   return {
     failedHookHarnesses: health.apps.filter((app) => app.checks.some((check) => check.check_id === "harness_hooks" && check.status === "fail")).map((app) => app.harness),
-    evidenceFailed: health.checks.some((check) => check.check_id === "decision_stream" && check.status === "fail")
+    evidenceFailed: health.checks.some((check) => check.check_id === "decision_stream" && check.status !== "pass")
   };
 }
 const TARGETS$1 = /* @__PURE__ */ new Set(["exact", "category", "server"]);

--- a/src/codex_plugin_scanner/guard/managed_install_proof.py
+++ b/src/codex_plugin_scanner/guard/managed_install_proof.py
@@ -16,6 +16,8 @@ _MANAGED_PATH_KEYS = (
     "managed_config_path",
     "managed_hooks_path",
     "plugin_path",
+    "pretool_hook_path",
+    "prompt_hook_path",
     "shim_path",
 )
 _MANAGED_PATH_LIST_KEYS = ("shim_paths",)

--- a/src/codex_plugin_scanner/guard/store_command_activity.py
+++ b/src/codex_plugin_scanner/guard/store_command_activity.py
@@ -82,7 +82,8 @@ class StoreCommandActivityMixin:
         self: _ConnectionOwner,
         evidence: CommandActivityEvidence,
         *,
-        shadow: CommandShadowObservation,
+        shadow: CommandShadowObservation | None = None,
+        shadow_evaluation_succeeded: bool = True,
     ) -> None:
         """Exercise and roll back the real command and shadow write path."""
 
@@ -95,7 +96,7 @@ class StoreCommandActivityMixin:
                     connection,
                     evidence,
                     shadow=shadow,
-                    shadow_evaluation_succeeded=True,
+                    shadow_evaluation_succeeded=shadow_evaluation_succeeded,
                 )
             except BaseException:
                 connection.execute("rollback to command_activity_repair_probe")
@@ -107,10 +108,11 @@ class StoreCommandActivityMixin:
                 connection,
                 error_domain=COMMAND_PERSISTENCE_ERROR_DOMAIN,
             )
-            recover_command_activity_persistence(
-                connection,
-                error_domain=SHADOW_PERSISTENCE_ERROR_DOMAIN,
-            )
+            if shadow is not None or shadow_evaluation_succeeded:
+                recover_command_activity_persistence(
+                    connection,
+                    error_domain=SHADOW_PERSISTENCE_ERROR_DOMAIN,
+                )
 
     def count_command_activities(self: _ConnectionOwner) -> int:
         with self._connect() as connection:

--- a/tests/test_grok_adapter.py
+++ b/tests/test_grok_adapter.py
@@ -97,6 +97,10 @@ class TestGrokInstallUninstall:
         pretool_hook = ctx.home_dir / ".grok" / "hooks" / "hol-guard-pretooluse.json"
         prompt_hook = ctx.home_dir / ".grok" / "hooks" / "hol-guard-prompt.json"
         assert manifest["active"] is True
+        assert manifest["config_path"] == str(managed_config)
+        assert manifest["managed_config_path"] == str(managed_config)
+        assert manifest["pretool_hook_path"] == str(pretool_hook)
+        assert manifest["prompt_hook_path"] == str(prompt_hook)
         assert managed_config.is_file()
         assert "BEGIN HOL GUARD MANAGED GROK" in managed_config.read_text(encoding="utf-8")
         assert pretool_hook.is_file()

--- a/tests/test_guard_command_activity_health_recovery.py
+++ b/tests/test_guard_command_activity_health_recovery.py
@@ -124,6 +124,23 @@ def test_successful_disabled_shadow_evaluation_recovers_shadow_health(tmp_path: 
     assert _health(store)["status"] == "healthy"
 
 
+def test_repair_probe_without_shadow_observation_recovers_command_and_shadow(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
+    store.record_command_activity_persistence_failure(error_code="post_record_failed", occurred_at=_NOW)
+    store.record_command_activity_persistence_failure(error_code="shadow_evaluation_failed", occurred_at=_NOW)
+    activity_evidence, _shadow = _shadow_evidence("activity:repair-probe-command-only")
+
+    store.probe_command_activity_persistence(
+        activity_evidence,
+        shadow=None,
+        shadow_evaluation_succeeded=True,
+    )
+
+    recovered = _health(store)
+    assert recovered["status"] == "healthy"
+    assert recovered["dropped_events"] == recovered["persistence_errors"] == 2
+
+
 def test_repair_probe_recovers_active_store_errors_without_resetting_history(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home", prime_policy_integrity=False)
     store.record_command_activity_persistence_failure(error_code="post_record_failed", occurred_at=_NOW)

--- a/tests/test_guard_grok_protection.py
+++ b/tests/test_guard_grok_protection.py
@@ -13,6 +13,7 @@ from codex_plugin_scanner.guard.cli.install_commands import (
     _grok_protection_checks,
     build_harness_setup_plan,
     build_harness_verification,
+    grok_hooks_protection_ready,
     uninstall_confirmation_token,
 )
 from codex_plugin_scanner.guard.models import GuardApprovalRequest
@@ -66,6 +67,7 @@ def test_grok_protection_checks_ready_after_install(tmp_path: Path, monkeypatch)
     assert checks["pretool_catchall_installed"] is True
     assert checks["managed_config_installed"] is True
     assert checks["ready"] is True
+    assert grok_hooks_protection_ready(ctx) is True
 
 
 def test_build_harness_verification_includes_grok_checks(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_guard_protect_workspace_asset.py
+++ b/tests/test_guard_protect_workspace_asset.py
@@ -17,11 +17,22 @@ def _authoritative_source() -> str:
     return "\n".join(path.read_text(encoding="utf-8") for path in (_AUTHORITATIVE_SOURCE, _RECOVERY_SOURCE))
 
 
+def test_repair_message_does_not_blame_apps_for_shared_evidence_failure() -> None:
+    app_source = Path(__file__).parents[1].joinpath("dashboard/src/app.tsx").read_text(encoding="utf-8")
+    health_source = Path(__file__).parents[1].joinpath("dashboard/src/protection-health.ts").read_text(
+        encoding="utf-8"
+    )
+    assert "remainingProtectionRepairParts" in health_source
+    assert "remainingProtectionRepairParts(remainingHealth)" in app_source
+    assert "Command evidence still needs repair." in app_source
+    assert 'app.checks.some((check) => check.status === "fail")' not in app_source
+
+
 def test_degraded_protection_exposes_recovery_actions() -> None:
     source = _source()
     authoritative_source = _authoritative_source()
 
-    assert "Restore full protection" in source
+    assert "Restore local protection" in source
     assert "protection-recovery" in source
     assert "View repair details" in source
     assert "Needs repair" in source
@@ -31,7 +42,7 @@ def test_degraded_protection_exposes_recovery_actions() -> None:
     assert "Guard could not confirm integrity protection yet." not in source
     assert 'hookCheck?.status === "fail"' in source
     assert 'check.check_id === "harness_hooks" && check.status === "fail"' in source
-    assert "Restore full protection" in authoritative_source
+    assert "Restore local protection" in authoritative_source
 
 
 def test_protection_repair_requires_local_auth_token() -> None:

--- a/tests/test_guard_protection_recovery.py
+++ b/tests/test_guard_protection_recovery.py
@@ -60,6 +60,116 @@ def test_protection_repair_probe_avoids_force_push() -> None:
     assert "git status --porcelain=v1" in _PROTECTION_REPAIR_PROBE_COMMAND
 
 
+def test_live_grok_hooks_reject_empty_observe_events(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = _ctx(tmp_path)
+    monkeypatch.setattr(Path, "home", lambda: ctx.home_dir)
+    hooks_dir = ctx.home_dir / ".grok" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    (hooks_dir / "hol-guard-pretooluse.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "hol-guard hook grok",
+                                    "timeout": 30,
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (hooks_dir / "hol-guard-prompt.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "UserPromptSubmit": [],
+                    "SubagentStart": [],
+                    "SessionStart": [],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (ctx.home_dir / ".grok" / "managed_config.toml").write_text(
+        '# BEGIN HOL GUARD MANAGED GROK\ndeny = ["Read(**/.grok/auth/**)"]\n# END HOL GUARD MANAGED GROK\n',
+        encoding="utf-8",
+    )
+    store = GuardStore(ctx.guard_home, prime_policy_integrity=False)
+    store.set_managed_install("grok", True, None, {"harness": "grok", "active": True}, "2026-08-17T12:00:00+00:00")
+    assert grok_hooks_protection_ready(ctx) is False
+
+
+def test_live_grok_hooks_reject_managed_rule_outside_block(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = _ctx(tmp_path)
+    monkeypatch.setattr(Path, "home", lambda: ctx.home_dir)
+    hooks_dir = ctx.home_dir / ".grok" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    command_hook = {
+        "hooks": [
+            {
+                "type": "command",
+                "command": "hol-guard hook grok",
+                "timeout": 15,
+            }
+        ]
+    }
+    (hooks_dir / "hol-guard-pretooluse.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "hol-guard hook grok",
+                                    "timeout": 30,
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (hooks_dir / "hol-guard-prompt.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "UserPromptSubmit": [command_hook],
+                    "SubagentStart": [command_hook],
+                    "SessionStart": [command_hook],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (ctx.home_dir / ".grok" / "managed_config.toml").write_text(
+        'deny = ["Read(**/.grok/auth/**)"]\n'
+        "# BEGIN HOL GUARD MANAGED GROK\n"
+        "# Read(**/.grok/auth/**)\n"
+        "# END HOL GUARD MANAGED GROK\n",
+        encoding="utf-8",
+    )
+    store = GuardStore(ctx.guard_home, prime_policy_integrity=False)
+    store.set_managed_install("grok", True, None, {"harness": "grok", "active": True}, "2026-08-17T12:00:00+00:00")
+    assert grok_hooks_protection_ready(ctx) is False
+
+
 def test_live_grok_hooks_fail_when_managed_config_is_missing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_guard_protection_recovery.py
+++ b/tests/test_guard_protection_recovery.py
@@ -56,10 +56,7 @@ def _stale_pretool_payload() -> dict[str, object]:
 
 
 def test_protection_repair_probe_avoids_force_push() -> None:
-    source = Path(__file__).parents[1].joinpath(
-        "src/codex_plugin_scanner/guard/daemon/server.py"
-    ).read_text(encoding="utf-8")
-    assert "git push origin release/2.1 --force" not in source
+    assert "git push" not in _PROTECTION_REPAIR_PROBE_COMMAND
     assert "git status --porcelain=v1" in _PROTECTION_REPAIR_PROBE_COMMAND
 
 
@@ -77,6 +74,33 @@ def test_live_grok_hooks_fail_when_managed_config_is_missing(
     )
     (hooks_dir / "hol-guard-prompt.json").write_text(
         json.dumps({"hooks": {"UserPromptSubmit": []}}),
+        encoding="utf-8",
+    )
+    store = GuardStore(ctx.guard_home, prime_policy_integrity=False)
+    store.set_managed_install("grok", True, None, {"harness": "grok", "active": True}, "2026-08-17T12:00:00+00:00")
+
+    assert grok_hooks_protection_ready(ctx) is False
+    assert _live_hook_verification(store.list_managed_installs(), store) == {"grok": False}
+
+
+def test_live_grok_hooks_reject_placeholder_command_and_marker_only_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = _ctx(tmp_path)
+    monkeypatch.setattr(Path, "home", lambda: ctx.home_dir)
+    hooks_dir = ctx.home_dir / ".grok" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    (hooks_dir / "hol-guard-pretooluse.json").write_text(
+        json.dumps({"hooks": {"PreToolUse": [{"hooks": [{"type": "command", "command": "true"}]}]}}),
+        encoding="utf-8",
+    )
+    (hooks_dir / "hol-guard-prompt.json").write_text(
+        json.dumps({"hooks": {"UserPromptSubmit": []}}),
+        encoding="utf-8",
+    )
+    (ctx.home_dir / ".grok" / "managed_config.toml").write_text(
+        "# BEGIN HOL GUARD MANAGED GROK\n# END HOL GUARD MANAGED GROK\n",
         encoding="utf-8",
     )
     store = GuardStore(ctx.guard_home, prime_policy_integrity=False)

--- a/tests/test_guard_protection_recovery.py
+++ b/tests/test_guard_protection_recovery.py
@@ -1,0 +1,177 @@
+"""Local protection recovery must restore hooks and evidence in one pass."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.approvals import _live_hook_verification
+from codex_plugin_scanner.guard.cli.install_commands import (
+    apply_managed_install,
+    grok_hooks_protection_ready,
+)
+from codex_plugin_scanner.guard.daemon.server import (
+    _PROTECTION_REPAIR_PROBE_COMMAND,
+    _repair_command_activity_persistence_health,
+    _repair_failing_managed_harness_hooks,
+)
+from codex_plugin_scanner.guard.managed_install_proof import (
+    bind_managed_install_proof,
+    verify_managed_install_proof,
+)
+from codex_plugin_scanner.guard.store import GuardStore
+
+_NOW = datetime(2026, 8, 17, 12, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def _clear_grok_home(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GROK_HOME", raising=False)
+
+
+def _ctx(tmp_path: Path) -> HarnessContext:
+    return HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=tmp_path / "workspace",
+        guard_home=tmp_path / "guard-home",
+    )
+
+
+def _stale_pretool_payload() -> dict[str, object]:
+    return {
+        "hooks": {
+            "PreToolUse": [
+                {"matcher": "Bash", "hooks": [{"type": "command", "command": "true", "timeout": 30}]},
+                {
+                    "matcher": "run_terminal_command",
+                    "hooks": [{"type": "command", "command": "true", "timeout": 30}],
+                },
+            ]
+        }
+    }
+
+
+def test_protection_repair_probe_avoids_force_push() -> None:
+    source = Path(__file__).parents[1].joinpath(
+        "src/codex_plugin_scanner/guard/daemon/server.py"
+    ).read_text(encoding="utf-8")
+    assert "git push origin release/2.1 --force" not in source
+    assert "git status --porcelain=v1" in _PROTECTION_REPAIR_PROBE_COMMAND
+
+
+def test_live_grok_hooks_fail_when_managed_config_is_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = _ctx(tmp_path)
+    monkeypatch.setattr(Path, "home", lambda: ctx.home_dir)
+    hooks_dir = ctx.home_dir / ".grok" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    (hooks_dir / "hol-guard-pretooluse.json").write_text(
+        json.dumps({"hooks": {"PreToolUse": [{"hooks": [{"type": "command", "command": "true"}]}]}}),
+        encoding="utf-8",
+    )
+    (hooks_dir / "hol-guard-prompt.json").write_text(
+        json.dumps({"hooks": {"UserPromptSubmit": []}}),
+        encoding="utf-8",
+    )
+    store = GuardStore(ctx.guard_home, prime_policy_integrity=False)
+    store.set_managed_install("grok", True, None, {"harness": "grok", "active": True}, "2026-08-17T12:00:00+00:00")
+
+    assert grok_hooks_protection_ready(ctx) is False
+    assert _live_hook_verification(store.list_managed_installs(), store) == {"grok": False}
+
+
+def test_live_grok_hooks_fail_stale_matchers_even_when_sha_proof_matches(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = _ctx(tmp_path)
+    monkeypatch.setattr(Path, "home", lambda: ctx.home_dir)
+    hooks_dir = ctx.home_dir / ".grok" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    pretool = hooks_dir / "hol-guard-pretooluse.json"
+    pretool.write_text(json.dumps(_stale_pretool_payload()), encoding="utf-8")
+    (hooks_dir / "hol-guard-prompt.json").write_text(
+        json.dumps({"hooks": {"UserPromptSubmit": []}}),
+        encoding="utf-8",
+    )
+    managed = ctx.home_dir / ".grok" / "managed_config.toml"
+    managed.write_text("# BEGIN HOL GUARD MANAGED GROK\n# END HOL GUARD MANAGED GROK\n", encoding="utf-8")
+    manifest = bind_managed_install_proof(
+        {
+            "config_path": str(managed),
+            "pretool_hook_path": str(pretool),
+        },
+        ctx,
+    )
+    assert verify_managed_install_proof(manifest, ctx) is True
+    store = GuardStore(ctx.guard_home, prime_policy_integrity=False)
+    store.set_managed_install("grok", True, None, manifest, "2026-08-17T12:00:00+00:00")
+
+    assert grok_hooks_protection_ready(ctx) is False
+    assert _live_hook_verification(store.list_managed_installs(), store) == {"grok": False}
+
+
+def test_grok_install_proof_covers_hooks_and_managed_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = _ctx(tmp_path)
+    monkeypatch.setattr(Path, "home", lambda: ctx.home_dir)
+    store = GuardStore(ctx.guard_home, prime_policy_integrity=False)
+    payload = apply_managed_install(
+        "install",
+        "grok",
+        False,
+        ctx,
+        store,
+        None,
+        "2026-08-17T12:00:00+00:00",
+    )
+    managed_install = payload["managed_install"]
+    assert isinstance(managed_install, dict)
+    manifest = managed_install["manifest"]
+    assert isinstance(manifest, dict)
+    assert grok_hooks_protection_ready(ctx) is True
+    assert verify_managed_install_proof(manifest, ctx) is True
+    assert _live_hook_verification(store.list_managed_installs(), store) == {"grok": True}
+    artifacts = manifest["protection_artifact_proof"]["artifacts"]
+    assert isinstance(artifacts, list)
+    artifact_paths = {item["path"] for item in artifacts if isinstance(item, dict)}
+    assert any(path.endswith("managed_config.toml") for path in artifact_paths)
+    assert any(path.endswith("hol-guard-pretooluse.json") for path in artifact_paths)
+    assert any(path.endswith("hol-guard-prompt.json") for path in artifact_paths)
+
+
+def test_one_pass_repair_restores_stale_grok_hooks_and_command_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = _ctx(tmp_path)
+    monkeypatch.setattr(Path, "home", lambda: ctx.home_dir)
+    store = GuardStore(ctx.guard_home, prime_policy_integrity=False)
+    apply_managed_install("install", "grok", False, ctx, store, None, "2026-08-17T12:00:00+00:00")
+    pretool = ctx.home_dir / ".grok" / "hooks" / "hol-guard-pretooluse.json"
+    pretool.write_text(json.dumps(_stale_pretool_payload()), encoding="utf-8")
+    (ctx.home_dir / ".grok" / "managed_config.toml").unlink()
+    store.record_command_activity_persistence_failure(error_code="post_record_failed", occurred_at=_NOW)
+    store.record_command_activity_persistence_failure(error_code="shadow_evaluation_failed", occurred_at=_NOW)
+    store.record_command_activity_persistence_failure(error_code="maintenance_failed", occurred_at=_NOW)
+    assert grok_hooks_protection_ready(ctx) is False
+    assert store.get_command_activity_persistence_health().active_error_count == 3
+
+    failed_hooks = _repair_failing_managed_harness_hooks(store)
+    _repair_command_activity_persistence_health(store)
+    store.maintain_command_activity(now=_NOW, detail_retain_days=30)
+
+    assert failed_hooks == []
+    assert grok_hooks_protection_ready(ctx) is True
+    assert _live_hook_verification(store.list_managed_installs(), store) == {"grok": True}
+    assert store.get_command_activity_persistence_health().active_error_count == 0
+    assert (ctx.home_dir / ".grok" / "managed_config.toml").is_file()
+    assert "matcher" not in json.loads(pretool.read_text(encoding="utf-8"))["hooks"]["PreToolUse"][0]

--- a/tests/test_guard_protection_recovery.py
+++ b/tests/test_guard_protection_recovery.py
@@ -13,6 +13,8 @@ from codex_plugin_scanner.guard.approvals import _live_hook_verification
 from codex_plugin_scanner.guard.cli.install_commands import (
     apply_managed_install,
     grok_hooks_protection_ready,
+    _grok_hook_command_is_guard,
+    _grok_managed_config_is_active,
 )
 from codex_plugin_scanner.guard.daemon.server import (
     _PROTECTION_REPAIR_PROBE_COMMAND,
@@ -309,3 +311,24 @@ def test_one_pass_repair_restores_stale_grok_hooks_and_command_evidence(
     assert store.get_command_activity_persistence_health().active_error_count == 0
     assert (ctx.home_dir / ".grok" / "managed_config.toml").is_file()
     assert "matcher" not in json.loads(pretool.read_text(encoding="utf-8"))["hooks"]["PreToolUse"][0]
+
+
+def test_grok_hook_command_rejects_placeholder_invocations() -> None:
+    assert _grok_hook_command_is_guard("hol-guard hook grok") is True
+    assert _grok_hook_command_is_guard("echo hol-guard hook") is False
+    assert _grok_hook_command_is_guard("true") is False
+
+
+def test_grok_managed_config_rejects_inline_commented_rule() -> None:
+    assert (
+        _grok_managed_config_is_active(
+            '# BEGIN HOL GUARD MANAGED GROK\ndeny = ["Read(**/.grok/auth/**)"]\n# END HOL GUARD MANAGED GROK\n'
+        )
+        is True
+    )
+    assert (
+        _grok_managed_config_is_active(
+            "# BEGIN HOL GUARD MANAGED GROK\ndeny = [] # Read(**/.grok/auth/**)\n# END HOL GUARD MANAGED GROK\n"
+        )
+        is False
+    )


### PR DESCRIPTION
## Summary
- Restore local protection now repairs failing app hooks and command-evidence health in one pass.
- Grok hook health uses live catch-all and managed-config checks instead of stale file hashes.
- Command-evidence repair no longer depends on a force-push probe or a selected shadow observation.
- Remaining-repair copy now separates hook failures from command-evidence failures.

## Testing
- `uv run --no-sync pytest tests/test_guard_protection_recovery.py tests/test_guard_command_activity_health_recovery.py tests/test_guard_protect_workspace_asset.py tests/test_grok_adapter.py tests/test_guard_grok_protection.py --tb=short -q`
- Dashboard protection-health unit test for remaining repair attribution

## Notes
- Local repair does not change Guard Cloud policy proof.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added comprehensive Grok protection checks for managed configuration, pre-tool hooks, and prompt hooks.
  - Enhanced protection recovery to repair hooks, configuration, and command-activity evidence in one pass.

- **Bug Fixes**
  - Improved recovery messages to distinguish failed application hooks from command-evidence failures.
  - Corrected protection health reporting when only command evidence is affected.
  - Improved validation for missing, outdated, or invalid protection configurations.
  - Made recovery more resilient when optional activity observations are unavailable.

- **Tests**
  - Expanded coverage for Grok installation, recovery, hook verification, and command-activity health.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->