### PR TITLE
feat(scanner): support native Kimi plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ See [`devcontainer-features/hol-guard/README.md`](devcontainer-features/hol-guar
 | Codex | `.codex-plugin/plugin.json`, `marketplace.json`, `.agents/plugins/marketplace.json` |
 | Claude Code | `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` |
 | Gemini CLI | `gemini-extension.json`, `commands/**/*.toml` |
+| Kimi Code | `kimi.plugin.json`, `.kimi-plugin/plugin.json`, declared skills, agents, commands, prompts, and MCP servers |
 | OpenCode | `opencode.json`, `opencode.jsonc`, `.opencode/commands`, `.opencode/plugins` |
 
 Use `--ecosystem auto` (default) to scan all detected packages in a repository, or select a single ecosystem explicitly.
@@ -496,6 +497,9 @@ plugin-scanner scan ./plugins-repo --ecosystem auto
 
 # Scan only Claude package surfaces
 plugin-scanner scan ./plugins-repo --ecosystem claude
+
+# Scan only native Kimi Code plugin surfaces
+plugin-scanner scan ./plugins-repo --ecosystem kimi
 
 # List supported ecosystems
 plugin-scanner --list-ecosystems

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 12730,
-  "maximum_test_source_lines": 290450,
+  "maximum_test_source_lines": 290569,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 12730,
-  "maximum_test_source_lines": 290569,
+  "maximum_test_source_lines": 290652,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/checks/code_quality.py
+++ b/src/codex_plugin_scanner/checks/code_quality.py
@@ -20,8 +20,17 @@ SHELL_INJECT_RE = re.compile(
 )
 
 
-def _find_code_files(plugin_dir: Path) -> list[Path]:
-    files = []
+def _find_code_files(plugin_dir: Path, files: tuple[Path, ...] | None = None) -> list[Path]:
+    if files is not None:
+        return [
+            path
+            for path in files
+            if path.is_file()
+            and not path.is_symlink()
+            and path.suffix in CODE_EXTS
+            and resolves_within_root(plugin_dir, path, require_exists=True)
+        ]
+    discovered: list[Path] = []
     for p in plugin_dir.rglob("*"):
         if not p.is_file() or p.suffix not in CODE_EXTS:
             continue
@@ -29,13 +38,13 @@ def _find_code_files(plugin_dir: Path) -> list[Path]:
             continue
         if not resolves_within_root(plugin_dir, p, require_exists=True):
             continue
-        files.append(p)
-    return files
+        discovered.append(p)
+    return discovered
 
 
-def check_no_eval(plugin_dir: Path) -> CheckResult:
+def check_no_eval(plugin_dir: Path, files: tuple[Path, ...] | None = None) -> CheckResult:
     findings: list[str] = []
-    for fpath in _find_code_files(plugin_dir):
+    for fpath in _find_code_files(plugin_dir, files):
         try:
             content = fpath.read_text(encoding="utf-8", errors="ignore")
         except OSError:
@@ -73,9 +82,9 @@ def check_no_eval(plugin_dir: Path) -> CheckResult:
     )
 
 
-def check_no_shell_injection(plugin_dir: Path) -> CheckResult:
+def check_no_shell_injection(plugin_dir: Path, files: tuple[Path, ...] | None = None) -> CheckResult:
     findings: list[str] = []
-    for fpath in _find_code_files(plugin_dir):
+    for fpath in _find_code_files(plugin_dir, files):
         try:
             content = fpath.read_text(encoding="utf-8", errors="ignore")
         except OSError:

--- a/src/codex_plugin_scanner/checks/kimi.py
+++ b/src/codex_plugin_scanner/checks/kimi.py
@@ -11,6 +11,7 @@ from ..ecosystems.types import NormalizedPackage
 from ..models import CheckResult, Finding, Severity
 from ..path_support import is_safe_relative_path
 from .code_quality import check_no_eval, check_no_shell_injection
+from .kimi_support import looks_like_path, manifest_label, object_sequence
 from .security import (
     DANGEROUS_MCP_PATTERNS,
     check_license,
@@ -34,10 +35,6 @@ KIMI_MANIFEST_PATHS = ("skills", "agents", "commands")
 UNSUPPORTED_RUNTIME_FIELDS = ("tools", "apps", "inject", "configFile")
 
 
-def _manifest_label(package: NormalizedPackage) -> str:
-    return package.manifest_path.name if package.manifest_path else "kimi.plugin.json"
-
-
 def _finding(
     rule_id: str,
     title: str,
@@ -53,7 +50,7 @@ def _finding(
         title=title,
         description=description,
         remediation=remediation,
-        file_path=_manifest_label(package),
+        file_path=manifest_label(package),
     )
 
 
@@ -74,12 +71,6 @@ def _string_mapping(value: object) -> dict[str, object] | None:
     if not all(isinstance(key, str) for key in mapping):
         return None
     return {cast(str, key): item for key, item in mapping.items()}
-
-
-def _object_sequence(value: object) -> list[object] | None:
-    if not isinstance(value, list):
-        return None
-    return cast(list[object], value)
 
 
 def check_kimi_manifest(package: NormalizedPackage) -> CheckResult:
@@ -173,13 +164,13 @@ def check_kimi_declared_paths(package: NormalizedPackage) -> CheckResult:
                     )
                 )
                 continue
-            if field == "commands" and target.is_file() and target.suffix.lower() != ".md":
+            if field in {"agents", "commands"} and target.is_file() and target.suffix.lower() != ".md":
                 findings.append(
                     _finding(
-                        "KIMI_COMMAND_PATH_INVALID",
-                        "Kimi command file is not Markdown",
-                        f'Command path "{value_path}" must be a directory or .md file.',
-                        "Point commands to a directory or Markdown file.",
+                        "KIMI_MARKDOWN_PATH_INVALID",
+                        f"Kimi {field} file is not Markdown",
+                        f'{field} path "{value_path}" must be a directory or .md file.',
+                        f"Point {field} to a directory or Markdown file.",
                         package,
                         Severity.LOW,
                     )
@@ -320,7 +311,7 @@ def check_kimi_mcp_servers(package: NormalizedPackage) -> CheckResult:
             )
             continue
         if isinstance(command, str):
-            raw_args = _object_sequence(server.get("args")) or []
+            raw_args = object_sequence(server.get("args")) or []
             joined = " ".join([command, *[item for item in raw_args if isinstance(item, str)]])
             command_name = Path(command).name.lower()
             launches_shell_code = command_name in SHELL_INTERPRETERS and any(
@@ -337,7 +328,18 @@ def check_kimi_mcp_servers(package: NormalizedPackage) -> CheckResult:
                         Severity.HIGH,
                     )
                 )
-            if command.startswith("./") and not is_safe_relative_path(
+            command_is_path = looks_like_path(command)
+            if command_is_path and not command.startswith("./"):
+                findings.append(
+                    _finding(
+                        "KIMI_MCP_COMMAND_PATH_INVALID",
+                        "Kimi MCP command path is invalid",
+                        f'MCP server "{name}" path-like command must use an in-plugin ./ path.',
+                        "Use a bare executable name or existing in-plugin executable path.",
+                        package,
+                    )
+                )
+            elif command.startswith("./") and not is_safe_relative_path(
                 package.root_path, command, require_prefix=True, require_exists=True
             ):
                 findings.append(
@@ -349,16 +351,6 @@ def check_kimi_mcp_servers(package: NormalizedPackage) -> CheckResult:
                         package,
                     )
                 )
-            elif command.startswith("./") and not (package.root_path / command).is_file():
-                findings.append(
-                    _finding(
-                        "KIMI_MCP_COMMAND_NOT_FILE",
-                        "Kimi MCP command is not a file",
-                        f'MCP server "{name}" command must reference an executable file.',
-                        "Point command to an in-plugin executable file.",
-                        package,
-                    )
-                )
             elif command.startswith("./") and (package.root_path / command).is_symlink():
                 findings.append(
                     _finding(
@@ -366,6 +358,16 @@ def check_kimi_mcp_servers(package: NormalizedPackage) -> CheckResult:
                         "Kimi MCP command path is a symlink",
                         f'MCP server "{name}" command must not be a symlink.',
                         "Use a regular in-plugin executable file.",
+                        package,
+                    )
+                )
+            elif command.startswith("./") and not (package.root_path / command).is_file():
+                findings.append(
+                    _finding(
+                        "KIMI_MCP_COMMAND_NOT_FILE",
+                        "Kimi MCP command is not a file",
+                        f'MCP server "{name}" command must reference an executable file.',
+                        "Point command to an in-plugin executable file.",
                         package,
                     )
                 )
