### PR TITLE
fix(cli): align local runtime before desktop bootstrap protection

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 15222,
-  "maximum_test_source_lines": 328200,
+  "maximum_collected_cases": 15223,
+  "maximum_test_source_lines": 328275,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_desktop.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_desktop.py
@@ -351,6 +351,9 @@ def _run_guard_desktop_command(
     if context is None or store is None or config is None:
         raise RuntimeError("Guard Desktop bootstrap requires local Guard context")
 
+    resolved_guard_home = guard_home or context.guard_home
+    # Start/adopt the matching local runtime before projecting protection.
+    session_url = build_desktop_dashboard_session_url(guard_home=resolved_guard_home)
     status_payload = importlib.import_module(".product", __package__).build_guard_status_payload(
         context,
         store,
@@ -381,10 +384,9 @@ def _run_guard_desktop_command(
         resolved_today_count=resolved_today_count,
         receipt_summary=receipt_summary,
     )
-    resolved_guard_home = guard_home or context.guard_home
     dashboard = payload.get("dashboard")
     if isinstance(dashboard, dict):
-        dashboard["sessionUrl"] = build_desktop_dashboard_session_url(guard_home=resolved_guard_home)
+        dashboard["sessionUrl"] = session_url
         dashboard["canonical"] = True
     print(json.dumps(payload, sort_keys=True), file=output_stream or sys.stdout)
     return 0

--- a/tests/test_guard_desktop_dashboard_session.py
+++ b/tests/test_guard_desktop_dashboard_session.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import argparse
+import json
+from io import StringIO
+from pathlib import Path
+from types import SimpleNamespace
 from urllib.parse import parse_qs, urlparse
 
 from codex_plugin_scanner.guard import dashboard_launcher
@@ -37,3 +42,74 @@ def test_desktop_bootstrap_uses_canonical_dashboard_session_builder() -> None:
     assert "build_desktop_dashboard_session_url" in source
     assert 'dashboard["sessionUrl"]' in source
     assert 'dashboard["canonical"] = True' in source
+    assert source.index("session_url = build_desktop_dashboard_session_url") < source.index(
+        "build_guard_status_payload"
+    )
+
+
+def test_desktop_bootstrap_aligns_runtime_before_projecting_protection(monkeypatch, tmp_path: Path) -> None:
+    runtime_ready = {"value": False}
+    call_order: list[str] = []
+
+    def fake_session_url(*, guard_home: Path) -> str:
+        del guard_home
+        call_order.append("session")
+        runtime_ready["value"] = True
+        return "http://127.0.0.1:43123/?desktop_embed=1#guard-token=gld1.test"
+
+    def fake_status(_context: object, _store: object, _config: object) -> dict[str, object]:
+        call_order.append("status")
+        return {
+            "runtime_status": "active" if runtime_ready["value"] else "offline",
+            "managed_harnesses": 1,
+            "receipt_count": 0,
+            "pending_approvals": 0,
+            "cloud_state": "local_only",
+            "last_sync_at": None,
+            "harnesses": [
+                {
+                    "harness": "codex",
+                    "installed": True,
+                    "command_available": True,
+                    "artifact_count": 1,
+                    "review_count": 0,
+                    "warning_count": 0,
+                    "managed": True,
+                }
+            ],
+        }
+
+    monkeypatch.setattr(commands_dispatch_desktop, "build_desktop_dashboard_session_url", fake_session_url)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.product.build_guard_status_payload",
+        fake_status,
+    )
+
+    output = StringIO()
+    result = commands_dispatch_desktop._run_guard_desktop_command(
+        argparse.Namespace(desktop_command="bootstrap"),
+        guard_home=tmp_path,
+        context=SimpleNamespace(guard_home=tmp_path),
+        store=SimpleNamespace(
+            list_approval_requests=lambda **_kwargs: [],
+            oldest_approval_request_created_at=lambda **_kwargs: None,
+            count_approval_requests=lambda **_kwargs: 0,
+            list_receipts=lambda **_kwargs: [],
+            receipt_summary_between=lambda **_kwargs: {
+                "blocked": 0,
+                "approved": 0,
+                "latest_at": None,
+            },
+        ),
+        config=SimpleNamespace(),
+        output_stream=output,
+    )
+
+    payload = json.loads(output.getvalue())
+    assert result == 0
+    assert call_order == ["session", "status"]
+    assert payload["status"] == "ready"
+    assert payload["protection"]["state"] == "protected"
+    assert payload["apps"][0]["protection"] == "protected"
+    assert payload["daemon"] == {"running": True}
+    assert payload["dashboard"]["sessionUrl"].startswith("http://127.0.0.1:43123/")


### PR DESCRIPTION
## Summary
- hol-guard desktop bootstrap starts/adopts the matching local runtime before projecting protection state
- Cold start and runtime-mismatch launches no longer report degraded / needs-repair while the daemon is about to start

## Testing
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/cli/commands_dispatch_desktop.py tests/test_guard_desktop_dashboard_session.py`
- `uv run --no-sync pytest tests/test_guard_desktop_dashboard_session.py tests/test_guard_desktop_contract.py --tb=short`

## Notes
- Focused pytest was blocked locally by a Guard terminal policy decision.
