### PR TITLE
fix(grok): refresh PreToolUse hook timeout during update

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 15064,
-  "maximum_test_source_lines": 325079,
+  "maximum_collected_cases": 15068,
+  "maximum_test_source_lines": 325191,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -56,6 +56,7 @@ from .update_artifact import (
     recover_local_wheel_original,
     stage_trusted_wheel,
 )
+from .update_grok_repair import append_grok_repair
 from .update_subprocess import (
     InstalledDistribution,
     TrustedUpdateContext,
@@ -2430,6 +2431,7 @@ def _repair_supported_harnesses_in_process(
         repaired_installs.append(repaired_cursor)
     if cursor_warning is not None:
         repair_notes.append(cursor_warning)
+    append_grok_repair(repaired_installs, repair_notes, context=context, store=store, workspace=workspace, now=now)
     legacy_omp_migration, legacy_omp_warning = _migrate_legacy_omp_install(
         context=context,
         store=store,
@@ -2507,13 +2509,7 @@ def _repair_pi_family_install(
     workspace: str | None,
     now: str,
 ) -> tuple[dict[str, object] | None, str | None]:
-    """Rewrite one managed Pi-family extension after package updates.
-
-    The extension embeds timeout and daemon-compat constants. Refreshing it after
-    update keeps the fast daemon path available and avoids cold CLI timeouts.
-    When the on-disk extension and settings already match the current package,
-    skip the rewrite so already-current updates stay silent.
-    """
+    """Rewrite one managed Pi-family extension after package updates."""
 
     try:
         managed_install = store.get_managed_install(harness)

--- a/src/codex_plugin_scanner/guard/cli/update_grok_repair.py
+++ b/src/codex_plugin_scanner/guard/cli/update_grok_repair.py
@@ -1,0 +1,121 @@
+"""Refresh managed Grok hooks after a Guard package update."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from ..adapters.base import HarnessContext
+from ..adapters.grok import GrokHarnessAdapter
+from ..adapters.grok_config import (
+    GROK_HOOK_INTERNAL_TIMEOUT_SECONDS,
+    GROK_PRETOOL_HOOK_TIMEOUT_SECONDS,
+    GUARD_HOOK_PRETOOL_FILE,
+)
+from ..store import GuardStore
+from .install_commands import apply_managed_install
+from .managed_install_context import managed_install_context as repair_context_from_managed_install
+
+
+def repair_grok_install(
+    *,
+    context: HarnessContext,
+    store: GuardStore,
+    workspace: str | None,
+    now: str,
+) -> tuple[dict[str, object] | None, str | None]:
+    """Rewrite Grok PreToolUse hooks when the baked timeout is stale."""
+
+    try:
+        managed_install = store.get_managed_install("grok")
+    except (json.JSONDecodeError, sqlite3.Error):
+        return None, None
+    if managed_install is None or not bool(managed_install.get("active")):
+        return None, None
+    try:
+        repair_context, repair_workspace = repair_context_from_managed_install(context, managed_install)
+        if _grok_hooks_are_current(repair_context):
+            return None, None
+        payload = apply_managed_install(
+            "install",
+            "grok",
+            False,
+            repair_context,
+            store,
+            repair_workspace or workspace,
+            now,
+        )
+    except (OSError, RuntimeError, ValueError, json.JSONDecodeError, sqlite3.Error) as error:
+        return None, f"Could not refresh Grok protection during update: {error}"
+    repaired = payload.get("managed_install")
+    if not isinstance(repaired, dict):
+        return None, "Could not refresh Grok protection during update: managed install was not recorded"
+    return repaired, None
+
+
+def _grok_hooks_are_current(context: HarnessContext) -> bool:
+    hook_path = GrokHarnessAdapter._hooks_dir(context) / GUARD_HOOK_PRETOOL_FILE
+    if not hook_path.is_file():
+        return False
+    try:
+        payload = json.loads(hook_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    timeout = _pretool_timeout(payload)
+    command = _pretool_command(payload)
+    marker = f'"timeout_seconds":{GROK_HOOK_INTERNAL_TIMEOUT_SECONDS}'
+    return timeout == GROK_PRETOOL_HOOK_TIMEOUT_SECONDS and marker in command.replace(" ", "")
+
+
+def _pretool_timeout(payload: object) -> int | None:
+    command = _pretool_entry(payload)
+    timeout = command.get("timeout") if command is not None else None
+    return timeout if isinstance(timeout, int) else None
+
+
+def _pretool_command(payload: object) -> str:
+    command = _pretool_entry(payload)
+    value = command.get("command") if command is not None else None
+    return value if isinstance(value, str) else ""
+
+
+def _pretool_entry(payload: object) -> dict[str, object] | None:
+    if not isinstance(payload, dict):
+        return None
+    hooks = payload.get("hooks")
+    if not isinstance(hooks, dict):
+        return None
+    pretool = hooks.get("PreToolUse")
+    if not isinstance(pretool, list) or not pretool:
+        return None
+    first = pretool[0]
+    if not isinstance(first, dict):
+        return None
+    inner = first.get("hooks")
+    if isinstance(inner, list) and inner and isinstance(inner[0], dict):
+        return inner[0]
+    return first
+
+
+def append_grok_repair(
+    repaired_installs: list[dict[str, object]],
+    repair_notes: list[str],
+    *,
+    context: HarnessContext,
+    store: GuardStore,
+    workspace: str | None,
+    now: str,
+) -> None:
+    repaired, warning = repair_grok_install(
+        context=context,
+        store=store,
+        workspace=workspace,
+        now=now,
+    )
+    if repaired is not None:
+        repaired_installs.append(repaired)
+    if warning is not None:
+        repair_notes.append(warning)
+
+
+__all__ = ["append_grok_repair", "repair_grok_install"]

--- a/tests/test_update_grok_repair.py
+++ b/tests/test_update_grok_repair.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.grok import GrokHarnessAdapter
+from codex_plugin_scanner.guard.adapters.grok_config import (
+    GROK_PRETOOL_HOOK_TIMEOUT_SECONDS,
+    GUARD_HOOK_PRETOOL_FILE,
+)
+from codex_plugin_scanner.guard.cli import update_commands
+from codex_plugin_scanner.guard.cli.update_grok_repair import repair_grok_install
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _context(tmp_path: Path) -> HarnessContext:
+    home = tmp_path / "home"
+    home.mkdir()
+    guard_home = home / ".hol-guard"
+    guard_home.mkdir()
+    return HarnessContext(home_dir=home, workspace_dir=None, guard_home=guard_home)
+
+
+def _seed_grok_install(context: HarnessContext, store: GuardStore, now: str) -> Path:
+    adapter = GrokHarnessAdapter()
+    manifest = adapter.install(context)
+    store.set_managed_install("grok", True, None, manifest, now)
+    return adapter._hooks_dir(context) / GUARD_HOOK_PRETOOL_FILE
+
+
+def _set_pretool_timeout(hook_path: Path, timeout: int) -> None:
+    payload = json.loads(hook_path.read_text(encoding="utf-8"))
+    payload["hooks"]["PreToolUse"][0]["hooks"][0]["timeout"] = timeout
+    hook_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def test_grok_repair_skips_when_hooks_already_current(tmp_path: Path) -> None:
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    now = "2026-08-17T00:00:00+00:00"
+    hook_path = _seed_grok_install(context, store, now)
+    before = hook_path.read_text(encoding="utf-8")
+
+    repaired, warning = repair_grok_install(
+        context=context,
+        store=store,
+        workspace=None,
+        now=now,
+    )
+
+    assert repaired is None
+    assert warning is None
+    assert hook_path.read_text(encoding="utf-8") == before
+
+
+def test_grok_repair_rewrites_stale_pretool_timeout(tmp_path: Path) -> None:
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    now = "2026-08-17T00:00:00+00:00"
+    hook_path = _seed_grok_install(context, store, now)
+    _set_pretool_timeout(hook_path, 30)
+
+    repaired, warning = repair_grok_install(
+        context=context,
+        store=store,
+        workspace=None,
+        now=now,
+    )
+
+    assert warning is None
+    assert isinstance(repaired, dict)
+    assert repaired.get("harness") == "grok"
+    payload = json.loads(hook_path.read_text(encoding="utf-8"))
+    assert payload["hooks"]["PreToolUse"][0]["hooks"][0]["timeout"] == GROK_PRETOOL_HOOK_TIMEOUT_SECONDS
+
+
+def test_grok_repair_skips_inactive_install(tmp_path: Path) -> None:
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    now = "2026-08-17T00:00:00+00:00"
+
+    repaired, warning = repair_grok_install(
+        context=context,
+        store=store,
+        workspace=None,
+        now=now,
+    )
+
+    assert repaired is None
+    assert warning is None
+
+
+def test_update_repair_rewrites_stale_grok_hooks(tmp_path: Path) -> None:
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    now = "2026-08-17T00:00:00+00:00"
+    hook_path = _seed_grok_install(context, store, now)
+    _set_pretool_timeout(hook_path, 30)
+
+    repaired, notes = update_commands._repair_supported_harnesses_in_process(
+        context=context,
+        store=store,
+        workspace=None,
+        now=now,
+        dry_run=False,
+    )
+
+    assert notes == []
+    assert any(item.get("harness") == "grok" for item in repaired)
+    payload = json.loads(hook_path.read_text(encoding="utf-8"))
+    assert payload["hooks"]["PreToolUse"][0]["hooks"][0]["timeout"] == GROK_PRETOOL_HOOK_TIMEOUT_SECONDS


### PR DESCRIPTION
## Summary
- Refresh managed Grok PreToolUse hooks during `hol-guard update` when the baked hook timeout is stale.
- Existing Grok installs kept a 30s hook budget after package updates, which is too short for live approval wait.
- Skip the rewrite when the on-disk hook already matches the current package timeout.

## Testing
- `uv run --no-sync pytest tests/test_update_grok_repair.py tests/test_update_pi_family_repair.py -q --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/cli/update_grok_repair.py src/codex_plugin_scanner/guard/cli/update_commands.py tests/test_update_grok_repair.py`

## Notes
- `update_commands.py` is smaller after the change. Grok repair lives in a new helper so the oversized update module does not grow.
