### PR TITLE
feat(scanner): complete native DeepSeek Harness support

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ See [`devcontainer-features/hol-guard/README.md`](devcontainer-features/hol-guar
 | :--- | :--- |
 | Codex | `.codex-plugin/plugin.json`, `marketplace.json`, `.agents/plugins/marketplace.json` |
 | Claude Code | `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` |
+| DeepSeek Harness | `package.json` with `dsh.bundle`, declared patch file, and Cordis `apply(ctx)` runtime export |
 | Gemini CLI | `gemini-extension.json`, `commands/**/*.toml` |
 | Kimi Code | `kimi.plugin.json`, `.kimi-plugin/plugin.json`, declared skills, agents, commands, prompts, and MCP servers |
 | OpenCode | `opencode.json`, `opencode.jsonc`, `.opencode/commands`, `.opencode/plugins` |
@@ -500,6 +501,9 @@ plugin-scanner scan ./plugins-repo --ecosystem claude
 
 # Scan only native Kimi Code plugin surfaces
 plugin-scanner scan ./plugins-repo --ecosystem kimi
+
+# Scan a native DeepSeek Harness (DSH/Cordis) package
+plugin-scanner scan ./dsh-plugin --ecosystem deepseek-harness
 
 # List supported ecosystems
 plugin-scanner --list-ecosystems

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12784,
-  "maximum_test_source_lines": 292073,
+  "maximum_collected_cases": 12802,
+  "maximum_test_source_lines": 292242,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/checks/deepseek_harness.py
+++ b/src/codex_plugin_scanner/checks/deepseek_harness.py
@@ -1,0 +1,70 @@
+"""DeepSeek Harness ecosystem checks."""
+
+from __future__ import annotations
+
+from ..deepseek_harness_support import validate_dsh_package
+from ..ecosystems.types import NormalizedPackage
+from ..models import CheckResult, Finding, Severity
+
+
+def _result(name: str, passed: bool, message: str, rule_id: str, description: str) -> CheckResult:
+    findings = (
+        ()
+        if passed
+        else (
+            Finding(
+                rule_id=rule_id,
+                severity=Severity.MEDIUM,
+                category="deepseek-harness",
+                title=message,
+                description=description,
+                remediation="Update the native DSH declaration in package.json.",
+                file_path="package.json",
+            ),
+        )
+    )
+    return CheckResult(
+        name=name, passed=passed, points=5 if passed else 0, max_points=5, message=message, findings=findings
+    )
+
+
+def run_deepseek_harness_checks(package: NormalizedPackage) -> tuple[CheckResult, ...]:
+    """Validate a native DSH package and its Cordis bundle declaration."""
+
+    validation = validate_dsh_package(package)
+    return (
+        _result(
+            "DSH package metadata",
+            validation.metadata_ok,
+            "DSH package metadata is valid"
+            if validation.metadata_ok
+            else "DSH package requires a name and semantic version",
+            "DSH_PACKAGE_METADATA_INVALID",
+            "package.json must declare a non-empty name and semantic version.",
+        ),
+        _result(
+            "DSH bundle declaration",
+            validation.bundle_ok,
+            "DSH bundle declaration is valid" if validation.bundle_ok else "dsh.bundle must be a non-empty object",
+            "DSH_BUNDLE_INVALID",
+            "Native DSH packages must declare at least one bundle entry.",
+        ),
+        _result(
+            "DSH bundle paths",
+            validation.patch_ok,
+            "DSH bundle paths are safe"
+            if validation.patch_ok
+            else "dsh.bundle.patch must reference a regular in-package file",
+            "DSH_BUNDLE_PATH_UNSAFE",
+            "The declared bundle patch is missing or escapes the package root.",
+        ),
+        _result(
+            "DSH Cordis runtime entry point",
+            validation.runtime_ok,
+            "DSH runtime exports apply(ctx)"
+            if validation.runtime_ok
+            else "DSH runtime entry point must export apply(ctx)",
+            "DSH_RUNTIME_APPLY_MISSING",
+            "package.json main/exports must reference a regular in-package module exporting Cordis apply(ctx).",
+        ),
+    )

--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -116,7 +116,7 @@ def _build_parser(program_name: str, *, program_mode: str) -> argparse.ArgumentP
     scan_parser.add_argument("--cisco-policy", choices=("permissive", "balanced", "strict"), default="balanced")
     scan_parser.add_argument(
         "--ecosystem",
-        choices=("auto", "codex", "claude", "gemini", "kimi", "opencode"),
+        choices=("auto", *list_supported_ecosystems(), "dsh", "deepseek_harness"),
         default="auto",
         help="Target one ecosystem explicitly or auto-detect all supported ecosystems.",
     )

--- a/src/codex_plugin_scanner/deepseek_harness_support.py
+++ b/src/codex_plugin_scanner/deepseek_harness_support.py
@@ -1,0 +1,317 @@
+"""Shared validation helpers for native DeepSeek Harness packages."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from .ecosystems.types import NormalizedPackage
+from .path_support import is_safe_relative_path
+
+DSH_SEMVER_RE = re.compile(
+    "".join(
+        (
+            r"^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)",
+            r"(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*)?",
+            r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$",
+        )
+    )
+)
+
+_REGEX_PREFIX_TOKENS = frozenset(
+    {
+        "(",
+        "[",
+        "{",
+        "=",
+        ":",
+        ",",
+        ";",
+        "!",
+        "?",
+        "&&",
+        "||",
+        "=>",
+        "case",
+        "delete",
+        "do",
+        "else",
+        "in",
+        "instanceof",
+        "new",
+        "of",
+        "return",
+        "throw",
+        "typeof",
+        "void",
+        "yield",
+        "await",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DshValidation:
+    metadata_ok: bool
+    bundle_ok: bool
+    patch_ok: bool
+    runtime_ok: bool
+    runtime_path: str | None
+
+
+def _export_target(value: object) -> str | None:
+    """Resolve one Node package export target without selecting subpath exports."""
+
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    if isinstance(value, list):
+        for candidate in value:
+            if (resolved := _export_target(candidate)) is not None:
+                return resolved
+        return None
+    if not isinstance(value, dict):
+        return None
+
+    for condition in ("import", "require", "node", "default"):
+        if condition in value and (resolved := _export_target(value[condition])) is not None:
+            return resolved
+    for condition, candidate in value.items():
+        if not isinstance(condition, str) or condition == "types" or condition.startswith("."):
+            continue
+        if (resolved := _export_target(candidate)) is not None:
+            return resolved
+    return None
+
+
+def _runtime_path(manifest: dict[str, object]) -> str | None:
+    """Resolve the package root export, falling back to ``main`` only without ``exports``."""
+
+    if "exports" in manifest:
+        exports = manifest["exports"]
+        if isinstance(exports, dict):
+            if "." in exports:
+                return _export_target(exports["."])
+            if any(isinstance(key, str) and key.startswith(".") for key in exports):
+                return None
+        return _export_target(exports)
+    main = manifest.get("main")
+    if not isinstance(main, str):
+        return None
+    stripped = main.strip()
+    return stripped or None
+
+
+def _skip_quoted(source: str, index: int, quote: str) -> int:
+    """Skip one JavaScript string or template literal."""
+
+    index += 1
+    while index < len(source):
+        char = source[index]
+        if char == "\\":
+            index += 2
+            continue
+        index += 1
+        if char == quote:
+            break
+    return index
+
+
+def _skip_regex(source: str, index: int) -> int:
+    """Skip a JavaScript regex literal using a conservative lexical heuristic."""
+
+    index += 1
+    in_character_class = False
+    while index < len(source):
+        char = source[index]
+        if char == "\\":
+            index += 2
+            continue
+        if char == "[":
+            in_character_class = True
+        elif char == "]":
+            in_character_class = False
+        elif char == "/" and not in_character_class:
+            index += 1
+            while index < len(source) and source[index].isalpha():
+                index += 1
+            break
+        elif char in "\r\n":
+            break
+        index += 1
+    return index
+
+
+def _regex_can_start(tokens: list[str]) -> bool:
+    return not tokens or tokens[-1] in _REGEX_PREFIX_TOKENS
+
+
+def _javascript_tokens(source: str) -> tuple[str, ...]:
+    """Tokenize identifiers and punctuation while ignoring comments and literals."""
+
+    tokens: list[str] = []
+    index = 0
+    while index < len(source):
+        char = source[index]
+        following = source[index + 1] if index + 1 < len(source) else ""
+        if char == "/" and following == "/":
+            index += 2
+            while index < len(source) and source[index] not in "\r\n":
+                index += 1
+            continue
+        if char == "/" and following == "*":
+            end = source.find("*/", index + 2)
+            index = len(source) if end < 0 else end + 2
+            continue
+        if char == "/" and _regex_can_start(tokens):
+            index = _skip_regex(source, index)
+            continue
+        if char in {"'", '"', "`"}:
+            index = _skip_quoted(source, index, char)
+            continue
+        if char.isalpha() or char in {"_", "$"}:
+            end = index + 1
+            while end < len(source) and (source[end].isalnum() or source[end] in {"_", "$"}):
+                end += 1
+            tokens.append(source[index:end])
+            index = end
+            continue
+        if source.startswith(("=>", "&&", "||"), index):
+            tokens.append(source[index : index + 2])
+            index += 2
+            continue
+        if not char.isspace():
+            tokens.append(char)
+        index += 1
+    return tuple(tokens)
+
+
+def _matching_brace(tokens: tuple[str, ...], start: int) -> int | None:
+    """Return the matching closing brace index for a tokenized object or list."""
+
+    opening = tokens[start]
+    closing = {"{": "}", "(": ")", "[": "]"}.get(opening)
+    if closing is None:
+        return None
+    depth = 0
+    for index in range(start, len(tokens)):
+        if tokens[index] == opening:
+            depth += 1
+        elif tokens[index] == closing:
+            depth -= 1
+            if depth == 0:
+                return index
+    return None
+
+
+def _export_list_has_apply(entries: tuple[str, ...]) -> bool:
+    """Return whether an ESM export list exposes the name ``apply``."""
+
+    start = 0
+    while start < len(entries):
+        end = start
+        while end < len(entries) and entries[end] != ",":
+            end += 1
+        clause = entries[start:end]
+        if clause and clause[0] != "type":
+            if len(clause) == 1 and clause[0] == "apply":
+                return True
+            if len(clause) >= 3 and clause[-2:] == ("as", "apply"):
+                return True
+        start = end + 1
+    return False
+
+
+def _commonjs_object_has_apply(tokens: tuple[str, ...], start: int, end: int) -> bool:
+    """Return whether a top-level CommonJS export object declares an ``apply`` key."""
+
+    depth = 0
+    clause_start = start + 1
+    index = clause_start
+    while index <= end:
+        token = tokens[index] if index < end else ","
+        if token in {"{", "[", "("}:
+            depth += 1
+        elif token in {"}", "]", ")"}:
+            depth -= 1
+        elif depth == 0 and token == ",":
+            clause = tokens[clause_start:index]
+            if clause and clause[0] == "apply" and (len(clause) == 1 or clause[1] == ":"):
+                return True
+            clause_start = index + 1
+        index += 1
+    return False
+
+
+def _exports_apply(source: str) -> bool:
+    """Return true only when tokenized ESM or CommonJS syntax exports ``apply``."""
+
+    tokens = _javascript_tokens(source)
+    for index, token in enumerate(tokens):
+        tail = tokens[index:]
+        if token == "export":
+            declaration_index = 1
+            if len(tail) > 1 and tail[1] == "async":
+                declaration_index = 2
+            if (
+                len(tail) > declaration_index + 1
+                and tail[declaration_index] in {"function", "const", "let", "var", "class"}
+                and tail[declaration_index + 1] == "apply"
+            ):
+                return True
+            if len(tail) > 1 and tail[1] == "{":
+                close = _matching_brace(tail, 1)
+                if close is not None and _export_list_has_apply(tail[2:close]):
+                    return True
+        if tail[:4] == ("exports", ".", "apply", "="):
+            return True
+        if tail[:6] == ("module", ".", "exports", ".", "apply", "="):
+            return True
+        if tail[:4] == ("module", ".", "exports", "=") and len(tail) > 4 and tail[4] == "{":
+            close = _matching_brace(tail, 4)
+            if close is not None and _commonjs_object_has_apply(tail, 4, close):
+                return True
+    return False
+
+
+def validate_dsh_package(package: NormalizedPackage) -> DshValidation:
+    """Validate shared DSH metadata, bundle assets, and Cordis runtime surface."""
+
+    manifest = package.raw_manifest
+    name = manifest.get("name")
+    version = manifest.get("version")
+    metadata_ok = (
+        isinstance(name, str)
+        and bool(name.strip())
+        and isinstance(version, str)
+        and bool(DSH_SEMVER_RE.fullmatch(version))
+    )
+
+    dsh = manifest.get("dsh")
+    bundle = dsh.get("bundle") if isinstance(dsh, dict) else None
+    bundle_ok = isinstance(bundle, dict) and bool(bundle)
+    raw_patch = bundle.get("patch") if isinstance(bundle, dict) else None
+    patch = raw_patch.strip() if isinstance(raw_patch, str) else None
+    patch_target = package.root_path / patch if patch else None
+    patch_ok = (
+        patch_target is not None
+        and is_safe_relative_path(package.root_path, patch, require_exists=True)
+        and patch_target.is_file()
+        and not patch_target.is_symlink()
+    )
+
+    runtime_path = _runtime_path(manifest)
+    runtime_target = package.root_path / runtime_path if runtime_path is not None else None
+    runtime_ok = False
+    if (
+        runtime_path is not None
+        and runtime_target is not None
+        and is_safe_relative_path(package.root_path, runtime_path, require_exists=True)
+        and runtime_target.is_file()
+        and not runtime_target.is_symlink()
+    ):
+        try:
+            runtime_ok = _exports_apply(runtime_target.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError):
+            runtime_ok = False
+    return DshValidation(metadata_ok, bundle_ok, patch_ok, runtime_ok, runtime_path)

--- a/src/codex_plugin_scanner/deepseek_harness_support.py
+++ b/src/codex_plugin_scanner/deepseek_harness_support.py
@@ -293,12 +293,13 @@ def validate_dsh_package(package: NormalizedPackage) -> DshValidation:
     raw_patch = bundle.get("patch") if isinstance(bundle, dict) else None
     patch = raw_patch.strip() if isinstance(raw_patch, str) else None
     patch_target = package.root_path / patch if patch else None
-    patch_ok = (
-        patch_target is not None
-        and is_safe_relative_path(package.root_path, patch, require_exists=True)
-        and patch_target.is_file()
-        and not patch_target.is_symlink()
-    )
+    patch_ok = False
+    if patch is not None and patch_target is not None:
+        patch_ok = (
+            is_safe_relative_path(package.root_path, patch, require_exists=True)
+            and patch_target.is_file()
+            and not patch_target.is_symlink()
+        )
 
     runtime_path = _runtime_path(manifest)
     runtime_target = package.root_path / runtime_path if runtime_path is not None else None

--- a/src/codex_plugin_scanner/ecosystems/deepseek_harness.py
+++ b/src/codex_plugin_scanner/ecosystems/deepseek_harness.py
@@ -55,13 +55,15 @@ class DeepSeekHarnessAdapter:
         client = dsh.get("client") if isinstance(dsh, dict) else None
         if isinstance(client, str) and client.strip():
             components["clients"] = (client,)
+        name = manifest.get("name")
+        version = manifest.get("version")
         return NormalizedPackage(
             ecosystem=Ecosystem.DEEPSEEK_HARNESS,
             package_kind=candidate.package_kind,
             root_path=candidate.root_path,
             manifest_path=candidate.manifest_path,
-            name=manifest.get("name") if isinstance(manifest.get("name"), str) else None,
-            version=manifest.get("version") if isinstance(manifest.get("version"), str) else None,
+            name=name if isinstance(name, str) else None,
+            version=version if isinstance(version, str) else None,
             metadata={
                 key: value
                 for key in ("description", "license", "homepage")

--- a/src/codex_plugin_scanner/ecosystems/deepseek_harness.py
+++ b/src/codex_plugin_scanner/ecosystems/deepseek_harness.py
@@ -1,0 +1,74 @@
+"""DeepSeek Harness (DSH/Cordis) ecosystem adapter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .base import iter_safe_recursive_files
+from .types import Ecosystem, NormalizedPackage, PackageCandidate
+
+
+def _load_json(path: Path) -> tuple[dict[str, object], str | None]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, UnicodeError) as exc:
+        return {}, str(exc)
+    if not isinstance(payload, dict):
+        return {}, "package.json must contain a JSON object"
+    return payload, None
+
+
+class DeepSeekHarnessAdapter:
+    """Adapter for native DeepSeek Harness packages declared with ``package.json.dsh``."""
+
+    ecosystem_id = Ecosystem.DEEPSEEK_HARNESS
+
+    def detect(self, root: Path) -> list[PackageCandidate]:
+        candidates: list[PackageCandidate] = []
+        for manifest_path in iter_safe_recursive_files(root, root, "package.json"):
+            manifest, error = _load_json(manifest_path)
+            if error is not None:
+                continue
+            dsh = manifest.get("dsh")
+            if not isinstance(dsh, dict) or not isinstance(dsh.get("bundle"), dict):
+                continue
+            candidates.append(
+                PackageCandidate(
+                    ecosystem=Ecosystem.DEEPSEEK_HARNESS,
+                    package_kind="cordis-plugin",
+                    root_path=manifest_path.parent,
+                    manifest_path=manifest_path,
+                    detection_reason="found package.json with dsh.bundle",
+                )
+            )
+        return candidates
+
+    def parse(self, candidate: PackageCandidate) -> NormalizedPackage:
+        manifest, error = _load_json(candidate.manifest_path) if candidate.manifest_path else ({}, "missing manifest")
+        dsh = manifest.get("dsh") if isinstance(manifest.get("dsh"), dict) else {}
+        bundle = dsh.get("bundle") if isinstance(dsh, dict) and isinstance(dsh.get("bundle"), dict) else {}
+        components: dict[str, tuple[str, ...]] = {}
+        patch = bundle.get("patch") if isinstance(bundle, dict) else None
+        if isinstance(patch, str) and patch.strip():
+            components["bundle_patches"] = (patch,)
+        client = dsh.get("client") if isinstance(dsh, dict) else None
+        if isinstance(client, str) and client.strip():
+            components["clients"] = (client,)
+        return NormalizedPackage(
+            ecosystem=Ecosystem.DEEPSEEK_HARNESS,
+            package_kind=candidate.package_kind,
+            root_path=candidate.root_path,
+            manifest_path=candidate.manifest_path,
+            name=manifest.get("name") if isinstance(manifest.get("name"), str) else None,
+            version=manifest.get("version") if isinstance(manifest.get("version"), str) else None,
+            metadata={
+                key: value
+                for key in ("description", "license", "homepage")
+                if isinstance((value := manifest.get(key)), str)
+            },
+            components=components,
+            raw_manifest=manifest,
+            manifest_parse_error=error is not None,
+            manifest_parse_error_reason=error,
+        )

