### PR TITLE
fix(store): bind SQLite recovery to failed database identity

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 15239,
-  "maximum_test_source_lines": 328602,
+  "maximum_collected_cases": 15243,
+  "maximum_test_source_lines": 328706,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/sqlite_recovery.py
+++ b/src/codex_plugin_scanner/guard/sqlite_recovery.py
@@ -1,0 +1,67 @@
+"""Bounded proof helpers for recovering an unusable Guard SQLite store."""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import suppress
+from pathlib import Path
+from typing import Literal
+from uuid import uuid4
+
+FATAL_SQLITE_ERROR_MARKERS = (
+    "database disk image is malformed",
+    "database corruption",
+    "file is not a database",
+)
+SQLITE_IO_ERROR_MARKER = "disk i/o error"
+SQLiteStoreProbe = Literal["fatal", "healthy", "io", "unknown"]
+
+
+def _probe_sqlite_store(path: Path) -> SQLiteStoreProbe:
+    try:
+        with sqlite3.connect(path, timeout=0.1) as connection:
+            result = connection.execute("pragma quick_check").fetchone()
+    except sqlite3.DatabaseError as error:
+        message = str(error).lower()
+        if any(marker in message for marker in FATAL_SQLITE_ERROR_MARKERS):
+            return "fatal"
+        if SQLITE_IO_ERROR_MARKER in message:
+            return "io"
+        return "unknown"
+    return "healthy" if result == ("ok",) else "fatal"
+
+
+def _guard_home_accepts_sqlite_write(guard_home: Path) -> bool:
+    probe_path = guard_home / f"storage-probe-{uuid4().hex}.db"
+    try:
+        with sqlite3.connect(probe_path, timeout=0.1) as probe:
+            probe.execute("create table probe (value integer)")
+            probe.execute("insert into probe values (1)")
+        return probe_path.is_file()
+    except sqlite3.DatabaseError:
+        return False
+    finally:
+        with suppress(OSError):
+            probe_path.unlink()
+
+
+def sqlite_store_is_proven_unusable(
+    *,
+    path: Path,
+    guard_home: Path,
+    error: BaseException,
+    fatal_error: bool,
+) -> bool:
+    """Revalidate the current path before permitting destructive recovery."""
+
+    io_error = SQLITE_IO_ERROR_MARKER in str(error).lower()
+    if not fatal_error and not io_error:
+        return False
+    state = _probe_sqlite_store(path)
+    if state == "healthy":
+        return False
+    if state == "fatal":
+        return True
+    if state != "io" or not _guard_home_accepts_sqlite_write(guard_home):
+        return False
+    return _probe_sqlite_store(path) in {"fatal", "io"}

--- a/src/codex_plugin_scanner/guard/store_connection_schema.py
+++ b/src/codex_plugin_scanner/guard/store_connection_schema.py
@@ -18,6 +18,11 @@ from .sqlite_profile import (
     SQLiteProfileSnapshot,
     sqlite_error_is_busy_locked,
 )
+from .sqlite_recovery import (
+    FATAL_SQLITE_ERROR_MARKERS,
+    SQLITE_IO_ERROR_MARKER,
+    sqlite_store_is_proven_unusable,
+)
 
 # ruff: noqa: F403,F405
 from .store_base import *
@@ -155,12 +160,6 @@ _REQUIRED_SCHEMA_MIGRATION_VERSIONS = (
     *range(2, STORAGE_QUERY_INDEX_MIGRATION_VERSION + 1),
     WORKFLOW_CAPABILITY_RECEIPT_EVENT_INDEX_MIGRATION_VERSION,
 )
-_FATAL_SQLITE_ERROR_MARKERS = (
-    "database disk image is malformed",
-    "database corruption",
-    "file is not a database",
-)
-_SQLITE_IO_ERROR_MARKER = "disk i/o error"
 
 
 @dataclass
@@ -190,7 +189,7 @@ class StoreConnectionSchemaMixin:
     @staticmethod
     def _is_fatal_sqlite_error(error: BaseException) -> bool:
         return isinstance(error, sqlite3.DatabaseError) and any(
-            marker in str(error).lower() for marker in _FATAL_SQLITE_ERROR_MARKERS
+            marker in str(error).lower() for marker in FATAL_SQLITE_ERROR_MARKERS
         )
 
     @contextmanager
