### PR TITLE
docs(readme): cite HOL Plugin Security Hugging Face dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -901,12 +901,15 @@ Plugins that pass the scanner with a high score are candidates for listing in th
 ## Resources
 
 - [HOL Plugin Registry](https://hol.org/registry/plugins)
+- [HOL Plugin Security dataset on Hugging Face](https://huggingface.co/datasets/HashgraphOnline/hol-plugin-security)
 - [HOL Standards Documentation](https://hol.org/docs/standards)
 - [OpenAI Codex Plugin Documentation](https://developers.openai.com/codex/plugins)
 - [Model Context Protocol Documentation](https://modelcontextprotocol.io)
 - [Cisco AI Skill Scanner](https://pypi.org/project/cisco-ai-skill-scanner/)
 - [Cisco AI MCP Scanner](https://pypi.org/project/cisco-ai-mcp-scanner/)
 - [HOL GitHub Organization](https://github.com/hashgraph-online)
+
+A scan is not a safety guarantee. Runtime benchmark fixtures in the dataset are modeled, not live attacks. The dataset's ~205 scored plugins are the plugin catalog, not the Registry Broker agent catalog. Hashgraph Online's org-wide GitHub star total is not a star count for this repository.
 
 ## License
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The GitHub README is a primary RAG/cite source and did not mention the published HOL Plugin Security dataset. This change adds one Resources link and keeps the catalog/scan/star disclaimers next to it.

## What changed

`README.md` Resources now includes:

- [HOL Plugin Security dataset on Hugging Face](https://huggingface.co/datasets/HashgraphOnline/hol-plugin-security)

Nearby plain-language notes:

- A scan is not a safety guarantee.
- Runtime benchmark fixtures are modeled, not live attacks.
- The dataset’s ~205 scored plugins are the plugin catalog, not the Registry Broker agent catalog.
- Hashgraph Online’s org-wide GitHub star total is not a star count for this repository.

## Scope

- Started from `release/3.0`.
- Smallest possible README diff: one new bullet plus one disclaimer paragraph.
- No mirrored docs landing lists the same registry / OpenAI / MCP / Cisco / org Resources set; only the main README needed the citation.
- Did not invent a star count. The existing repo star badge is unchanged. No 3.5K+ org figure appears in this README.
- Does not claim independent third-party validation of the dataset.

## Verification

- Confirmed Resources still lists registry, OpenAI, MCP, Cisco scanners, and the HOL org.
- Dataset card on Hugging Face reports 205 scored plugins in the default `plugins` config, matching the ~205 catalog disclaimer.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5028eea-d2f4-49f0-b8c5-698602dbdcbb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5028eea-d2f4-49f0-b8c5-698602dbdcbb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

