### PR TITLE
fix(daemon): make startup rollback transactional

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 12738,
-  "maximum_test_source_lines": 291020,
+  "maximum_test_source_lines": 291146,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/daemon/request_executor.py
+++ b/src/codex_plugin_scanner/guard/daemon/request_executor.py
@@ -1,0 +1,90 @@
+"""Bounded request execution for the local Guard daemon."""
+
+from __future__ import annotations
+
+import queue
+import socket
+import threading
+import time
+from collections.abc import Callable
+from typing import TypeAlias
+
+_TransportWorkItem: TypeAlias = tuple[socket.socket, tuple[str, int]]
+
+
+class BoundedRequestExecutor:
+    def __init__(
+        self,
+        *,
+        name: str,
+        workers: int,
+        queue_limit: int,
+        run: Callable[[socket.socket, tuple[str, int]], None],
+        discard: Callable[[socket.socket], None],
+    ) -> None:
+        self._queue: queue.Queue[_TransportWorkItem | None] = queue.Queue(maxsize=queue_limit)
+        self._run = run
+        self._discard = discard
+        self._stopped = threading.Event()
+        self._lifecycle_lock = threading.Lock()
+        self._threads: list[threading.Thread] = []
+        try:
+            for index in range(workers):
+                thread = threading.Thread(
+                    target=self._worker,
+                    daemon=True,
+                    name=f"guard-http-{name}-{index + 1}",
+                )
+                thread.start()
+                self._threads.append(thread)
+        except BaseException:
+            self._stopped.set()
+            for _ in self._threads:
+                self._queue.put(None, timeout=1.0)
+            for thread in self._threads:
+                thread.join(timeout=1.0)
+            raise
+
+    @property
+    def threads(self) -> tuple[threading.Thread, ...]:
+        return tuple(self._threads)
+
+    def submit(self, request: socket.socket, client_address: tuple[str, int]) -> bool:
+        with self._lifecycle_lock:
+            if self._stopped.is_set():
+                return False
+            try:
+                self._queue.put_nowait((request, client_address))
+            except queue.Full:
+                return False
+        return True
+
+    def shutdown(self, *, timeout_seconds: float) -> bool:
+        with self._lifecycle_lock:
+            if not self._stopped.is_set():
+                self._stopped.set()
+                while True:
+                    try:
+                        item = self._queue.get_nowait()
+                    except queue.Empty:
+                        break
+                    if item is not None:
+                        self._discard(item[0])
+                    self._queue.task_done()
+                for _ in self._threads:
+                    self._queue.put_nowait(None)
+        deadline = time.monotonic() + timeout_seconds
+        for thread in self._threads:
+            if thread is not threading.current_thread():
+                thread.join(timeout=max(0.0, deadline - time.monotonic()))
+        return all(not thread.is_alive() for thread in self._threads)
+
+    def _worker(self) -> None:
+        while True:
+            item = self._queue.get()
+            try:
+                if item is None:
+                    return
+                self._run(*item)
+            finally:
+                self._queue.task_done()

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -12,7 +12,6 @@ import math
 import mimetypes
 import os
 import platform
-import queue
 import secrets
 import socket
 import sqlite3
@@ -21,7 +20,7 @@ import tempfile
 import threading
 import time
 import uuid
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from contextlib import suppress
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -250,6 +249,7 @@ from .manager import (
     repair_approval_center_locator,
     write_guard_daemon_state,
 )
+from .request_executor import BoundedRequestExecutor as _BoundedRequestExecutor
 from .runtime_heartbeat import RuntimeHeartbeatWriter
 from .runtime_hook_deadline import RuntimeHookDeadline
 from .runtime_hook_evidence_writer import RuntimeHookEvidenceWriter
@@ -384,80 +384,6 @@ def _runtime_hook_remaining_hint(payload: dict[str, object]) -> float:
 _PEER_DISCONNECT_ERRORS = (BrokenPipeError, ConnectionResetError, ConnectionAbortedError)
 
 
