### PR TITLE
feat(scanner): support native DeepSeek Harness plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,9 @@ plugin-scanner scan ./plugins-repo --ecosystem claude
 # Scan only native Kimi Code plugin surfaces
 plugin-scanner scan ./plugins-repo --ecosystem kimi
 
+# Scan a native DeepSeek Harness (DSH/Cordis) package
+plugin-scanner scan ./dsh-plugin --ecosystem deepseek-harness
+
 # List supported ecosystems
 plugin-scanner --list-ecosystems
 

--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ See [`devcontainer-features/hol-guard/README.md`](devcontainer-features/hol-guar
 | :--- | :--- |
 | Codex | `.codex-plugin/plugin.json`, `marketplace.json`, `.agents/plugins/marketplace.json` |
 | Claude Code | `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` |
+| DeepSeek Harness | `package.json` with `dsh.bundle`, declared patch file, and Cordis `apply(ctx)` runtime export |
 | Gemini CLI | `gemini-extension.json`, `commands/**/*.toml` |
 | Kimi Code | `kimi.plugin.json`, `.kimi-plugin/plugin.json`, declared skills, agents, commands, prompts, and MCP servers |
 | OpenCode | `opencode.json`, `opencode.jsonc`, `.opencode/commands`, `.opencode/plugins` |

--- a/src/codex_plugin_scanner/checks/deepseek_harness.py
+++ b/src/codex_plugin_scanner/checks/deepseek_harness.py
@@ -1,0 +1,72 @@
+"""DeepSeek Harness ecosystem checks."""
+
+from __future__ import annotations
+
+from ..ecosystems.types import NormalizedPackage
+from ..models import CheckResult, Finding, Severity
+from ..path_support import is_safe_relative_path
+from .ecosystem_common import SEMVER_RE
+
+
+def _result(name: str, passed: bool, message: str, rule_id: str, description: str) -> CheckResult:
+    findings = (
+        ()
+        if passed
+        else (
+            Finding(
+                rule_id=rule_id,
+                severity=Severity.MEDIUM,
+                category="deepseek-harness",
+                title=message,
+                description=description,
+                remediation="Update the native DSH declaration in package.json.",
+                file_path="package.json",
+            ),
+        )
+    )
+    return CheckResult(
+        name=name, passed=passed, points=5 if passed else 0, max_points=5, message=message, findings=findings
+    )
+
+
+def run_deepseek_harness_checks(package: NormalizedPackage) -> tuple[CheckResult, ...]:
+    """Validate a native DSH package and its Cordis bundle declaration."""
+
+    manifest = package.raw_manifest
+    required_ok = all(isinstance(manifest.get(key), str) and manifest[key].strip() for key in ("name", "version"))
+    version = manifest.get("version")
+    semver_ok = isinstance(version, str) and bool(SEMVER_RE.match(version))
+    dsh = manifest.get("dsh")
+    bundle = dsh.get("bundle") if isinstance(dsh, dict) else None
+    bundle_ok = isinstance(bundle, dict) and bool(bundle)
+    patch = bundle.get("patch") if isinstance(bundle, dict) else None
+    patch_ok = patch is None or (
+        isinstance(patch, str)
+        and bool(patch.strip())
+        and is_safe_relative_path(package.root_path, patch, require_exists=True)
+    )
+    return (
+        _result(
+            "DSH package metadata",
+            required_ok and semver_ok,
+            "DSH package metadata is valid"
+            if required_ok and semver_ok
+            else "DSH package requires a name and semantic version",
+            "DSH_PACKAGE_METADATA_INVALID",
+            "package.json must declare a non-empty name and semantic version.",
+        ),
+        _result(
+            "DSH bundle declaration",
+            bundle_ok,
+            "DSH bundle declaration is valid" if bundle_ok else "dsh.bundle must be a non-empty object",
+            "DSH_BUNDLE_INVALID",
+            "Native DSH packages must declare at least one bundle entry.",
+        ),
+        _result(
+            "DSH bundle paths",
+            patch_ok,
+            "DSH bundle paths are safe" if patch_ok else "dsh.bundle.patch must resolve inside the package",
+            "DSH_BUNDLE_PATH_UNSAFE",
+            "The declared bundle patch is missing or escapes the package root.",
+        ),
+    )

--- a/src/codex_plugin_scanner/checks/deepseek_harness.py
+++ b/src/codex_plugin_scanner/checks/deepseek_harness.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
+from ..deepseek_harness_support import validate_dsh_package
 from ..ecosystems.types import NormalizedPackage
 from ..models import CheckResult, Finding, Severity
-from ..path_support import is_safe_relative_path
-from .ecosystem_common import SEMVER_RE
 
 
 def _result(name: str, passed: bool, message: str, rule_id: str, description: str) -> CheckResult:
@@ -32,41 +31,40 @@ def _result(name: str, passed: bool, message: str, rule_id: str, description: st
 def run_deepseek_harness_checks(package: NormalizedPackage) -> tuple[CheckResult, ...]:
     """Validate a native DSH package and its Cordis bundle declaration."""
 
-    manifest = package.raw_manifest
-    required_ok = all(isinstance(manifest.get(key), str) and manifest[key].strip() for key in ("name", "version"))
-    version = manifest.get("version")
-    semver_ok = isinstance(version, str) and bool(SEMVER_RE.match(version))
-    dsh = manifest.get("dsh")
-    bundle = dsh.get("bundle") if isinstance(dsh, dict) else None
-    bundle_ok = isinstance(bundle, dict) and bool(bundle)
-    patch = bundle.get("patch") if isinstance(bundle, dict) else None
-    patch_ok = patch is None or (
-        isinstance(patch, str)
-        and bool(patch.strip())
-        and is_safe_relative_path(package.root_path, patch, require_exists=True)
-    )
+    validation = validate_dsh_package(package)
     return (
         _result(
             "DSH package metadata",
-            required_ok and semver_ok,
+            validation.metadata_ok,
             "DSH package metadata is valid"
-            if required_ok and semver_ok
+            if validation.metadata_ok
             else "DSH package requires a name and semantic version",
             "DSH_PACKAGE_METADATA_INVALID",
             "package.json must declare a non-empty name and semantic version.",
         ),
         _result(
             "DSH bundle declaration",
-            bundle_ok,
-            "DSH bundle declaration is valid" if bundle_ok else "dsh.bundle must be a non-empty object",
+            validation.bundle_ok,
+            "DSH bundle declaration is valid" if validation.bundle_ok else "dsh.bundle must be a non-empty object",
             "DSH_BUNDLE_INVALID",
             "Native DSH packages must declare at least one bundle entry.",
         ),
         _result(
             "DSH bundle paths",
-            patch_ok,
-            "DSH bundle paths are safe" if patch_ok else "dsh.bundle.patch must resolve inside the package",
+            validation.patch_ok,
+            "DSH bundle paths are safe"
+            if validation.patch_ok
+            else "dsh.bundle.patch must reference a regular in-package file",
             "DSH_BUNDLE_PATH_UNSAFE",
             "The declared bundle patch is missing or escapes the package root.",
+        ),
+        _result(
+            "DSH Cordis runtime entry point",
+            validation.runtime_ok,
+            "DSH runtime exports apply(ctx)"
+            if validation.runtime_ok
+            else "DSH runtime entry point must export apply(ctx)",
+            "DSH_RUNTIME_APPLY_MISSING",
+            "package.json main/exports must reference a regular in-package module exporting Cordis apply(ctx).",
         ),
     )

--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -116,7 +116,7 @@ def _build_parser(program_name: str, *, program_mode: str) -> argparse.ArgumentP
     scan_parser.add_argument("--cisco-policy", choices=("permissive", "balanced", "strict"), default="balanced")
     scan_parser.add_argument(
         "--ecosystem",
-        choices=("auto", *list_supported_ecosystems()),
+        choices=("auto", *list_supported_ecosystems(), "dsh", "deepseek_harness"),
         default="auto",
         help="Target one ecosystem explicitly or auto-detect all supported ecosystems.",
     )

--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -116,7 +116,7 @@ def _build_parser(program_name: str, *, program_mode: str) -> argparse.ArgumentP
     scan_parser.add_argument("--cisco-policy", choices=("permissive", "balanced", "strict"), default="balanced")
     scan_parser.add_argument(
         "--ecosystem",
-        choices=("auto", "codex", "claude", "gemini", "kimi", "opencode"),
+        choices=("auto", *list_supported_ecosystems()),
         default="auto",
         help="Target one ecosystem explicitly or auto-detect all supported ecosystems.",
     )

--- a/src/codex_plugin_scanner/deepseek_harness_support.py
+++ b/src/codex_plugin_scanner/deepseek_harness_support.py
@@ -1,0 +1,92 @@
+"""Shared validation helpers for native DeepSeek Harness packages."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from .ecosystems.types import NormalizedPackage
+from .path_support import is_safe_relative_path
+
+DSH_SEMVER_RE = re.compile(
+    "".join(
+        (
+            r"^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)",
+            r"(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*)?",
+            r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$",
+        )
+    )
+)
+APPLY_EXPORT_RE = re.compile(
+    r"(?:\bexport\s+(?:async\s+)?function\s+apply\b|\bexport\s*\{[^}]*\bapply\b|\bexports\.apply\s*=|\bmodule\.exports\.apply\s*=)",
+    re.DOTALL,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DshValidation:
+    metadata_ok: bool
+    bundle_ok: bool
+    patch_ok: bool
+    runtime_ok: bool
+    runtime_path: str | None
+
+
+def _runtime_path(manifest: dict[str, object]) -> str | None:
+    main = manifest.get("main")
+    if isinstance(main, str) and main.strip():
+        return main
+    exports = manifest.get("exports")
+    if isinstance(exports, str) and exports.strip():
+        return exports
+    if isinstance(exports, dict):
+        root_export = exports.get(".")
+        if isinstance(root_export, str) and root_export.strip():
+            return root_export
+        if isinstance(root_export, dict):
+            default = root_export.get("default")
+            if isinstance(default, str) and default.strip():
+                return default
+    return None
+
+
+def validate_dsh_package(package: NormalizedPackage) -> DshValidation:
+    """Validate shared DSH metadata, bundle assets, and Cordis runtime surface."""
+
+    manifest = package.raw_manifest
+    name = manifest.get("name")
+    version = manifest.get("version")
+    metadata_ok = (
+        isinstance(name, str)
+        and bool(name.strip())
+        and isinstance(version, str)
+        and bool(DSH_SEMVER_RE.fullmatch(version))
+    )
+    dsh = manifest.get("dsh")
+    bundle = dsh.get("bundle") if isinstance(dsh, dict) else None
+    bundle_ok = isinstance(bundle, dict) and bool(bundle)
+    patch = bundle.get("patch") if isinstance(bundle, dict) else None
+    patch_target = package.root_path / patch if isinstance(patch, str) else None
+    patch_ok = patch is None or (
+        isinstance(patch, str)
+        and bool(patch.strip())
+        and is_safe_relative_path(package.root_path, patch, require_exists=True)
+        and patch_target is not None
+        and patch_target.is_file()
+        and not patch_target.is_symlink()
+    )
+    runtime_path = _runtime_path(manifest)
+    runtime_target = package.root_path / runtime_path if runtime_path is not None else None
+    runtime_ok = False
+    if (
+        runtime_path is not None
+        and runtime_target is not None
+        and is_safe_relative_path(package.root_path, runtime_path, require_exists=True)
+        and runtime_target.is_file()
+        and not runtime_target.is_symlink()
+    ):
+        try:
+            runtime_ok = APPLY_EXPORT_RE.search(runtime_target.read_text(encoding="utf-8")) is not None
+        except OSError:
+            runtime_ok = False
+    return DshValidation(metadata_ok, bundle_ok, patch_ok, runtime_ok, runtime_path)

--- a/src/codex_plugin_scanner/deepseek_harness_support.py
+++ b/src/codex_plugin_scanner/deepseek_harness_support.py
@@ -17,10 +17,6 @@ DSH_SEMVER_RE = re.compile(
         )
     )
 )
-APPLY_EXPORT_RE = re.compile(
-    r"(?:\bexport\s+(?:async\s+)?function\s+apply\b|\bexport\s*\{[^}]*\bapply\b|\bexports\.apply\s*=|\bmodule\.exports\.apply\s*=)",
-    re.DOTALL,
-)
 
 
 @dataclass(frozen=True, slots=True)
@@ -32,22 +28,106 @@ class DshValidation:
     runtime_path: str | None
 
 
-def _runtime_path(manifest: dict[str, object]) -> str | None:
-    main = manifest.get("main")
-    if isinstance(main, str) and main.strip():
-        return main
-    exports = manifest.get("exports")
-    if isinstance(exports, str) and exports.strip():
-        return exports
-    if isinstance(exports, dict):
-        root_export = exports.get(".")
-        if isinstance(root_export, str) and root_export.strip():
-            return root_export
-        if isinstance(root_export, dict):
-            default = root_export.get("default")
-            if isinstance(default, str) and default.strip():
-                return default
+def _export_target(value: object) -> str | None:
+    """Resolve a package export target, preferring import/default conditions."""
+
+    if isinstance(value, str) and value.strip():
+        return value
+    if not isinstance(value, dict):
+        return None
+    for condition in ("import", "default", "require", "node"):
+        if condition in value and (resolved := _export_target(value[condition])) is not None:
+            return resolved
+    for nested in value.values():
+        if (resolved := _export_target(nested)) is not None:
+            return resolved
     return None
+
+
+def _runtime_path(manifest: dict[str, object]) -> str | None:
+    """Resolve the root runtime export, falling back to main only without exports."""
+
+    if "exports" in manifest:
+        exports = manifest["exports"]
+        if isinstance(exports, dict) and "." in exports:
+            return _export_target(exports["."])
+        return _export_target(exports)
+    main = manifest.get("main")
+    return main if isinstance(main, str) and main.strip() else None
+
+
+def _javascript_tokens(source: str) -> tuple[str, ...]:
+    """Tokenize identifiers and punctuation while ignoring JS comments and literals."""
+
+    tokens: list[str] = []
+    index = 0
+    length = len(source)
+    while index < length:
+        char = source[index]
+        following = source[index + 1] if index + 1 < length else ""
+        if char == "/" and following == "/":
+            index += 2
+            while index < length and source[index] not in "\r\n":
+                index += 1
+            continue
+        if char == "/" and following == "*":
+            end = source.find("*/", index + 2)
+            index = length if end < 0 else end + 2
+            continue
+        if char in {"'", '"', "`"}:
+            quote = char
+            index += 1
+            while index < length:
+                if source[index] == "\\":
+                    index += 2
+                    continue
+                if source[index] == quote:
+                    index += 1
+                    break
+                index += 1
+            continue
+        if char.isalpha() or char in {"_", "$"}:
+            end = index + 1
+            while end < length and (source[end].isalnum() or source[end] in {"_", "$"}):
+                end += 1
+            tokens.append(source[index:end])
+            index = end
+            continue
+        if not char.isspace():
+            tokens.append(char)
+        index += 1
+    return tuple(tokens)
+
+
+def _exports_apply(source: str) -> bool:
+    """Return true only when tokenized ESM/CommonJS syntax exports ``apply``."""
+
+    tokens = _javascript_tokens(source)
+    for index, token in enumerate(tokens):
+        tail = tokens[index:]
+        if token == "export":
+            declaration_index = 1
+            if len(tail) > 1 and tail[1] == "async":
+                declaration_index = 2
+            if (
+                len(tail) > declaration_index + 1
+                and tail[declaration_index] in {"function", "const", "let", "var", "class"}
+                and tail[declaration_index + 1] == "apply"
+            ):
+                return True
+            if len(tail) > 1 and tail[1] == "{":
+                close = tail.index("}") if "}" in tail else len(tail)
+                entries = tail[2:close]
+                if "apply" in entries:
+                    return True
+                if any(entries[pos : pos + 3] == (name, "as", "apply") for pos, name in enumerate(entries[:-2])):
+                    return True
+        if tail[:4] in (("exports", ".", "apply", "="), ("module", ".", "exports", ".")):
+            if tail[:4] == ("exports", ".", "apply", "="):
+                return True
+            if len(tail) >= 6 and tail[4:6] == ("apply", "="):
+                return True
+    return False
 
 
 def validate_dsh_package(package: NormalizedPackage) -> DshValidation:
@@ -67,7 +147,7 @@ def validate_dsh_package(package: NormalizedPackage) -> DshValidation:
     bundle_ok = isinstance(bundle, dict) and bool(bundle)
     patch = bundle.get("patch") if isinstance(bundle, dict) else None
     patch_target = package.root_path / patch if isinstance(patch, str) else None
-    patch_ok = patch is None or (
+    patch_ok = (
         isinstance(patch, str)
         and bool(patch.strip())
         and is_safe_relative_path(package.root_path, patch, require_exists=True)
@@ -86,7 +166,7 @@ def validate_dsh_package(package: NormalizedPackage) -> DshValidation:
         and not runtime_target.is_symlink()
     ):
         try:
-            runtime_ok = APPLY_EXPORT_RE.search(runtime_target.read_text(encoding="utf-8")) is not None
-        except OSError:
+            runtime_ok = _exports_apply(runtime_target.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError):
             runtime_ok = False
     return DshValidation(metadata_ok, bundle_ok, patch_ok, runtime_ok, runtime_path)

--- a/src/codex_plugin_scanner/ecosystems/deepseek_harness.py
+++ b/src/codex_plugin_scanner/ecosystems/deepseek_harness.py
@@ -12,7 +12,7 @@ from .types import Ecosystem, NormalizedPackage, PackageCandidate
 def _load_json(path: Path) -> tuple[dict[str, object], str | None]:
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as exc:
+    except (json.JSONDecodeError, OSError, UnicodeError) as exc:
         return {}, str(exc)
     if not isinstance(payload, dict):
         return {}, "package.json must contain a JSON object"

--- a/src/codex_plugin_scanner/ecosystems/deepseek_harness.py
+++ b/src/codex_plugin_scanner/ecosystems/deepseek_harness.py
@@ -1,0 +1,74 @@
+"""DeepSeek Harness (DSH/Cordis) ecosystem adapter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .base import iter_safe_recursive_files
+from .types import Ecosystem, NormalizedPackage, PackageCandidate
+
+
+def _load_json(path: Path) -> tuple[dict[str, object], str | None]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        return {}, str(exc)
+    if not isinstance(payload, dict):
+        return {}, "package.json must contain a JSON object"
+    return payload, None
+
+
+class DeepSeekHarnessAdapter:
+    """Adapter for native DeepSeek Harness packages declared with ``package.json.dsh``."""
+
+    ecosystem_id = Ecosystem.DEEPSEEK_HARNESS
+
+    def detect(self, root: Path) -> list[PackageCandidate]:
+        candidates: list[PackageCandidate] = []
+        for manifest_path in iter_safe_recursive_files(root, root, "package.json"):
+            manifest, error = _load_json(manifest_path)
+            if error is not None:
+                continue
+            dsh = manifest.get("dsh")
+            if not isinstance(dsh, dict) or not isinstance(dsh.get("bundle"), dict):
+                continue
+            candidates.append(
+                PackageCandidate(
+                    ecosystem=Ecosystem.DEEPSEEK_HARNESS,
+                    package_kind="cordis-plugin",
+                    root_path=manifest_path.parent,
+                    manifest_path=manifest_path,
+                    detection_reason="found package.json with dsh.bundle",
+                )
+            )
+        return candidates
+
+    def parse(self, candidate: PackageCandidate) -> NormalizedPackage:
+        manifest, error = _load_json(candidate.manifest_path) if candidate.manifest_path else ({}, "missing manifest")
+        dsh = manifest.get("dsh") if isinstance(manifest.get("dsh"), dict) else {}
+        bundle = dsh.get("bundle") if isinstance(dsh, dict) and isinstance(dsh.get("bundle"), dict) else {}
+        components: dict[str, tuple[str, ...]] = {}
+        patch = bundle.get("patch") if isinstance(bundle, dict) else None
+        if isinstance(patch, str) and patch.strip():
+            components["bundle_patches"] = (patch,)
+        client = dsh.get("client") if isinstance(dsh, dict) else None
+        if isinstance(client, str) and client.strip():
+            components["clients"] = (client,)
+        return NormalizedPackage(
+            ecosystem=Ecosystem.DEEPSEEK_HARNESS,
+            package_kind=candidate.package_kind,
+            root_path=candidate.root_path,
+            manifest_path=candidate.manifest_path,
+            name=manifest.get("name") if isinstance(manifest.get("name"), str) else None,
+            version=manifest.get("version") if isinstance(manifest.get("version"), str) else None,
+            metadata={
+                key: value
+                for key in ("description", "license", "homepage")
+                if isinstance((value := manifest.get(key)), str)
+            },
+            components=components,
+            raw_manifest=manifest,
+            manifest_parse_error=error is not None,
+            manifest_parse_error_reason=error,
+        )

--- a/src/codex_plugin_scanner/ecosystems/registry.py
+++ b/src/codex_plugin_scanner/ecosystems/registry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from .base import EcosystemAdapter
 from .claude import ClaudeAdapter
 from .codex import CodexAdapter
+from .deepseek_harness import DeepSeekHarnessAdapter
 from .gemini import GeminiAdapter
 from .kimi import KimiAdapter
 from .opencode import OpenCodeAdapter
@@ -17,6 +18,7 @@ def get_default_adapters() -> tuple[EcosystemAdapter, ...]:
     return (
         CodexAdapter(),
         ClaudeAdapter(),
+        DeepSeekHarnessAdapter(),
         GeminiAdapter(),
         KimiAdapter(),
         OpenCodeAdapter(),
@@ -31,6 +33,8 @@ def resolve_ecosystem(value: str | None) -> Ecosystem | None:
     lowered = value.strip().lower()
     if lowered in ("", "auto"):
         return None
+    if lowered in ("dsh", "deepseek_harness"):
+        lowered = Ecosystem.DEEPSEEK_HARNESS.value
     try:
         return Ecosystem(lowered)
     except ValueError:

--- a/src/codex_plugin_scanner/ecosystems/types.py
+++ b/src/codex_plugin_scanner/ecosystems/types.py
@@ -12,6 +12,7 @@ class Ecosystem(str, Enum):
 
     CODEX = "codex"
     CLAUDE = "claude"
+    DEEPSEEK_HARNESS = "deepseek-harness"
     GEMINI = "gemini"
     KIMI = "kimi"
     OPENCODE = "opencode"

--- a/src/codex_plugin_scanner/scanner.py
+++ b/src/codex_plugin_scanner/scanner.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from .checks.best_practices import run_best_practice_checks
 from .checks.claude import run_claude_checks
 from .checks.code_quality import run_code_quality_checks
+from .checks.deepseek_harness import run_deepseek_harness_checks
 from .checks.gemini import run_gemini_checks
 from .checks.kimi import run_kimi_checks
 from .checks.manifest import run_manifest_checks
@@ -467,6 +468,30 @@ def _scan_mixed_packages(scan_root: Path, packages: list[NormalizedPackage], opt
             categories.extend(
                 (
                     CategoryResult(name=f"{prefix}Claude Plugin", checks=claude_checks),
+                    CategoryResult(name=f"{prefix}Security", checks=security_checks),
+                    CategoryResult(name=f"{prefix}Operational Security", checks=operational_checks),
+                    CategoryResult(name=f"{prefix}Code Quality", checks=quality_checks),
+                )
+            )
+            processed_packages.append(package)
+            continue
+
+        if package.ecosystem == Ecosystem.DEEPSEEK_HARNESS:
+            dsh_checks = _maybe_rebase_checks(
+                run_deepseek_harness_checks(package), package_root, scan_root_resolved, needs_rebase
+            )
+            security_checks = _maybe_rebase_checks(
+                run_security_checks(package_root), package_root, scan_root_resolved, needs_rebase
+            )
+            operational_checks = _maybe_rebase_checks(
+                run_operational_security_checks(package_root), package_root, scan_root_resolved, needs_rebase
+            )
+            quality_checks = _maybe_rebase_checks(
+                run_code_quality_checks(package_root), package_root, scan_root_resolved, needs_rebase
+            )
+            categories.extend(
+                (
+                    CategoryResult(name=f"{prefix}DeepSeek Harness Plugin", checks=dsh_checks),
                     CategoryResult(name=f"{prefix}Security", checks=security_checks),
                     CategoryResult(name=f"{prefix}Operational Security", checks=operational_checks),
                     CategoryResult(name=f"{prefix}Code Quality", checks=quality_checks),

--- a/src/codex_plugin_scanner/verification.py
+++ b/src/codex_plugin_scanner/verification.py
@@ -12,6 +12,9 @@ from pathlib import Path
 
 from .checks.manifest import load_manifest
 from .checks.manifest_support import safe_manifest_path
+from .ecosystems.detect import detect_packages
+from .ecosystems.registry import get_default_adapters
+from .ecosystems.types import Ecosystem
 from .marketplace_support import (
     extract_marketplace_source,
     load_marketplace_context,
@@ -668,6 +671,66 @@ def _verify_single_plugin(plugin_dir: Path, *, online: bool) -> VerificationResu
     )
 
 
+def _verify_deepseek_harness(plugin_dir: Path) -> VerificationResult:
+    candidates = detect_packages(plugin_dir, Ecosystem.DEEPSEEK_HARNESS)
+    candidate = next((item for item in candidates if item.root_path.resolve() == plugin_dir.resolve()), None)
+    adapter = next(item for item in get_default_adapters() if item.ecosystem_id == Ecosystem.DEEPSEEK_HARNESS)
+    package = adapter.parse(candidate) if candidate is not None else None
+    cases: list[VerificationCase] = []
+    if package is None:
+        cases.append(
+            VerificationCase(
+                "manifest",
+                "native DSH declaration",
+                False,
+                "package.json with dsh.bundle is missing",
+                "missing-manifest",
+            )
+        )
+    else:
+        manifest = package.raw_manifest
+        valid_fields = all(isinstance(manifest.get(key), str) and manifest[key].strip() for key in ("name", "version"))
+        cases.append(
+            VerificationCase(
+                "manifest",
+                "package.json metadata",
+                valid_fields,
+                "Native DSH package metadata is valid" if valid_fields else "package.json requires name and version",
+                "schema" if not valid_fields else "pass",
+            )
+        )
+        bundle = manifest.get("dsh", {}).get("bundle") if isinstance(manifest.get("dsh"), dict) else None
+        valid_bundle = isinstance(bundle, dict) and bool(bundle)
+        cases.append(
+            VerificationCase(
+                "manifest",
+                "dsh.bundle declaration",
+                valid_bundle,
+                "Native DSH bundle is declared" if valid_bundle else "dsh.bundle must be a non-empty object",
+                "schema" if not valid_bundle else "pass",
+            )
+        )
+        patch = bundle.get("patch") if isinstance(bundle, dict) else None
+        valid_patch = patch is None or (
+            isinstance(patch, str) and is_safe_relative_path(plugin_dir, patch, require_exists=True)
+        )
+        cases.append(
+            VerificationCase(
+                "assets",
+                "bundle patch path",
+                valid_patch,
+                "Bundle patch path is safe and exists" if valid_patch else "dsh.bundle.patch is missing or unsafe",
+                "path" if not valid_patch else "pass",
+            )
+        )
+    return VerificationResult(
+        verify_pass=all(case.passed for case in cases),
+        cases=tuple(cases),
+        workspace=str(plugin_dir.resolve()),
+        scope="plugin",
+    )
+
+
 def _prefixed_cases(plugin_name: str, cases: tuple[VerificationCase, ...]) -> tuple[VerificationCase, ...]:
     return tuple(
         VerificationCase(
@@ -732,6 +795,10 @@ def _verify_repository(repo_root: Path, *, online: bool) -> VerificationResult:
 
 def verify_plugin(plugin_dir: str | Path, *, online: bool = False) -> VerificationResult:
     resolved = Path(plugin_dir).resolve()
+    if any(
+        candidate.root_path.resolve() == resolved for candidate in detect_packages(resolved, Ecosystem.DEEPSEEK_HARNESS)
+    ):
+        return _verify_deepseek_harness(resolved)
     discovery = discover_scan_targets(resolved)
     if discovery.scope == "repository":
         return _verify_repository(resolved, online=online)

--- a/src/codex_plugin_scanner/verification.py
+++ b/src/codex_plugin_scanner/verification.py
@@ -12,9 +12,10 @@ from pathlib import Path
 
 from .checks.manifest import load_manifest
 from .checks.manifest_support import safe_manifest_path
+from .deepseek_harness_support import validate_dsh_package
 from .ecosystems.detect import detect_packages
 from .ecosystems.registry import get_default_adapters
-from .ecosystems.types import Ecosystem
+from .ecosystems.types import Ecosystem, PackageCandidate
 from .marketplace_support import (
     extract_marketplace_source,
     load_marketplace_context,
@@ -671,63 +672,73 @@ def _verify_single_plugin(plugin_dir: Path, *, online: bool) -> VerificationResu
     )
 
 
-def _verify_deepseek_harness(plugin_dir: Path) -> VerificationResult:
-    candidates = detect_packages(plugin_dir, Ecosystem.DEEPSEEK_HARNESS)
-    candidate = next((item for item in candidates if item.root_path.resolve() == plugin_dir.resolve()), None)
+def _verify_deepseek_harness_candidate(candidate: PackageCandidate) -> VerificationResult:
+    plugin_dir = candidate.root_path.resolve()
     adapter = next(item for item in get_default_adapters() if item.ecosystem_id == Ecosystem.DEEPSEEK_HARNESS)
-    package = adapter.parse(candidate) if candidate is not None else None
-    cases: list[VerificationCase] = []
-    if package is None:
-        cases.append(
-            VerificationCase(
-                "manifest",
-                "native DSH declaration",
-                False,
-                "package.json with dsh.bundle is missing",
-                "missing-manifest",
-            )
-        )
-    else:
-        manifest = package.raw_manifest
-        valid_fields = all(isinstance(manifest.get(key), str) and manifest[key].strip() for key in ("name", "version"))
-        cases.append(
-            VerificationCase(
-                "manifest",
-                "package.json metadata",
-                valid_fields,
-                "Native DSH package metadata is valid" if valid_fields else "package.json requires name and version",
-                "schema" if not valid_fields else "pass",
-            )
-        )
-        bundle = manifest.get("dsh", {}).get("bundle") if isinstance(manifest.get("dsh"), dict) else None
-        valid_bundle = isinstance(bundle, dict) and bool(bundle)
-        cases.append(
-            VerificationCase(
-                "manifest",
-                "dsh.bundle declaration",
-                valid_bundle,
-                "Native DSH bundle is declared" if valid_bundle else "dsh.bundle must be a non-empty object",
-                "schema" if not valid_bundle else "pass",
-            )
-        )
-        patch = bundle.get("patch") if isinstance(bundle, dict) else None
-        valid_patch = patch is None or (
-            isinstance(patch, str) and is_safe_relative_path(plugin_dir, patch, require_exists=True)
-        )
-        cases.append(
-            VerificationCase(
-                "assets",
-                "bundle patch path",
-                valid_patch,
-                "Bundle patch path is safe and exists" if valid_patch else "dsh.bundle.patch is missing or unsafe",
-                "path" if not valid_patch else "pass",
-            )
-        )
+    package = adapter.parse(candidate)
+    validation = validate_dsh_package(package)
+    cases = [
+        VerificationCase(
+            "manifest",
+            "package.json metadata",
+            validation.metadata_ok,
+            "Native DSH package metadata is valid"
+            if validation.metadata_ok
+            else "package.json requires a name and semantic version",
+            "schema" if not validation.metadata_ok else "pass",
+        ),
+        VerificationCase(
+            "manifest",
+            "dsh.bundle declaration",
+            validation.bundle_ok,
+            "Native DSH bundle is declared" if validation.bundle_ok else "dsh.bundle must be a non-empty object",
+            "schema" if not validation.bundle_ok else "pass",
+        ),
+        VerificationCase(
+            "assets",
+            "bundle patch path",
+            validation.patch_ok,
+            "Bundle patch path is a safe regular file"
+            if validation.patch_ok
+            else "dsh.bundle.patch is missing, unsafe, or not a regular file",
+            "path" if not validation.patch_ok else "pass",
+        ),
+        VerificationCase(
+            "runtime",
+            "Cordis apply(ctx) export",
+            validation.runtime_ok,
+            "Runtime entry point exports apply(ctx)"
+            if validation.runtime_ok
+            else "Runtime entry point is missing a detectable apply(ctx) export",
+            "runtime" if not validation.runtime_ok else "pass",
+        ),
+    ]
     return VerificationResult(
         verify_pass=all(case.passed for case in cases),
         cases=tuple(cases),
         workspace=str(plugin_dir.resolve()),
         scope="plugin",
+        plugin_name=package.name,
+    )
+
+
+def _verify_deepseek_harness(
+    plugin_dir: Path, candidates: tuple[PackageCandidate, ...] | list[PackageCandidate]
+) -> VerificationResult:
+    plugin_results = tuple(_verify_deepseek_harness_candidate(candidate) for candidate in candidates)
+    if len(plugin_results) == 1 and candidates[0].root_path.resolve() == plugin_dir.resolve():
+        return plugin_results[0]
+    cases = tuple(
+        case
+        for result in plugin_results
+        for case in _prefixed_cases(result.plugin_name or Path(result.workspace).name, result.cases)
+    )
+    return VerificationResult(
+        verify_pass=bool(plugin_results) and all(result.verify_pass for result in plugin_results),
+        cases=cases,
+        workspace=str(plugin_dir.resolve()),
+        scope="repository",
+        plugin_results=plugin_results,
     )
 
 
@@ -795,10 +806,9 @@ def _verify_repository(repo_root: Path, *, online: bool) -> VerificationResult:
 
 def verify_plugin(plugin_dir: str | Path, *, online: bool = False) -> VerificationResult:
     resolved = Path(plugin_dir).resolve()
-    if any(
-        candidate.root_path.resolve() == resolved for candidate in detect_packages(resolved, Ecosystem.DEEPSEEK_HARNESS)
-    ):
-        return _verify_deepseek_harness(resolved)
+    dsh_candidates = detect_packages(resolved, Ecosystem.DEEPSEEK_HARNESS)
+    if dsh_candidates:
+        return _verify_deepseek_harness(resolved, dsh_candidates)
     discovery = discover_scan_targets(resolved)
     if discovery.scope == "repository":
         return _verify_repository(resolved, online=online)

--- a/tests/fixtures/deepseek-harness-good/cordis.patch.yml
+++ b/tests/fixtures/deepseek-harness-good/cordis.patch.yml
@@ -1,0 +1,2 @@
+- name: example
+  apply: dsh-example

--- a/tests/fixtures/deepseek-harness-good/index.js
+++ b/tests/fixtures/deepseek-harness-good/index.js
@@ -1,0 +1,3 @@
+export function apply(ctx) {
+  ctx.plugin("example")
+}

--- a/tests/fixtures/deepseek-harness-good/package.json
+++ b/tests/fixtures/deepseek-harness-good/package.json
@@ -2,6 +2,7 @@
   "name": "dsh-example",
   "version": "1.0.0",
   "description": "A native DeepSeek Harness plugin",
+  "main": "index.js",
   "dsh": {
     "bundle": {
       "patch": "cordis.patch.yml"

--- a/tests/fixtures/deepseek-harness-good/package.json
+++ b/tests/fixtures/deepseek-harness-good/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "dsh-example",
+  "version": "1.0.0",
+  "description": "A native DeepSeek Harness plugin",
+  "dsh": {
+    "bundle": {
+      "patch": "cordis.patch.yml"
+    }
+  }
+}

--- a/tests/test_ecosystems.py
+++ b/tests/test_ecosystems.py
@@ -123,6 +123,36 @@ def test_verify_deepseek_harness_rejects_missing_apply_export(tmp_path: Path) ->
     assert rc == 1
 
 
+def test_verify_deepseek_harness_ignores_apply_in_comments_and_strings(tmp_path: Path) -> None:
+    shutil.copytree(FIXTURES / "deepseek-harness-good", tmp_path / "plugin")
+    (tmp_path / "plugin" / "index.js").write_text(
+        "// export function apply(ctx) {}\nexport const text = 'exports.apply = fake'\n", encoding="utf-8"
+    )
+    rc = main(["verify", str(tmp_path / "plugin"), "--format", "json"])
+    assert rc == 1
+
+
+def test_verify_deepseek_harness_requires_patch(tmp_path: Path) -> None:
+    shutil.copytree(FIXTURES / "deepseek-harness-good", tmp_path / "plugin")
+    manifest_path = tmp_path / "plugin" / "package.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    del manifest["dsh"]["bundle"]["patch"]
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    rc = main(["verify", str(tmp_path / "plugin"), "--format", "json"])
+    assert rc == 1
+
+
+def test_verify_deepseek_harness_prefers_conditional_exports(tmp_path: Path) -> None:
+    shutil.copytree(FIXTURES / "deepseek-harness-good", tmp_path / "plugin")
+    manifest_path = tmp_path / "plugin" / "package.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["main"] = "missing.js"
+    manifest["exports"] = {".": {"import": "./index.js", "default": "./missing.js"}}
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    rc = main(["verify", str(tmp_path / "plugin"), "--format", "json"])
+    assert rc == 0
+
+
 def test_verify_nested_deepseek_harness_package(capsys, tmp_path: Path) -> None:
     shutil.copytree(FIXTURES / "deepseek-harness-good", tmp_path / "packages" / "plugin")
     rc = main(["verify", str(tmp_path), "--format", "json"])

--- a/tests/test_ecosystems.py
+++ b/tests/test_ecosystems.py
@@ -55,7 +55,9 @@ def test_scan_native_deepseek_harness_package() -> None:
         ScanOptions(ecosystem="auto", cisco_skill_scan="off"),
     )
     assert result.ecosystems == ("deepseek-harness",)
-    assert any(category.name.endswith("DeepSeek Harness Plugin") for category in result.categories)
+    dsh_category = next(category for category in result.categories if category.name.endswith("DeepSeek Harness Plugin"))
+    assert sum(check.points for check in dsh_category.checks) == 20
+    assert sum(check.max_points for check in dsh_category.checks) == 20
     assert all(finding.rule_id != "PLUGIN_JSON_MISSING" for finding in result.findings)
 
 
@@ -65,6 +67,35 @@ def test_verify_native_deepseek_harness_package(capsys) -> None:
     assert rc == 0
     assert payload["verify_pass"] is True
     assert all(".codex-plugin/plugin.json" not in case["message"] for case in payload["cases"])
+
+
+def test_scan_deepseek_harness_accepts_prerelease_semver(tmp_path: Path) -> None:
+    shutil.copytree(FIXTURES / "deepseek-harness-good", tmp_path / "plugin")
+    manifest_path = tmp_path / "plugin" / "package.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["version"] = "0.1.0-rc.8+build.1"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    result = scan_plugin(tmp_path / "plugin", ScanOptions(cisco_skill_scan="off"))
+    assert all(finding.rule_id != "DSH_PACKAGE_METADATA_INVALID" for finding in result.findings)
+
+
+def test_verify_deepseek_harness_rejects_directory_patch(tmp_path: Path) -> None:
+    shutil.copytree(FIXTURES / "deepseek-harness-good", tmp_path / "plugin")
+    manifest_path = tmp_path / "plugin" / "package.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["dsh"]["bundle"]["patch"] = "."
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    rc = main(["verify", str(tmp_path / "plugin"), "--format", "json"])
+    assert rc == 1
+
+
+def test_verify_nested_deepseek_harness_package(capsys, tmp_path: Path) -> None:
+    shutil.copytree(FIXTURES / "deepseek-harness-good", tmp_path / "packages" / "plugin")
+    rc = main(["verify", str(tmp_path), "--format", "json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["scope"] == "repository"
+    assert payload["repository"]["localPluginCount"] == 1
 
 
 def test_detect_opencode_package() -> None:

--- a/tests/test_ecosystems.py
+++ b/tests/test_ecosystems.py
@@ -12,6 +12,7 @@ from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.ecosystems.claude import ClaudeAdapter
 from codex_plugin_scanner.ecosystems.detect import detect_packages
 from codex_plugin_scanner.ecosystems.opencode import OpenCodeAdapter
+from codex_plugin_scanner.ecosystems.registry import resolve_ecosystem
 from codex_plugin_scanner.ecosystems.types import Ecosystem, NormalizedPackage
 from codex_plugin_scanner.models import ScanOptions
 from codex_plugin_scanner.scanner import scan_plugin
@@ -37,6 +38,33 @@ def test_detect_gemini_package() -> None:
     packages = detect_packages(FIXTURES / "gemini-extension-good")
     ecosystems = {package.ecosystem for package in packages}
     assert Ecosystem.GEMINI in ecosystems
+
+
+def test_detect_native_deepseek_harness_package() -> None:
+    packages = detect_packages(FIXTURES / "deepseek-harness-good")
+    assert [package.ecosystem for package in packages] == [Ecosystem.DEEPSEEK_HARNESS]
+
+
+def test_deepseek_harness_ecosystem_alias() -> None:
+    assert resolve_ecosystem("dsh") == Ecosystem.DEEPSEEK_HARNESS
+
+
+def test_scan_native_deepseek_harness_package() -> None:
+    result = scan_plugin(
+        FIXTURES / "deepseek-harness-good",
+        ScanOptions(ecosystem="auto", cisco_skill_scan="off"),
+    )
+    assert result.ecosystems == ("deepseek-harness",)
+    assert any(category.name.endswith("DeepSeek Harness Plugin") for category in result.categories)
+    assert all(finding.rule_id != "PLUGIN_JSON_MISSING" for finding in result.findings)
+
+
+def test_verify_native_deepseek_harness_package(capsys) -> None:
+    rc = main(["verify", str(FIXTURES / "deepseek-harness-good"), "--format", "json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["verify_pass"] is True
+    assert all(".codex-plugin/plugin.json" not in case["message"] for case in payload["cases"])
 
 
 def test_detect_opencode_package() -> None:

--- a/tests/test_ecosystems.py
+++ b/tests/test_ecosystems.py
@@ -45,6 +45,11 @@ def test_detect_native_deepseek_harness_package() -> None:
     assert [package.ecosystem for package in packages] == [Ecosystem.DEEPSEEK_HARNESS]
 
 
+def test_detect_deepseek_harness_skips_non_utf8_package_json(tmp_path: Path) -> None:
+    (tmp_path / "package.json").write_bytes(b'\xff\xfe{"dsh":{"bundle":{"patch":"x"}}}')
+    assert detect_packages(tmp_path, ecosystem=Ecosystem.DEEPSEEK_HARNESS) == []
+
+
 def test_deepseek_harness_ecosystem_alias() -> None:
     assert resolve_ecosystem("dsh") == Ecosystem.DEEPSEEK_HARNESS
 

--- a/tests/test_ecosystems.py
+++ b/tests/test_ecosystems.py
@@ -60,6 +60,33 @@ def test_scan_native_deepseek_harness_package() -> None:
     assert sum(check.max_points for check in dsh_category.checks) == 20
     assert all(finding.rule_id != "PLUGIN_JSON_MISSING" for finding in result.findings)
 
+    explicit_result = scan_plugin(
+        FIXTURES / "deepseek-harness-good",
+        ScanOptions(ecosystem="deepseek-harness", cisco_skill_scan="off"),
+    )
+    assert explicit_result.ecosystems == ("deepseek-harness",)
+    assert all(finding.rule_id != "PLUGIN_JSON_MISSING" for finding in explicit_result.findings)
+
+
+def test_scan_deepseek_harness_cli_alias(capsys) -> None:
+    rc = main(
+        [
+            "scan",
+            str(FIXTURES / "deepseek-harness-good"),
+            "--ecosystem",
+            "dsh",
+            "--cisco-skill-scan",
+            "off",
+            "--cisco-mcp-scan",
+            "off",
+            "--format",
+            "json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["ecosystems"] == ["deepseek-harness"]
+
 
 def test_verify_native_deepseek_harness_package(capsys) -> None:
     rc = main(["verify", str(FIXTURES / "deepseek-harness-good"), "--format", "json"])
@@ -85,6 +112,13 @@ def test_verify_deepseek_harness_rejects_directory_patch(tmp_path: Path) -> None
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     manifest["dsh"]["bundle"]["patch"] = "."
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    rc = main(["verify", str(tmp_path / "plugin"), "--format", "json"])
+    assert rc == 1
+
+
+def test_verify_deepseek_harness_rejects_missing_apply_export(tmp_path: Path) -> None:
+    shutil.copytree(FIXTURES / "deepseek-harness-good", tmp_path / "plugin")
+    (tmp_path / "plugin" / "index.js").write_text("export const name = 'missing-apply'\n", encoding="utf-8")
     rc = main(["verify", str(tmp_path / "plugin"), "--format", "json"])
     assert rc == 1
 


### PR DESCRIPTION
## Summary

- detect native DeepSeek Harness packages through `package.json.dsh.bundle`
- add DSH-specific manifest, bundle, path, security, and quality scan routing
- make runtime verification understand DSH packages without requiring a Codex manifest
- add `deepseek-harness` CLI selection plus the `dsh` resolver alias

## Why

Native DSH/Cordis packages are currently auto-classified through the Codex fallback and fail with `PLUGIN_JSON_MISSING`, even though `.codex-plugin/plugin.json` is not part of the DSH package contract. This blocks valid packages from meeting the scanner requirement used by the HOL plugin directory.

Closes #2501.

## Validation

- `ruff check` passes on every changed Python/test file
- native DSH fixture scan reports ecosystem `deepseek-harness` and no `PLUGIN_JSON_MISSING`
- native DSH fixture `verify --format json` passes without `.codex-plugin/plugin.json`
- the full pytest process exits 139 during native dependency initialization in this macOS environment before reporting test assertions; CI is expected to provide the authoritative full-suite result


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for scanning and verifying native DeepSeek Harness packages.
  - Added validation for metadata, semantic versions, bundle configuration, safe patch paths, and runtime entry points.
  - Added `deepseek-harness`, `dsh`, and `deepseek_harness` ecosystem options.
  - Added support for mixed and nested package verification.
  - Added README examples for DeepSeek Harness scanning.

- **Bug Fixes**
  - DeepSeek Harness packages are now handled correctly during mixed-package scans and verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->