### PR TITLE
ci: notify hol-guard-plugin after stable runtime publishes

### DIFF
--- a/.github/workflows/notify-hol-guard-plugin.yml
+++ b/.github/workflows/notify-hol-guard-plugin.yml
@@ -1,0 +1,356 @@
+name: Notify HOL Guard Plugin of Runtime Releases
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/notify-hol-guard-plugin.yml"
+      - "tests/test_notify_hol_guard_plugin_workflow.py"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Exact stable HOL Guard version to notify (defaults to latest stable GitHub release)"
+        required: false
+        type: string
+  workflow_run:
+    workflows: ["Publish to PyPI"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: notify-hol-guard-plugin-runtime
+  cancel-in-progress: false
+
+jobs:
+  resolve_publication:
+    name: Resolve exact published HOL Guard release
+    if: >-
+      github.event_name == 'pull_request' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_branch == 'main')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      published: ${{ steps.verify.outputs.published }}
+      version: ${{ steps.verify.outputs.version }}
+      source_sha: ${{ steps.verify.outputs.source_sha }}
+    steps:
+      - name: Verify the triggering run completed stable publication
+        id: publication
+        if: github.event_name == 'workflow_run'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRIGGER_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${TRIGGER_RUN_ID}/jobs?filter=latest&per_page=100" \
+            > "${RUNNER_TEMP}/trigger-jobs.json"
+
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          payload = json.loads(
+              Path(os.environ["RUNNER_TEMP"], "trigger-jobs.json").read_text(encoding="utf-8")
+          )
+          jobs = payload.get("jobs", [])
+          total = payload.get("total_count")
+          if total != len(jobs):
+              raise SystemExit("Triggering publish run has more than 100 jobs; refusing to infer publication")
+
+          required = {
+              "Publish main release to PyPI": "success",
+              "Create main GitHub release": "success",
+          }
+          conclusions = {}
+          for name, expected in required.items():
+              matches = [job for job in jobs if job.get("name") == name]
+              if len(matches) != 1:
+                  print(f"Expected exactly one {name!r} job; found {len(matches)}")
+                  print("eligible=false", file=open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8"))
+                  raise SystemExit(0)
+              conclusions[name] = matches[0].get("conclusion")
+              if conclusions[name] != expected:
+                  print(f"{name} concluded {conclusions[name]!r}; no stable publication will be dispatched")
+                  print("eligible=false", file=open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8"))
+                  raise SystemExit(0)
+
+          print("Verified stable publication jobs:", conclusions)
+          print("eligible=true", file=open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8"))
+          PY
+
+      # The run-scoped receipt prevents mutable registry state from re-identifying this publication.
+      - name: Download the triggering run's immutable version artifact
+        if: >-
+          github.event_name == 'workflow_run' &&
+          steps.publication.outputs.eligible == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: release-toolchain-sbom
+          path: triggering-release
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Read the triggering run's exact version
+        id: run_identity
+        if: >-
+          github.event_name == 'workflow_run' &&
+          steps.publication.outputs.eligible == 'true'
+        env:
+          SOURCE_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          stable = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+          source_sha = os.environ["SOURCE_SHA"].strip().lower()
+          if not re.fullmatch(r"[0-9a-f]{40}", source_sha):
+              raise SystemExit(f"Triggering source SHA is invalid: {source_sha!r}")
+
+          receipts = list(Path("triggering-release").glob("*.toolchain.cdx.json"))
+          if len(receipts) != 1:
+              raise SystemExit(f"Expected one release toolchain receipt, found {len(receipts)}")
+
+          payload = json.loads(receipts[0].read_text(encoding="utf-8"))
+          component = payload.get("metadata", {}).get("component", {})
+          if component.get("name") != "hol-guard-release-toolchain":
+              raise SystemExit("Release artifact is not a HOL Guard toolchain receipt")
+          version = component.get("version")
+          if not isinstance(version, str) or not stable.fullmatch(version):
+              raise SystemExit(f"Triggering run did not produce an exact stable version: {version!r}")
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              print(f"version={version}", file=output)
+              print(f"expected_source_sha={source_sha}", file=output)
+          print(f"Triggering run produced hol-guard=={version} from {source_sha}")
+          PY
+
+      - name: Resolve the requested stable GitHub release
+        id: requested_identity
+        if: github.event_name != 'workflow_run'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_VERSION: ${{ inputs.version }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          import urllib.parse
+          import urllib.request
+
+          stable = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+          requested = os.environ.get("REQUESTED_VERSION", "").strip()
+          if requested and not stable.fullmatch(requested):
+              raise SystemExit(
+                  f"Requested HOL Guard version is not an exact stable X.Y.Z release: {requested!r}"
+              )
+
+          repository = os.environ["GITHUB_REPOSITORY"]
+          token = os.environ["GH_TOKEN"]
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {token}",
+              "User-Agent": "hol-guard-plugin-release-notifier",
+              "X-GitHub-Api-Version": "2022-11-28",
+          }
+
+          def github_json(path: str):
+              request = urllib.request.Request(
+                  f"https://api.github.com/repos/{repository}/{path}",
+                  headers=headers,
+              )
+              with urllib.request.urlopen(request, timeout=30) as response:
+                  return json.load(response)
+
+          if requested:
+              version = requested
+          else:
+              candidates = []
+              page = 1
+              while True:
+                  releases = github_json(f"releases?per_page=100&page={page}")
+                  for release in releases:
+                      tag = release.get("tag_name", "")
+                      match = re.fullmatch(r"v((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*))", tag)
+                      if match and not release.get("draft") and not release.get("prerelease"):
+                          version = match.group(1)
+                          candidates.append((tuple(int(part) for part in version.split(".")), version))
+                  if len(releases) < 100:
+                      break
+                  page += 1
+              if not candidates:
+                  raise SystemExit("GitHub did not return a stable HOL Guard release")
+              version = max(candidates)[1]
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              print(f"version={version}", file=output)
+          print(f"Selected stable GitHub release v{version}")
+          PY
+
+      - name: Verify the release identity and PyPI publication
+        id: verify
+        if: >-
+          github.event_name != 'workflow_run' ||
+          steps.publication.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ github.event_name == 'workflow_run' && steps.run_identity.outputs.version || steps.requested_identity.outputs.version }}
+          EXPECTED_SOURCE_SHA: ${{ github.event_name == 'workflow_run' && steps.run_identity.outputs.expected_source_sha || '' }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import re
+          import time
+          import urllib.error
+          import urllib.parse
+          import urllib.request
+
+          stable = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+          version = os.environ["VERSION"].strip()
+          expected_source_sha = os.environ.get("EXPECTED_SOURCE_SHA", "").strip().lower()
+          if not stable.fullmatch(version):
+              raise SystemExit(f"Resolved version is not an exact stable X.Y.Z release: {version!r}")
+          if expected_source_sha and not re.fullmatch(r"[0-9a-f]{40}", expected_source_sha):
+              raise SystemExit(f"Expected source SHA is invalid: {expected_source_sha!r}")
+
+          repository = os.environ["GITHUB_REPOSITORY"]
+          token = os.environ["GH_TOKEN"]
+          github_headers = {
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {token}",
+              "User-Agent": "hol-guard-plugin-release-notifier",
+              "X-GitHub-Api-Version": "2022-11-28",
+          }
+
+          def get_json(url: str, headers: dict[str, str] | None = None):
+              request = urllib.request.Request(url, headers=headers or {})
+              with urllib.request.urlopen(request, timeout=30) as response:
+                  return json.load(response)
+
+          tag = f"v{version}"
+          encoded_tag = urllib.parse.quote(tag, safe="")
+          release = get_json(
+              f"https://api.github.com/repos/{repository}/releases/tags/{encoded_tag}",
+              github_headers,
+          )
+          if release.get("tag_name") != tag or release.get("draft") or release.get("prerelease"):
+              raise SystemExit(f"{tag} is not a published stable GitHub release")
+
+          reference = get_json(
+              f"https://api.github.com/repos/{repository}/git/ref/tags/{encoded_tag}",
+              github_headers,
+          )
+          target = reference.get("object", {})
+          for _ in range(5):
+              object_type = target.get("type")
+              object_sha = str(target.get("sha", "")).lower()
+              if object_type == "commit":
+                  source_sha = object_sha
+                  break
+              if object_type != "tag" or not re.fullmatch(r"[0-9a-f]{40}", object_sha):
+                  raise SystemExit(f"{tag} does not resolve to a commit")
+              annotated = get_json(
+                  f"https://api.github.com/repos/{repository}/git/tags/{object_sha}",
+                  github_headers,
+              )
+              target = annotated.get("object", {})
+          else:
+              raise SystemExit(f"{tag} contains too many nested annotated tags")
+
+          if not re.fullmatch(r"[0-9a-f]{40}", source_sha):
+              raise SystemExit(f"{tag} resolved to an invalid source SHA")
+          if expected_source_sha and source_sha != expected_source_sha:
+              raise SystemExit(
+                  f"{tag} targets {source_sha}, not triggering source {expected_source_sha}"
+              )
+
+          pypi_url = f"https://pypi.org/pypi/hol-guard/{version}/json"
+          last_error = None
+          for attempt in range(1, 11):
+              try:
+                  payload = get_json(
+                      pypi_url,
+                      {"Accept": "application/json", "User-Agent": "hol-guard-plugin-release-notifier"},
+                  )
+                  files = payload.get("urls", [])
+                  if payload.get("info", {}).get("version") != version:
+                      raise RuntimeError("PyPI returned a different release version")
+                  if not files or not any(not file.get("yanked", False) for file in files):
+                      raise RuntimeError("PyPI release has no non-yanked files")
+                  break
+              except (OSError, RuntimeError, urllib.error.HTTPError) as error:
+                  last_error = error
+                  if attempt == 10:
+                      raise SystemExit(
+                          f"Could not verify non-yanked hol-guard=={version} on PyPI: {last_error}"
+                      )
+                  print(f"PyPI has not exposed hol-guard=={version} yet ({attempt}/10): {error}")
+                  time.sleep(15)
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              print("published=true", file=output)
+              print(f"version={version}", file=output)
+              print(f"source_sha={source_sha}", file=output)
+          print(f"Verified hol-guard=={version} from {source_sha}")
+          PY
+
+  dispatch_plugin_sync:
+    name: Dispatch plugin runtime sync
+    if: >-
+      github.event_name != 'pull_request' &&
+      needs.resolve_publication.outputs.published == 'true'
+    needs: resolve_publication
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      TARGET_REPOSITORY: hashgraph-online/hol-guard-plugin
+      HOL_GUARD_VERSION: ${{ needs.resolve_publication.outputs.version }}
+      SOURCE_SHA: ${{ needs.resolve_publication.outputs.source_sha }}
+    steps:
+      - name: Validate dispatch credential
+        env:
+          GH_TOKEN: ${{ secrets.ACTION_REPO_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "ACTION_REPO_TOKEN must be configured to notify the HOL Guard plugin repository." >&2
+            exit 1
+          fi
+
+      - name: Dispatch exact published version
+        env:
+          GH_TOKEN: ${{ secrets.ACTION_REPO_TOKEN }}
+        run: |
+          python3 - <<'PY' > "${RUNNER_TEMP}/hol-guard-plugin-dispatch.json"
+          import json
+          import os
+
+          print(json.dumps({
+              "event_type": "hol-guard-published",
+              "client_payload": {
+                  "version": os.environ["HOL_GUARD_VERSION"],
+                  "source_repository": os.environ["GITHUB_REPOSITORY"],
+                  "source_sha": os.environ["SOURCE_SHA"],
+              },
+          }))
+          PY
+
+          gh api \
+            --method POST \
+            "repos/${TARGET_REPOSITORY}/dispatches" \
+            --input "${RUNNER_TEMP}/hol-guard-plugin-dispatch.json"
+
+          echo "Dispatched hol-guard==${HOL_GUARD_VERSION} to ${TARGET_REPOSITORY}."

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 15250,
-  "maximum_test_source_lines": 328910,
+  "maximum_collected_cases": 15255,
+  "maximum_test_source_lines": 329029,
   "schema_version": 1
 }

--- a/tests/test_notify_hol_guard_plugin_workflow.py
+++ b/tests/test_notify_hol_guard_plugin_workflow.py
@@ -1,0 +1,119 @@
+"""Contracts for the stable HOL Guard plugin release notification."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "notify-hol-guard-plugin.yml"
+
+
+def _workflow() -> dict[object, object]:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    assert isinstance(workflow, dict)
+    return workflow
+
+
+def _step(job: dict[str, object], name: str) -> dict[str, object]:
+    steps = job["steps"]
+    assert isinstance(steps, list)
+    return next(step for step in steps if isinstance(step, dict) and step.get("name") == name)
+
+
+def test_workflow_run_is_fail_closed_to_successful_main_publications() -> None:
+    workflow = _workflow()
+    trigger = workflow[True]["workflow_run"]
+    resolve = workflow["jobs"]["resolve_publication"]
+
+    assert trigger["workflows"] == ["Publish to PyPI"]
+    assert trigger["types"] == ["completed"]
+    assert trigger["branches"] == ["main"]
+    assert workflow["permissions"] == {"actions": "read", "contents": "read"}
+
+    condition = resolve["if"]
+    assert "github.event.workflow_run.conclusion == 'success'" in condition
+    assert "github.event.workflow_run.event == 'push'" in condition
+    assert "github.event.workflow_run.head_branch == 'main'" in condition
+
+    publication = _step(resolve, "Verify the triggering run completed stable publication")
+    publication_run = publication["run"]
+    assert "actions/runs/${TRIGGER_RUN_ID}/jobs?filter=latest&per_page=100" in publication_run
+    assert '"Publish main release to PyPI": "success"' in publication_run
+    assert '"Create main GitHub release": "success"' in publication_run
+    assert 'print("eligible=false"' in publication_run
+    assert 'print("eligible=true"' in publication_run
+
+
+def test_triggering_version_and_sha_come_from_the_same_immutable_run() -> None:
+    workflow = _workflow()
+    resolve = workflow["jobs"]["resolve_publication"]
+    download = _step(resolve, "Download the triggering run's immutable version artifact")
+    read_identity = _step(resolve, "Read the triggering run's exact version")
+    dispatch = workflow["jobs"]["dispatch_plugin_sync"]
+
+    assert download["uses"] == (
+        "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"
+    )
+    assert download["with"] == {
+        "name": "release-toolchain-sbom",
+        "path": "triggering-release",
+        "github-token": "${{ github.token }}",
+        "repository": "${{ github.repository }}",
+        "run-id": "${{ github.event.workflow_run.id }}",
+    }
+
+    identity_run = read_identity["run"]
+    assert read_identity["env"]["SOURCE_SHA"] == "${{ github.event.workflow_run.head_sha }}"
+    assert 'component.get("name") != "hol-guard-release-toolchain"' in identity_run
+    assert 'component.get("version")' in identity_run
+    assert "exact stable version" in identity_run
+    assert "expected_source_sha" in identity_run
+
+    assert dispatch["env"]["HOL_GUARD_VERSION"] == (
+        "${{ needs.resolve_publication.outputs.version }}"
+    )
+    assert dispatch["env"]["SOURCE_SHA"] == (
+        "${{ needs.resolve_publication.outputs.source_sha }}"
+    )
+    assert "github.event.workflow_run.head_sha" not in dispatch["env"]["SOURCE_SHA"]
+
+
+def test_release_identity_is_cross_checked_against_github_and_exact_pypi_version() -> None:
+    workflow = _workflow()
+    resolve = workflow["jobs"]["resolve_publication"]
+    verify = _step(resolve, "Verify the release identity and PyPI publication")
+    verify_run = verify["run"]
+    workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "releases/tags/{encoded_tag}" in verify_run
+    assert "git/ref/tags/{encoded_tag}" in verify_run
+    assert "source_sha != expected_source_sha" in verify_run
+    assert "pypi.org/pypi/hol-guard/{version}/json" in verify_run
+    assert "no non-yanked files" in verify_run
+    assert "published=true" in verify_run
+    assert "https://pypi.org/pypi/hol-guard/json" not in workflow_text
+
+
+def test_manual_recovery_resolves_source_sha_from_the_selected_stable_release() -> None:
+    workflow = _workflow()
+    inputs = workflow[True]["workflow_dispatch"]["inputs"]
+    resolve = workflow["jobs"]["resolve_publication"]
+    requested = _step(resolve, "Resolve the requested stable GitHub release")
+    verify = _step(resolve, "Verify the release identity and PyPI publication")
+
+    assert inputs["version"]["required"] is False
+    assert "latest stable GitHub release" in inputs["version"]["description"]
+    assert requested["if"] == "github.event_name != 'workflow_run'"
+    assert "releases?per_page=100&page={page}" in requested["run"]
+    assert "version = max(candidates)[1]" in requested["run"]
+    assert verify["env"]["EXPECTED_SOURCE_SHA"].endswith("|| '' }}")
+
+
+def test_pull_request_validation_cannot_dispatch_downstream() -> None:
+    workflow = _workflow()
+    dispatch = workflow["jobs"]["dispatch_plugin_sync"]
+
+    assert "github.event_name != 'pull_request'" in dispatch["if"]
+    assert "needs.resolve_publication.outputs.published == 'true'" in dispatch["if"]


### PR DESCRIPTION
## What changed

- adds a follow-up workflow for completed `Publish to PyPI` runs on `main`;
- requires the exact triggering run's stable PyPI publication and GitHub release jobs to have succeeded before notification;
- downloads the triggering run's immutable release toolchain artifact to recover its exact stable version;
- binds that version to the triggering run's source SHA, matching stable GitHub tag/release, and exact non-yanked PyPI release before dispatch;
- dispatches `hol-guard-published` with the verified version and source SHA to `hashgraph-online/hol-guard-plugin`;
- keeps manual exact-version recovery, resolving the source SHA from the selected stable release tag;
- adds regression contracts covering skipped publishes, version/SHA binding, verification, and pull-request no-dispatch behavior.

## Downstream

This pairs with hashgraph-online/hol-guard-plugin#33. The plugin repository owns the fail-closed pin updater, PyPI installation verification, payload tests, direct commit, and scheduled recovery path.

## Credential

Uses the existing `ACTION_REPO_TOKEN` already used by the downstream plugin-scanner publishing workflow. It must include access to `hashgraph-online/hol-guard-plugin` for repository dispatch.