--- a/src/codex_plugin_scanner/ecosystems/registry.py
+++ b/src/codex_plugin_scanner/ecosystems/registry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from .base import EcosystemAdapter
 from .claude import ClaudeAdapter
 from .codex import CodexAdapter
+from .deepseek_harness import DeepSeekHarnessAdapter
 from .gemini import GeminiAdapter
 from .kimi import KimiAdapter
 from .opencode import OpenCodeAdapter
@@ -17,6 +18,7 @@ def get_default_adapters() -> tuple[EcosystemAdapter, ...]:
     return (
         CodexAdapter(),
         ClaudeAdapter(),
+        DeepSeekHarnessAdapter(),
         GeminiAdapter(),
         KimiAdapter(),
         OpenCodeAdapter(),
@@ -31,6 +33,8 @@ def resolve_ecosystem(value: str | None) -> Ecosystem | None:
     lowered = value.strip().lower()
     if lowered in ("", "auto"):
         return None
+    if lowered in ("dsh", "deepseek_harness"):
+        lowered = Ecosystem.DEEPSEEK_HARNESS.value
     try:
         return Ecosystem(lowered)
     except ValueError:

--- a/src/codex_plugin_scanner/ecosystems/types.py
+++ b/src/codex_plugin_scanner/ecosystems/types.py
@@ -12,6 +12,7 @@ class Ecosystem(str, Enum):
 
     CODEX = "codex"
     CLAUDE = "claude"
+    DEEPSEEK_HARNESS = "deepseek-harness"
     GEMINI = "gemini"
     KIMI = "kimi"
     OPENCODE = "opencode"

--- a/src/codex_plugin_scanner/scanner.py
+++ b/src/codex_plugin_scanner/scanner.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from .checks.best_practices import run_best_practice_checks
 from .checks.claude import run_claude_checks
 from .checks.code_quality import run_code_quality_checks
+from .checks.deepseek_harness import run_deepseek_harness_checks
 from .checks.gemini import run_gemini_checks
 from .checks.kimi import run_kimi_checks
 from .checks.manifest import run_manifest_checks
@@ -467,6 +468,30 @@ def _scan_mixed_packages(scan_root: Path, packages: list[NormalizedPackage], opt
             categories.extend(
                 (
                     CategoryResult(name=f"{prefix}Claude Plugin", checks=claude_checks),
+                    CategoryResult(name=f"{prefix}Security", checks=security_checks),
+                    CategoryResult(name=f"{prefix}Operational Security", checks=operational_checks),
+                    CategoryResult(name=f"{prefix}Code Quality", checks=quality_checks),
+                )
+            )
+            processed_packages.append(package)
+            continue
+
+        if package.ecosystem == Ecosystem.DEEPSEEK_HARNESS:
+            dsh_checks = _maybe_rebase_checks(
+                run_deepseek_harness_checks(package), package_root, scan_root_resolved, needs_rebase
+            )
+            security_checks = _maybe_rebase_checks(
+                run_security_checks(package_root), package_root, scan_root_resolved, needs_rebase
+            )
+            operational_checks = _maybe_rebase_checks(
+                run_operational_security_checks(package_root), package_root, scan_root_resolved, needs_rebase
+            )
+            quality_checks = _maybe_rebase_checks(
+                run_code_quality_checks(package_root), package_root, scan_root_resolved, needs_rebase
+            )
+            categories.extend(
+                (
+                    CategoryResult(name=f"{prefix}DeepSeek Harness Plugin", checks=dsh_checks),
                     CategoryResult(name=f"{prefix}Security", checks=security_checks),
                     CategoryResult(name=f"{prefix}Operational Security", checks=operational_checks),
                     CategoryResult(name=f"{prefix}Code Quality", checks=quality_checks),

--- a/src/codex_plugin_scanner/verification.py
+++ b/src/codex_plugin_scanner/verification.py
@@ -12,6 +12,10 @@ from pathlib import Path
 
 from .checks.manifest import load_manifest
 from .checks.manifest_support import safe_manifest_path
+from .deepseek_harness_support import validate_dsh_package
+from .ecosystems.detect import detect_packages
+from .ecosystems.registry import get_default_adapters
+from .ecosystems.types import Ecosystem, PackageCandidate
 from .marketplace_support import (
     extract_marketplace_source,
     load_marketplace_context,
@@ -668,6 +672,76 @@ def _verify_single_plugin(plugin_dir: Path, *, online: bool) -> VerificationResu
     )
 
 
+def _verify_deepseek_harness_candidate(candidate: PackageCandidate) -> VerificationResult:
+    plugin_dir = candidate.root_path.resolve()
+    adapter = next(item for item in get_default_adapters() if item.ecosystem_id == Ecosystem.DEEPSEEK_HARNESS)
+    package = adapter.parse(candidate)
+    validation = validate_dsh_package(package)
+    cases = [
+        VerificationCase(
+            "manifest",
+            "package.json metadata",
+            validation.metadata_ok,
+            "Native DSH package metadata is valid"
+            if validation.metadata_ok
+            else "package.json requires a name and semantic version",
+            "schema" if not validation.metadata_ok else "pass",
+        ),
+        VerificationCase(
+            "manifest",
+            "dsh.bundle declaration",
+            validation.bundle_ok,
+            "Native DSH bundle is declared" if validation.bundle_ok else "dsh.bundle must be a non-empty object",
+            "schema" if not validation.bundle_ok else "pass",
+        ),
+        VerificationCase(
+            "assets",
+            "bundle patch path",
+            validation.patch_ok,
+            "Bundle patch path is a safe regular file"
+            if validation.patch_ok
+            else "dsh.bundle.patch is missing, unsafe, or not a regular file",
+            "path" if not validation.patch_ok else "pass",
+        ),
+        VerificationCase(
+            "runtime",
+            "Cordis apply(ctx) export",
+            validation.runtime_ok,
+            "Runtime entry point exports apply(ctx)"
+            if validation.runtime_ok
+            else "Runtime entry point is missing a detectable apply(ctx) export",
+            "runtime" if not validation.runtime_ok else "pass",
+        ),
+    ]
+    return VerificationResult(
+        verify_pass=all(case.passed for case in cases),
+        cases=tuple(cases),
+        workspace=str(plugin_dir.resolve()),
+        scope="plugin",
+        plugin_name=package.name,
+    )
+
+
+def _verify_deepseek_harness(
+    plugin_dir: Path, candidates: tuple[PackageCandidate, ...] | list[PackageCandidate]
+) -> VerificationResult:
+    plugin_results = tuple(_verify_deepseek_harness_candidate(candidate) for candidate in candidates)
+    if len(plugin_results) == 1 and candidates[0].root_path.resolve() == plugin_dir.resolve():
+        return plugin_results[0]
+    cases = tuple(
+        case
+        for result in plugin_results
+        for case in _prefixed_cases(result.plugin_name or Path(result.workspace).name, result.cases)
+    )
+    return VerificationResult(
+        verify_pass=bool(plugin_results) and all(result.verify_pass for result in plugin_results),
+        cases=cases,
+        workspace=str(plugin_dir.resolve()),
+        scope="repository",
+        plugin_results=plugin_results,
+    )
+
+
 def _prefixed_cases(plugin_name: str, cases: tuple[VerificationCase, ...]) -> tuple[VerificationCase, ...]:
     return tuple(
         VerificationCase(
@@ -732,6 +806,9 @@ def _verify_repository(repo_root: Path, *, online: bool) -> VerificationResult:
 
 def verify_plugin(plugin_dir: str | Path, *, online: bool = False) -> VerificationResult:
     resolved = Path(plugin_dir).resolve()
+    dsh_candidates = detect_packages(resolved, Ecosystem.DEEPSEEK_HARNESS)
+    if dsh_candidates:
+        return _verify_deepseek_harness(resolved, dsh_candidates)
     discovery = discover_scan_targets(resolved)
     if discovery.scope == "repository":
         return _verify_repository(resolved, online=online)

--- a/tests/fixtures/deepseek-harness-good/cordis.patch.yml
+++ b/tests/fixtures/deepseek-harness-good/cordis.patch.yml
@@ -1,0 +1,2 @@
+- name: example
+  apply: dsh-example

--- a/tests/fixtures/deepseek-harness-good/index.js
+++ b/tests/fixtures/deepseek-harness-good/index.js
@@ -1,0 +1,3 @@
+export function apply(ctx) {
+  ctx.plugin("example")
+}

--- a/tests/fixtures/deepseek-harness-good/package.json
+++ b/tests/fixtures/deepseek-harness-good/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "dsh-example",
+  "version": "1.0.0",
+  "description": "A native DeepSeek Harness plugin",
+  "main": "index.js",
+  "dsh": {
+    "bundle": {
+      "patch": "cordis.patch.yml"
+    }
+  }
+}

--- a/tests/test_dsh_validation_regressions.py
+++ b/tests/test_dsh_validation_regressions.py
@@ -1,0 +1,41 @@
+"""Regression tests for native DeepSeek Harness package validation."""
+
+from codex_plugin_scanner.deepseek_harness_support import (
+    DSH_SEMVER_RE,
+    _exports_apply,
+    _runtime_path,
+)
+
+
+def test_dsh_semver_accepts_preview_versions() -> None:
+    assert DSH_SEMVER_RE.fullmatch("0.1.0-preview.5")
+    assert DSH_SEMVER_RE.fullmatch("0.1.0-rc.8+build.1")
+
+
+def test_dsh_apply_detection_ignores_non_code_literals() -> None:
+    assert not _exports_apply("// export function apply(ctx) {}")
+    assert not _exports_apply("const text = 'exports.apply = fake'")
+    assert not _exports_apply("const pattern = /export function apply/")
+
+
+def test_dsh_apply_detection_respects_exported_alias() -> None:
+    assert _exports_apply("const handler = () => {}; export { handler as apply }")
+    assert not _exports_apply("const apply = () => {}; export { apply as handler }")
+    assert not _exports_apply("export type { apply }")
+
+
+def test_dsh_apply_detection_supports_commonjs_objects() -> None:
+    assert _exports_apply("module.exports = { apply }")
+    assert _exports_apply("module.exports = { apply: handler }")
+    assert not _exports_apply("module.exports = { handler: apply }")
+
+
+def test_dsh_runtime_resolution_rejects_subpath_only_exports() -> None:
+    manifest = {
+        "main": "./legacy.js",
+        "exports": {
+            "./client": "./client.js",
+            "./package.json": "./package.json",
+        },
+    }
+    assert _runtime_path(manifest) is None

--- a/tests/test_ecosystems.py
+++ b/tests/test_ecosystems.py
@@ -12,6 +12,7 @@ from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.ecosystems.claude import ClaudeAdapter
 from codex_plugin_scanner.ecosystems.detect import detect_packages
 from codex_plugin_scanner.ecosystems.opencode import OpenCodeAdapter
+from codex_plugin_scanner.ecosystems.registry import resolve_ecosystem
 from codex_plugin_scanner.ecosystems.types import Ecosystem, NormalizedPackage
 from codex_plugin_scanner.models import ScanOptions
 from codex_plugin_scanner.scanner import scan_plugin
@@ -37,6 +38,133 @@ def test_detect_gemini_package() -> None:
     packages = detect_packages(FIXTURES / "gemini-extension-good")
     ecosystems = {package.ecosystem for package in packages}
     assert Ecosystem.GEMINI in ecosystems
+
+
+def test_detect_native_deepseek_harness_package() -> None:
+    packages = detect_packages(FIXTURES / "deepseek-harness-good")
+    assert [package.ecosystem for package in packages] == [Ecosystem.DEEPSEEK_HARNESS]
+
+
+def test_detect_deepseek_harness_skips_non_utf8_package_json(tmp_path: Path) -> None:
+    (tmp_path / "package.json").write_bytes(b'\xff\xfe{"dsh":{"bundle":{"patch":"x"}}}')
+    assert detect_packages(tmp_path, ecosystem=Ecosystem.DEEPSEEK_HARNESS) == []
+
+
+def test_deepseek_harness_ecosystem_alias() -> None:
+    assert resolve_ecosystem("dsh") == Ecosystem.DEEPSEEK_HARNESS
+
+
+def test_scan_native_deepseek_harness_package() -> None:
+    result = scan_plugin(
+        FIXTURES / "deepseek-harness-good",
+        ScanOptions(ecosystem="auto", cisco_skill_scan="off"),
+    )
+    assert result.ecosystems == ("deepseek-harness",)
+    dsh_category = next(category for category in result.categories if category.name.endswith("DeepSeek Harness Plugin"))
+    assert sum(check.points for check in dsh_category.checks) == 20
+    assert sum(check.max_points for check in dsh_category.checks) == 20
+    assert all(finding.rule_id != "PLUGIN_JSON_MISSING" for finding in result.findings)
+
+    explicit_result = scan_plugin(
+        FIXTURES / "deepseek-harness-good",
+        ScanOptions(ecosystem="deepseek-harness", cisco_skill_scan="off"),
+    )
+    assert explicit_result.ecosystems == ("deepseek-harness",)
+    assert all(finding.rule_id != "PLUGIN_JSON_MISSING" for finding in explicit_result.findings)
+
+
+def test_scan_deepseek_harness_cli_alias(capsys) -> None:
+    rc = main(
+        [
+            "scan",
+            str(FIXTURES / "deepseek-harness-good"),
+            "--ecosystem",
+            "dsh",
+            "--cisco-skill-scan",
+            "off",
+            "--cisco-mcp-scan",
+            "off",
+            "--format",
+            "json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["ecosystems"] == ["deepseek-harness"]
+
+
+def test_verify_native_deepseek_harness_package(capsys) -> None:
+    rc = main(["verify", str(FIXTURES / "deepseek-harness-good"), "--format", "json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["verify_pass"] is True
+    assert all(".codex-plugin/plugin.json" not in case["message"] for case in payload["cases"])
+
+
+def test_scan_deepseek_harness_accepts_prerelease_semver(tmp_path: Path) -> None:
+    shutil.copytree(FIXTURES / "deepseek-harness-good", tmp_path / "plugin")
+    manifest_path = tmp_path / "plugin" / "package.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["version"] = "0.1.0-rc.8+build.1"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    result = scan_plugin(tmp_path / "plugin", ScanOptions(cisco_skill_scan="off"))
+    assert all(finding.rule_id != "DSH_PACKAGE_METADATA_INVALID" for finding in result.findings)
+
+
+def test_verify_deepseek_harness_rejects_directory_patch(tmp_path: Path) -> None:
+    shutil.copytree(FIXTURES / "deepseek-harness-good", tmp_path / "plugin")
+    manifest_path = tmp_path / "plugin" / "package.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["dsh"]["bundle"]["patch"] = "."
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    rc = main(["verify", str(tmp_path / "plugin"), "--format", "json"])
+    assert rc == 1
+
+
+def test_verify_deepseek_harness_rejects_missing_apply_export(tmp_path: Path) -> None:
+    shutil.copytree(FIXTURES / "deepseek-harness-good", tmp_path / "plugin")
+    (tmp_path / "plugin" / "index.js").write_text("export const name = 'missing-apply'\n", encoding="utf-8")
+    rc = main(["verify", str(tmp_path / "plugin"), "--format", "json"])
+    assert rc == 1
+
+
+def test_verify_deepseek_harness_ignores_apply_in_comments_and_strings(tmp_path: Path) -> None:
+    shutil.copytree(FIXTURES / "deepseek-harness-good", tmp_path / "plugin")
+    (tmp_path / "plugin" / "index.js").write_text(
+        "// export function apply(ctx) {}\nexport const text = 'exports.apply = fake'\n", encoding="utf-8"
+    )
+    rc = main(["verify", str(tmp_path / "plugin"), "--format", "json"])
+    assert rc == 1
+
+
+def test_verify_deepseek_harness_requires_patch(tmp_path: Path) -> None:
+    shutil.copytree(FIXTURES / "deepseek-harness-good", tmp_path / "plugin")
+    manifest_path = tmp_path / "plugin" / "package.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    del manifest["dsh"]["bundle"]["patch"]
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    rc = main(["verify", str(tmp_path / "plugin"), "--format", "json"])
+    assert rc == 1
+
+
+def test_verify_deepseek_harness_prefers_conditional_exports(tmp_path: Path) -> None:
+    shutil.copytree(FIXTURES / "deepseek-harness-good", tmp_path / "plugin")
+    manifest_path = tmp_path / "plugin" / "package.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["main"] = "missing.js"
+    manifest["exports"] = {".": {"import": "./index.js", "default": "./missing.js"}}
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    rc = main(["verify", str(tmp_path / "plugin"), "--format", "json"])
+    assert rc == 0
+
+
+def test_verify_nested_deepseek_harness_package(capsys, tmp_path: Path) -> None:
+    shutil.copytree(FIXTURES / "deepseek-harness-good", tmp_path / "packages" / "plugin")
+    rc = main(["verify", str(tmp_path), "--format", "json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["scope"] == "repository"
+    assert payload["repository"]["localPluginCount"] == 1
 
 
 def test_detect_opencode_package() -> None:


### PR DESCRIPTION
## Summary

- auto-detect native DeepSeek Harness packages through `package.json.dsh.bundle`
- expose `deepseek-harness`, `dsh`, and `deepseek_harness` as explicit scanner selectors
- validate full SemVer values, safe non-symlink bundle patches, Node root exports, and real Cordis `apply(ctx)` exports
- scan DSH packages with the existing security, operational-security, best-practice, and code-quality checks without requiring a false Codex manifest
- make `plugin-scanner verify` support root and nested DSH packages, including repository aggregation
- document DSH support and add positive, malformed-input, alias, prerelease, path, runtime, conditional-export, nested-package, regex-literal, ESM-alias, and CommonJS regression coverage

## Why

A standards-compliant native DSH package was being classified as Codex, scored with zero manifest points, and rejected by `verify` because it did not contain `.codex-plugin/plugin.json`. The implementation now follows the native DSH package contract used by the public reproduction in #2501 while preserving the directory's existing score and severity gates.

## Validation contract

- recognizes `package.json` with a valid `dsh.bundle`
- accepts prerelease/build SemVer such as `0.1.0-preview.5` and `0.1.0-rc.8+build.1`
- resolves the package root `exports` target before `main` and does not mistake subpath-only exports for the runtime
- ignores comments, strings, template literals, and regex literals when detecting exported `apply`
- supports named ESM exports, aliases exported as `apply`, direct CommonJS exports, and CommonJS export objects
- rejects missing, escaping, directory, or symlinked patch/runtime targets
- verifies native DSH-only packages without requiring a Codex manifest

Closes #2501.