@@ -250,29 +249,20 @@ class StoreConnectionSchemaMixin:
                     fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
     def _store_is_proven_unusable(self, error: BaseException) -> bool:
-        if self._is_fatal_sqlite_error(error):
-            return True
-        if _SQLITE_IO_ERROR_MARKER not in str(error).lower():
-            return False
-        # An I/O error alone does not prove corruption. Only replace the active
-        # path when the same directory supports a fresh SQLite transaction and
-        # the existing database remains unreadable on a second probe.
-        probe_path = self.guard_home / f"storage-probe-{uuid4().hex}.db"
-        try:
-            with sqlite3.connect(probe_path, timeout=0.1) as probe:
-                probe.execute("create table probe (value integer)")
-                probe.execute("insert into probe values (1)")
-            with sqlite3.connect(self.path, timeout=0.1) as existing:
-                _ = existing.execute("pragma schema_version").fetchone()
-                return False
-        except sqlite3.DatabaseError as probe_error:
-            return _SQLITE_IO_ERROR_MARKER in str(probe_error).lower() and probe_path.is_file()
-        finally:
-            with suppress(OSError):
-                probe_path.unlink()
+        return sqlite_store_is_proven_unusable(
+            path=self.path,
+            guard_home=self.guard_home,
+            error=error,
+            fatal_error=self._is_fatal_sqlite_error(error),
+        )
 
-    def _recover_fatal_sqlite_store(self, error: BaseException) -> bool:
-        is_io_error = _SQLITE_IO_ERROR_MARKER in str(error).lower()
+    def _recover_fatal_sqlite_store(
+        self,
+        error: BaseException,
+        *,
+        failed_identity: tuple[int, int] | None = None,
+    ) -> bool:
+        is_io_error = SQLITE_IO_ERROR_MARKER in str(error).lower()
         if (
             not isinstance(error, sqlite3.DatabaseError)
             or (not self._is_fatal_sqlite_error(error) and not is_io_error)
@@ -280,11 +270,12 @@ class StoreConnectionSchemaMixin:
             or self.path.is_symlink()
         ):
             return False
-        try:
-            failed_stat = self.path.stat()
-            failed_identity = failed_stat.st_dev, failed_stat.st_ino
-        except OSError:
-            failed_identity = None
+        if failed_identity is None:
+            try:
+                failed_stat = self.path.stat()
+                failed_identity = failed_stat.st_dev, failed_stat.st_ino
+            except OSError:
+                failed_identity = None
         with self._hold_storage_gate(exclusive=True):
             # Another process may already have replaced the failed store.
             try:
@@ -344,14 +335,20 @@ class StoreConnectionSchemaMixin:
                 yield connection
             return
         fatal_error: sqlite3.DatabaseError | None = None
+        failed_identity: tuple[int, int] | None = None
         with self._hold_storage_gate(exclusive=False):
             try:
                 with self._connect_once() as connection:
                     yield connection
             except sqlite3.DatabaseError as error:
                 fatal_error = error
+                try:
+                    failed_stat = self.path.stat()
+                    failed_identity = failed_stat.st_dev, failed_stat.st_ino
+                except OSError:
+                    failed_identity = None
         if fatal_error is not None:
-            self._recover_fatal_sqlite_store(fatal_error)
+            self._recover_fatal_sqlite_store(fatal_error, failed_identity=failed_identity)
             raise fatal_error
 
     @contextmanager