@@ -388,7 +390,7 @@ def check_kimi_mcp_servers(package: NormalizedPackage) -> CheckResult:
                 )
         args = server.get("args")
         env = server.get("env")
-        args_sequence = _object_sequence(args)
+        args_sequence = object_sequence(args)
         if args is not None and (args_sequence is None or not all(isinstance(item, str) for item in args_sequence)):
             findings.append(
                 _finding(
@@ -401,7 +403,18 @@ def check_kimi_mcp_servers(package: NormalizedPackage) -> CheckResult:
             )
         if args_sequence is not None:
             for arg in args_sequence:
-                if not isinstance(arg, str) or not arg.startswith("./"):
+                if not isinstance(arg, str) or not looks_like_path(arg):
+                    continue
+                if not arg.startswith("./"):
+                    findings.append(
+                        _finding(
+                            "KIMI_MCP_ARG_PATH_INVALID",
+                            "Kimi MCP argument path is unsafe",
+                            f'MCP server "{name}" path-like argument "{arg}" must use an in-plugin ./ path.',
+                            "Use an existing regular in-plugin path for local MCP arguments.",
+                            package,
+                        )
+                    )
                     continue
                 arg_target = package.root_path / arg
                 if (
@@ -437,7 +450,9 @@ def check_kimi_mcp_servers(package: NormalizedPackage) -> CheckResult:
         cwd_is_safe = isinstance(cwd, str) and is_safe_relative_path(
             package.root_path, cwd, require_prefix=True, require_exists=True
         )
-        if cwd is not None and (cwd_target is None or not cwd_is_safe or cwd_target.is_symlink()):
+        if cwd is not None and (
+            cwd_target is None or not cwd_is_safe or cwd_target.is_symlink() or not cwd_target.is_dir()
+        ):
             findings.append(
                 _finding(
                     "KIMI_MCP_CWD_INVALID",

--- a/src/codex_plugin_scanner/checks/kimi.py
+++ b/src/codex_plugin_scanner/checks/kimi.py
@@ -408,11 +408,13 @@ def check_kimi_mcp_servers(package: NormalizedPackage) -> CheckResult:
                     not is_safe_relative_path(package.root_path, arg, require_prefix=True, require_exists=True)
                     or arg_target.is_symlink()
                 ):
+                    detail = f'MCP server "{name}" local argument "{arg}" must exist inside the plugin '
+                    detail += "and not be a symlink."
                     findings.append(
                         _finding(
                             "KIMI_MCP_ARG_PATH_INVALID",
                             "Kimi MCP argument path is unsafe",
-                            f'MCP server "{name}" local argument "{arg}" must exist inside the plugin and not be a symlink.',
+                            detail,
                             "Use a regular in-plugin path for local MCP arguments.",
                             package,
                         )

--- a/src/codex_plugin_scanner/checks/kimi.py
+++ b/src/codex_plugin_scanner/checks/kimi.py
@@ -1,0 +1,481 @@
+"""Kimi Code plugin manifest and declared-bundle checks."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import cast
+from urllib.parse import urlparse
+
+from ..ecosystems.types import NormalizedPackage
+from ..models import CheckResult, Finding, Severity
+from ..path_support import is_safe_relative_path
+from .code_quality import check_no_eval, check_no_shell_injection
+from .security import (
+    DANGEROUS_MCP_PATTERNS,
+    check_license,
+    check_no_approval_bypass_defaults,
+    check_no_hardcoded_secrets,
+    check_security_md,
+)
+
+KIMI_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+KIMI_SEMVER_RE = re.compile(
+    "".join(
+        (
+            r"^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)",
+            r"(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*)?",
+            r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$",
+        )
+    )
+)
+SHELL_INTERPRETERS = frozenset({"bash", "cmd", "dash", "fish", "ksh", "powershell", "pwsh", "sh", "zsh"})
+KIMI_MANIFEST_PATHS = ("skills", "agents", "commands")
+UNSUPPORTED_RUNTIME_FIELDS = ("tools", "apps", "inject", "configFile")
+
+
+def _manifest_label(package: NormalizedPackage) -> str:
+    return package.manifest_path.name if package.manifest_path else "kimi.plugin.json"
+
+
+def _finding(
+    rule_id: str,
+    title: str,
+    description: str,
+    remediation: str,
+    package: NormalizedPackage,
+    severity: Severity = Severity.MEDIUM,
+) -> Finding:
+    return Finding(
+        rule_id=rule_id,
+        severity=severity,
+        category="kimi",
+        title=title,
+        description=description,
+        remediation=remediation,
+        file_path=_manifest_label(package),
+    )
+
+
+def _path_values(value: object) -> tuple[str, ...] | None:
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, list):
+        items = cast(list[object], value)
+        if all(isinstance(item, str) for item in items):
+            return tuple(cast(str, item) for item in items)
+    return None
+
+
+def _string_mapping(value: object) -> dict[str, object] | None:
+    if not isinstance(value, dict):
+        return None
+    mapping = cast(dict[object, object], value)
+    if not all(isinstance(key, str) for key in mapping):
+        return None
+    return {cast(str, key): item for key, item in mapping.items()}
+
+
+def _object_sequence(value: object) -> list[object] | None:
+    if not isinstance(value, list):
+        return None
+    return cast(list[object], value)
+
+
+def check_kimi_manifest(package: NormalizedPackage) -> CheckResult:
+    if package.manifest_parse_error:
+        reason = package.manifest_parse_error_reason or "invalid-json"
+        return CheckResult(
+            name="Kimi manifest parses",
+            passed=False,
+            points=0,
+            max_points=5,
+            message=f"Kimi manifest could not be parsed: {reason}.",
+            findings=(
+                _finding(
+                    "KIMI_MANIFEST_INVALID",
+                    "Kimi plugin manifest is invalid",
+                    f"The Kimi manifest could not be parsed: {reason}.",
+                    "Provide a readable JSON object in kimi.plugin.json or .kimi-plugin/plugin.json.",
+                    package,
+                ),
+            ),
+        )
+    name = package.raw_manifest.get("name")
+    version = package.raw_manifest.get("version")
+    findings: list[Finding] = []
+    if not isinstance(name, str) or not KIMI_NAME_RE.fullmatch(name):
+        findings.append(
+            _finding(
+                "KIMI_NAME_INVALID",
+                "Kimi plugin name is invalid",
+                "Kimi plugin names must match [a-z0-9][a-z0-9_-]{0,63}.",
+                "Set name to a valid Kimi plugin id.",
+                package,
+            )
+        )
+    if version is not None and (not isinstance(version, str) or not KIMI_SEMVER_RE.fullmatch(version)):
+        findings.append(
+            _finding(
+                "KIMI_VERSION_INVALID",
+                "Kimi plugin version is invalid",
+                "When present, the Kimi plugin version must use X.Y.Z semantic versioning.",
+                "Set version to a semantic version or remove it.",
+                package,
+                Severity.LOW,
+            )
+        )
+    if not findings:
+        return CheckResult("Kimi manifest parses", True, 5, 5, "Kimi manifest and plugin identity are valid.")
+    return CheckResult("Kimi manifest parses", False, 0, 5, f"Kimi manifest issues: {len(findings)}", tuple(findings))
+
+
+def check_kimi_declared_paths(package: NormalizedPackage) -> CheckResult:
+    manifest = package.raw_manifest
+    findings: list[Finding] = []
+    for field in KIMI_MANIFEST_PATHS:
+        value = manifest.get(field)
+        if value is None:
+            continue
+        paths = _path_values(value)
+        if paths is None:
+            findings.append(
+                _finding(
+                    "KIMI_PATHS_INVALID",
+                    f"Kimi {field} paths are invalid",
+                    f"{field} must be a ./ path or an array of ./ paths.",
+                    f"Update {field} to use in-plugin paths.",
+                    package,
+                )
+            )
+            continue
+        for value_path in paths:
+            if not is_safe_relative_path(package.root_path, value_path, require_prefix=True, require_exists=True):
+                findings.append(
+                    _finding(
+                        "KIMI_PATH_UNSAFE_OR_MISSING",
+                        f"Kimi {field} path is unsafe or missing",
+                        f'{field} path "{value_path}" must resolve inside the plugin and exist.',
+                        f"Use an existing ./ path within the plugin for {field}.",
+                        package,
+                    )
+                )
+                continue
+            target = package.root_path / value_path
+            if target.is_symlink():
+                findings.append(
+                    _finding(
+                        "KIMI_PATH_SYMLINK_UNSUPPORTED",
+                        f"Kimi {field} path is a symlink",
+                        f'{field} path "{value_path}" must not be a symlink.',
+                        f"Use a regular in-plugin path for {field}.",
+                        package,
+                    )
+                )
+                continue
+            if field == "commands" and target.is_file() and target.suffix.lower() != ".md":
+                findings.append(
+                    _finding(
+                        "KIMI_COMMAND_PATH_INVALID",
+                        "Kimi command file is not Markdown",
+                        f'Command path "{value_path}" must be a directory or .md file.',
+                        "Point commands to a directory or Markdown file.",
+                        package,
+                        Severity.LOW,
+                    )
+                )
+    system_prompt_path = manifest.get("systemPromptPath")
+    system_prompt_target = package.root_path / system_prompt_path if isinstance(system_prompt_path, str) else None
+    system_prompt_is_safe = isinstance(system_prompt_path, str) and is_safe_relative_path(
+        package.root_path, system_prompt_path, require_prefix=True, require_exists=True
+    )
+    if system_prompt_path is not None and (
+        system_prompt_target is None
+        or not system_prompt_is_safe
+        or not system_prompt_target.is_file()
+        or system_prompt_target.is_symlink()
+    ):
+        findings.append(
+            _finding(
+                "KIMI_SYSTEM_PROMPT_PATH_INVALID",
+                "Kimi system prompt path is invalid",
+                "systemPromptPath must reference an existing ./ file inside the plugin.",
+                "Use an existing in-plugin UTF-8 text file.",
+                package,
+            )
+        )
+    if not findings:
+        return CheckResult("Kimi declared paths resolve", True, 5, 5, "Kimi bundle paths stay inside the plugin.")
+    return CheckResult(
+        "Kimi declared paths resolve", False, 0, 5, f"Kimi path issues: {len(findings)}", tuple(findings)
+    )
+
+
+def check_kimi_manifest_shapes(package: NormalizedPackage) -> CheckResult:
+    manifest = package.raw_manifest
+    findings: list[Finding] = []
+    interface = manifest.get("interface")
+    interface_mapping = _string_mapping(interface)
+    if interface is not None and (
+        interface_mapping is None or not all(isinstance(value, str) for value in interface_mapping.values())
+    ):
+        findings.append(
+            _finding(
+                "KIMI_INTERFACE_INVALID",
+                "Kimi interface metadata is invalid",
+                "interface must be an object containing string display metadata.",
+                "Use string values for Kimi interface metadata.",
+                package,
+                Severity.LOW,
+            )
+        )
+    session_start = manifest.get("sessionStart")
+    session_start_mapping = _string_mapping(session_start)
+    if session_start is not None and (
+        session_start_mapping is None or not isinstance(session_start_mapping.get("skill"), str)
+    ):
+        findings.append(
+            _finding(
+                "KIMI_SESSION_START_INVALID",
+                "Kimi sessionStart is invalid",
+                "sessionStart must be an object with a string skill field.",
+                "Reference a declared plugin skill by name.",
+                package,
+                Severity.LOW,
+            )
+        )
+    system_prompt = manifest.get("systemPrompt")
+    if system_prompt is not None and (
+        not isinstance(system_prompt, str) or len(system_prompt.encode("utf-8")) > 32 * 1024
+    ):
+        findings.append(
+            _finding(
+                "KIMI_SYSTEM_PROMPT_INVALID",
+                "Kimi system prompt is invalid",
+                "systemPrompt must be a UTF-8 string no larger than 32 KiB.",
+                "Shorten or remove the inline system prompt.",
+                package,
+                Severity.LOW,
+            )
+        )
+    unsupported = [field for field in UNSUPPORTED_RUNTIME_FIELDS if field in manifest]
+    if unsupported:
+        findings.append(
+            _finding(
+                "KIMI_UNSUPPORTED_RUNTIME_FIELDS",
+                "Kimi manifest contains unsupported runtime fields",
+                f"Kimi ignores these runtime fields: {', '.join(unsupported)}.",
+                "Remove fields that Kimi Code ignores.",
+                package,
+                Severity.LOW,
+            )
+        )
+    if not findings:
+        return CheckResult("Kimi manifest field shapes", True, 4, 4, "Kimi manifest field shapes are valid.")
+    return CheckResult(
+        "Kimi manifest field shapes", False, 0, 4, f"Kimi field-shape issues: {len(findings)}", tuple(findings)
+    )
+
+
+def check_kimi_mcp_servers(package: NormalizedPackage) -> CheckResult:
+    raw_servers = package.raw_manifest.get("mcpServers")
+    if raw_servers is None:
+        return CheckResult("Kimi MCP servers", True, 0, 0, "No Kimi MCP servers declared.", applicable=False)
+    servers = _string_mapping(raw_servers)
+    if servers is None:
+        finding = _finding(
+            "KIMI_MCP_SERVERS_INVALID",
+            "Kimi MCP servers are invalid",
+            "mcpServers must be an object keyed by server name.",
+            "Use an object for Kimi MCP server declarations.",
+            package,
+        )
+        return CheckResult("Kimi MCP servers", False, 0, 5, finding.description, (finding,))
+
+    findings: list[Finding] = []
+    for name, server_value in servers.items():
+        server = _string_mapping(server_value)
+        if server is None:
+            findings.append(
+                _finding(
+                    "KIMI_MCP_SERVER_INVALID",
+                    "Kimi MCP server entry is invalid",
+                    "Each mcpServers entry must have a string name and object value.",
+                    "Use an object-shaped MCP server declaration.",
+                    package,
+                )
+            )
+            continue
+        command = server.get("command")
+        url = server.get("url")
+        if (isinstance(command, str)) == (isinstance(url, str)):
+            findings.append(
+                _finding(
+                    "KIMI_MCP_TRANSPORT_INVALID",
+                    "Kimi MCP transport is ambiguous",
+                    f'MCP server "{name}" must declare exactly one of command or url.',
+                    "Choose one supported MCP transport.",
+                    package,
+                )
+            )
+            continue
+        if isinstance(command, str):
+            raw_args = _object_sequence(server.get("args")) or []
+            joined = " ".join([command, *[item for item in raw_args if isinstance(item, str)]])
+            command_name = Path(command).name.lower()
+            launches_shell_code = command_name in SHELL_INTERPRETERS and any(
+                item.lower() in {"-c", "/c", "-command"} for item in raw_args if isinstance(item, str)
+            )
+            if launches_shell_code or any(pattern.search(joined) for pattern in DANGEROUS_MCP_PATTERNS):
+                findings.append(
+                    _finding(
+                        "KIMI_MCP_COMMAND_DANGEROUS",
+                        "Kimi MCP command is dangerous",
+                        f'MCP server "{name}" uses a dangerous shell command pattern.',
+                        "Use a structured executable and argument list without shell indirection.",
+                        package,
+                        Severity.HIGH,
+                    )
+                )
+            if command.startswith("./") and not is_safe_relative_path(
+                package.root_path, command, require_prefix=True, require_exists=True
+            ):
+                findings.append(
+                    _finding(
+                        "KIMI_MCP_COMMAND_PATH_INVALID",
+                        "Kimi MCP command path is invalid",
+                        f'MCP server "{name}" command must remain inside the plugin.',
+                        "Use an existing in-plugin executable path.",
+                        package,
+                    )
+                )
+            elif command.startswith("./") and not (package.root_path / command).is_file():
+                findings.append(
+                    _finding(
+                        "KIMI_MCP_COMMAND_NOT_FILE",
+                        "Kimi MCP command is not a file",
+                        f'MCP server "{name}" command must reference an executable file.',
+                        "Point command to an in-plugin executable file.",
+                        package,
+                    )
+                )
+            elif command.startswith("./") and (package.root_path / command).is_symlink():
+                findings.append(
+                    _finding(
+                        "KIMI_MCP_COMMAND_SYMLINK_UNSUPPORTED",
+                        "Kimi MCP command path is a symlink",
+                        f'MCP server "{name}" command must not be a symlink.',
+                        "Use a regular in-plugin executable file.",
+                        package,
+                    )
+                )
+        if isinstance(url, str):
+            parsed = urlparse(url)
+            loopback = parsed.hostname in {"127.0.0.1", "localhost", "::1"}
+            secure_remote = parsed.scheme == "https" and parsed.hostname is not None
+            secure_loopback = parsed.scheme == "http" and loopback
+            has_credentials = parsed.username is not None or parsed.password is not None
+            if not (secure_remote or secure_loopback) or has_credentials or bool(parsed.fragment):
+                findings.append(
+                    _finding(
+                        "KIMI_MCP_URL_INSECURE",
+                        "Kimi MCP URL is insecure",
+                        f'MCP server "{name}" must use HTTPS unless it is loopback-only.',
+                        "Use HTTPS for remote MCP servers.",
+                        package,
+                        Severity.HIGH,
+                    )
+                )
+        args = server.get("args")
+        env = server.get("env")
+        args_sequence = _object_sequence(args)
+        if args is not None and (args_sequence is None or not all(isinstance(item, str) for item in args_sequence)):
+            findings.append(
+                _finding(
+                    "KIMI_MCP_ARGS_INVALID",
+                    "Kimi MCP args are invalid",
+                    f'MCP server "{name}" args must be an array of strings.',
+                    "Use string arguments.",
+                    package,
+                )
+            )
+        if args_sequence is not None:
+            for arg in args_sequence:
+                if not isinstance(arg, str) or not arg.startswith("./"):
+                    continue
+                arg_target = package.root_path / arg
+                if (
+                    not is_safe_relative_path(package.root_path, arg, require_prefix=True, require_exists=True)
+                    or arg_target.is_symlink()
+                ):
+                    findings.append(
+                        _finding(
+                            "KIMI_MCP_ARG_PATH_INVALID",
+                            "Kimi MCP argument path is unsafe",
+                            f'MCP server "{name}" local argument "{arg}" must exist inside the plugin and not be a symlink.',
+                            "Use a regular in-plugin path for local MCP arguments.",
+                            package,
+                        )
+                    )
+        env_mapping = _string_mapping(env)
+        if env is not None and (
+            env_mapping is None or not all(isinstance(value, str) for value in env_mapping.values())
+        ):
+            findings.append(
+                _finding(
+                    "KIMI_MCP_ENV_INVALID",
+                    "Kimi MCP environment is invalid",
+                    f'MCP server "{name}" env must map string names to string values.',
+                    "Use string environment values.",
+                    package,
+                )
+            )
+        cwd = server.get("cwd")
+        cwd_target = package.root_path / cwd if isinstance(cwd, str) else None
+        cwd_is_safe = isinstance(cwd, str) and is_safe_relative_path(
+            package.root_path, cwd, require_prefix=True, require_exists=True
+        )
+        if cwd is not None and (cwd_target is None or not cwd_is_safe or cwd_target.is_symlink()):
+            findings.append(
+                _finding(
+                    "KIMI_MCP_CWD_INVALID",
+                    "Kimi MCP working directory is invalid",
+                    f'MCP server "{name}" cwd must be an existing ./ path inside the plugin.',
+                    "Use an in-plugin working directory.",
+                    package,
+                )
+            )
+
+    if not findings:
+        return CheckResult("Kimi MCP servers", True, 5, 5, "Kimi MCP server declarations are valid.")
+    return CheckResult("Kimi MCP servers", False, 0, 5, f"Kimi MCP issues: {len(findings)}", tuple(findings))
+
+
+def _bundle_files(package: NormalizedPackage) -> tuple[Path, ...]:
+    relative_files = {
+        relative
+        for component, values in package.components.items()
+        if component != "mcp_servers"
+        for relative in values
+    }
+    if package.manifest_path is not None:
+        relative_files.add(package.manifest_path.relative_to(package.root_path).as_posix())
+    return tuple(sorted((package.root_path / relative for relative in relative_files), key=str))
+
+
+def run_kimi_checks(package: NormalizedPackage) -> tuple[CheckResult, ...]:
+    """Run Kimi schema, path, MCP, and declared-content checks."""
+
+    files = _bundle_files(package)
+    return (
+        check_kimi_manifest(package),
+        check_kimi_declared_paths(package),
+        check_kimi_manifest_shapes(package),
+        check_kimi_mcp_servers(package),
+        check_security_md(package.root_path),
+        check_license(package.root_path),
+        check_no_hardcoded_secrets(package.root_path, files),
+        check_no_approval_bypass_defaults(package.root_path, files),
+        check_no_eval(package.root_path, files),
+        check_no_shell_injection(package.root_path, files),
+    )

--- a/src/codex_plugin_scanner/checks/kimi_support.py
+++ b/src/codex_plugin_scanner/checks/kimi_support.py
@@ -1,0 +1,29 @@
+"""Shared strict helpers for Kimi plugin checks."""
+
+from __future__ import annotations
+
+import re
+from typing import cast
+from urllib.parse import urlparse
+
+from ..ecosystems.types import NormalizedPackage
+
+NPM_PACKAGE_RE = re.compile(r"^@[a-z0-9._-]+/[a-z0-9._-]+(?:@[^/\\]+)?$", re.IGNORECASE)
+
+
+def manifest_label(package: NormalizedPackage) -> str:
+    return package.manifest_path.name if package.manifest_path else "kimi.plugin.json"
+
+
+def object_sequence(value: object) -> list[object] | None:
+    if not isinstance(value, list):
+        return None
+    return cast(list[object], value)
+
+
+def looks_like_path(value: str) -> bool:
+    if re.match(r"^[A-Za-z]:", value):
+        return True
+    if NPM_PACKAGE_RE.fullmatch(value) or urlparse(value).scheme in {"http", "https"}:
+        return False
+    return value.startswith((".", "/", "\\", "~")) or "/" in value or "\\" in value

--- a/src/codex_plugin_scanner/checks/security.py
+++ b/src/codex_plugin_scanner/checks/security.py
@@ -158,9 +158,18 @@ APACHE_LICENSE_VERSION_RE = re.compile(r"apache\s+license\s*,?\s*version\s+2\.0"
 LICENSE_URL_RE = re.compile(r"https?://[^\s<>()\"']+")
 
 
-def _scan_all_files(plugin_dir: Path) -> list[Path]:
+def _scan_all_files(plugin_dir: Path, files: tuple[Path, ...] | None = None) -> list[Path]:
     """Recursively find all files, skipping excluded dirs."""
-    files = []
+    if files is not None:
+        return [
+            path
+            for path in files
+            if path.is_file()
+            and not path.is_symlink()
+            and path.suffix.lower() not in BINARY_EXTS
+            and resolves_within_root(plugin_dir, path, require_exists=True)
+        ]
+    discovered: list[Path] = []
     for p in plugin_dir.rglob("*"):
         if not p.is_file():
             continue
@@ -170,8 +179,8 @@ def _scan_all_files(plugin_dir: Path) -> list[Path]:
             continue
         if not resolves_within_root(plugin_dir, p, require_exists=True):
             continue
-        files.append(p)
-    return files
+        discovered.append(p)
+    return discovered
 
 
 def _is_example_surface(relative_path: Path) -> bool:
@@ -451,9 +460,9 @@ def check_license(plugin_dir: Path) -> CheckResult:
         )
 
 
-def check_no_hardcoded_secrets(plugin_dir: Path) -> CheckResult:
+def check_no_hardcoded_secrets(plugin_dir: Path, files: tuple[Path, ...] | None = None) -> CheckResult:
     findings: list[tuple[str, int]] = []
-    for fpath in _scan_all_files(plugin_dir):
+    for fpath in _scan_all_files(plugin_dir, files):
         try:
             content = fpath.read_text(encoding="utf-8", errors="ignore")
         except OSError:
@@ -677,9 +686,9 @@ def check_mcp_transport_security(plugin_dir: Path) -> CheckResult:
     )
 
 
-def check_no_approval_bypass_defaults(plugin_dir: Path) -> CheckResult:
+def check_no_approval_bypass_defaults(plugin_dir: Path, files: tuple[Path, ...] | None = None) -> CheckResult:
     findings: list[str] = []
-    for file_path in _scan_all_files(plugin_dir):
+    for file_path in _scan_all_files(plugin_dir, files):
         try:
             content = file_path.read_text(encoding="utf-8", errors="ignore")
         except OSError:

--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -116,7 +116,7 @@ def _build_parser(program_name: str, *, program_mode: str) -> argparse.ArgumentP
     scan_parser.add_argument("--cisco-policy", choices=("permissive", "balanced", "strict"), default="balanced")
     scan_parser.add_argument(
         "--ecosystem",
-        choices=("auto", "codex", "claude", "gemini", "opencode"),
+        choices=("auto", "codex", "claude", "gemini", "kimi", "opencode"),
         default="auto",
         help="Target one ecosystem explicitly or auto-detect all supported ecosystems.",
     )

--- a/src/codex_plugin_scanner/ecosystems/kimi.py
+++ b/src/codex_plugin_scanner/ecosystems/kimi.py
@@ -1,0 +1,156 @@
+"""Kimi Code plugin ecosystem adapter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import cast
+
+from ..path_support import is_safe_relative_path
+from .base import iter_safe_recursive_dirs, iter_safe_recursive_files
+from .types import Ecosystem, NormalizedPackage, PackageCandidate
+
+
+def _load_manifest(path: Path) -> tuple[dict[str, object], bool, str | None]:
+    try:
+        payload = cast(object, json.loads(path.read_text(encoding="utf-8")))
+    except FileNotFoundError:
+        return {}, True, "file-not-found"
+    except PermissionError:
+        return {}, True, "permission-denied"
+    except json.JSONDecodeError:
+        return {}, True, "invalid-json"
+    except OSError:
+        return {}, True, "read-error"
+    manifest = _string_mapping(payload)
+    if manifest is None:
+        return {}, True, "not-object"
+    return manifest, False, None
+
+
+def _string_mapping(value: object) -> dict[str, object] | None:
+    if not isinstance(value, dict):
+        return None
+    mapping = cast(dict[object, object], value)
+    if not all(isinstance(key, str) for key in mapping):
+        return None
+    return {cast(str, key): item for key, item in mapping.items()}
+
+
+def _path_values(value: object) -> tuple[str, ...]:
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, list):
+        items = cast(list[object], value)
+        return tuple(item for item in items if isinstance(item, str))
+    return ()
+
+
+def _declared_files(root: Path, value: object, pattern: str) -> tuple[str, ...]:
+    files: set[str] = set()
+    for raw_path in _path_values(value):
+        if not is_safe_relative_path(root, raw_path, require_prefix=True, require_exists=True):
+            continue
+        path = root / raw_path
+        if path.is_symlink():
+            continue
+        if path.is_file():
+            if pattern == "*" or path.match(pattern):
+                files.add(path.relative_to(root).as_posix())
+            continue
+        files.update(file.relative_to(root).as_posix() for file in iter_safe_recursive_files(root, path, pattern))
+    return tuple(sorted(files))
+
+
+class KimiAdapter:
+    """Adapter for native Kimi Code plugin bundles."""
+
+    ecosystem_id: Ecosystem = Ecosystem.KIMI
+
+    def detect(self, root: Path) -> list[PackageCandidate]:
+        candidates: dict[Path, PackageCandidate] = {}
+        for manifest_path in iter_safe_recursive_files(root, root, "kimi.plugin.json"):
+            package_root = manifest_path.parent
+            candidates[package_root] = PackageCandidate(
+                ecosystem=Ecosystem.KIMI,
+                package_kind="plugin",
+                root_path=package_root,
+                manifest_path=manifest_path,
+                detection_reason="found kimi.plugin.json",
+            )
+        for manifest_dir in iter_safe_recursive_dirs(root, root, ".kimi-plugin"):
+            manifest_path = manifest_dir / "plugin.json"
+            package_root = manifest_dir.parent
+            if package_root in candidates or manifest_path.is_symlink() or not manifest_path.is_file():
+                continue
+            if not is_safe_relative_path(root, manifest_path.relative_to(root).as_posix(), require_exists=True):
+                continue
+            candidates[package_root] = PackageCandidate(
+                ecosystem=Ecosystem.KIMI,
+                package_kind="plugin",
+                root_path=package_root,
+                manifest_path=manifest_path,
+                detection_reason="found .kimi-plugin/plugin.json",
+            )
+        return sorted(candidates.values(), key=lambda candidate: str(candidate.root_path))
+
+    def parse(self, candidate: PackageCandidate) -> NormalizedPackage:
+        manifest, parse_error, parse_error_reason = (
+            _load_manifest(candidate.manifest_path) if candidate.manifest_path else ({}, True, "file-not-found")
+        )
+        root = candidate.root_path
+        components: dict[str, tuple[str, ...]] = {}
+        path_components = {
+            "skills": (manifest.get("skills"), "*"),
+            "agents": (manifest.get("agents"), "*.md"),
+            "commands": (manifest.get("commands"), "*.md"),
+            "system_prompt": (manifest.get("systemPromptPath"), "*"),
+        }
+        if manifest.get("skills") is None and (root / "SKILL.md").is_file():
+            path_components["skills"] = ("./SKILL.md", "*")
+        if manifest.get("agents") is None and (root / "agents").is_dir():
+            path_components["agents"] = ("./agents/", "*.md")
+        for name, (value, pattern) in path_components.items():
+            files = _declared_files(root, value, pattern)
+            if files:
+                components[name] = files
+
+        mcp_servers = manifest.get("mcpServers")
+        mcp_mapping = _string_mapping(mcp_servers)
+        if mcp_mapping is not None:
+            components["mcp_servers"] = tuple(sorted(mcp_mapping))
+            local_files: set[str] = set()
+            for server_value in mcp_mapping.values():
+                server = _string_mapping(server_value)
+                if server is None:
+                    continue
+                command = server.get("command")
+                if isinstance(command, str) and command.startswith("./"):
+                    local_files.update(_declared_files(root, command, "*"))
+                args = server.get("args")
+                if isinstance(args, list):
+                    for arg in cast(list[object], args):
+                        if isinstance(arg, str) and arg.startswith("./"):
+                            local_files.update(_declared_files(root, arg, "*"))
+            if local_files:
+                components["mcp_files"] = tuple(sorted(local_files))
+
+        raw_name = manifest.get("name")
+        raw_version = manifest.get("version")
+        return NormalizedPackage(
+            ecosystem=Ecosystem.KIMI,
+            package_kind=candidate.package_kind,
+            root_path=root,
+            manifest_path=candidate.manifest_path,
+            name=raw_name if isinstance(raw_name, str) else None,
+            version=raw_version if isinstance(raw_version, str) else None,
+            metadata={
+                key: value
+                for key in ("description", "homepage", "license")
+                if isinstance((value := manifest.get(key)), str)
+            },
+            components=components,
+            raw_manifest=manifest,
+            manifest_parse_error=parse_error,
+            manifest_parse_error_reason=parse_error_reason,
+        )

--- a/src/codex_plugin_scanner/ecosystems/kimi.py
+++ b/src/codex_plugin_scanner/ecosystems/kimi.py
@@ -14,6 +14,8 @@ from .types import Ecosystem, NormalizedPackage, PackageCandidate
 def _load_manifest(path: Path) -> tuple[dict[str, object], bool, str | None]:
     try:
         payload = cast(object, json.loads(path.read_text(encoding="utf-8")))
+    except UnicodeDecodeError:
+        return {}, True, "invalid-encoding"
     except FileNotFoundError:
         return {}, True, "file-not-found"
     except PermissionError:

--- a/src/codex_plugin_scanner/ecosystems/registry.py
+++ b/src/codex_plugin_scanner/ecosystems/registry.py
@@ -6,6 +6,7 @@ from .base import EcosystemAdapter
 from .claude import ClaudeAdapter
 from .codex import CodexAdapter
 from .gemini import GeminiAdapter
+from .kimi import KimiAdapter
 from .opencode import OpenCodeAdapter
 from .types import Ecosystem
 
@@ -17,6 +18,7 @@ def get_default_adapters() -> tuple[EcosystemAdapter, ...]:
         CodexAdapter(),
         ClaudeAdapter(),
         GeminiAdapter(),
+        KimiAdapter(),
         OpenCodeAdapter(),
     )
 

--- a/src/codex_plugin_scanner/ecosystems/types.py
+++ b/src/codex_plugin_scanner/ecosystems/types.py
@@ -13,6 +13,7 @@ class Ecosystem(str, Enum):
     CODEX = "codex"
     CLAUDE = "claude"
     GEMINI = "gemini"
+    KIMI = "kimi"
     OPENCODE = "opencode"
 
 

--- a/src/codex_plugin_scanner/scanner.py
+++ b/src/codex_plugin_scanner/scanner.py
@@ -10,6 +10,7 @@ from .checks.best_practices import run_best_practice_checks
 from .checks.claude import run_claude_checks
 from .checks.code_quality import run_code_quality_checks
 from .checks.gemini import run_gemini_checks
+from .checks.kimi import run_kimi_checks
 from .checks.manifest import run_manifest_checks
 from .checks.marketplace import run_marketplace_checks
 from .checks.mcp_security import resolve_mcp_security_context, run_mcp_security_checks
@@ -543,6 +544,17 @@ def _scan_mixed_packages(scan_root: Path, packages: list[NormalizedPackage], opt
                     CategoryResult(name=f"{prefix}Code Quality", checks=quality_checks),
                 )
             )
+            processed_packages.append(package)
+            continue
+
+        if package.ecosystem == Ecosystem.KIMI:
+            kimi_checks = _maybe_rebase_checks(
+                run_kimi_checks(package),
+                package_root,
+                scan_root_resolved,
+                needs_rebase,
+            )
+            categories.append(CategoryResult(name=f"{prefix}Kimi Plugin", checks=kimi_checks))
             processed_packages.append(package)
 
     findings = tuple(finding for category in categories for check in category.checks for finding in check.findings)

--- a/tests/fixtures/kimi-plugin-good/LICENSE
+++ b/tests/fixtures/kimi-plugin-good/LICENSE
@@ -1,0 +1,3 @@
+MIT License
+
+Permission is hereby granted to use this fixture for testing.

--- a/tests/fixtures/kimi-plugin-good/SECURITY.md
+++ b/tests/fixtures/kimi-plugin-good/SECURITY.md
@@ -1,0 +1,3 @@
+# Security
+
+Report security issues privately to the fixture maintainer.

--- a/tests/fixtures/kimi-plugin-good/SYSTEM.md
+++ b/tests/fixtures/kimi-plugin-good/SYSTEM.md
@@ -1,0 +1,1 @@
+Use the declared tools only when they are relevant to the user's request.

--- a/tests/fixtures/kimi-plugin-good/agents/reviewer.md
+++ b/tests/fixtures/kimi-plugin-good/agents/reviewer.md
@@ -1,0 +1,6 @@
+---
+name: reviewer
+description: Review recalled context.
+---
+
+Review the evidence returned by the demo server.

--- a/tests/fixtures/kimi-plugin-good/commands/recall.md
+++ b/tests/fixtures/kimi-plugin-good/commands/recall.md
@@ -1,0 +1,5 @@
+---
+description: Recall relevant project context
+---
+
+Recall context for $ARGUMENTS.

--- a/tests/fixtures/kimi-plugin-good/kimi.plugin.json
+++ b/tests/fixtures/kimi-plugin-good/kimi.plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "demo-memory",
+  "version": "1.2.3",
+  "description": "A native Kimi Code plugin fixture.",
+  "skills": "./skills/",
+  "agents": "./agents/",
+  "commands": "./commands/",
+  "systemPromptPath": "./SYSTEM.md",
+  "sessionStart": {
+    "skill": "using-demo"
+  },
+  "mcpServers": {
+    "demo": {
+      "command": "npx",
+      "args": ["-y", "demo-memory@1.2.3", "serve"],
+      "env": {
+        "DEMO_MODE": "read-only"
+      }
+    }
+  },
+  "interface": {
+    "displayName": "Demo Memory",
+    "shortDescription": "A Kimi plugin scanner fixture"
+  }
+}