-_TransportWorkItem: TypeAlias = tuple[socket.socket, tuple[str, int]]
-
-
-class _BoundedRequestExecutor:
-    def __init__(
-        self,
-        *,
-        name: str,
-        workers: int,
-        queue_limit: int,
-        run: Callable[[socket.socket, tuple[str, int]], None],
-        discard: Callable[[socket.socket], None],
-    ) -> None:
-        self._queue: queue.Queue[_TransportWorkItem | None] = queue.Queue(maxsize=queue_limit)
-        self._run = run
-        self._discard = discard
-        self._stopped = threading.Event()
-        self._lifecycle_lock = threading.Lock()
-        self._threads = [
-            threading.Thread(
-                target=self._worker,
-                daemon=True,
-                name=f"guard-http-{name}-{index + 1}",
-            )
-            for index in range(workers)
-        ]
-        for thread in self._threads:
-            thread.start()
-
-    @property
-    def threads(self) -> tuple[threading.Thread, ...]:
-        return tuple(self._threads)
-
-    def submit(self, request: socket.socket, client_address: tuple[str, int]) -> bool:
-        with self._lifecycle_lock:
-            if self._stopped.is_set():
-                return False
-            try:
-                self._queue.put_nowait((request, client_address))
-            except queue.Full:
-                return False
-        return True
-
-    def shutdown(self, *, timeout_seconds: float) -> bool:
-        with self._lifecycle_lock:
-            if not self._stopped.is_set():
-                self._stopped.set()
-                while True:
-                    try:
-                        item = self._queue.get_nowait()
-                    except queue.Empty:
-                        break
-                    if item is not None:
-                        self._discard(item[0])
-                    self._queue.task_done()
-                for _ in self._threads:
-                    self._queue.put_nowait(None)
-        deadline = time.monotonic() + timeout_seconds
-        for thread in self._threads:
-            if thread is not threading.current_thread():
-                thread.join(timeout=max(0.0, deadline - time.monotonic()))
-        return all(not thread.is_alive() for thread in self._threads)
-
-    def _worker(self) -> None:
-        while True:
-            item = self._queue.get()
-            try:
-                if item is None:
-                    return
-                self._run(*item)
-            finally:
-                self._queue.task_done()
-
-
 class _GuardDaemonHttpServer(HTTPServer):
     request_queue_size = _MAX_CONCURRENT_DAEMON_CONNECTIONS
 
@@ -558,7 +484,9 @@ class _GuardDaemonHttpServer(HTTPServer):
         shutdown_started: threading.Event,
         diagnostics: DaemonDiagnostics,
     ) -> None:
-        super().__init__(server_address, handler_class)
+        # TCPServer calls server_close() when bind/activation fails. Treat the
+        # request executors as already stopped until their construction finishes.
+        self.request_executors_stopped = True
         self.store = store
         self.runtime = GuardSurfaceRuntime(store)
         self.auth_token = auth_token
@@ -630,30 +558,43 @@ class _GuardDaemonHttpServer(HTTPServer):
             retry_interval_seconds=0.05,
         )
         self.store.set_policy_integrity_state_listener(self.publish_trust_state)
+        self.runtime_hook_evidence_writer = RuntimeHookEvidenceWriter(store=store)
+        self._initialize_request_services()
+        self.request_executors_stopped = False
+        super().__init__(server_address, handler_class)
+
+    def _initialize_request_services(self) -> None:
         from .hook_worker import HookWorker
 
-        self.runtime_hook_evidence_writer = RuntimeHookEvidenceWriter(store=store)
-        self.hook_worker = HookWorker(store=store, activity_writer=self.runtime_hook_evidence_writer)
-        self.approval_attention = ApprovalAttentionCoordinator(
-            store=store,
-            runtime=self.runtime,
-            opener=open_browser_url,
-        )
-        self.request_executors_stopped = False
-        self.general_request_executor = _BoundedRequestExecutor(
-            name="general",
-            workers=_MAX_CONCURRENT_DAEMON_REQUESTS,
-            queue_limit=_MAX_CONCURRENT_DAEMON_CONNECTIONS,
-            run=self._process_request_worker,
-            discard=self._discard_request,
-        )
-        self.control_request_executor = _BoundedRequestExecutor(
-            name="control",
-            workers=_MAX_CONCURRENT_DAEMON_CONTROL_REQUESTS,
-            queue_limit=_MAX_CONCURRENT_DAEMON_CONNECTIONS,
-            run=self._process_request_worker,
-            discard=self._discard_request,
-        )
+        try:
+            self.hook_worker = HookWorker(store=self.store, activity_writer=self.runtime_hook_evidence_writer)
+            self.approval_attention = ApprovalAttentionCoordinator(
+                store=self.store,
+                runtime=self.runtime,
+                opener=open_browser_url,
+            )
+            self.general_request_executor = _BoundedRequestExecutor(
+                name="general",
+                workers=_MAX_CONCURRENT_DAEMON_REQUESTS,
+                queue_limit=_MAX_CONCURRENT_DAEMON_CONNECTIONS,
+                run=self._process_request_worker,
+                discard=self._discard_request,
+            )
+            self.control_request_executor = _BoundedRequestExecutor(
+                name="control",
+                workers=_MAX_CONCURRENT_DAEMON_CONTROL_REQUESTS,
+                queue_limit=_MAX_CONCURRENT_DAEMON_CONNECTIONS,
+                run=self._process_request_worker,
+                discard=self._discard_request,
+            )
+        except BaseException:
+            for executor_name in ("control_request_executor", "general_request_executor"):
+                executor = getattr(self, executor_name, None)
+                if executor is not None:
+                    _ = executor.shutdown(timeout_seconds=1.0)
+            _ = self.runtime_hook_evidence_writer.stop(timeout_seconds=1.0)
+            _ = self.hook_process_runner.close_contained()
+            raise
 
     def process_request(self, request: object, client_address: tuple[str, int]) -> None:
         request_socket = cast(socket.socket, request)
