### PR TITLE
docs: cite HOL Plugin Security Hugging Face dataset on main

### DIFF
--- a/README.md
+++ b/README.md
@@ -896,12 +896,15 @@ Plugins that pass the scanner with a high score are candidates for listing in th
 ## Resources
 
 - [HOL Plugin Registry](https://hol.org/registry/plugins)
+- [HOL Plugin Security dataset on Hugging Face](https://huggingface.co/datasets/HashgraphOnline/hol-plugin-security)
 - [HOL Standards Documentation](https://hol.org/docs/standards)
 - [OpenAI Codex Plugin Documentation](https://developers.openai.com/codex/plugins)
 - [Model Context Protocol Documentation](https://modelcontextprotocol.io)
 - [Cisco AI Skill Scanner](https://pypi.org/project/cisco-ai-skill-scanner/)
 - [Cisco AI MCP Scanner](https://pypi.org/project/cisco-ai-mcp-scanner/)
 - [HOL GitHub Organization](https://github.com/hashgraph-online)
+
+A scan is not a safety guarantee. Runtime benchmark fixtures in the dataset are modeled, not live attacks. The dataset's ~205 scored plugins are the plugin catalog, not the Registry Broker agent catalog. Hashgraph Online's org-wide GitHub star total is not a star count for this repository.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ Documentation = "https://github.com/hashgraph-online/hol-guard/tree/main/docs/gu
 Repository = "https://github.com/hashgraph-online/hol-guard"
 Issues = "https://github.com/hashgraph-online/hol-guard/issues"
 Changelog = "https://github.com/hashgraph-online/hol-guard/releases"
+Dataset = "https://huggingface.co/datasets/HashgraphOnline/hol-plugin-security"
 
 [tool.ruff]
 target-version = "py310"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`main` is what github.com/hashgraph-online/hol-guard serves, but the Hugging Face dataset cite from PR 2476 merged only to `release/3.0`. This ports the honest README Resources bullet plus disclaimer, and adds the missing PyPI `project.urls` Dataset key.

Rebased onto current `main` (includes #2490). The earlier `tests (3.12, 10)` failure was isolated-review fail-closed (`worker_stats.failures: 1`), not this +4 cite diff. Daemon test is not being fixed in this PR.

## What changed

- `pyproject.toml` `[project.urls]` now includes:
  `Dataset = "https://huggingface.co/datasets/HashgraphOnline/hol-plugin-security"`
- `README.md` Resources now includes the same cite used after PR 2476:
  - [HOL Plugin Security dataset on Hugging Face](https://huggingface.co/datasets/HashgraphOnline/hol-plugin-security)
- Nearby disclaimer (scan ≠ safety; fixtures modeled; ~205 plugins ≠ Registry Broker agent counts; do not attribute org-wide HOL GitHub stars to this repo)

## Scope

- Smallest possible diff: one URL key, one README bullet, one disclaimer paragraph.
- Did not bump the package version and did not publish to PyPI.
- Did not change the 3.5K+ org-wide stars figure (it is not present in this README).
- Did not add unlabeled 450K+ downloads.
- Did not revert unrelated work.

## Verification

- Confirmed `main` previously had no huggingface / hol-plugin-security cite and no Dataset project URL.
- Dataset card on Hugging Face reports 205 scored plugins in the default `plugins` config, matching the ~205 catalog disclaimer.
- Version in `pyproject.toml` remains `2.2.0`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1ab1a15-77ca-4f76-8e4f-a9ecd70c41a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1ab1a15-77ca-4f76-8e4f-a9ecd70c41a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added links to the HOL Plugin Security dataset.
  - Expanded the Resources section with details about dataset scope, modeled attacks, plugin counts, and organization-wide star totals.
  - Added the dataset URL to the project metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->