### PR TITLE
fix(settings): keep local protection changes off the cloud-plan gate

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 15208,
-  "maximum_test_source_lines": 327772,
+  "maximum_collected_cases": 15211,
+  "maximum_test_source_lines": 327866,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -669,9 +669,7 @@ def update_guard_settings(
         ]
         if weakened:
             raise ValueError(f"Managed policy locks prevent weakening: {', '.join(sorted(weakened))}")
-    locally_persisted_sync = current.get("sync") is True
-    enabling_cloud_sync = next_payload.get("sync") is True and not locally_persisted_sync
-    if enabling_cloud_sync and not cloud_sync_entitled:
+    if next_payload.get("sync") is True and current.get("sync") is not True and not cloud_sync_entitled:
         raise ValueError("Cloud sync requires a paid team plan.")
     _write_guard_config(guard_home / "config.toml", next_payload)
     updated = load_guard_config(guard_home)

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -669,7 +669,8 @@ def update_guard_settings(
         ]
         if weakened:
             raise ValueError(f"Managed policy locks prevent weakening: {', '.join(sorted(weakened))}")
-    enabling_cloud_sync = next_payload.get("sync") is True and current_config.sync is not True
+    locally_persisted_sync = current.get("sync") is True
+    enabling_cloud_sync = next_payload.get("sync") is True and not locally_persisted_sync
     if enabling_cloud_sync and not cloud_sync_entitled:
         raise ValueError("Cloud sync requires a paid team plan.")
     _write_guard_config(guard_home / "config.toml", next_payload)

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -669,7 +669,8 @@ def update_guard_settings(
         ]
         if weakened:
             raise ValueError(f"Managed policy locks prevent weakening: {', '.join(sorted(weakened))}")
-    if next_payload.get("sync") is True and not cloud_sync_entitled:
+    enabling_cloud_sync = next_payload.get("sync") is True and current_config.sync is not True
+    if enabling_cloud_sync and not cloud_sync_entitled:
         raise ValueError("Cloud sync requires a paid team plan.")
     _write_guard_config(guard_home / "config.toml", next_payload)
     updated = load_guard_config(guard_home)

--- a/tests/test_guard_settings_api.py
+++ b/tests/test_guard_settings_api.py
@@ -8,6 +8,8 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from codex_plugin_scanner.guard.config import load_guard_config, resolve_risk_action, update_guard_settings
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.daemon import server as daemon_server_module
@@ -360,6 +362,42 @@ def test_watch_to_protected_api_ignores_existing_sync_without_entitlement(
     assert status == 200
     assert payload["settings"]["protection_posture"] == "protected"
     assert payload["settings"]["sync"] is True
+
+
+def test_managed_policy_sync_does_not_persist_local_sync_without_entitlement(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from codex_plugin_scanner.guard import config as config_module
+    from codex_plugin_scanner.guard.mdm.contracts import (
+        MDM_POLICY_SCHEMA_VERSION,
+        ManagedPolicy,
+        ManagedPolicyState,
+        ManagedUpdatePolicy,
+    )
+
+    guard_home = tmp_path / "guard-home"
+    policy = ManagedPolicy(
+        schema_version=MDM_POLICY_SCHEMA_VERSION,
+        settings={"sync": True},
+        locked_settings=frozenset(),
+        update=ManagedUpdatePolicy(owner="mdm", allow_downgrade=False),
+        content_hash="managed-sync",
+    )
+    monkeypatch.setattr(
+        config_module,
+        "load_managed_policy",
+        lambda: ManagedPolicyState(status="active", source="test", policy=policy),
+    )
+    with pytest.raises(ValueError, match="Cloud sync requires a paid team plan"):
+        update_guard_settings(
+            guard_home,
+            {"sync": True},
+            cloud_sync_entitled=False,
+        )
+    config_path = guard_home / "config.toml"
+    persisted = config_path.read_text(encoding="utf-8") if config_path.exists() else ""
+    assert "sync = true" not in persisted.lower()
 
 
 def test_risk_settings_drive_runtime_policy_resolution(tmp_path: Path) -> None:

--- a/tests/test_guard_settings_api.py
+++ b/tests/test_guard_settings_api.py
@@ -285,6 +285,13 @@ def test_cloud_sync_requires_trusted_paid_team_entitlement(tmp_path: Path, monke
             "resolve_package_firewall_entitlement",
             lambda _store: {"allowed": False, "reason": "paid_guard_cloud_required", "tier": "free"},
         )
+        _json_request(
+            daemon.port,
+            daemon._server.auth_token,
+            "/v1/settings",
+            method="POST",
+            payload={"settings": {"sync": False}},
+        )
         expired_status, expired_payload = _json_request(
             daemon.port,
             daemon._server.auth_token,
@@ -304,6 +311,55 @@ def test_cloud_sync_requires_trusted_paid_team_entitlement(tmp_path: Path, monke
     assert allowed_payload["settings"]["sync"] is True
     assert expired_status == 400
     assert expired_payload["message"] == "Cloud sync requires a paid team plan."
+
+
+def test_existing_cloud_sync_does_not_block_protection_posture_change(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    update_guard_settings(
+        guard_home,
+        {"sync": True, "protection_posture": "watch"},
+        cloud_sync_entitled=True,
+    )
+    updated = update_guard_settings(
+        guard_home,
+        {"protection_posture": "protected"},
+        cloud_sync_entitled=False,
+    )
+
+    assert updated.protection_posture == "protected"
+    assert updated.sync is True
+
+
+def test_watch_to_protected_api_ignores_existing_sync_without_entitlement(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    update_guard_settings(
+        guard_home,
+        {"sync": True, "protection_posture": "watch"},
+        cloud_sync_entitled=True,
+    )
+    _store, daemon = _with_daemon(guard_home)
+    monkeypatch.setattr(
+        daemon_server_module,
+        "resolve_package_firewall_entitlement",
+        lambda _store: {"allowed": False, "reason": "paid_guard_cloud_required", "tier": "free"},
+    )
+    try:
+        status, payload = _json_request(
+            daemon.port,
+            daemon._server.auth_token,
+            "/v1/settings",
+            method="POST",
+            payload={"settings": {"protection_posture": "protected"}},
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert payload["settings"]["protection_posture"] == "protected"
+    assert payload["settings"]["sync"] is True
 
 
 def test_risk_settings_drive_runtime_policy_resolution(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Require a paid team plan only when enabling cloud sync, not when other local settings change.
- Allow Watch only to Protected updates when cloud sync is already on without a current paid entitlement.

## Testing
- `uv run --no-sync pytest -q tests/test_guard_settings_api.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/config.py tests/test_guard_settings_api.py`
