### PR TITLE
fix(release): stop stranding unpublished 3.0 alpha reservations

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -421,7 +421,7 @@ jobs:
       )
     needs: build
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 25
+    timeout-minutes: 45
     permissions:
       contents: read
     strategy:
@@ -777,12 +777,13 @@ jobs:
       always() &&
       vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
       needs.build.result == 'success' &&
+      needs.assemble-native-guard-distributions.result == 'success' &&
       needs.build.outputs.channel == 'alpha' &&
       (
         (github.event_name == 'workflow_dispatch' && github.run_attempt == 1) ||
         (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0') || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged && github.event.pull_request.base.ref == 'release/3.0' && github.event.pull_request.head.repo.full_name == github.repository)
       )
-    needs: [build]
+    needs: [build, assemble-native-guard-distributions]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1084,6 +1085,38 @@ jobs:
           [[ -n "$guard_wheel" && -n "$scanner_wheel" ]]
           [[ "$(uv tool run --from "$guard_wheel" hol-guard --version)" == "hol-guard $VERSION" ]]
           [[ "$(uv tool run --from "$scanner_wheel" plugin-scanner --version)" == "plugin-scanner $VERSION" ]]
+
+  release-unpublished-alpha-reservation:
+    name: Release unpublished alpha reservation
+    if: >-
+      always() &&
+      vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
+      needs.build.outputs.channel == 'alpha' &&
+      needs.reserve-alpha-tag.result == 'success' &&
+      needs.publish-alpha-pypi.result != 'success'
+    needs: [build, reserve-alpha-tag, publish-alpha-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Delete unpublished reservation tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          tag="alpha/v${VERSION}"
+          remote_json=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}" || true)
+          remote_tag_sha=$(printf '%s' "$remote_json" | jq -r '.object.sha // empty')
+          if [[ -z "$remote_tag_sha" ]]; then
+            echo "No reservation tag to release"
+            exit 0
+          fi
+          if [[ "$remote_tag_sha" != "$SOURCE_SHA" ]]; then
+            echo "Reservation tag no longer points at this source"
+            exit 0
+          fi
+          gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/${tag}"
 
   publish-main-testpypi:
     name: Verify main artifact on TestPyPI

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1105,18 +1105,54 @@ jobs:
           SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
           VERSION: ${{ needs.build.outputs.version }}
         run: |
+          set -euo pipefail
           tag="alpha/v${VERSION}"
-          remote_json=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}" || true)
-          remote_tag_sha=$(printf '%s' "$remote_json" | jq -r '.object.sha // empty')
+          set +e
+          ref_json=$(gh api --method GET "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}" 2>ref.err)
+          ref_code=$?
+          set -e
+          if [[ "$ref_code" -ne 0 ]]; then
+            if grep -q 'Not Found' ref.err; then
+              echo "No reservation tag to release"
+              exit 0
+            fi
+            cat ref.err >&2
+            exit "$ref_code"
+          fi
+          remote_tag_sha=$(printf '%s' "$ref_json" | jq -r '.object.sha // empty')
           if [[ -z "$remote_tag_sha" ]]; then
-            echo "No reservation tag to release"
-            exit 0
+            echo "Reservation lookup returned no object sha" >&2
+            exit 1
           fi
           if [[ "$remote_tag_sha" != "$SOURCE_SHA" ]]; then
             echo "Reservation tag no longer points at this source"
             exit 0
           fi
+          set +e
+          curl -fsS "https://pypi.org/pypi/hol-guard/${VERSION}/json" >/dev/null
+          pypi_code=$?
+          set -e
+          if [[ "$pypi_code" -eq 0 ]]; then
+            echo "PyPI already has ${VERSION}; keeping reservation"
+            exit 0
+          fi
+          if [[ "$pypi_code" -ne 22 ]]; then
+            echo "Could not inspect PyPI for ${VERSION}" >&2
+            exit "$pypi_code"
+          fi
           gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/${tag}"
+          set +e
+          gh api --method GET "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}" 2>deleted.err
+          deleted_code=$?
+          set -e
+          if [[ "$deleted_code" -eq 0 ]]; then
+            echo "Reservation tag still exists after delete" >&2
+            exit 1
+          fi
+          if ! grep -q 'Not Found' deleted.err; then
+            cat deleted.err >&2
+            exit "$deleted_code"
+          fi
 
   publish-main-testpypi:
     name: Verify main artifact on TestPyPI

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -776,8 +776,7 @@ jobs:
     if: >-
       always() &&
       vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