--- a/tests/fixtures/kimi-plugin-good/skills/using-demo/SKILL.md
+++ b/tests/fixtures/kimi-plugin-good/skills/using-demo/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: using-demo
+description: Recall project context.
+---
+
+Use the demo MCP server to recall relevant context.

--- a/tests/test_ecosystems.py
+++ b/tests/test_ecosystems.py
@@ -53,12 +53,14 @@ def test_detect_packages_skips_symlinked_manifest_files_outside_root(tmp_path: P
     (outside / "marketplace.json").write_text("{}", encoding="utf-8")
     (outside / "gemini-extension.json").write_text("{}", encoding="utf-8")
     (outside / "opencode.json").write_text("{}", encoding="utf-8")
+    (outside / "kimi.plugin.json").write_text('{"name":"outside"}', encoding="utf-8")
 
     _symlink_or_skip(tmp_path / "codex-plugin" / ".codex-plugin" / "plugin.json", outside / "plugin.json")
     _symlink_or_skip(tmp_path / "claude-plugin" / ".claude-plugin" / "plugin.json", outside / "plugin.json")
     _symlink_or_skip(tmp_path / "claude-market" / ".claude-plugin" / "marketplace.json", outside / "marketplace.json")
     _symlink_or_skip(tmp_path / "gemini-ext" / "gemini-extension.json", outside / "gemini-extension.json")
     _symlink_or_skip(tmp_path / "opencode-workspace" / "opencode.json", outside / "opencode.json")
+    _symlink_or_skip(tmp_path / "kimi-plugin" / "kimi.plugin.json", outside / "kimi.plugin.json")
 
     assert detect_packages(tmp_path) == []
 
@@ -234,6 +236,7 @@ def test_cli_lists_supported_ecosystems(capsys) -> None:
     assert "codex" in captured.out
     assert "claude" in captured.out
     assert "gemini" in captured.out
+    assert "kimi" in captured.out
     assert "opencode" in captured.out
 
 

--- a/tests/test_kimi_ecosystem.py
+++ b/tests/test_kimi_ecosystem.py
@@ -156,6 +156,18 @@ def test_kimi_alternate_manifest_is_scanned_when_root_manifest_is_absent(tmp_pat
     assert all(finding.rule_id != "KIMI_VERSION_INVALID" for finding in result.findings)
 
 
+def test_kimi_invalid_utf8_manifest_reports_parse_finding(tmp_path: Path) -> None:
+    (tmp_path / "kimi.plugin.json").write_bytes(b'\xff\xfe{"name":"plugin"}')
+
+    result = scan_plugin(
+        tmp_path,
+        ScanOptions(ecosystem="kimi", cisco_skill_scan="off", cisco_mcp_scan="off"),
+    )
+
+    finding = next(finding for finding in result.findings if finding.rule_id == "KIMI_MANIFEST_INVALID")
+    assert "invalid-encoding" in finding.description
+
+
 def test_kimi_declared_path_escape_is_rejected(tmp_path: Path) -> None:
     outside = tmp_path.parent / "outside-kimi-skill"
     outside.mkdir(exist_ok=True)
@@ -191,6 +203,21 @@ def test_kimi_declared_symlink_path_is_rejected(tmp_path: Path) -> None:
     assert any(finding.rule_id == "KIMI_PATH_SYMLINK_UNSUPPORTED" for finding in result.findings)
 
 
+def test_kimi_explicit_agent_file_must_be_markdown(tmp_path: Path) -> None:
+    (tmp_path / "agent.py").write_text("print('not an agent')", encoding="utf-8")
+    (tmp_path / "kimi.plugin.json").write_text(
+        json.dumps({"name": "invalid-agent-plugin", "agents": "./agent.py"}),
+        encoding="utf-8",
+    )
+
+    result = scan_plugin(
+        tmp_path,
+        ScanOptions(ecosystem="kimi", cisco_skill_scan="off", cisco_mcp_scan="off"),
+    )
+
+    assert any(finding.rule_id == "KIMI_MARKDOWN_PATH_INVALID" for finding in result.findings)
+
+
 def test_kimi_dangerous_mcp_command_is_high_severity(tmp_path: Path) -> None:
     (tmp_path / "kimi.plugin.json").write_text(
         json.dumps(
@@ -209,6 +236,62 @@ def test_kimi_dangerous_mcp_command_is_high_severity(tmp_path: Path) -> None:
 
     finding = next(finding for finding in result.findings if finding.rule_id == "KIMI_MCP_COMMAND_DANGEROUS")
     assert finding.severity.value == "high"
+
+
+def test_kimi_local_mcp_command_symlink_is_rejected(tmp_path: Path) -> None:
+    target = tmp_path / "server-target.js"
+    target.write_text("export {};", encoding="utf-8")
+    _symlink_or_skip(tmp_path / "server.js", target)
+    (tmp_path / "kimi.plugin.json").write_text(
+        json.dumps({"name": "symlink-plugin", "mcpServers": {"local": {"command": "./server.js"}}}),
+        encoding="utf-8",
+    )
+
+    result = scan_plugin(
+        tmp_path,
+        ScanOptions(ecosystem="kimi", cisco_skill_scan="off", cisco_mcp_scan="off"),
+    )
+
+    assert any(finding.rule_id == "KIMI_MCP_COMMAND_SYMLINK_UNSUPPORTED" for finding in result.findings)
+
+
+@pytest.mark.parametrize("path_value", ["../outside.js", "/outside.js", "C:outside.js"])
+@pytest.mark.parametrize("field", ["command", "args"])
+def test_kimi_external_mcp_command_or_arg_path_is_rejected(tmp_path: Path, field: str, path_value: str) -> None:
+    server: dict[str, object] = {"command": "node"}
+    server[field] = [path_value] if field == "args" else path_value
+    (tmp_path / "kimi.plugin.json").write_text(
+        json.dumps({"name": "external-path-plugin", "mcpServers": {"local": server}}),
+        encoding="utf-8",
+    )
+
+    result = scan_plugin(
+        tmp_path,
+        ScanOptions(ecosystem="kimi", cisco_skill_scan="off", cisco_mcp_scan="off"),
+    )
+
+    expected = "KIMI_MCP_ARG_PATH_INVALID" if field == "args" else "KIMI_MCP_COMMAND_PATH_INVALID"
+    assert any(finding.rule_id == expected for finding in result.findings)
+
+
+def test_kimi_mcp_cwd_must_be_directory(tmp_path: Path) -> None:
+    (tmp_path / "cwd.txt").write_text("not a directory", encoding="utf-8")
+    (tmp_path / "kimi.plugin.json").write_text(
+        json.dumps(
+            {
+                "name": "invalid-cwd-plugin",
+                "mcpServers": {"local": {"command": "node", "cwd": "./cwd.txt"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = scan_plugin(
+        tmp_path,
+        ScanOptions(ecosystem="kimi", cisco_skill_scan="off", cisco_mcp_scan="off"),
+    )
+
+    assert any(finding.rule_id == "KIMI_MCP_CWD_INVALID" for finding in result.findings)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_kimi_ecosystem.py
+++ b/tests/test_kimi_ecosystem.py
@@ -1,0 +1,254 @@
+"""Tests for native Kimi plugin detection and scanning."""
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.ecosystems.detect import detect_packages
+from codex_plugin_scanner.ecosystems.kimi import KimiAdapter
+from codex_plugin_scanner.ecosystems.types import Ecosystem
+from codex_plugin_scanner.models import ScanOptions
+from codex_plugin_scanner.scanner import scan_plugin
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _symlink_or_skip(link_path: Path, target: Path) -> None:
+    link_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        link_path.symlink_to(target, target_is_directory=target.is_dir())
+    except (NotImplementedError, OSError):
+        pytest.skip("symlinks are not supported in this environment")
+
+
+def test_detect_kimi_package() -> None:
+    packages = detect_packages(FIXTURES / "kimi-plugin-good")
+
+    assert len(packages) == 1
+    assert packages[0].ecosystem == Ecosystem.KIMI
+    assert packages[0].manifest_path and packages[0].manifest_path.name == "kimi.plugin.json"
+
+
+def test_scan_kimi_auto_detects_native_manifest() -> None:
+    result = scan_plugin(
+        FIXTURES / "kimi-plugin-good",
+        ScanOptions(ecosystem="auto", cisco_skill_scan="off", cisco_mcp_scan="off"),
+    )
+
+    assert result.ecosystems == ("kimi",)
+    assert len(result.packages) == 1
+    assert result.packages[0].manifest_path
+    assert result.packages[0].manifest_path.endswith("kimi.plugin.json")
+    assert any(category.name.endswith("Kimi Plugin") for category in result.categories)
+    assert all(finding.rule_id != "PLUGIN_JSON_MISSING" for finding in result.findings)
+    assert result.score >= 90
+
+
+def test_kimi_scan_excludes_unrelated_application_files(tmp_path: Path) -> None:
+    shutil.copytree(FIXTURES / "kimi-plugin-good", tmp_path, dirs_exist_ok=True)
+    unrelated = tmp_path / "src" / "application.py"
+    unrelated.parent.mkdir()
+    unrelated.write_text('api_key = "sk-proj-abcdefghijklmnopqrstuvwxyz123456"\n', encoding="utf-8")
+
+    result = scan_plugin(
+        tmp_path,
+        ScanOptions(ecosystem="auto", cisco_skill_scan="off", cisco_mcp_scan="off"),
+    )
+
+    assert all(finding.rule_id != "HARDCODED_SECRET" for finding in result.findings)
+
+
+def test_kimi_scan_checks_declared_bundle_files_for_secrets(tmp_path: Path) -> None:
+    shutil.copytree(FIXTURES / "kimi-plugin-good", tmp_path, dirs_exist_ok=True)
+    manifest_path = tmp_path / "kimi.plugin.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["mcpServers"] = {"local": {"command": "./server.js"}}
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    (tmp_path / "server.js").write_text(
+        'api_key = "sk-proj-abcdefghijklmnopqrstuvwxyz123456"\n',
+        encoding="utf-8",
+    )
+
+    result = scan_plugin(
+        tmp_path,
+        ScanOptions(ecosystem="kimi", cisco_skill_scan="off", cisco_mcp_scan="off"),
+    )
+
+    secrets = [finding for finding in result.findings if finding.rule_id == "HARDCODED_SECRET"]
+    assert len(secrets) == 1
+    assert secrets[0].file_path == "server.js"
+
+
+def test_kimi_scan_checks_local_mcp_entrypoints_in_args(tmp_path: Path) -> None:
+    shutil.copytree(FIXTURES / "kimi-plugin-good", tmp_path, dirs_exist_ok=True)
+    manifest_path = tmp_path / "kimi.plugin.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["mcpServers"] = {"local": {"command": "node", "args": ["./server.js"]}}
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    (tmp_path / "server.js").write_text(
+        'const apiKey = "sk-proj-abcdefghijklmnopqrstuvwxyz123456"; eval(apiKey);\n',
+        encoding="utf-8",
+    )
+
+    result = scan_plugin(
+        tmp_path,
+        ScanOptions(ecosystem="kimi", cisco_skill_scan="off", cisco_mcp_scan="off"),
+    )
+    rule_ids = {finding.rule_id for finding in result.findings}
+
+    assert "HARDCODED_SECRET" in rule_ids
+    assert "DANGEROUS_DYNAMIC_EXECUTION" in rule_ids
+
+
+def test_kimi_local_mcp_arg_symlink_is_rejected(tmp_path: Path) -> None:
+    outside = tmp_path / "outside.js"
+    outside.write_text("eval('unsafe');", encoding="utf-8")
+    _symlink_or_skip(tmp_path / "server.js", outside)
+    (tmp_path / "kimi.plugin.json").write_text(
+        json.dumps(
+            {
+                "name": "symlink-plugin",
+                "mcpServers": {"local": {"command": "node", "args": ["./server.js"]}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = scan_plugin(
+        tmp_path,
+        ScanOptions(ecosystem="kimi", cisco_skill_scan="off", cisco_mcp_scan="off"),
+    )
+
+    assert any(finding.rule_id == "KIMI_MCP_ARG_PATH_INVALID" for finding in result.findings)
+
+
+def test_kimi_root_manifest_takes_precedence_over_alternate_manifest(tmp_path: Path) -> None:
+    (tmp_path / ".kimi-plugin").mkdir()
+    (tmp_path / "kimi.plugin.json").write_text('{"name":"root-plugin"}', encoding="utf-8")
+    (tmp_path / ".kimi-plugin" / "plugin.json").write_text('{"name":"alternate-plugin"}', encoding="utf-8")
+
+    candidates = KimiAdapter().detect(tmp_path)
+    package = KimiAdapter().parse(candidates[0])
+
+    assert len(candidates) == 1
+    assert package.name == "root-plugin"
+    assert package.manifest_path == tmp_path / "kimi.plugin.json"
+
+
+def test_kimi_alternate_manifest_is_scanned_when_root_manifest_is_absent(tmp_path: Path) -> None:
+    (tmp_path / ".kimi-plugin").mkdir()
+    (tmp_path / ".kimi-plugin" / "plugin.json").write_text(
+        '{"name":"alternate-plugin","version":"1.0.0-beta.1+build.2"}',
+        encoding="utf-8",
+    )
+
+    result = scan_plugin(
+        tmp_path,
+        ScanOptions(ecosystem="auto", cisco_skill_scan="off", cisco_mcp_scan="off"),
+    )
+
+    assert result.ecosystems == ("kimi",)
+    assert result.packages[0].manifest_path
+    assert result.packages[0].manifest_path.endswith(".kimi-plugin/plugin.json")
+    assert all(finding.rule_id != "KIMI_VERSION_INVALID" for finding in result.findings)
+
+
+def test_kimi_declared_path_escape_is_rejected(tmp_path: Path) -> None:
+    outside = tmp_path.parent / "outside-kimi-skill"
+    outside.mkdir(exist_ok=True)
+    (outside / "SKILL.md").write_text("outside", encoding="utf-8")
+    (tmp_path / "kimi.plugin.json").write_text(
+        json.dumps({"name": "unsafe-plugin", "skills": "../outside-kimi-skill/"}),
+        encoding="utf-8",
+    )
+
+    result = scan_plugin(
+        tmp_path,
+        ScanOptions(ecosystem="auto", cisco_skill_scan="off", cisco_mcp_scan="off"),
+    )
+
+    assert any(finding.rule_id == "KIMI_PATH_UNSAFE_OR_MISSING" for finding in result.findings)
+
+
+def test_kimi_declared_symlink_path_is_rejected(tmp_path: Path) -> None:
+    real_commands = tmp_path / "real-commands"
+    real_commands.mkdir()
+    (real_commands / "review.md").write_text("Review safely.", encoding="utf-8")
+    _symlink_or_skip(tmp_path / "commands", real_commands)
+    (tmp_path / "kimi.plugin.json").write_text(
+        json.dumps({"name": "symlink-plugin", "commands": "./commands/"}),
+        encoding="utf-8",
+    )
+
+    result = scan_plugin(
+        tmp_path,
+        ScanOptions(ecosystem="kimi", cisco_skill_scan="off", cisco_mcp_scan="off"),
+    )
+
+    assert any(finding.rule_id == "KIMI_PATH_SYMLINK_UNSUPPORTED" for finding in result.findings)
+
+
+def test_kimi_dangerous_mcp_command_is_high_severity(tmp_path: Path) -> None:
+    (tmp_path / "kimi.plugin.json").write_text(
+        json.dumps(
+            {
+                "name": "unsafe-plugin",
+                "mcpServers": {"unsafe": {"command": "sh", "args": ["-c", "printf unsafe"]}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = scan_plugin(
+        tmp_path,
+        ScanOptions(ecosystem="kimi", cisco_skill_scan="off", cisco_mcp_scan="off"),
+    )
+
+    finding = next(finding for finding in result.findings if finding.rule_id == "KIMI_MCP_COMMAND_DANGEROUS")
+    assert finding.severity.value == "high"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https:attacker.example/mcp",
+        "https://user:secret@example.com/mcp",
+        "https://example.com/mcp#fragment",
+    ],
+)
+def test_kimi_malformed_or_credentialed_remote_mcp_url_is_rejected(tmp_path: Path, url: str) -> None:
+    (tmp_path / "kimi.plugin.json").write_text(
+        json.dumps({"name": "unsafe-plugin", "mcpServers": {"remote": {"url": url}}}),
+        encoding="utf-8",
+    )
+
+    result = scan_plugin(
+        tmp_path,
+        ScanOptions(ecosystem="kimi", cisco_skill_scan="off", cisco_mcp_scan="off"),
+    )
+
+    assert any(finding.rule_id == "KIMI_MCP_URL_INSECURE" for finding in result.findings)
+
+
+def test_cli_scans_kimi_ecosystem_explicitly(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(
+        [
+            "scan",
+            str(FIXTURES / "kimi-plugin-good"),
+            "--ecosystem",
+            "kimi",
+            "--cisco-skill-scan",
+            "off",
+            "--cisco-mcp-scan",
+            "off",
+            "--format",
+            "json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["ecosystems"] == ["kimi"]


### PR DESCRIPTION
## Summary
- detect and validate native Kimi plugin manifests in both supported locations
- scan declared Kimi skills, agents, commands, prompts, and local MCP entrypoints without treating the surrounding application as plugin content
- fail closed on unsafe paths, ambiguous symlinks, dangerous MCP commands, and malformed remote MCP endpoints

## Testing
- `uv run --no-sync pytest -q tests/test_kimi_ecosystem.py tests/test_ecosystems.py --tb=short`
- `uv run --no-sync pytest -q tests/test_ecosystems.py tests/test_kimi_ecosystem.py tests/test_scanner.py tests/test_code_quality.py tests/test_security.py tests/test_security_ops.py tests/test_cli.py tests/test_ci_test_suite_ratchet.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/checks/code_quality.py src/codex_plugin_scanner/checks/security.py src/codex_plugin_scanner/checks/kimi.py src/codex_plugin_scanner/cli.py src/codex_plugin_scanner/ecosystems/kimi.py src/codex_plugin_scanner/ecosystems/registry.py src/codex_plugin_scanner/ecosystems/types.py src/codex_plugin_scanner/scanner.py tests/test_ecosystems.py tests/test_kimi_ecosystem.py`
- `uv run --no-sync basedpyright src/codex_plugin_scanner/checks/kimi.py src/codex_plugin_scanner/ecosystems/kimi.py`

Closes #2446


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for scanning Kimi Code plugins, including manifests, skills, agents, commands, prompts, and MCP servers.
  - Added automatic detection and explicit CLI scanning with `--ecosystem kimi`.
  - Added validation for plugin metadata, declared files, paths, commands, URLs, MCP configuration, and security risks.

- **Documentation**
  - Updated ecosystem support documentation with Kimi Code coverage and usage examples.

- **Testing**
  - Added comprehensive coverage for detection, scanning, security findings, malformed configurations, symlinks, and path traversal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->