@@ -7719,21 +7660,26 @@ class GuardDaemonServer:
         self._shutdown_started = threading.Event()
         self._finish_service_lock = threading.Lock()
         self._owner_lock: BinaryIO | None = None
-        self._server = _GuardDaemonHttpServer(
-            (host, port),
-            _GuardDaemonHandler,
-            store=store,
-            auth_token=load_guard_daemon_auth_token(store.guard_home) or uuid.uuid4().hex,
-            runtime_host=host,
-            runtime_session_id=uuid.uuid4().hex,
-            runtime_started_at=_now(),
-            idle_timeout_seconds=_guard_daemon_idle_timeout_seconds(
-                store.guard_home,
-                idle_timeout_seconds=idle_timeout_seconds,
-            ),
-            shutdown_started=self._shutdown_started,
-            diagnostics=self._diagnostics,
-        )
+        try:
+            self._server = _GuardDaemonHttpServer(
+                (host, port),
+                _GuardDaemonHandler,
+                store=store,
+                auth_token=load_guard_daemon_auth_token(store.guard_home) or uuid.uuid4().hex,
+                runtime_host=host,
+                runtime_session_id=uuid.uuid4().hex,
+                runtime_started_at=_now(),
+                idle_timeout_seconds=_guard_daemon_idle_timeout_seconds(
+                    store.guard_home,
+                    idle_timeout_seconds=idle_timeout_seconds,
+                ),
+                shutdown_started=self._shutdown_started,
+                diagnostics=self._diagnostics,
+            )
+        except BaseException:
+            self._diagnostics.record_exception("daemon_initialization_failed")
+            self._diagnostics.close(timeout_seconds=0.5)
+            raise
         self.port = self._server.daemon_port()
         self._bundle_refresh_backoff_seconds = bundle_refresh_backoff_seconds
         self._bundle_refresh_interval_seconds = bundle_refresh_interval_seconds

--- a/tests/test_guard_daemon_startup_rollback.py
+++ b/tests/test_guard_daemon_startup_rollback.py
@@ -2,16 +2,142 @@
 
 from __future__ import annotations
 
+import errno
 import gc
+import socket
 import threading
 import weakref
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
 
 from codex_plugin_scanner.guard.daemon import manager as daemon_manager
+from codex_plugin_scanner.guard.daemon import server as daemon_server_module
 from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
 from codex_plugin_scanner.guard.store import GuardStore