-      needs.build.result == 'success' &&
-      needs.assemble-native-guard-distributions.result == 'success' &&
+      needs.build.result == 'success' && needs.assemble-native-guard-distributions.result == 'success' &&
       needs.build.outputs.channel == 'alpha' &&
       (
         (github.event_name == 'workflow_dispatch' && github.run_attempt == 1) ||
@@ -1085,85 +1084,6 @@ jobs:
           [[ -n "$guard_wheel" && -n "$scanner_wheel" ]]
           [[ "$(uv tool run --from "$guard_wheel" hol-guard --version)" == "hol-guard $VERSION" ]]
           [[ "$(uv tool run --from "$scanner_wheel" plugin-scanner --version)" == "plugin-scanner $VERSION" ]]
-
-  release-unpublished-alpha-reservation:
-    name: Release unpublished alpha reservation
-    if: >-
-      always() &&
-      vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
-      needs.build.outputs.channel == 'alpha' &&
-      needs.reserve-alpha-tag.result == 'success' &&
-      needs.publish-alpha-pypi.result != 'success'
-    needs: [build, reserve-alpha-tag, publish-alpha-pypi]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Delete unpublished reservation tag
-        env:
-          GH_TOKEN: ${{ github.token }}
-          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
-          VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          set -euo pipefail
-          tag="alpha/v${VERSION}"
-          set +e
-          ref_json=$(gh api --method GET "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}" 2>ref.err)
-          ref_code=$?
-          set -e
-          if [[ "$ref_code" -ne 0 ]]; then
-            if grep -q 'Not Found' ref.err; then
-              echo "No reservation tag to release"
-              exit 0
-            fi
-            cat ref.err >&2
-            exit "$ref_code"
-          fi
-          remote_tag_sha=$(printf '%s' "$ref_json" | jq -r '.object.sha // empty')
-          if [[ -z "$remote_tag_sha" ]]; then
-            echo "Reservation lookup returned no object sha" >&2
-            exit 1
-          fi
-          if [[ "$remote_tag_sha" != "$SOURCE_SHA" ]]; then
-            echo "Reservation tag no longer points at this source"
-            exit 0
-          fi
-          keep_reservation=false
-          for project in hol-guard plugin-scanner; do
-            set +e
-            http_code=$(curl -sS -o /dev/null -w '%{http_code}' "https://pypi.org/pypi/${project}/${VERSION}/json")
-            curl_code=$?
-            set -e
-            if [[ "$curl_code" -ne 0 ]]; then
-              echo "Could not inspect PyPI for ${project} ${VERSION}" >&2
-              exit "$curl_code"
-            fi
-            if [[ "$http_code" == "200" ]]; then
-              echo "PyPI already has ${project} ${VERSION}; keeping reservation"
-              keep_reservation=true
-              continue
-            fi
-            if [[ "$http_code" != "404" ]]; then
-              echo "Unexpected PyPI status ${http_code} for ${project} ${VERSION}" >&2
-              exit 1
-            fi
-          done
-          if [[ "$keep_reservation" == "true" ]]; then
-            exit 0
-          fi
-          gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/${tag}"
-          set +e
-          gh api --method GET "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}" 2>deleted.err
-          deleted_code=$?
-          set -e
-          if [[ "$deleted_code" -eq 0 ]]; then
-            echo "Reservation tag still exists after delete" >&2
-            exit 1
-          fi
-          if ! grep -q 'Not Found' deleted.err; then
-            cat deleted.err >&2
-            exit "$deleted_code"
-          fi
 
   publish-main-testpypi:
     name: Verify main artifact on TestPyPI

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -796,34 +796,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
           VERSION: ${{ needs.build.outputs.version }}
-        run: |
-          tag="alpha/v${VERSION}"
-          for attempt in 1 2 3; do
-            remote_tag_sha=$(git ls-remote origin "refs/tags/${tag}" | awk '{print $1}')
-            if [[ -n "$remote_tag_sha" ]]; then
-              break
-            fi
-            if gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
-              -f ref="refs/tags/${tag}" \
-              -f sha="$SOURCE_SHA" >/dev/null; then
-              remote_tag_sha=$(git ls-remote origin "refs/tags/${tag}" | awk '{print $1}')
-              if [[ -n "$remote_tag_sha" ]]; then
-                break
-              fi
-            fi
-            if [[ "$attempt" != "3" ]]; then
-              sleep $((attempt * 5))
-            fi
-          done
-          if [[ -z "$remote_tag_sha" ]]; then
-            git tag "$tag" "$SOURCE_SHA"
-            git push origin "refs/tags/${tag}" || true
-            remote_tag_sha=$(git ls-remote origin "refs/tags/${tag}" | awk '{print $1}')
-          fi
-          if [[ "$remote_tag_sha" != "$SOURCE_SHA" ]]; then
-            echo "Alpha tag reservation does not target the published source" >&2
-            exit 1
-          fi
+        run: bash scripts/reserve_alpha_tag.sh
 
   publish-alpha-testpypi:
     name: Verify alpha artifact on TestPyPI
@@ -1084,6 +1057,29 @@ jobs:
           [[ -n "$guard_wheel" && -n "$scanner_wheel" ]]
           [[ "$(uv tool run --from "$guard_wheel" hol-guard --version)" == "hol-guard $VERSION" ]]
           [[ "$(uv tool run --from "$scanner_wheel" plugin-scanner --version)" == "plugin-scanner $VERSION" ]]
+
+  release-unpublished-alpha-reservation:
+    name: Release unpublished alpha reservation
+    if: >-
+      always() &&
+      vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
+      needs.build.outputs.channel == 'alpha' &&
+      needs.reserve-alpha-tag.result == 'success' &&
+      needs.publish-alpha-pypi.result != 'success'
+    needs: [build, reserve-alpha-tag, publish-alpha-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - name: Delete unpublished reservation tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: bash scripts/release_unpublished_alpha_reservation.sh
 
   publish-main-testpypi:
     name: Verify main artifact on TestPyPI

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1128,17 +1128,28 @@ jobs:
             echo "Reservation tag no longer points at this source"
             exit 0
           fi
-          set +e
-          curl -fsS "https://pypi.org/pypi/hol-guard/${VERSION}/json" >/dev/null
-          pypi_code=$?
-          set -e
-          if [[ "$pypi_code" -eq 0 ]]; then
-            echo "PyPI already has ${VERSION}; keeping reservation"
+          keep_reservation=false
+          for project in hol-guard plugin-scanner; do
+            set +e
+            http_code=$(curl -sS -o /dev/null -w '%{http_code}' "https://pypi.org/pypi/${project}/${VERSION}/json")
+            curl_code=$?
+            set -e
+            if [[ "$curl_code" -ne 0 ]]; then
+              echo "Could not inspect PyPI for ${project} ${VERSION}" >&2
+              exit "$curl_code"
+            fi
+            if [[ "$http_code" == "200" ]]; then
+              echo "PyPI already has ${project} ${VERSION}; keeping reservation"
+              keep_reservation=true
+              continue
+            fi
+            if [[ "$http_code" != "404" ]]; then
+              echo "Unexpected PyPI status ${http_code} for ${project} ${VERSION}" >&2
+              exit 1
+            fi
+          done
+          if [[ "$keep_reservation" == "true" ]]; then
             exit 0
-          fi
-          if [[ "$pypi_code" -ne 22 ]]; then
-            echo "Could not inspect PyPI for ${VERSION}" >&2
-            exit "$pypi_code"
           fi
           gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/${tag}"
           set +e

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 15208,
-  "maximum_test_source_lines": 327772,
+  "maximum_collected_cases": 15211,
+  "maximum_test_source_lines": 327812,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 15214,
-  "maximum_test_source_lines": 327899,
+  "maximum_test_source_lines": 327913,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 15213,
-  "maximum_test_source_lines": 327883,
+  "maximum_collected_cases": 15214,
+  "maximum_test_source_lines": 327899,
   "schema_version": 1
 }

--- a/scripts/release_unpublished_alpha_reservation.sh
+++ b/scripts/release_unpublished_alpha_reservation.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+tag="alpha/v${VERSION}"
+set +e
+ref_json=$(gh api --method GET "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}" 2>ref.err)
+ref_code=$?
+set -e
+if [[ "$ref_code" -ne 0 ]]; then
+  if grep -q 'Not Found' ref.err; then
+    echo "No reservation tag to release"
+    exit 0
+  fi
+  cat ref.err >&2
+  exit "$ref_code"
+fi
+remote_tag_sha=$(printf '%s' "$ref_json" | jq -r '.object.sha // empty')
+if [[ -z "$remote_tag_sha" ]]; then
+  echo "Reservation lookup returned no object sha" >&2
+  exit 1
+fi
+if [[ "$remote_tag_sha" != "$SOURCE_SHA" ]]; then
+  echo "Reservation tag no longer points at this source"
+  exit 0
+fi
+keep_reservation=false
+for project in hol-guard plugin-scanner; do
+  set +e
+  http_code=$(curl -sS -o /dev/null -w '%{http_code}' "https://pypi.org/pypi/${project}/${VERSION}/json")
+  curl_code=$?
+  set -e
+  if [[ "$curl_code" -ne 0 ]]; then
+    echo "Could not inspect PyPI for ${project} ${VERSION}" >&2
+    exit "$curl_code"
+  fi
+  if [[ "$http_code" == "200" ]]; then
+    echo "PyPI already has ${project} ${VERSION}; keeping reservation"
+    keep_reservation=true
+    continue
+  fi
+  if [[ "$http_code" != "404" ]]; then
+    echo "Unexpected PyPI status ${http_code} for ${project} ${VERSION}" >&2
+    exit 1
+  fi
+done
+if [[ "$keep_reservation" == "true" ]]; then
+  exit 0
+fi
+gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/${tag}"
+set +e
+gh api --method GET "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}" 2>deleted.err
+deleted_code=$?
+set -e
+if [[ "$deleted_code" -eq 0 ]]; then
+  echo "Reservation tag still exists after delete" >&2
+  exit 1
+fi
+if ! grep -q 'Not Found' deleted.err; then
+  cat deleted.err >&2
+  exit "$deleted_code"
+fi

--- a/scripts/reserve_alpha_tag.sh
+++ b/scripts/reserve_alpha_tag.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+tag="alpha/v${VERSION}"
+for attempt in 1 2 3; do
+  remote_tag_sha=$(git ls-remote origin "refs/tags/${tag}" | awk '{print $1}')
+  if [[ -n "$remote_tag_sha" ]]; then
+    break
+  fi
+  if gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+    -f ref="refs/tags/${tag}" \
+    -f sha="$SOURCE_SHA" >/dev/null; then
+    remote_tag_sha=$(git ls-remote origin "refs/tags/${tag}" | awk '{print $1}')
+    if [[ -n "$remote_tag_sha" ]]; then
+      break
+    fi
+  fi
+  if [[ "$attempt" != "3" ]]; then
+    sleep $((attempt * 5))
+  fi
+done
+if [[ -z "${remote_tag_sha:-}" ]]; then
+  git tag "$tag" "$SOURCE_SHA"
+  git push origin "refs/tags/${tag}" || true
+  remote_tag_sha=$(git ls-remote origin "refs/tags/${tag}" | awk '{print $1}')
+fi
+if [[ "$remote_tag_sha" != "$SOURCE_SHA" ]]; then
+  echo "Alpha tag reservation does not target the published source" >&2
+  exit 1
+fi

--- a/tests/release_workflow_helpers.py
+++ b/tests/release_workflow_helpers.py
@@ -1,0 +1,16 @@
+"""Shared loaders for GitHub workflow contract tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+PUBLISH_WORKFLOW = ROOT / ".github" / "workflows" / "publish.yml"
+
+
+def load_workflow(path: Path) -> dict[object, object]:
+    workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(workflow, dict)
+    return workflow

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -274,10 +274,10 @@ def test_alpha_tag_reservation_binds_version_to_build_source() -> None:
     assert job["permissions"] == {"contents": "write"}
     assert "needs.build.outputs.channel == 'alpha'" in job["if"]
     reservation_run = next(step["run"] for step in job["steps"] if step.get("name") == "Reserve exact alpha tag")
-    assert 'tag="alpha/v${VERSION}"' in reservation_run
-    assert "refs/tags/${tag}" in reservation_run
-    assert '-f sha="$SOURCE_SHA"' in reservation_run
-    assert 'remote_tag_sha" != "$SOURCE_SHA"' in reservation_run
+    script = ROOT.joinpath("scripts", "reserve_alpha_tag.sh").read_text(encoding="utf-8")
+    assert reservation_run == "bash scripts/reserve_alpha_tag.sh"
+    assert 'tag="alpha/v${VERSION}"' in script
+    assert '-f sha="$SOURCE_SHA"' in script
 
 
 def test_publish_jobs_use_registered_protected_environments() -> None:

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -270,7 +270,7 @@ def test_alpha_tag_reservation_binds_version_to_build_source() -> None:
     workflow = _workflow(PUBLISH_WORKFLOW)
     job = workflow["jobs"]["reserve-alpha-tag"]
 
-    assert job["needs"] == ["build"]
+    assert job["needs"] == ["build", "assemble-native-guard-distributions"]
     assert job["permissions"] == {"contents": "write"}
     assert "needs.build.outputs.channel == 'alpha'" in job["if"]
     reservation_run = next(step["run"] for step in job["steps"] if step.get("name") == "Reserve exact alpha tag")

--- a/tests/test_unpublished_alpha_reservation.py
+++ b/tests/test_unpublished_alpha_reservation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from tests.test_release_train_workflow import _workflow, PUBLISH_WORKFLOW
+from tests.test_release_train_workflow import PUBLISH_WORKFLOW, _workflow
 
 
 def test_alpha_reservation_waits_for_native_assemble() -> None:
@@ -10,22 +10,6 @@ def test_alpha_reservation_waits_for_native_assemble() -> None:
     job = jobs["reserve-alpha-tag"]
     assert job["needs"] == ["build", "assemble-native-guard-distributions"]
     assert "needs.assemble-native-guard-distributions.result == 'success'" in job["if"]
-
-
-def test_unpublished_alpha_reservation_is_released_when_publish_fails() -> None:
-    jobs = _workflow(PUBLISH_WORKFLOW)["jobs"]
-    job = jobs["release-unpublished-alpha-reservation"]
-    cleanup_run = next(step["run"] for step in job["steps"] if step.get("name") == "Delete unpublished reservation tag")
-    assert job["needs"] == ["build", "reserve-alpha-tag", "publish-alpha-pypi"]
-    assert job["permissions"] == {"contents": "write"}
-    assert "needs.reserve-alpha-tag.result == 'success'" in job["if"]
-    assert "needs.publish-alpha-pypi.result != 'success'" in job["if"]
-    assert "git/ref/tags/${tag}" in cleanup_run
-    assert "git/refs/tags/${tag}" in cleanup_run
-    assert "pypi.org/pypi/${project}/${VERSION}/json" in cleanup_run
-    assert "hol-guard plugin-scanner" in cleanup_run
-    assert "%{http_code}" in cleanup_run
-    assert "Not Found" in cleanup_run
 
 
 def test_native_guard_wheel_timeout_covers_musl_builds() -> None:

--- a/tests/test_unpublished_alpha_reservation.py
+++ b/tests/test_unpublished_alpha_reservation.py
@@ -2,39 +2,30 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
-import yaml
-
-ROOT = Path(__file__).resolve().parents[1]
-PUBLISH_WORKFLOW = ROOT / ".github" / "workflows" / "publish.yml"
-
-
-def _workflow() -> dict[object, object]:
-    workflow = yaml.safe_load(PUBLISH_WORKFLOW.read_text(encoding="utf-8"))
-    assert isinstance(workflow, dict)
-    return workflow
+from tests.test_release_train_workflow import _workflow, PUBLISH_WORKFLOW
 
 
 def test_alpha_reservation_waits_for_native_assemble() -> None:
-    jobs = _workflow()["jobs"]
+    jobs = _workflow(PUBLISH_WORKFLOW)["jobs"]
     job = jobs["reserve-alpha-tag"]
     assert job["needs"] == ["build", "assemble-native-guard-distributions"]
     assert "needs.assemble-native-guard-distributions.result == 'success'" in job["if"]
 
 
 def test_unpublished_alpha_reservation_is_released_when_publish_fails() -> None:
-    jobs = _workflow()["jobs"]
+    jobs = _workflow(PUBLISH_WORKFLOW)["jobs"]
     job = jobs["release-unpublished-alpha-reservation"]
     cleanup_run = next(step["run"] for step in job["steps"] if step.get("name") == "Delete unpublished reservation tag")
     assert job["needs"] == ["build", "reserve-alpha-tag", "publish-alpha-pypi"]
     assert job["permissions"] == {"contents": "write"}
     assert "needs.reserve-alpha-tag.result == 'success'" in job["if"]
     assert "needs.publish-alpha-pypi.result != 'success'" in job["if"]
-    assert "git/refs/tags/${tag}" in cleanup_run
     assert "git/ref/tags/${tag}" in cleanup_run
+    assert "git/refs/tags/${tag}" in cleanup_run
+    assert "pypi.org/pypi/hol-guard/${VERSION}/json" in cleanup_run
+    assert "Not Found" in cleanup_run
 
 
 def test_native_guard_wheel_timeout_covers_musl_builds() -> None:
-    native = _workflow()["jobs"]["build-native-guard-wheels"]
+    native = _workflow(PUBLISH_WORKFLOW)["jobs"]["build-native-guard-wheels"]
     assert native["timeout-minutes"] == 45

--- a/tests/test_unpublished_alpha_reservation.py
+++ b/tests/test_unpublished_alpha_reservation.py
@@ -2,23 +2,21 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
-from tests.test_release_train_workflow import PUBLISH_WORKFLOW, ROOT, _workflow
+from tests.release_workflow_helpers import PUBLISH_WORKFLOW, ROOT, load_workflow
 
 
 def test_alpha_reservation_waits_for_native_assemble() -> None:
-    jobs = _workflow(PUBLISH_WORKFLOW)["jobs"]
+    jobs = load_workflow(PUBLISH_WORKFLOW)["jobs"]
     job = jobs["reserve-alpha-tag"]
     assert job["needs"] == ["build", "assemble-native-guard-distributions"]
     assert "needs.assemble-native-guard-distributions.result == 'success'" in job["if"]
 
 
 def test_unpublished_alpha_reservation_is_released_when_publish_fails() -> None:
-    jobs = _workflow(PUBLISH_WORKFLOW)["jobs"]
+    jobs = load_workflow(PUBLISH_WORKFLOW)["jobs"]
     job = jobs["release-unpublished-alpha-reservation"]
     cleanup_run = next(step["run"] for step in job["steps"] if step.get("name") == "Delete unpublished reservation tag")
-    script = Path(ROOT / "scripts" / "release_unpublished_alpha_reservation.sh").read_text(encoding="utf-8")
+    script = (ROOT / "scripts" / "release_unpublished_alpha_reservation.sh").read_text(encoding="utf-8")
     assert job["needs"] == ["build", "reserve-alpha-tag", "publish-alpha-pypi"]
     assert job["permissions"] == {"contents": "write"}
     assert "needs.publish-alpha-pypi.result != 'success'" in job["if"]
@@ -29,5 +27,5 @@ def test_unpublished_alpha_reservation_is_released_when_publish_fails() -> None:
 
 
 def test_native_guard_wheel_timeout_covers_musl_builds() -> None:
-    native = _workflow(PUBLISH_WORKFLOW)["jobs"]["build-native-guard-wheels"]
+    native = load_workflow(PUBLISH_WORKFLOW)["jobs"]["build-native-guard-wheels"]
     assert native["timeout-minutes"] == 45

--- a/tests/test_unpublished_alpha_reservation.py
+++ b/tests/test_unpublished_alpha_reservation.py
@@ -1,0 +1,40 @@
+"""Contracts for unpublished alpha reservation recovery."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+PUBLISH_WORKFLOW = ROOT / ".github" / "workflows" / "publish.yml"
+
+
+def _workflow() -> dict[object, object]:
+    workflow = yaml.safe_load(PUBLISH_WORKFLOW.read_text(encoding="utf-8"))
+    assert isinstance(workflow, dict)
+    return workflow
+
+
+def test_alpha_reservation_waits_for_native_assemble() -> None:
+    jobs = _workflow()["jobs"]
+    job = jobs["reserve-alpha-tag"]
+    assert job["needs"] == ["build", "assemble-native-guard-distributions"]
+    assert "needs.assemble-native-guard-distributions.result == 'success'" in job["if"]
+
+
+def test_unpublished_alpha_reservation_is_released_when_publish_fails() -> None:
+    jobs = _workflow()["jobs"]
+    job = jobs["release-unpublished-alpha-reservation"]
+    cleanup_run = next(step["run"] for step in job["steps"] if step.get("name") == "Delete unpublished reservation tag")
+    assert job["needs"] == ["build", "reserve-alpha-tag", "publish-alpha-pypi"]
+    assert job["permissions"] == {"contents": "write"}
+    assert "needs.reserve-alpha-tag.result == 'success'" in job["if"]
+    assert "needs.publish-alpha-pypi.result != 'success'" in job["if"]
+    assert "git/refs/tags/${tag}" in cleanup_run
+    assert "git/ref/tags/${tag}" in cleanup_run
+
+
+def test_native_guard_wheel_timeout_covers_musl_builds() -> None:
+    native = _workflow()["jobs"]["build-native-guard-wheels"]
+    assert native["timeout-minutes"] == 45

--- a/tests/test_unpublished_alpha_reservation.py
+++ b/tests/test_unpublished_alpha_reservation.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from tests.test_release_train_workflow import PUBLISH_WORKFLOW, _workflow
+from pathlib import Path
+
+from tests.test_release_train_workflow import PUBLISH_WORKFLOW, ROOT, _workflow
 
 
 def test_alpha_reservation_waits_for_native_assemble() -> None:
@@ -10,6 +12,20 @@ def test_alpha_reservation_waits_for_native_assemble() -> None:
     job = jobs["reserve-alpha-tag"]
     assert job["needs"] == ["build", "assemble-native-guard-distributions"]
     assert "needs.assemble-native-guard-distributions.result == 'success'" in job["if"]
+
+
+def test_unpublished_alpha_reservation_is_released_when_publish_fails() -> None:
+    jobs = _workflow(PUBLISH_WORKFLOW)["jobs"]
+    job = jobs["release-unpublished-alpha-reservation"]
+    cleanup_run = next(step["run"] for step in job["steps"] if step.get("name") == "Delete unpublished reservation tag")
+    script = Path(ROOT / "scripts" / "release_unpublished_alpha_reservation.sh").read_text(encoding="utf-8")
+    assert job["needs"] == ["build", "reserve-alpha-tag", "publish-alpha-pypi"]
+    assert job["permissions"] == {"contents": "write"}
+    assert "needs.publish-alpha-pypi.result != 'success'" in job["if"]
+    assert cleanup_run == "bash scripts/release_unpublished_alpha_reservation.sh"
+    assert "hol-guard plugin-scanner" in script
+    assert "%{http_code}" in script
+    assert "Not Found" in script
 
 
 def test_native_guard_wheel_timeout_covers_musl_builds() -> None:

--- a/tests/test_unpublished_alpha_reservation.py
+++ b/tests/test_unpublished_alpha_reservation.py
@@ -22,7 +22,9 @@ def test_unpublished_alpha_reservation_is_released_when_publish_fails() -> None:
     assert "needs.publish-alpha-pypi.result != 'success'" in job["if"]
     assert "git/ref/tags/${tag}" in cleanup_run
     assert "git/refs/tags/${tag}" in cleanup_run
-    assert "pypi.org/pypi/hol-guard/${VERSION}/json" in cleanup_run
+    assert "pypi.org/pypi/${project}/${VERSION}/json" in cleanup_run
+    assert "hol-guard plugin-scanner" in cleanup_run
+    assert "%{http_code}" in cleanup_run
     assert "Not Found" in cleanup_run
 
 


### PR DESCRIPTION
## Summary
- Reserve a 3.0 alpha tag only after native distributions assemble successfully
- Give native wheel builds 45 minutes so a long musl compile cannot skip publication
- If PyPI publication still fails, drop the unpublished reservation unless hol-guard or plugin-scanner already has that version

## Testing
- `uv run --no-sync pytest tests/test_unpublished_alpha_reservation.py tests/test_release_train_workflow.py::test_alpha_tag_reservation_binds_version_to_build_source --tb=short`
