### PR TITLE
fix(daemon): recover dashboard after stale process exit

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12739,
-  "maximum_test_source_lines": 291196,
+  "maximum_collected_cases": 12741,
+  "maximum_test_source_lines": 291218,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12738,
-  "maximum_test_source_lines": 291146,
+  "maximum_collected_cases": 12739,
+  "maximum_test_source_lines": 291196,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -300,7 +300,7 @@ def _resolve_legacy_args(
 
 
 def main(argv: list[str] | None = None) -> int:
-    effective_argv = argv or sys.argv[1:]
+    effective_argv = sys.argv[1:] if argv is None else argv
     if bool(getattr(sys, "frozen", False)) and effective_argv[:1] == ["__guard-bounded-hook"]:
         from .guard.adapters.bounded_cli_hook_bridge import main_from_argv
 
@@ -314,6 +314,8 @@ def main(argv: list[str] | None = None) -> int:
         program_mode = "scanner"
     else:
         program_mode = "combined"
+    if program_mode in {"guard", "hol-guard"} and effective_argv[:1] == ["help"]:
+        effective_argv = [*effective_argv[1:], "--help"]
     parser = _build_parser(program_name, program_mode=program_mode)
     resolved_argv = _resolve_legacy_args(
         effective_argv,

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -2676,8 +2676,10 @@ def _retire_guard_daemon_pid(
         return windows_terminate_process_if_creation_time(pid, observed_creation_time)
     try:
         os.kill(pid, signal.SIGTERM)
-    except OSError:
+    except ProcessLookupError:
         return True
+    except OSError:
+        return _guard_daemon_pid_is_proven_dead(pid)
     if _wait_for_guard_daemon_pid_death(pid):
         return True
     sigkill = getattr(signal, "SIGKILL", None)
@@ -2685,8 +2687,10 @@ def _retire_guard_daemon_pid(
         return False
     try:
         os.kill(pid, sigkill)
-    except OSError:
+    except ProcessLookupError:
         return True
+    except OSError:
+        return _guard_daemon_pid_is_proven_dead(pid)
     return _wait_for_guard_daemon_pid_death(pid)
 
 

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -2535,6 +2535,15 @@ def _guard_daemon_pid_is_proven_dead(pid: int) -> bool:
     return not _guard_daemon_pid_is_running(pid)
 
 
+def _wait_for_guard_daemon_pid_death(pid: int, *, timeout: float = 1.0) -> bool:
+    deadline = time.monotonic() + max(0.0, timeout)
+    while time.monotonic() < deadline:
+        if _guard_daemon_pid_is_proven_dead(pid):
+            return True
+        time.sleep(GUARD_DAEMON_POLL_INTERVAL_SECONDS)
+    return _guard_daemon_pid_is_proven_dead(pid)
+
+
 def _guard_daemon_pid_matches_command(pid: int, expected_guard_home: Path | None = None) -> bool:
     return _guard_daemon_pid_command_identity(pid, expected_guard_home=expected_guard_home) is True
 
@@ -2669,11 +2678,8 @@ def _retire_guard_daemon_pid(
         os.kill(pid, signal.SIGTERM)
     except OSError:
         return True
-    deadline = time.monotonic() + 1.0
-    while time.monotonic() < deadline:
-        if not _guard_daemon_pid_is_running(pid):
-            return True
-        time.sleep(GUARD_DAEMON_POLL_INTERVAL_SECONDS)
+    if _wait_for_guard_daemon_pid_death(pid):
+        return True
     sigkill = getattr(signal, "SIGKILL", None)
     if sigkill is None:
         return False
@@ -2681,7 +2687,7 @@ def _retire_guard_daemon_pid(
         os.kill(pid, sigkill)
     except OSError:
         return True
-    return not _guard_daemon_pid_is_running(pid)
+    return _wait_for_guard_daemon_pid_death(pid)
 
 
 def _wait_for_guard_daemon_url(

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -908,6 +908,27 @@ class TestGuardCli:
         assert "usage: hol-guard" in output
         assert "Run `hol-guard --help`" not in output
 
+    def test_hol_guard_help_alias_shows_root_help(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr(sys, "argv", ["hol-guard"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            main(["help"])
+
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        assert "usage: hol-guard" in output
+        assert "dashboard" in output
+
+    def test_hol_guard_help_alias_shows_command_help(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr(sys, "argv", ["hol-guard"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            main(["help", "dashboard"])
+
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        assert "usage: hol-guard dashboard" in output
+
     def test_hol_guard_routes_flat_commands_without_nested_guard_alias(self, monkeypatch, capsys) -> None:
         called: dict[str, object] = {}
 

--- a/tests/test_guard_daemon_manager.py
+++ b/tests/test_guard_daemon_manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import signal
 import stat
 import subprocess
 import sys
@@ -36,6 +37,15 @@ class _WindowsOSProxy:
     """Expose Windows branching without mutating process-wide ``os.name``."""
 
     name = "nt"
+
+    def __getattr__(self, name: str):
+        return getattr(os, name)
+
+
+class _PosixOSProxy:
+    """Expose POSIX branching without mutating process-wide ``os.name``."""
+
+    name = "posix"
 
     def __getattr__(self, name: str):
         return getattr(os, name)
@@ -2940,6 +2950,25 @@ def test_authenticated_state_with_proven_foreign_recycled_pid_is_tombstoned(tmp_
 
     assert daemon_manager_module.retire_all_guard_daemons_for_home(guard_home) == []
     assert state_clears == [62_222]
+
+
+def test_posix_daemon_retirement_waits_for_sigkill_to_finish(monkeypatch) -> None:
+    pid = 62_223
+    signals: list[int] = []
+    waits = iter((False, True))
+
+    monkeypatch.setattr(daemon_manager_module, "os", _PosixOSProxy())
+    monkeypatch.setattr(daemon_manager_module, "_guard_daemon_pid_is_proven_dead", lambda _pid: False)
+    monkeypatch.setattr(daemon_manager_module, "_guard_daemon_pid_matches_command", lambda *_args: True)
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "_wait_for_guard_daemon_pid_death",
+        lambda _pid: next(waits),
+    )
+    monkeypatch.setattr(daemon_manager_module.os, "kill", lambda _pid, sig: signals.append(sig))
+
+    assert daemon_manager_module._retire_guard_daemon_pid(pid) is True
+    assert signals == [signal.SIGTERM, signal.SIGKILL]
 
 
 def test_malformed_windows_lifecycle_records_are_quarantined_after_two_empty_inventories(

--- a/tests/test_guard_daemon_manager.py
+++ b/tests/test_guard_daemon_manager.py
@@ -2956,8 +2956,10 @@ def test_posix_daemon_retirement_waits_for_sigkill_to_finish(monkeypatch) -> Non
     pid = 62_223
     signals: list[int] = []
     waits = iter((False, True))
+    sigkill = getattr(signal, "SIGKILL", 9)
 
     monkeypatch.setattr(daemon_manager_module, "os", _PosixOSProxy())
+    monkeypatch.setattr(daemon_manager_module.signal, "SIGKILL", sigkill, raising=False)
     monkeypatch.setattr(daemon_manager_module, "_guard_daemon_pid_is_proven_dead", lambda _pid: False)
     monkeypatch.setattr(daemon_manager_module, "_guard_daemon_pid_matches_command", lambda *_args: True)
     monkeypatch.setattr(
@@ -2968,7 +2970,27 @@ def test_posix_daemon_retirement_waits_for_sigkill_to_finish(monkeypatch) -> Non
     monkeypatch.setattr(daemon_manager_module.os, "kill", lambda _pid, sig: signals.append(sig))
 
     assert daemon_manager_module._retire_guard_daemon_pid(pid) is True
-    assert signals == [signal.SIGTERM, signal.SIGKILL]
+    assert signals == [signal.SIGTERM, sigkill]
+
+
+@pytest.mark.parametrize("failing_signal", (signal.SIGTERM, getattr(signal, "SIGKILL", 9)))
+def test_posix_daemon_retirement_does_not_accept_signal_permission_error(monkeypatch, failing_signal) -> None:
+    pid = 62_224
+    sigkill = getattr(signal, "SIGKILL", 9)
+
+    monkeypatch.setattr(daemon_manager_module, "os", _PosixOSProxy())
+    monkeypatch.setattr(daemon_manager_module.signal, "SIGKILL", sigkill, raising=False)
+    monkeypatch.setattr(daemon_manager_module, "_guard_daemon_pid_is_proven_dead", lambda _pid: False)
+    monkeypatch.setattr(daemon_manager_module, "_guard_daemon_pid_matches_command", lambda *_args: True)
+    monkeypatch.setattr(daemon_manager_module, "_wait_for_guard_daemon_pid_death", lambda _pid: False)
+
+    def deny_signal(_pid: int, sent_signal: int) -> None:
+        if sent_signal == failing_signal:
+            raise PermissionError("signal denied")
+
+    monkeypatch.setattr(daemon_manager_module.os, "kill", deny_signal)
+
+    assert daemon_manager_module._retire_guard_daemon_pid(pid) is False
 
 
 def test_malformed_windows_lifecycle_records_are_quarantined_after_two_empty_inventories(


### PR DESCRIPTION
## Summary

- wait for POSIX Guard daemon termination to complete after both TERM and KILL
- support `hol-guard help` and `hol-guard help <command>` as conventional help aliases
- add focused regressions and update the reviewed test-suite ratchet

## Root cause

The POSIX retirement path waited after SIGTERM but checked liveness only once immediately after SIGKILL. A process that had accepted SIGKILL but had not yet been scheduled out was reported as an unsafe stale daemon, preventing the dashboard from recovering after an update.

The Guard entry point also passed the literal `help` token to argparse even though only `--help` was registered.

## Verification

- `uv run pytest tests/test_guard_daemon_manager.py tests/test_guard_daemon_wake.py tests/test_guard_cli.py -q -k 'posix_daemon_retirement_waits or bare_hol_guard or help_alias'`
- `uv run ruff check src/codex_plugin_scanner/cli.py src/codex_plugin_scanner/guard/daemon/manager.py tests/test_guard_cli.py tests/test_guard_daemon_manager.py`
- `uv run basedpyright src/codex_plugin_scanner/cli.py src/codex_plugin_scanner/guard/daemon/manager.py`
- `uv run --no-sync python scripts/ci/test_inventory.py --output /tmp/hol-guard-stale-daemon-help-test-inventory.json`
- `uv run --no-sync python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory /tmp/hol-guard-stale-daemon-help-test-inventory.json`
- `uv build`
- isolated wheel smoke: `hol-guard help` exited 0 and rendered Guard command help


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for using `help` as an alias for `--help` in Guard and HOL Guard commands.
  - Added command-specific help output with successful exit codes.

- **Bug Fixes**
  - Improved Guard daemon shutdown handling by confirming process termination after graceful and forced stops.
  - Added safer handling when shutdown permissions prevent termination.

- **Tests**
  - Expanded coverage for command-line help behavior and daemon retirement scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->