--- a/tests/test_guard_sqlite_failure_containment.py
+++ b/tests/test_guard_sqlite_failure_containment.py
@@ -134,6 +134,110 @@ def test_transient_io_error_does_not_quarantine_healthy_store(
     assert store.get_runtime_state() is None
 
 
+def test_io_error_that_clears_after_directory_probe_does_not_quarantine(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard", prime_policy_integrity=False)
+    real_connect = store_connection_schema.sqlite3.connect
+    active_attempts = 0
+
+    def fail_first_active_probe(database: str | Path, timeout: float = 5.0) -> sqlite3.Connection:
+        nonlocal active_attempts
+        if Path(database) == store.path:
+            active_attempts += 1
+            if active_attempts == 1:
+                raise sqlite3.OperationalError("disk I/O error")
+        return real_connect(database, timeout=timeout)
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.sqlite_recovery.sqlite3.connect", fail_first_active_probe)
+
+    assert (
+        store._store_is_proven_unusable(  # pyright: ignore[reportPrivateUsage]
+            sqlite3.OperationalError("disk I/O error")
+        )
+        is False
+    )
+    assert active_attempts == 2
+    assert _quarantined_databases(store.guard_home) == []
+
+
+def test_fatal_error_recovers_when_rechecks_report_persistent_io(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard", prime_policy_integrity=False)
+    real_connect = store_connection_schema.sqlite3.connect
+    active_attempts = 0
+
+    def fail_active_probes(database: str | Path, timeout: float = 5.0) -> sqlite3.Connection:
+        nonlocal active_attempts
+        if Path(database) == store.path:
+            active_attempts += 1
+            raise sqlite3.OperationalError("disk I/O error")
+        return real_connect(database, timeout=timeout)
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.sqlite_recovery.sqlite3.connect", fail_active_probes)
+
+    assert (
+        store._store_is_proven_unusable(  # pyright: ignore[reportPrivateUsage]
+            sqlite3.DatabaseError("database disk image is malformed")
+        )
+        is True
+    )
+    assert active_attempts == 2
+
+
+def test_stale_fatal_error_does_not_quarantine_healthy_store(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard", prime_policy_integrity=False)
+
+    recovered = store._recover_fatal_sqlite_store(  # pyright: ignore[reportPrivateUsage]
+        sqlite3.DatabaseError("database disk image is malformed")
+    )
+
+    assert recovered is False
+    assert _quarantined_databases(store.guard_home) == []
+    with sqlite3.connect(store.path) as connection:
+        assert connection.execute("pragma quick_check").fetchone() == ("ok",)
+
+
+def test_connect_does_not_quarantine_replacement_inode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard"
+    store = GuardStore(guard_home, prime_policy_integrity=False)
+    corrupt_bytes = _corrupt_store(store.path)
+    failed_stat = store.path.stat()
+    failed_identity = failed_stat.st_dev, failed_stat.st_ino
+    original_path = guard_home / "failed.db"
+    observed_identity: tuple[int, int] | None = None
+    original_recover = store._recover_fatal_sqlite_store  # pyright: ignore[reportPrivateUsage]
+
+    def replace_before_recovery(
+        error: BaseException,
+        *,
+        failed_identity: tuple[int, int] | None = None,
+    ) -> bool:
+        nonlocal observed_identity
+        observed_identity = failed_identity
+        store.path.replace(original_path)
+        with sqlite3.connect(store.path) as connection:
+            connection.execute("create table replacement (value integer)")
+        return original_recover(error, failed_identity=failed_identity)
+
+    monkeypatch.setattr(store, "_recover_fatal_sqlite_store", replace_before_recovery)
+
+    with pytest.raises(sqlite3.DatabaseError, match="file is not a database"):
+        store.get_runtime_state()
+
+    assert observed_identity == failed_identity
+    assert original_path.read_bytes() == corrupt_bytes
+    assert _quarantined_databases(store.guard_home) == []
+    with sqlite3.connect(store.path) as connection:
+        assert connection.execute("pragma quick_check").fetchone() == ("ok",)
+
+
 def test_recovery_waits_for_in_flight_connection(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard", prime_policy_integrity=False)
     entered = threading.Event()


### PR DESCRIPTION
## Summary
- bind fatal SQLite recovery to the database identity that produced the error
- revalidate the current database before quarantine so concurrent recovery cannot replace healthy state
- cover stale fatal errors and replacement races with regression tests

## Testing
- `uv run --no-sync pytest -q tests/test_guard_sqlite_failure_containment.py tests/test_guard_sqlite_profile.py tests/test_guard_daemon_startup_rollback.py tests/test_guard_daemon_lifecycle_journal.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/store_connection_schema.py tests/test_guard_sqlite_failure_containment.py`
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/store_connection_schema.py tests/test_guard_sqlite_failure_containment.py`
- `uv run --no-sync basedpyright --level error src/codex_plugin_scanner/guard/store_connection_schema.py tests/test_guard_sqlite_failure_containment.py`
- `uv run --no-sync python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory test-inventory.json`
- `uv build`
