### PR TITLE
docs: add Hugging Face Dataset URL and honest README cite

### DIFF
--- a/README.md
+++ b/README.md
@@ -892,12 +892,15 @@ Plugins that pass the scanner with a high score are candidates for listing in th
 ## Resources
 
 - [HOL Plugin Registry](https://hol.org/registry/plugins)
+- [HOL Plugin Security dataset on Hugging Face](https://huggingface.co/datasets/HashgraphOnline/hol-plugin-security)
 - [HOL Standards Documentation](https://hol.org/docs/standards)
 - [OpenAI Codex Plugin Documentation](https://developers.openai.com/codex/plugins)
 - [Model Context Protocol Documentation](https://modelcontextprotocol.io)
 - [Cisco AI Skill Scanner](https://pypi.org/project/cisco-ai-skill-scanner/)
 - [Cisco AI MCP Scanner](https://pypi.org/project/cisco-ai-mcp-scanner/)
 - [HOL GitHub Organization](https://github.com/hashgraph-online)
+
+A scan is not a safety guarantee. Runtime benchmark fixtures in the dataset are modeled, not live attacks. The dataset's ~205 scored plugins are the plugin catalog, not the Registry Broker agent catalog. Hashgraph Online's org-wide GitHub star total is not a star count for this repository.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ Documentation = "https://github.com/hashgraph-online/hol-guard/tree/main/docs/gu
 Repository = "https://github.com/hashgraph-online/hol-guard"
 Issues = "https://github.com/hashgraph-online/hol-guard/issues"
 Changelog = "https://github.com/hashgraph-online/hol-guard/releases"
+Dataset = "https://huggingface.co/datasets/HashgraphOnline/hol-plugin-security"
 
 [tool.ruff]
 target-version = "py310"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Crawlers see `github.com/hashgraph-online/hol-guard` and `pypi.org/project/hol-guard` (2.2.x). The Hugging Face dataset cite from PR 2476 only landed on `release/3.0`. This branch is the current publish train, so this change adds the Dataset project URL and the same honest README cite here.

## What changed

`pyproject.toml` `[project.urls]` now includes:

```
Dataset = "https://huggingface.co/datasets/HashgraphOnline/hol-plugin-security"
```

The same `pyproject.toml` still feeds `plugin-scanner` via the existing publish rewrite (name/description/scripts only). `[project.urls]` is left intact, so both packages pick up the Dataset URL on the next publish. No other URLs were added. Package version is unchanged.

`README.md` Resources now includes:

- [HOL Plugin Security dataset on Hugging Face](https://huggingface.co/datasets/HashgraphOnline/hol-plugin-security)

Nearby plain-language notes (same wording as `release/3.0` after PR 2476):

- A scan is not a safety guarantee.
- Runtime benchmark fixtures are modeled, not live attacks.
- The dataset’s ~205 scored plugins are the plugin catalog, not the Registry Broker agent catalog.
- Hashgraph Online’s org-wide GitHub star total is not a star count for this repository.

## Scope

- Started from `release/2.2`.
- Did not bump the package version and did not publish to PyPI.
- Did not invent other project URLs (this branch still has no `Security` entry; that is unchanged).
- Did not change any org-wide star figure. No unlabeled 450K+ downloads were added.
- Did not revert unrelated work.

## Verification

- Confirmed Hugging Face dataset `HashgraphOnline/hol-plugin-security` default `plugins` config has 205 scored plugins.
- Confirmed `[project.scripts]` still exposes `hol-guard` and `plugin-scanner`.
- Confirmed publish.yml still slices scripts by `\n\n[project.urls]`, so adding a Dataset key does not break the scanner package rewrite.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87b214dc-b093-4ca2-bfd5-fb6bb3fecd97?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87b214dc-b093-4ca2-bfd5-fb6bb3fecd97&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a link to the HOL Plugin Security dataset in the project resources.
  * Documented limitations related to scan safety guarantees, benchmark fixtures, dataset scope, and organization-wide GitHub star counts.
* **Metadata**
  * Added the dataset URL to the project information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->