+
+
+def test_occupied_port_preserves_bind_error_during_partial_server_cleanup(tmp_path: Path) -> None:
+    diagnostics_threads_before = {
+        thread.ident
+        for thread in threading.enumerate()
+        if thread.name == "guard-daemon-diagnostics" and thread.is_alive()
+    }
+    executor_threads_before = {
+        thread.ident for thread in threading.enumerate() if thread.name.startswith("guard-http-")
+    }
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen()
+    port = listener.getsockname()[1]
+
+    try:
+        with pytest.raises(OSError) as error:
+            _ = GuardDaemonServer(
+                GuardStore(tmp_path / "guard-home"),
+                host="127.0.0.1",
+                port=port,
+                idle_timeout_seconds=0,
+            )
+    finally:
+        listener.close()
+
+    assert error.value.errno == errno.EADDRINUSE
+    assert "request_executors_stopped" not in str(error.value)
+    assert not any(
+        thread.ident not in diagnostics_threads_before
+        and thread.name == "guard-daemon-diagnostics"
+        and thread.is_alive()
+        for thread in threading.enumerate()
+    )
+    assert not any(
+        thread.ident not in executor_threads_before and thread.name.startswith("guard-http-") and thread.is_alive()
+        for thread in threading.enumerate()
+    )
+
+
+def test_executor_construction_failure_rolls_back_threads_before_bind(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.bind(("127.0.0.1", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+    executor_threads_before = {
+        thread.ident for thread in threading.enumerate() if thread.name.startswith("guard-http-")
+    }
+    real_executor = daemon_server_module._BoundedRequestExecutor
+    construction_count = 0
+
+    def fail_second_executor(
+        *,
+        name: str,
+        workers: int,
+        queue_limit: int,
+        run: Callable[[socket.socket, tuple[str, int]], None],
+        discard: Callable[[socket.socket], None],
+    ) -> object:
+        nonlocal construction_count
+        construction_count += 1
+        if construction_count == 2:
+            raise RuntimeError("injected executor exhaustion")
+        return real_executor(name=name, workers=workers, queue_limit=queue_limit, run=run, discard=discard)
+
+    monkeypatch.setattr(daemon_server_module, "_BoundedRequestExecutor", fail_second_executor)
+
+    with pytest.raises(RuntimeError, match="injected executor exhaustion"):
+        _ = GuardDaemonServer(
+            GuardStore(tmp_path / "guard-home"),
+            host="127.0.0.1",
+            port=port,
+            idle_timeout_seconds=0,
+        )
+
+    assert not any(
+        thread.ident not in executor_threads_before and thread.name.startswith("guard-http-") and thread.is_alive()
+        for thread in threading.enumerate()
+    )
+    replacement = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        replacement.bind(("127.0.0.1", port))
+    finally:
+        replacement.close()
+
+
+def test_executor_worker_start_failure_rolls_back_started_threads(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor_threads_before = {
+        thread.ident for thread in threading.enumerate() if thread.name.startswith("guard-http-")
+    }
+    real_start = threading.Thread.start
+    guard_http_start_count = 0
+
+    def fail_third_guard_http_start(thread: threading.Thread) -> None:
+        nonlocal guard_http_start_count
+        if thread.name.startswith("guard-http-"):
+            guard_http_start_count += 1
+            if guard_http_start_count == 3:
+                raise RuntimeError("injected HTTP worker exhaustion")
+        real_start(thread)
+
+    monkeypatch.setattr(threading.Thread, "start", fail_third_guard_http_start)
+
+    with pytest.raises(RuntimeError, match="injected HTTP worker exhaustion"):
+        _ = GuardDaemonServer(
+            GuardStore(tmp_path / "guard-home"),
+            host="127.0.0.1",
+            port=0,
+            idle_timeout_seconds=0,
+        )
+
+    assert not any(
+        thread.ident not in executor_threads_before and thread.name.startswith("guard-http-") and thread.is_alive()
+        for thread in threading.enumerate()
+    )
 
 
 def test_serve_thread_start_failure_rolls_back_initialized_service(


### PR DESCRIPTION
## Summary
- preserve the original socket bind failure when daemon startup cannot complete
- roll back partially initialized request workers and diagnostics without leaving live resources

## Testing
- `uv run --no-sync pytest -q tests/test_guard_daemon_startup_rollback.py tests/test_guard_daemon_owner_lock.py tests/test_guard_daemon_adversarial_transport.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/daemon/request_executor.py src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_daemon_startup_rollback.py`
- `uv run --no-sync basedpyright --level error src/codex_plugin_scanner/guard/daemon/request_executor.py src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_daemon_startup_rollback.py`
- `uv run --no-sync python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory <inventory-file>`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Guard daemon startup cleanup when initialization fails.
  - Prevented leftover worker threads, diagnostics, and occupied ports after failed starts.
  - Preserved the original bind error when a port is unavailable.
  - Added bounded request handling with queue limits and graceful shutdown behavior.
  - Ensured queued requests are safely discarded during shutdown.

- **Tests**
  - Added coverage for startup failures, worker creation errors, occupied ports, and partial cleanup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->