### PR TITLE
fix(guard): allow bounded guidance reads

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12810,
-  "maximum_test_source_lines": 292515,
+  "maximum_collected_cases": 12821,
+  "maximum_test_source_lines": 292609,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/benign_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/benign_requests.py
@@ -14,12 +14,14 @@ from ..command_decision_adapter import effect_decision_to_dict
 from ..command_evaluation import evaluate_command
 from ..direct_vitest import direct_local_typescript_execution_context, direct_local_vitest_execution_context
 from ..extension_control_contract import ExtensionControlLayer
+from ..false_positive_rules import KNOWN_AGENT_DOC_SUFFIXES, target_is_known_skill_doc_path
 from ..github_actions_read_workflow import is_nonexecuting_github_actions_read_workflow
 from ..github_capability_contract import GitHubCommandAssessment
 from ..github_capability_interaction import github_capability_requires_confirmation
 from ..read_only_git_audit import is_read_only_git_ancestry_audit
 from ..routine_setup_commands import is_safe_codex_memory_registry_search, is_safe_git_worktree_add
 from ..shell_command_wrappers import normalize_transparent_shell_command
+from ..shell_execution_context import model_shell_execution_context
 from .constants_core import _SHELL_TOOL_NAMES
 from .destructive_shell_detection import _shell_command_names_from_parts
 from .developer_routines import (
@@ -104,6 +106,13 @@ def is_explicitly_benign_tool_action_request(
         if github_assessment is not None and github_capability_requires_confirmation(github_assessment):
             return False
         if _quote_aware_direct_github_read_is_safe(stripped_command, assessment=github_assessment):
+            found_benign_candidate = True
+            continue
+        if home_dir is not None and _is_bounded_agent_guidance_read_chain(
+            stripped_command,
+            cwd=cwd,
+            home_dir=home_dir,
+        ):
             found_benign_candidate = True
             continue
         if home_dir is not None and _is_guard_safety_doc_read(stripped_command, home_dir=home_dir):
@@ -207,6 +216,75 @@ def is_explicitly_benign_tool_action_request(
     return found_benign_candidate
 
 
+def _is_bounded_agent_guidance_read_chain(
+    command_text: str,
+    *,
+    cwd: Path | None,
+    home_dir: Path,
+) -> bool:
+    if any(marker in command_text for marker in ("$(", "`", "<(", ">(")):
+        return False
+    context = model_shell_execution_context(
+        command_text,
+        cwd=cwd,
+        workspace_root=cwd,
+        home_dir=home_dir,
+    )
+    if not context.complete or not 1 <= len(context.segments) <= 8:
+        return False
+    for segment in context.segments:
+        controls = (*segment.control_before, *segment.control_after)
+        if any(operator != "&&" for operator in controls) or segment.directory_operation is not None:
+            return False
+        parts = list(segment.tokens)
+        target = _bounded_sed_read_target(parts)
+        if target is None:
+            return False
+        if _is_approved_agent_guidance_target(target, home_dir=home_dir):
+            continue
+        if _is_guard_safety_doc_target(target, home_dir=home_dir):
+            continue
+        return False
+    return True
+
+
+def _bounded_sed_read_target(parts: list[str]) -> str | None:
+    if len(parts) != 4 or parts[:2] != ["sed", "-n"]:
+        return None
+    match = re.fullmatch(r"([1-9][0-9]{0,3}),([1-9][0-9]{0,3})p", parts[2])
+    if match is None:
+        return None
+    start, end = map(int, match.groups())
+    return parts[3] if start <= end and end - start + 1 <= 500 else None
+
+
+def _is_approved_agent_guidance_target(target: str, *, home_dir: Path) -> bool:
+    if not target_is_known_skill_doc_path(target, home_dir=home_dir):
+        return False
+    normalized = target.replace("\\", "/").rstrip("/")
+    return normalized.endswith("/SKILL.md") or any(normalized.endswith(suffix) for suffix in KNOWN_AGENT_DOC_SUFFIXES)
+
+
+def _is_guard_safety_doc_target(target: str, *, home_dir: Path) -> bool:
+    expected = home_dir / ".hol-support" / "SAFETY.md"
+    candidate = home_dir / target[2:] if target.startswith("~/") else Path(target)
+    try:
+        resolved_home = home_dir.resolve(strict=True)
+        resolved_support = (home_dir / ".hol-support").resolve(strict=True)
+        resolved_expected = expected.resolve(strict=True)
+        return (
+            candidate.absolute() == expected.absolute()
+            and not home_dir.is_symlink()
+            and not (home_dir / ".hol-support").is_symlink()
+            and not expected.is_symlink()
+            and resolved_support == resolved_home / ".hol-support"
+            and resolved_expected == resolved_support / "SAFETY.md"
+            and resolved_expected.is_file()
+        )
+    except (OSError, RuntimeError):
+        return False
+
+
 def _quote_aware_direct_github_read_is_safe(
     command_text: str,
     *,
@@ -269,18 +347,8 @@ def _is_guard_safety_doc_read(command_text: str, *, home_dir: Path) -> bool:
         parts = shlex.split(command_text)
     except ValueError:
         return False
-    if len(parts) != 4 or parts[:2] != ["sed", "-n"]:
-        return False
-    match = re.fullmatch(r"([1-9][0-9]{0,3}),([1-9][0-9]{0,3})p", parts[2])
-    if match is None or int(match.group(2)) - int(match.group(1)) > 500:
-        return False
-    target = parts[3]
-    expected = home_dir / ".hol-support" / "SAFETY.md"
-    candidate = home_dir / target[2:] if target.startswith("~/") else Path(target)
-    try:
-        return candidate.absolute() == expected.absolute() and expected.is_file() and not expected.is_symlink()
-    except OSError:
-        return False
+    target = _bounded_sed_read_target(parts)
+    return target is not None and _is_guard_safety_doc_target(target, home_dir=home_dir)
 
 
 def _skip_shell_wrapper_options(segment: list[_ShellTokenWithQuoteContext], index: int) -> int:

--- a/tests/test_guard_agent_guidance_reads.py
+++ b/tests/test_guard_agent_guidance_reads.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.secret_file_requests import is_explicitly_benign_tool_action_request
+
+
+def _is_benign(command: str, *, workspace: Path, home: Path) -> bool:
+    return is_explicitly_benign_tool_action_request(
+        "Bash",
+        {"command": command},
+        cwd=workspace,
+        home_dir=home,
+    )
+
+
+@pytest.fixture
+def guidance_home(tmp_path: Path) -> Path:
+    skill = tmp_path / ".agents" / "skills" / "github-pr-review-loop" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text("# PR review\n", encoding="utf-8")
+    safety = tmp_path / ".hol-support" / "SAFETY.md"
+    safety.parent.mkdir(parents=True)
+    safety.write_text("# Safety\n", encoding="utf-8")
+    docs = tmp_path / ".codex" / "docs"
+    docs.mkdir(parents=True)
+    (docs / "harness-engineering.md").write_text("# Harness\n", encoding="utf-8")
+    (docs / "token-discipline.md").write_text("# Tokens\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_bounded_agent_guidance_read_chain_is_benign(guidance_home: Path, tmp_path: Path) -> None:
+    command = (
+        "sed -n '1,240p' ~/.agents/skills/github-pr-review-loop/SKILL.md && "
+        "sed -n '1,240p' ~/.hol-support/SAFETY.md && "
+        "sed -n '1,220p' ~/.codex/docs/harness-engineering.md && "
+        "sed -n '1,180p' ~/.codex/docs/token-discipline.md"
+    )
+
+    assert _is_benign(command, workspace=tmp_path, home=guidance_home)
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    (
+        "&& cat ~/.ssh/id_rsa",
+        "&& rm ~/.hol-support/SAFETY.md",
+        "> /tmp/guidance.txt",
+        "&& sed -n '1,20p' ~/.codex/docs/credentials.json",
+        "&& sed -n '1,20p' ~/.agents/skills/github-pr-review-loop/credentials",
+        "&& sed -n '1,20p' \"$(printf ~/.hol-support/SAFETY.md)\"",
+        "&& sed -n '1,501p' ~/.hol-support/SAFETY.md",
+        "&& sed -n '20,1p' ~/.hol-support/SAFETY.md",
+    ),
+)
+def test_agent_guidance_read_chain_rejects_unsafe_variants(
+    guidance_home: Path,
+    tmp_path: Path,
+    suffix: str,
+) -> None:
+    command = f"sed -n '1,20p' ~/.hol-support/SAFETY.md {suffix}"
+
+    assert not _is_benign(command, workspace=tmp_path, home=guidance_home)
+
+
+def test_agent_guidance_read_rejects_skill_symlink_escape(guidance_home: Path, tmp_path: Path) -> None:
+    skill = guidance_home / ".agents" / "skills" / "github-pr-review-loop" / "SKILL.md"
+    skill.unlink()
+    outside = tmp_path / "outside.md"
+    outside.write_text("outside\n", encoding="utf-8")
+    skill.symlink_to(outside)
+
+    assert not _is_benign(
+        "sed -n '1,20p' ~/.agents/skills/github-pr-review-loop/SKILL.md",
+        workspace=tmp_path,
+        home=guidance_home,
+    )
+
+
+def test_agent_guidance_read_rejects_safety_parent_symlink(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "SAFETY.md").write_text("outside\n", encoding="utf-8")
+    (home / ".hol-support").symlink_to(outside, target_is_directory=True)
+
+    assert not _is_benign(
+        "sed -n '1,20p' ~/.hol-support/SAFETY.md",
+        workspace=tmp_path,
+        home=home,
+    )


### PR DESCRIPTION
## Summary
- allow bounded chained reads of verified agent guidance documents
- retain review for sensitive targets, symlink escapes, substitutions, redirects, and mixed commands

## Testing
- `uv run pytest -q tests/test_guard_agent_guidance_reads.py tests/test_guard_compound_readonly_auto_allow.py tests/test_secret_file_request_service_regressions.py tests/test_guard_unmatched_tool_approval.py`
- `uv run ruff check src/codex_plugin_scanner/guard/runtime/secret_file_request_services/benign_requests.py tests/test_guard_agent_guidance_reads.py`
- `uv run --no-sync python scripts/ci/test_inventory.py --output test-inventory.json && uv run --no-sync python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory test-inventory.json && uv run --no-sync python -m ruff check src/ && uv run --no-sync python -m ruff format --check src/ && uv run --no-sync basedpyright --level error`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved protection for shell commands that read agent guidance files.
  * Allows bounded reads from approved documentation and verified safety files.
  * Rejects unsafe commands, credential access, file deletion, redirection, command substitution, and symlink escapes.
  * Prevents unapproved paths, malformed commands, and overly long command chains.

* **Tests**
  * Added coverage for valid guidance reads and unsafe command variants.
  * Updated test baselines to reflect the expanded validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->