### PR TITLE
feat(cli): accept a Desktop child approval factor without a TTY

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 15214,
-  "maximum_test_source_lines": 327913,
+  "maximum_collected_cases": 15222,
+  "maximum_test_source_lines": 328200,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/cli/approval_gate_prompt.py
+++ b/src/codex_plugin_scanner/guard/cli/approval_gate_prompt.py
@@ -14,19 +14,20 @@ _PASSWORD_ENV = "HOL_GUARD_APPROVAL_PASSWORD"
 _TOTP_ENV = "HOL_GUARD_APPROVAL_TOTP_CODE"
 
 
-def _take_env(name: str) -> str | None:
+def _take_env(name: str, *, strip: bool) -> str | None:
     value = os.environ.pop(name, None)
     if not isinstance(value, str):
         return None
-    stripped = value.strip()
-    return stripped or None
+    if strip:
+        value = value.strip()
+    return value or None
 
 
 def _desktop_child_proof(*, totp_enabled: bool, use_cooldown: bool, cooldown_seconds: int) -> ApprovalGateInput | None:
     if os.environ.get(_DESKTOP_CHILD_ENV) != "1":
         return None
-    password = _take_env(_PASSWORD_ENV)
-    totp_code = _take_env(_TOTP_ENV)
+    password = _take_env(_PASSWORD_ENV, strip=False)
+    totp_code = _take_env(_TOTP_ENV, strip=True)
     if password is not None and totp_code is not None:
         raise ApprovalGateError(
             "approval_gate_factor_conflict",
@@ -50,19 +51,22 @@ def prompt_for_approval_gate(
     *,
     use_cooldown: bool = True,
     summary: str | None = None,
+    allow_desktop_env: bool = False,
 ) -> ApprovalGateInput | None:
     gate = public_config(guard_home)
     if not gate.enabled:
         return None
-    desktop_proof = _desktop_child_proof(
-        totp_enabled=gate.totp_enabled,
-        use_cooldown=use_cooldown,
-        cooldown_seconds=gate.cooldown_seconds,
-    )
-    if desktop_proof is not None:
-        return desktop_proof
+    desktop_proof = None
+    if allow_desktop_env:
+        desktop_proof = _desktop_child_proof(
+            totp_enabled=gate.totp_enabled,
+            use_cooldown=use_cooldown,
+            cooldown_seconds=gate.cooldown_seconds,
+        )
     if gate.totp_enabled and recent_totp_satisfied(guard_home):
         return None
+    if desktop_proof is not None:
+        return desktop_proof
     if not sys.stdin.isatty():
         proof_name = "Authenticator code" if gate.totp_enabled else "Approval password"
         raise ApprovalGateError(

--- a/src/codex_plugin_scanner/guard/cli/approval_gate_prompt.py
+++ b/src/codex_plugin_scanner/guard/cli/approval_gate_prompt.py
@@ -14,20 +14,28 @@ _PASSWORD_ENV = "HOL_GUARD_APPROVAL_PASSWORD"
 _TOTP_ENV = "HOL_GUARD_APPROVAL_TOTP_CODE"
 
 
-def _take_env(name: str, *, strip: bool) -> str | None:
+def _pop_env(name: str) -> str | None:
     value = os.environ.pop(name, None)
-    if not isinstance(value, str):
-        return None
-    if strip:
-        value = value.strip()
-    return value or None
+    return value if isinstance(value, str) else None
 
 
-def _desktop_child_proof(*, totp_enabled: bool, use_cooldown: bool, cooldown_seconds: int) -> ApprovalGateInput | None:
+def consume_desktop_lifecycle_env(
+    *,
+    totp_enabled: bool,
+    use_cooldown: bool,
+    cooldown_seconds: int,
+) -> ApprovalGateInput | None:
+    """Take Desktop child proof for protection lifecycle commands only.
+
+    The approval factor variables are always removed from the process environment
+    so later subprocesses cannot inherit unused credentials.
+    """
+
+    password = _pop_env(_PASSWORD_ENV)
+    totp_raw = _pop_env(_TOTP_ENV)
+    totp_code = totp_raw.strip() if totp_raw is not None and totp_raw.strip() else None
     if os.environ.get(_DESKTOP_CHILD_ENV) != "1":
         return None
-    password = _take_env(_PASSWORD_ENV, strip=False)
-    totp_code = _take_env(_TOTP_ENV, strip=True)
     if password is not None and totp_code is not None:
         raise ApprovalGateError(
             "approval_gate_factor_conflict",
@@ -37,7 +45,7 @@ def _desktop_child_proof(*, totp_enabled: bool, use_cooldown: bool, cooldown_sec
         if totp_code is None:
             return None
         return ApprovalGateInput(password=None, totp_code=totp_code, use_cooldown=False)
-    if password is None:
+    if not password:
         return None
     return ApprovalGateInput(
         password=password,
@@ -51,22 +59,12 @@ def prompt_for_approval_gate(
     *,
     use_cooldown: bool = True,
     summary: str | None = None,
-    allow_desktop_env: bool = False,
 ) -> ApprovalGateInput | None:
     gate = public_config(guard_home)
     if not gate.enabled:
         return None
-    desktop_proof = None
-    if allow_desktop_env:
-        desktop_proof = _desktop_child_proof(
-            totp_enabled=gate.totp_enabled,
-            use_cooldown=use_cooldown,
-            cooldown_seconds=gate.cooldown_seconds,
-        )
     if gate.totp_enabled and recent_totp_satisfied(guard_home):
         return None
-    if desktop_proof is not None:
-        return desktop_proof
     if not sys.stdin.isatty():
         proof_name = "Authenticator code" if gate.totp_enabled else "Approval password"
         raise ApprovalGateError(

--- a/src/codex_plugin_scanner/guard/cli/approval_gate_prompt.py
+++ b/src/codex_plugin_scanner/guard/cli/approval_gate_prompt.py
@@ -3,10 +3,46 @@
 from __future__ import annotations
 
 import getpass
+import os
 import sys
 from pathlib import Path
 
 from ..approval_gate import ApprovalGateError, ApprovalGateInput, public_config, recent_totp_satisfied
+
+_DESKTOP_CHILD_ENV = "HOL_GUARD_DESKTOP"
+_PASSWORD_ENV = "HOL_GUARD_APPROVAL_PASSWORD"
+_TOTP_ENV = "HOL_GUARD_APPROVAL_TOTP_CODE"
+
+
+def _take_env(name: str) -> str | None:
+    value = os.environ.pop(name, None)
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _desktop_child_proof(*, totp_enabled: bool, use_cooldown: bool, cooldown_seconds: int) -> ApprovalGateInput | None:
+    if os.environ.get(_DESKTOP_CHILD_ENV) != "1":
+        return None
+    password = _take_env(_PASSWORD_ENV)
+    totp_code = _take_env(_TOTP_ENV)
+    if password is not None and totp_code is not None:
+        raise ApprovalGateError(
+            "approval_gate_factor_conflict",
+            "Enter the approval password or the authenticator code, never both.",
+        )
+    if totp_enabled:
+        if totp_code is None:
+            return None
+        return ApprovalGateInput(password=None, totp_code=totp_code, use_cooldown=False)
+    if password is None:
+        return None
+    return ApprovalGateInput(
+        password=password,
+        totp_code=None,
+        use_cooldown=use_cooldown and cooldown_seconds > 0,
+    )
 
 
 def prompt_for_approval_gate(
@@ -18,6 +54,13 @@ def prompt_for_approval_gate(
     gate = public_config(guard_home)
     if not gate.enabled:
         return None
+    desktop_proof = _desktop_child_proof(
+        totp_enabled=gate.totp_enabled,
+        use_cooldown=use_cooldown,
+        cooldown_seconds=gate.cooldown_seconds,
+    )
+    if desktop_proof is not None:
+        return desktop_proof
     if gate.totp_enabled and recent_totp_satisfied(guard_home):
         return None
     if not sys.stdin.isatty():

--- a/src/codex_plugin_scanner/guard/cli/commands_lifecycle_gate.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_lifecycle_gate.py
@@ -81,7 +81,11 @@ def enforce_lifecycle_gate(
     if not gate.enabled:
         print(_ENROLLMENT_NOTICE, file=error_stream or sys.stderr)
         return
-    gate_input = prompt_for_approval_gate(authority_home, use_cooldown=False)
+    gate_input = prompt_for_approval_gate(
+        authority_home,
+        use_cooldown=False,
+        allow_desktop_env=True,
+    )
     _ = require_high_risk(
         authority_home,
         purpose="protection_lifecycle",

--- a/src/codex_plugin_scanner/guard/cli/commands_lifecycle_gate.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_lifecycle_gate.py
@@ -9,10 +9,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TextIO, cast
 
-from ..approval_gate import public_config, require_high_risk
+from ..approval_gate import public_config, recent_totp_satisfied, require_high_risk
 from ..config import resolve_guard_home_for_user_home
 from ..windows_paths import trusted_windows_user_profile
-from .approval_gate_prompt import prompt_for_approval_gate
+from .approval_gate_prompt import consume_desktop_lifecycle_env, prompt_for_approval_gate
 
 _ENROLLMENT_NOTICE = (
     "Security recommendation: protect Guard administration with an approval password or Authenticator. "
@@ -78,14 +78,20 @@ def enforce_lifecycle_gate(
         return
     authority_home = lifecycle_authority_home(guard_home, requirement=requirement)
     gate = public_config(authority_home)
+    desktop_proof = consume_desktop_lifecycle_env(
+        totp_enabled=gate.totp_enabled,
+        use_cooldown=False,
+        cooldown_seconds=gate.cooldown_seconds,
+    )
     if not gate.enabled:
         print(_ENROLLMENT_NOTICE, file=error_stream or sys.stderr)
         return
-    gate_input = prompt_for_approval_gate(
-        authority_home,
-        use_cooldown=False,
-        allow_desktop_env=True,
-    )
+    if gate.totp_enabled and recent_totp_satisfied(authority_home):
+        gate_input = None
+    elif desktop_proof is not None:
+        gate_input = desktop_proof
+    else:
+        gate_input = prompt_for_approval_gate(authority_home, use_cooldown=False)
     _ = require_high_risk(
         authority_home,
         purpose="protection_lifecycle",

--- a/tests/test_guard_cli_lifecycle_gate.py
+++ b/tests/test_guard_cli_lifecycle_gate.py
@@ -290,24 +290,18 @@ def test_desktop_child_env_rejects_password_and_totp_together(
 
 
 def test_desktop_child_env_supplies_totp_when_authenticator_is_on(
-    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from codex_plugin_scanner.guard.cli.approval_gate_prompt import prompt_for_approval_gate
+    from codex_plugin_scanner.guard.cli.approval_gate_prompt import consume_desktop_lifecycle_env
 
-    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
     monkeypatch.setenv("HOL_GUARD_DESKTOP", "1")
     monkeypatch.setenv("HOL_GUARD_APPROVAL_TOTP_CODE", "123456")
-    monkeypatch.setattr(
-        "codex_plugin_scanner.guard.cli.approval_gate_prompt.public_config",
-        lambda _home: SimpleNamespace(enabled=True, totp_enabled=True, cooldown_seconds=0),
-    )
-    monkeypatch.setattr(
-        "codex_plugin_scanner.guard.cli.approval_gate_prompt.recent_totp_satisfied",
-        lambda _home: False,
-    )
 
-    proof = prompt_for_approval_gate(tmp_path, allow_desktop_env=True)
+    proof = consume_desktop_lifecycle_env(
+        totp_enabled=True,
+        use_cooldown=False,
+        cooldown_seconds=0,
+    )
 
     assert proof is not None
     assert proof.password is None
@@ -338,20 +332,18 @@ def test_desktop_child_env_is_ignored_outside_lifecycle_enforcement(
 
 
 def test_desktop_child_env_preserves_password_whitespace(
-    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from codex_plugin_scanner.guard.cli.approval_gate_prompt import prompt_for_approval_gate
+    from codex_plugin_scanner.guard.cli.approval_gate_prompt import consume_desktop_lifecycle_env
 
-    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
     monkeypatch.setenv("HOL_GUARD_DESKTOP", "1")
     monkeypatch.setenv("HOL_GUARD_APPROVAL_PASSWORD", " secret ")
-    monkeypatch.setattr(
-        "codex_plugin_scanner.guard.cli.approval_gate_prompt.public_config",
-        lambda _home: SimpleNamespace(enabled=True, totp_enabled=False, cooldown_seconds=0),
-    )
 
-    proof = prompt_for_approval_gate(tmp_path, allow_desktop_env=True)
+    proof = consume_desktop_lifecycle_env(
+        totp_enabled=False,
+        use_cooldown=False,
+        cooldown_seconds=0,
+    )
 
     assert proof is not None
     assert proof.password == " secret "
@@ -361,21 +353,52 @@ def test_desktop_child_env_totp_defers_to_recent_session_proof(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from codex_plugin_scanner.guard.cli.approval_gate_prompt import prompt_for_approval_gate
-
+    password = "correct horse battery staple"
+    monkeypatch.setattr(commands_lifecycle_gate, "canonical_lifecycle_home", lambda: tmp_path)
+    _ = update_settings(
+        tmp_path,
+        {"enabled": True, "new_password": password, "confirm_password": password},
+    )
     monkeypatch.setattr("sys.stdin.isatty", lambda: False)
     monkeypatch.setenv("HOL_GUARD_DESKTOP", "1")
     monkeypatch.setenv("HOL_GUARD_APPROVAL_TOTP_CODE", "123456")
     monkeypatch.setattr(
-        "codex_plugin_scanner.guard.cli.approval_gate_prompt.public_config",
-        lambda _home: SimpleNamespace(enabled=True, totp_enabled=True, cooldown_seconds=0),
+        "codex_plugin_scanner.guard.cli.commands_lifecycle_gate.public_config",
+        lambda _home: SimpleNamespace(
+            enabled=True,
+            totp_enabled=True,
+            cooldown_seconds=0,
+        ),
     )
     monkeypatch.setattr(
-        "codex_plugin_scanner.guard.cli.approval_gate_prompt.recent_totp_satisfied",
+        "codex_plugin_scanner.guard.cli.commands_lifecycle_gate.recent_totp_satisfied",
         lambda _home: True,
     )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.commands_lifecycle_gate.require_high_risk",
+        lambda *_args, **_kwargs: None,
+    )
 
-    proof = prompt_for_approval_gate(tmp_path, allow_desktop_env=True)
+    enforce_lifecycle_gate(
+        argparse.Namespace(guard_command="update"),
+        guard_home=tmp_path,
+    )
 
-    assert proof is None
     assert "HOL_GUARD_APPROVAL_TOTP_CODE" not in os.environ
+
+
+def test_desktop_child_env_is_cleared_when_the_gate_is_disabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(commands_lifecycle_gate, "canonical_lifecycle_home", lambda: tmp_path)
+    monkeypatch.setenv("HOL_GUARD_DESKTOP", "1")
+    monkeypatch.setenv("HOL_GUARD_APPROVAL_PASSWORD", "correct horse battery staple")
+
+    enforce_lifecycle_gate(
+        argparse.Namespace(guard_command="update"),
+        guard_home=tmp_path,
+        error_stream=io.StringIO(),
+    )
+
+    assert "HOL_GUARD_APPROVAL_PASSWORD" not in os.environ

--- a/tests/test_guard_cli_lifecycle_gate.py
+++ b/tests/test_guard_cli_lifecycle_gate.py
@@ -302,11 +302,80 @@ def test_desktop_child_env_supplies_totp_when_authenticator_is_on(
         "codex_plugin_scanner.guard.cli.approval_gate_prompt.public_config",
         lambda _home: SimpleNamespace(enabled=True, totp_enabled=True, cooldown_seconds=0),
     )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.approval_gate_prompt.recent_totp_satisfied",
+        lambda _home: False,
+    )
 
-    proof = prompt_for_approval_gate(tmp_path)
+    proof = prompt_for_approval_gate(tmp_path, allow_desktop_env=True)
 
     assert proof is not None
     assert proof.password is None
     assert proof.totp_code == "123456"
     assert proof.use_cooldown is False
+    assert "HOL_GUARD_APPROVAL_TOTP_CODE" not in os.environ
+
+
+def test_desktop_child_env_is_ignored_outside_lifecycle_enforcement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codex_plugin_scanner.guard.cli.approval_gate_prompt import prompt_for_approval_gate
+
+    password = "correct horse battery staple"
+    _ = update_settings(
+        tmp_path,
+        {"enabled": True, "new_password": password, "confirm_password": password},
+    )
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    monkeypatch.setenv("HOL_GUARD_DESKTOP", "1")
+    monkeypatch.setenv("HOL_GUARD_APPROVAL_PASSWORD", password)
+
+    with pytest.raises(ApprovalGateError, match="interactive terminal"):
+        prompt_for_approval_gate(tmp_path)
+
+    assert os.environ.get("HOL_GUARD_APPROVAL_PASSWORD") == password
+
+
+def test_desktop_child_env_preserves_password_whitespace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codex_plugin_scanner.guard.cli.approval_gate_prompt import prompt_for_approval_gate
+
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    monkeypatch.setenv("HOL_GUARD_DESKTOP", "1")
+    monkeypatch.setenv("HOL_GUARD_APPROVAL_PASSWORD", " secret ")
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.approval_gate_prompt.public_config",
+        lambda _home: SimpleNamespace(enabled=True, totp_enabled=False, cooldown_seconds=0),
+    )
+
+    proof = prompt_for_approval_gate(tmp_path, allow_desktop_env=True)
+
+    assert proof is not None
+    assert proof.password == " secret "
+
+
+def test_desktop_child_env_totp_defers_to_recent_session_proof(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codex_plugin_scanner.guard.cli.approval_gate_prompt import prompt_for_approval_gate
+
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    monkeypatch.setenv("HOL_GUARD_DESKTOP", "1")
+    monkeypatch.setenv("HOL_GUARD_APPROVAL_TOTP_CODE", "123456")
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.approval_gate_prompt.public_config",
+        lambda _home: SimpleNamespace(enabled=True, totp_enabled=True, cooldown_seconds=0),
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.approval_gate_prompt.recent_totp_satisfied",
+        lambda _home: True,
+    )
+
+    proof = prompt_for_approval_gate(tmp_path, allow_desktop_env=True)
+
+    assert proof is None
     assert "HOL_GUARD_APPROVAL_TOTP_CODE" not in os.environ

--- a/tests/test_guard_cli_lifecycle_gate.py
+++ b/tests/test_guard_cli_lifecycle_gate.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import argparse
 import io
 import json
+import os
 from pathlib import Path
+from types import SimpleNamespace
 from typing import cast
 
 import pytest
@@ -221,3 +223,90 @@ def test_cloud_disconnect_uses_canonical_authority(
             argparse.Namespace(guard_command="disconnect", source="default"),
             guard_home=alternate_home,
         )
+
+
+def test_desktop_child_env_password_satisfies_lifecycle_gate_without_tty(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    password = "correct horse battery staple"
+    monkeypatch.setattr(commands_lifecycle_gate, "canonical_lifecycle_home", lambda: tmp_path)
+    _ = update_settings(
+        tmp_path,
+        {"enabled": True, "new_password": password, "confirm_password": password},
+    )
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    monkeypatch.setenv("HOL_GUARD_DESKTOP", "1")
+    monkeypatch.setenv("HOL_GUARD_APPROVAL_PASSWORD", password)
+
+    enforce_lifecycle_gate(
+        argparse.Namespace(guard_command="update"),
+        guard_home=tmp_path,
+    )
+
+    assert "HOL_GUARD_APPROVAL_PASSWORD" not in os.environ
+
+
+def test_desktop_child_env_is_ignored_without_desktop_marker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    password = "correct horse battery staple"
+    monkeypatch.setattr(commands_lifecycle_gate, "canonical_lifecycle_home", lambda: tmp_path)
+    _ = update_settings(
+        tmp_path,
+        {"enabled": True, "new_password": password, "confirm_password": password},
+    )
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    monkeypatch.setenv("HOL_GUARD_APPROVAL_PASSWORD", password)
+
+    with pytest.raises(ApprovalGateError, match="interactive terminal"):
+        enforce_lifecycle_gate(
+            argparse.Namespace(guard_command="update"),
+            guard_home=tmp_path,
+        )
+
+
+def test_desktop_child_env_rejects_password_and_totp_together(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    password = "correct horse battery staple"
+    monkeypatch.setattr(commands_lifecycle_gate, "canonical_lifecycle_home", lambda: tmp_path)
+    _ = update_settings(
+        tmp_path,
+        {"enabled": True, "new_password": password, "confirm_password": password},
+    )
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    monkeypatch.setenv("HOL_GUARD_DESKTOP", "1")
+    monkeypatch.setenv("HOL_GUARD_APPROVAL_PASSWORD", password)
+    monkeypatch.setenv("HOL_GUARD_APPROVAL_TOTP_CODE", "123456")
+
+    with pytest.raises(ApprovalGateError, match="never both"):
+        enforce_lifecycle_gate(
+            argparse.Namespace(guard_command="update"),
+            guard_home=tmp_path,
+        )
+
+
+def test_desktop_child_env_supplies_totp_when_authenticator_is_on(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codex_plugin_scanner.guard.cli.approval_gate_prompt import prompt_for_approval_gate
+
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    monkeypatch.setenv("HOL_GUARD_DESKTOP", "1")
+    monkeypatch.setenv("HOL_GUARD_APPROVAL_TOTP_CODE", "123456")
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.approval_gate_prompt.public_config",
+        lambda _home: SimpleNamespace(enabled=True, totp_enabled=True, cooldown_seconds=0),
+    )
+
+    proof = prompt_for_approval_gate(tmp_path)
+
+    assert proof is not None
+    assert proof.password is None
+    assert proof.totp_code == "123456"
+    assert proof.use_cooldown is False
+    assert "HOL_GUARD_APPROVAL_TOTP_CODE" not in os.environ


### PR DESCRIPTION
## Summary
- Desktop-launched Core children can satisfy the lifecycle gate with a single approval factor from the child environment when no TTY is available.
- The enrolled factor remains exclusive: authenticator code replaces the approval password, and both factors together are rejected.
- The child environment values are consumed for that command and are not kept for later use.

## Testing
- ruff check src/codex_plugin_scanner/guard/cli/approval_gate_prompt.py tests/test_guard_cli_lifecycle_gate.py
- pytest tests/test_guard_cli_lifecycle_gate.py
