### PR TITLE
docs: add CITATION.cff for GitHub cite-this-repository

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,16 @@
+cff-version: 1.2.0
+title: "HOL Guard"
+message: "If you reference HOL Guard, please cite this software repository. A scan is not a safety guarantee."
+type: software
+authors:
+  - name: "Hashgraph Online"
+url: "https://github.com/hashgraph-online/hol-guard"
+repository-code: "https://github.com/hashgraph-online/hol-guard"
+license: "Apache-2.0"
+identifiers:
+  - type: url
+    value: "https://hol.org/guard"
+    description: "HOL Guard product site."
+  - type: url
+    value: "https://huggingface.co/datasets/HashgraphOnline/hol-plugin-security"
+    description: "Related Hugging Face dataset (HOL Plugin Security). Runtime fixtures in that dataset are modeled, not live attacks. A scan is not a safety guarantee."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

GitHub’s “Cite this repository” box 404s because hol-guard has no `CITATION.cff` on `main`. This adds a **software** citation file at the repo root, matching the tone of hol-guard-benchmark’s CFF, without replacing the software cite with the Hugging Face dataset.

## What changed

- Added `CITATION.cff` (`type: software`, Apache-2.0)
- Primary `url` / `repository-code`: https://github.com/hashgraph-online/hol-guard
- Also cites https://hol.org/guard as a related URL identifier
- Lists https://huggingface.co/datasets/HashgraphOnline/hol-plugin-security as a **related** identifier only (dataset is not `preferred-citation`)
- Honest wording: a scan is not a safety guarantee; runtime fixtures in the dataset are modeled, not live attacks
- Does not attribute Hashgraph Online org-wide GitHub stars to this repository

## Scope

- CFF-only. No version bump, no PyPI publish, no product-code changes, no 450K/download marketing copy.

## Verification

- Confirmed `CITATION.cff` 404 on current `main`
- YAML parses; required CFF fields present; `type` is `software`
- Dataset URL matches README Resources and `pyproject.toml` `[project.urls]` Dataset key

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8e3ce36-fed8-4037-99da-740265cb7e1d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8e3ce36-fed8-4037-99da-740265cb7e1d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added citation metadata for HOL Guard, including authorship, licensing, repository, product, and related dataset information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->