### PR TITLE
fix(guard): validate the approved Extension policy contract

### DIFF
--- a/contracts/managed-controls/v1/policy-extension-fields.json
+++ b/contracts/managed-controls/v1/policy-extension-fields.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": "guard.managed-controls.policy-extension-fields.v1",
+  "capabilities": [
+    "extension-control-layer.v1",
+    "managed-controls-atomic-apply.v1",
+    "policy-extension-targets.v1"
+  ],
+  "documentField": {
+    "field": "x-hol-extension-controls",
+    "schemaVersion": "guard.extension-controls.v1",
+    "authorityModes": [
+      "personal-shared",
+      "workspace-shared",
+      "managed-restrictive"
+    ],
+    "targetKinds": [
+      "extension",
+      "permission"
+    ],
+    "states": [
+      "enabled",
+      "disabled"
+    ],
+    "example": {
+      "schemaVersion": "guard.extension-controls.v1",
+      "authorityMode": "managed-restrictive",
+      "controls": [
+        {
+          "targetKind": "permission",
+          "targetId": "command.git.permission.force-push",
+          "state": "disabled"
+        }
+      ]
+    }
+  },
+  "ruleField": {
+    "field": "x-hol-extension-targets",
+    "schemaVersion": "guard.policy-extension-targets.v1",
+    "example": {
+      "schemaVersion": "guard.policy-extension-targets.v1",
+      "extensionIds": [
+        "command.git"
+      ],
+      "permissionIds": [
+        "command.git.permission.force-push"
+      ]
+    }
+  },
+  "invariants": {
+    "canonicalLocalRegistryIsAuthoritative": true,
+    "legacyFallbackMayNotDropSemantics": true,
+    "managedRestrictiveMayEnable": false,
+    "policyAndExtensionProjectionMustApplyAtomically": true,
+    "rawDetectorMatchersAreNotSynchronized": true
+  }
+}

--- a/src/codex_plugin_scanner/guard/policy_bundle_v2.py
+++ b/src/codex_plugin_scanner/guard/policy_bundle_v2.py
@@ -22,6 +22,15 @@ from .policy_bundle_trusted_keys import (
 )
 from .policy_document import JsonValue, canonical_json_bytes, canonical_policy_document_bytes
 from .policy_document_yaml import PolicyDocumentError, parse_policy_document_yaml
+from .policy_extension_fields import (
+    PolicyExtensionFieldError,
+    ValidatedPolicyExtensionProjection,
+    validate_and_project_policy_extension_fields,
+)
+from .runtime.command_extensions import (
+    BUILT_IN_COMMAND_EXTENSION_REGISTRY,
+    CommandSafetyExtensionRegistry,
+)
 
 POLICY_BUNDLE_V2_CONTRACT = "guard-policy-bundle.v2"
 POLICY_BUNDLE_V2_ENVELOPE_VERSION = 2
@@ -275,73 +284,108 @@ def _verify_signature(
     return None
 
 
-def validated_policy_bundle_v2_payload(
+def validated_policy_bundle_v2_payload_with_extensions(
     policy_bundle: dict[str, object],
     *,
     trusted_verification_keys: tuple[PolicyBundleVerificationKey, ...] = (),
     anchored_verification_keys: tuple[PolicyBundleVerificationKey, ...] = (),
+    negotiated_capabilities: frozenset[str] = frozenset(),
+    extension_registry: CommandSafetyExtensionRegistry = BUILT_IN_COMMAND_EXTENSION_REGISTRY,
     now: datetime | None = None,
-) -> tuple[dict[str, object] | None, str | None]:
-    """Validate one bounded signed v2 envelope and its canonical policy document."""
+) -> tuple[dict[str, object] | None, ValidatedPolicyExtensionProjection | None, str | None]:
+    """Validate one signed v2 envelope and project negotiated Extension semantics."""
 
     try:
         encoded = canonical_json_bytes(_json_value(policy_bundle))
     except ValueError as error:
-        return None, str(error)
+        return None, None, str(error)
     if len(encoded) > POLICY_BUNDLE_MAX_BYTES:
-        return None, "limit_bytes"
+        return None, None, "limit_bytes"
     if not _validate_keys(policy_bundle, _ALLOWED_TOP_LEVEL):
-        return None, "unknown_field"
+        return None, None, "unknown_field"
     required = _ALLOWED_TOP_LEVEL - {"expiresAt", "rollback"}
     if any(key not in policy_bundle for key in required):
-        return None, "missing_required_field"
+        return None, None, "missing_required_field"
     if policy_bundle.get("envelopeVersion") != POLICY_BUNDLE_V2_ENVELOPE_VERSION:
-        return None, "unsupported_envelope_version"
+        return None, None, "unsupported_envelope_version"
     if policy_bundle.get("contractVersion") != POLICY_BUNDLE_V2_CONTRACT:
-        return None, "unsupported_contract_version"
+        return None, None, "unsupported_contract_version"
     bundle_version = policy_bundle.get("bundleVersion")
     if not isinstance(bundle_version, int) or isinstance(bundle_version, bool) or bundle_version < 1:
-        return None, "invalid_bundle_version"
+        return None, None, "invalid_bundle_version"
     if _non_empty_string(policy_bundle.get("workspaceId"), maximum=128) is None:
-        return None, "invalid_workspace_id"
+        return None, None, "invalid_workspace_id"
     canonicalization = policy_bundle.get("canonicalization")
     if canonicalization != POLICY_BUNDLE_V2_CANONICALIZATION:
-        return None, "unsupported_canonicalization"
+        return None, None, "unsupported_canonicalization"
     issued_at = _strict_utc_timestamp(policy_bundle.get("issuedAt"))
     if issued_at is None:
-        return None, "invalid_issued_at"
+        return None, None, "invalid_issued_at"
     expires_at_value = policy_bundle.get("expiresAt")
     expires_at = None if expires_at_value is None else _strict_utc_timestamp(expires_at_value)
     if expires_at_value is not None and expires_at is None:
-        return None, "invalid_expires_at"
+        return None, None, "invalid_expires_at"
     if expires_at is not None and expires_at <= issued_at:
-        return None, "invalid_expires_at"
+        return None, None, "invalid_expires_at"
     comparison_time = now or datetime.now(timezone.utc)
     if expires_at is not None and expires_at <= comparison_time:
-        return None, "bundle_expired"
+        return None, None, "bundle_expired"
     rollback_error = _validate_rollback(policy_bundle.get("rollback"))
     if rollback_error is not None:
-        return None, rollback_error
+        return None, None, rollback_error
     try:
         expected_payload_hash = payload_hash_for_policy_bundle_v2(policy_bundle)
     except (PolicyDocumentError, ValueError):
-        return None, "invalid_policy_document"
+        return None, None, "invalid_policy_document"
     if policy_bundle.get("payloadHash") != expected_payload_hash:
-        return None, "payload_hash_mismatch"
+        return None, None, "payload_hash_mismatch"
     try:
         expected_bundle_hash = computed_policy_bundle_v2_hash(policy_bundle)
     except ValueError:
-        return None, "invalid_bundle"
+        return None, None, "invalid_bundle"
     if policy_bundle.get("bundleHash") != expected_bundle_hash:
-        return None, "bundle_hash_mismatch"
+        return None, None, "bundle_hash_mismatch"
     signature_error = _verify_signature(
         policy_bundle,
         trusted_verification_keys=trusted_verification_keys,
         anchored_verification_keys=anchored_verification_keys,
     )
     if signature_error is not None:
-        return None, signature_error
-    return policy_bundle, None
+        return None, None, signature_error
+    payload = policy_bundle.get("payload")
+    if not _is_object_mapping(payload):
+        return None, None, "invalid_policy_document"
+    try:
+        projection = validate_and_project_policy_extension_fields(
+            payload,
+            negotiated_capabilities=negotiated_capabilities,
+            registry=extension_registry,
+        )
+    except PolicyExtensionFieldError as error:
+        return None, None, error.code
+    return policy_bundle, projection, None
+
+
+def validated_policy_bundle_v2_payload(
+    policy_bundle: dict[str, object],
+    *,
+    trusted_verification_keys: tuple[PolicyBundleVerificationKey, ...] = (),
+    anchored_verification_keys: tuple[PolicyBundleVerificationKey, ...] = (),
+    negotiated_capabilities: frozenset[str] = frozenset(),
+    extension_registry: CommandSafetyExtensionRegistry = BUILT_IN_COMMAND_EXTENSION_REGISTRY,
+    now: datetime | None = None,
+) -> tuple[dict[str, object] | None, str | None]:
+    """Compatibility wrapper returning the validated signed envelope."""
+
+    validated, _projection, reason = validated_policy_bundle_v2_payload_with_extensions(
+        policy_bundle,
+        trusted_verification_keys=trusted_verification_keys,
+        anchored_verification_keys=anchored_verification_keys,
+        negotiated_capabilities=negotiated_capabilities,
+        extension_registry=extension_registry,
+        now=now,
+    )
+    return validated, reason
 
 
 def validate_policy_bundle_v2_transition(
@@ -445,7 +489,10 @@ def validated_policy_bundle_v2_acknowledgement(
     if sequence < previous_sequence:
         return None, "acknowledgement_replay"
     if sequence == previous_sequence:
-        return (acknowledgement, None) if acknowledgement == previous else (None, "acknowledgement_sequence_conflict")
+        return (acknowledgement, None) if acknowledgement == previous else (
+            None,
+            "acknowledgement_sequence_conflict",
+        )
     if status not in _ALLOWED_ACK_TRANSITIONS[str(previous_status)]:
         return None, "acknowledgement_transition_rejected"
     return acknowledgement, None

--- a/src/codex_plugin_scanner/guard/policy_extension_fields.py
+++ b/src/codex_plugin_scanner/guard/policy_extension_fields.py
@@ -1,0 +1,368 @@
+"""Strict HOL Guard Extension fields embedded in canonical GuardPolicy documents.
+
+The Cloud owns signed orchestration. The Local registry remains authoritative for
+Extension and permission identities, detector ownership, floors, delegation,
+and configurability.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Final, TypeGuard, cast
+
+from .runtime.command_extensions import CommandSafetyExtensionRegistry
+from .runtime.extension_control_contract import (
+    CONTROL_SCHEMA_VERSION,
+    ControlLayerKind,
+    ControlState,
+    ControlTarget,
+    ControlTargetKind,
+    ExtensionControl,
+    ExtensionControlLayer,
+)
+from .runtime.extension_control_limits import MAX_CONTROL_SET_TARGETS, MAX_CONTROLS_PER_LAYER
+
+HOL_EXTENSION_CONTROLS_FIELD: Final = "x-hol-extension-controls"
+HOL_EXTENSION_TARGETS_FIELD: Final = "x-hol-extension-targets"
+HOL_EXTENSION_CONTROLS_SCHEMA_VERSION: Final = "guard.extension-controls.v1"
+HOL_EXTENSION_TARGETS_SCHEMA_VERSION: Final = "guard.policy-extension-targets.v1"
+
+EXTENSION_CONTROL_LAYER_CAPABILITY: Final = "extension-control-layer.v1"
+POLICY_EXTENSION_TARGETS_CAPABILITY: Final = "policy-extension-targets.v1"
+MANAGED_CONTROLS_ATOMIC_APPLY_CAPABILITY: Final = "managed-controls-atomic-apply.v1"
+
+_LEGACY_CAPABILITY_ALIASES: Final[dict[str, frozenset[str]]] = {
+    EXTENSION_CONTROL_LAYER_CAPABILITY: frozenset({"guard.managed-extension-controls.v1"}),
+    POLICY_EXTENSION_TARGETS_CAPABILITY: frozenset({"guard.policy-extension-targets.v1"}),
+    MANAGED_CONTROLS_ATOMIC_APPLY_CAPABILITY: frozenset({"guard.managed-controls-atomic-apply.v1"}),
+}
+
+_AUTHORITY_MODES: Final = frozenset({"personal-shared", "workspace-shared", "managed-restrictive"})
+_TARGET_KINDS: Final = frozenset({"extension", "permission"})
+_CONTROL_STATES: Final = frozenset({"enabled", "disabled"})
+_EXTENSION_ID = re.compile(r"^command\.[a-z0-9]+(?:[.-][a-z0-9]+)*$")
+_PERMISSION_ID = re.compile(
+    r"^command\.[a-z0-9]+(?:[.-][a-z0-9]+)*\.permission\.[a-z0-9]+(?:[.-][a-z0-9]+)*$"
+)
+_MAX_ID_BYTES: Final = 256
+
+
+class PolicyExtensionFieldError(ValueError):
+    """A stable, bounded rejection for malformed or unsupported Extension fields."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class PolicyExtensionControl:
+    target_kind: str
+    target_id: str
+    state: str
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyExtensionControlEnvelope:
+    authority_mode: str
+    global_lockdown: bool
+    controls: tuple[PolicyExtensionControl, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyExtensionRuleTargets:
+    extension_ids: tuple[str, ...]
+    permission_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedPolicyExtensionFields:
+    controls: PolicyExtensionControlEnvelope | None
+    rule_targets: tuple[tuple[str, PolicyExtensionRuleTargets], ...]
+
+    @property
+    def has_semantics(self) -> bool:
+        return self.controls is not None or bool(self.rule_targets)
+
+    def targets_for_rule(self, rule_id: str) -> PolicyExtensionRuleTargets | None:
+        return next((targets for candidate, targets in self.rule_targets if candidate == rule_id), None)
+
+
+@dataclass(frozen=True, slots=True)
+class ValidatedPolicyExtensionProjection:
+    parsed: ParsedPolicyExtensionFields
+    signed_cloud_layer: ExtensionControlLayer | None
+
+
+
+def _is_mapping(value: object) -> TypeGuard[dict[str, object]]:
+    return isinstance(value, dict) and all(isinstance(key, str) for key in cast(dict[object, object], value))
+
+
+def _mapping(value: object, *, label: str) -> dict[str, object]:
+    if not _is_mapping(value):
+        raise PolicyExtensionFieldError("invalid_shape", f"{label} must be an object")
+    return value
+
+
+def _exact_keys(value: Mapping[str, object], *, allowed: frozenset[str], label: str) -> None:
+    if any(key not in allowed for key in value):
+        raise PolicyExtensionFieldError("unknown_field", f"{label} contains an unknown field")
+
+
+def _canonical_extension_id(value: object) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value.encode("utf-8")) > _MAX_ID_BYTES
+        or _EXTENSION_ID.fullmatch(value) is None
+        or ".permission." in value
+    ):
+        raise PolicyExtensionFieldError("invalid_extension_id", "Extension ID is not canonical")
+    return value
+
+
+def _canonical_permission_id(value: object) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value.encode("utf-8")) > _MAX_ID_BYTES
+        or _PERMISSION_ID.fullmatch(value) is None
+    ):
+        raise PolicyExtensionFieldError("invalid_permission_id", "Permission ID is not canonical")
+    return value
+
+
+def _unique_ids(value: object, *, label: str, parser: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise PolicyExtensionFieldError("invalid_shape", f"{label} must be an array")
+    parse = cast(object, parser)
+    if parse is _canonical_extension_id:
+        parsed = tuple(sorted(_canonical_extension_id(item) for item in value))
+    elif parse is _canonical_permission_id:
+        parsed = tuple(sorted(_canonical_permission_id(item) for item in value))
+    else:
+        raise AssertionError("unsupported ID parser")
+    if len(parsed) != len(set(parsed)):
+        raise PolicyExtensionFieldError("duplicate_target", f"{label} contains a duplicate target")
+    return parsed
+
+
+def _parse_control(value: object) -> PolicyExtensionControl:
+    control = _mapping(value, label="Extension control")
+    _exact_keys(
+        control,
+        allowed=frozenset({"targetKind", "targetId", "state"}),
+        label="Extension control",
+    )
+    target_kind = control.get("targetKind")
+    state = control.get("state")
+    if target_kind not in _TARGET_KINDS:
+        raise PolicyExtensionFieldError("invalid_target_kind", "Extension control target kind is invalid")
+    if state not in _CONTROL_STATES:
+        raise PolicyExtensionFieldError("invalid_control_state", "Extension control state is invalid")
+    target_id = (
+        _canonical_extension_id(control.get("targetId"))
+        if target_kind == "extension"
+        else _canonical_permission_id(control.get("targetId"))
+    )
+    return PolicyExtensionControl(str(target_kind), target_id, str(state))
+
+
+def _parse_controls(value: object) -> PolicyExtensionControlEnvelope:
+    envelope = _mapping(value, label=HOL_EXTENSION_CONTROLS_FIELD)
+    _exact_keys(
+        envelope,
+        allowed=frozenset({"schemaVersion", "authorityMode", "globalLockdown", "controls"}),
+        label=HOL_EXTENSION_CONTROLS_FIELD,
+    )
+    if envelope.get("schemaVersion") != HOL_EXTENSION_CONTROLS_SCHEMA_VERSION:
+        raise PolicyExtensionFieldError("unsupported_control_schema", "Extension control schema is unsupported")
+    authority_mode = envelope.get("authorityMode")
+    if authority_mode not in _AUTHORITY_MODES:
+        raise PolicyExtensionFieldError("invalid_authority", "Extension authority mode is invalid")
+    raw_controls = envelope.get("controls")
+    if not isinstance(raw_controls, list):
+        raise PolicyExtensionFieldError("invalid_shape", "Extension controls must be an array")
+    if len(raw_controls) > MAX_CONTROLS_PER_LAYER:
+        raise PolicyExtensionFieldError("control_limit_exceeded", "Extension control layer exceeds its limit")
+    controls = tuple(sorted(_parse_control(item) for item in raw_controls))
+    for previous, current in zip(controls, controls[1:], strict=False):
+        if previous.target_kind == current.target_kind and previous.target_id == current.target_id:
+            code = "duplicate_target" if previous.state == current.state else "conflicting_target"
+            raise PolicyExtensionFieldError(code, "Duplicate or conflicting Extension controls are not allowed")
+    raw_lockdown = envelope.get("globalLockdown", False)
+    if type(raw_lockdown) is not bool:
+        raise PolicyExtensionFieldError("invalid_global_lockdown", "Global lockdown must be a boolean")
+    global_lockdown = cast(bool, raw_lockdown)
+    if global_lockdown and authority_mode != "managed-restrictive":
+        raise PolicyExtensionFieldError("invalid_authority", "Global lockdown requires managed-restrictive authority")
+    if authority_mode == "managed-restrictive" and any(control.state != "disabled" for control in controls):
+        raise PolicyExtensionFieldError(
+            "managed_restrictive_broadening",
+            "Managed-restrictive controls cannot enable a capability",
+        )
+    return PolicyExtensionControlEnvelope(str(authority_mode), global_lockdown, controls)
+
+
+def _parse_rule_targets(value: object) -> PolicyExtensionRuleTargets:
+    targets = _mapping(value, label=HOL_EXTENSION_TARGETS_FIELD)
+    _exact_keys(
+        targets,
+        allowed=frozenset({"schemaVersion", "extensionIds", "permissionIds"}),
+        label=HOL_EXTENSION_TARGETS_FIELD,
+    )
+    if targets.get("schemaVersion") != HOL_EXTENSION_TARGETS_SCHEMA_VERSION:
+        raise PolicyExtensionFieldError("unsupported_target_schema", "Extension target schema is unsupported")
+    extension_ids = _unique_ids(
+        targets.get("extensionIds"),
+        label="extensionIds",
+        parser=_canonical_extension_id,
+    )
+    permission_ids = _unique_ids(
+        targets.get("permissionIds"),
+        label="permissionIds",
+        parser=_canonical_permission_id,
+    )
+    if len(extension_ids) + len(permission_ids) > MAX_CONTROL_SET_TARGETS:
+        raise PolicyExtensionFieldError("target_limit_exceeded", "Extension targets exceed their limit")
+    return PolicyExtensionRuleTargets(extension_ids, permission_ids)
+
+
+def parse_policy_extension_fields(document: Mapping[str, object]) -> ParsedPolicyExtensionFields:
+    controls = (
+        _parse_controls(document[HOL_EXTENSION_CONTROLS_FIELD])
+        if HOL_EXTENSION_CONTROLS_FIELD in document
+        else None
+    )
+    spec = _mapping(document.get("spec"), label="GuardPolicy spec")
+    rules = spec.get("rules")
+    if not isinstance(rules, list):
+        raise PolicyExtensionFieldError("invalid_policy_document", "GuardPolicy rules must be an array")
+    parsed_targets: list[tuple[str, PolicyExtensionRuleTargets]] = []
+    seen_rule_ids: set[str] = set()
+    for item in rules:
+        rule = _mapping(item, label="GuardPolicy rule")
+        rule_id = rule.get("id")
+        if not isinstance(rule_id, str) or not rule_id:
+            raise PolicyExtensionFieldError("invalid_policy_document", "GuardPolicy rule ID is invalid")
+        if rule_id in seen_rule_ids:
+            raise PolicyExtensionFieldError("duplicate_rule_id", "GuardPolicy rule IDs must be unique")
+        seen_rule_ids.add(rule_id)
+        if HOL_EXTENSION_TARGETS_FIELD in rule:
+            parsed_targets.append((rule_id, _parse_rule_targets(rule[HOL_EXTENSION_TARGETS_FIELD])))
+    return ParsedPolicyExtensionFields(controls, tuple(sorted(parsed_targets)))
+
+
+def _capability_present(capabilities: frozenset[str], required: str) -> bool:
+    return required in capabilities or any(alias in capabilities for alias in _LEGACY_CAPABILITY_ALIASES[required])
+
+
+def required_policy_extension_capabilities(parsed: ParsedPolicyExtensionFields) -> tuple[str, ...]:
+    if not parsed.has_semantics:
+        return ()
+    required = {
+        POLICY_EXTENSION_TARGETS_CAPABILITY,
+        MANAGED_CONTROLS_ATOMIC_APPLY_CAPABILITY,
+    }
+    if parsed.controls is not None:
+        required.add(EXTENSION_CONTROL_LAYER_CAPABILITY)
+    return tuple(sorted(required))
+
+
+def validate_policy_extension_capabilities(
+    parsed: ParsedPolicyExtensionFields,
+    negotiated_capabilities: frozenset[str],
+) -> None:
+    missing = tuple(
+        capability
+        for capability in required_policy_extension_capabilities(parsed)
+        if not _capability_present(negotiated_capabilities, capability)
+    )
+    if missing:
+        raise PolicyExtensionFieldError(
+            "unnegotiated_extension_semantics",
+            "Extension semantics require negotiated capabilities: " + ", ".join(missing),
+        )
+
+
+def _validate_extension_target(registry: CommandSafetyExtensionRegistry, target_id: str) -> None:
+    extension = registry.get(target_id)
+    if extension is None:
+        raise PolicyExtensionFieldError("unknown_extension_target", "Extension target is not in the Local catalog")
+    if extension.extension_id != target_id:
+        raise PolicyExtensionFieldError("non_canonical_target", "Extension target uses an alias")
+
+
+def _validate_permission_target(registry: CommandSafetyExtensionRegistry, target_id: str) -> None:
+    permission = registry.permission(target_id)
+    if permission is None:
+        raise PolicyExtensionFieldError("unknown_permission_target", "Permission target is not in the Local catalog")
+    if permission.permission_id != target_id:
+        raise PolicyExtensionFieldError("non_canonical_target", "Permission target is not canonical")
+
+
+def validate_policy_extension_targets(
+    parsed: ParsedPolicyExtensionFields,
+    registry: CommandSafetyExtensionRegistry,
+) -> None:
+    if parsed.controls is not None:
+        for control in parsed.controls.controls:
+            if control.target_kind == "extension":
+                _validate_extension_target(registry, control.target_id)
+            else:
+                _validate_permission_target(registry, control.target_id)
+                permission = registry.permission(control.target_id)
+                if (
+                    control.state == "enabled"
+                    and permission is not None
+                    and not permission.configurable
+                ):
+                    raise PolicyExtensionFieldError(
+                        "immutable_permission_enable",
+                        "Cloud cannot enable an immutable permission",
+                    )
+    for _rule_id, targets in parsed.rule_targets:
+        for extension_id in targets.extension_ids:
+            _validate_extension_target(registry, extension_id)
+        for permission_id in targets.permission_ids:
+            _validate_permission_target(registry, permission_id)
+
+
+def signed_cloud_extension_layer(
+    parsed: ParsedPolicyExtensionFields,
+    registry: CommandSafetyExtensionRegistry,
+) -> ExtensionControlLayer | None:
+    if parsed.controls is None:
+        return None
+    controls = tuple(
+        ExtensionControl(
+            target=ControlTarget(
+                ControlTargetKind.EXTENSION
+                if control.target_kind == "extension"
+                else ControlTargetKind.PERMISSION,
+                control.target_id,
+            ),
+            state=ControlState.ENABLED if control.state == "enabled" else ControlState.DISABLED,
+        )
+        for control in parsed.controls.controls
+    )
+    return ExtensionControlLayer(
+        schema_version=CONTROL_SCHEMA_VERSION,
+        kind=ControlLayerKind.SIGNED_CLOUD,
+        catalog_digest=registry.catalog_digest,
+        global_lockdown=parsed.controls.global_lockdown,
+        controls=controls,
+    )
+
+
+def validate_and_project_policy_extension_fields(
+    document: Mapping[str, object],
+    *,
+    negotiated_capabilities: frozenset[str],
+    registry: CommandSafetyExtensionRegistry,
+) -> ValidatedPolicyExtensionProjection:
+    parsed = parse_policy_extension_fields(document)
+    validate_policy_extension_capabilities(parsed, negotiated_capabilities)
+    validate_policy_extension_targets(parsed, registry)
+    return ValidatedPolicyExtensionProjection(parsed, signed_cloud_extension_layer(parsed, registry))

--- a/tests/test_policy_extension_fields.py
+++ b/tests/test_policy_extension_fields.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from codex_plugin_scanner.guard.policy_extension_fields import (
+    EXTENSION_CONTROL_LAYER_CAPABILITY,
+    MANAGED_CONTROLS_ATOMIC_APPLY_CAPABILITY,
+    POLICY_EXTENSION_TARGETS_CAPABILITY,
+    PolicyExtensionFieldError,
+    parse_policy_extension_fields,
+    required_policy_extension_capabilities,
+    validate_and_project_policy_extension_fields,
+)
+from codex_plugin_scanner.guard.runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
+from codex_plugin_scanner.guard.runtime.extension_control_contract import (
+    ControlLayerKind,
+    ControlState,
+    ControlTargetKind,
+)
+
+_GIT_EXTENSION = "command.git"
+_GIT_PERMISSION = "command.git.permission.force-push"
+_REQUIRED_CAPABILITIES = frozenset(
+    {
+        EXTENSION_CONTROL_LAYER_CAPABILITY,
+        POLICY_EXTENSION_TARGETS_CAPABILITY,
+        MANAGED_CONTROLS_ATOMIC_APPLY_CAPABILITY,
+    }
+)
+
+
+def _document() -> dict[str, object]:
+    return {
+        "apiVersion": "guard.hashgraphonline.com/v1alpha1",
+        "kind": "GuardPolicy",
+        "metadata": {
+            "id": "managed-controls-test",
+            "name": "Managed Controls test",
+            "revision": 1,
+        },
+        "spec": {
+            "defaults": {"mode": "enforce", "defaultAction": "block"},
+            "rolloutState": "enforcing",
+            "rules": [
+                {
+                    "id": "rule-git-force-push",
+                    "description": "Review force pushes",
+                    "enabled": True,
+                    "effect": "review",
+                    "match": {"tools": ["git"]},
+                    "lifetime": {"mode": "workspace", "expiresAt": None},
+                    "provenance": {
+                        "source": "builder",
+                        "createdAt": "2026-08-21T12:00:00.000Z",
+                    },
+                }
+            ],
+        },
+    }
+
+
+def _extension_document(*, authority_mode: str = "managed-restrictive", state: str = "disabled") -> dict[str, object]:
+    document = _document()
+    document["x-hol-extension-controls"] = {
+        "schemaVersion": "guard.extension-controls.v1",
+        "authorityMode": authority_mode,
+        "controls": [
+            {
+                "targetKind": "permission",
+                "targetId": _GIT_PERMISSION,
+                "state": state,
+            }
+        ],
+    }
+    spec = document["spec"]
+    assert isinstance(spec, dict)
+    rules = spec["rules"]
+    assert isinstance(rules, list)
+    rule = rules[0]
+    assert isinstance(rule, dict)
+    rule["x-hol-extension-targets"] = {
+        "schemaVersion": "guard.policy-extension-targets.v1",
+        "extensionIds": [_GIT_EXTENSION],
+        "permissionIds": [_GIT_PERMISSION],
+    }
+    return document
+
+
+def test_approved_extension_envelopes_parse_and_project_to_signed_cloud_layer() -> None:
+    projection = validate_and_project_policy_extension_fields(
+        _extension_document(),
+        negotiated_capabilities=_REQUIRED_CAPABILITIES,
+        registry=BUILT_IN_COMMAND_EXTENSION_REGISTRY,
+    )
+
+    assert required_policy_extension_capabilities(projection.parsed) == tuple(sorted(_REQUIRED_CAPABILITIES))
+    assert projection.parsed.targets_for_rule("rule-git-force-push") is not None
+    layer = projection.signed_cloud_layer
+    assert layer is not None
+    assert layer.kind is ControlLayerKind.SIGNED_CLOUD
+    assert layer.catalog_digest == BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest
+    assert layer.controls[0].target.kind is ControlTargetKind.PERMISSION
+    assert layer.controls[0].target.target_id == _GIT_PERMISSION
+    assert layer.controls[0].state is ControlState.DISABLED
+
+
+def test_documents_without_extension_semantics_remain_compatible() -> None:
+    parsed = parse_policy_extension_fields(_document())
+    assert parsed.has_semantics is False
+    assert required_policy_extension_capabilities(parsed) == ()
+
+
+def test_unnegotiated_runtime_rejects_extension_semantics() -> None:
+    with pytest.raises(PolicyExtensionFieldError) as caught:
+        validate_and_project_policy_extension_fields(
+            _extension_document(),
+            negotiated_capabilities=frozenset(),
+            registry=BUILT_IN_COMMAND_EXTENSION_REGISTRY,
+        )
+    assert caught.value.code == "unnegotiated_extension_semantics"
+
+
+def test_legacy_prefixed_capability_aliases_remain_accepted_during_transition() -> None:
+    projection = validate_and_project_policy_extension_fields(
+        _extension_document(),
+        negotiated_capabilities=frozenset(
+            {
+                "guard.managed-extension-controls.v1",
+                "guard.policy-extension-targets.v1",
+                "guard.managed-controls-atomic-apply.v1",
+            }
+        ),
+        registry=BUILT_IN_COMMAND_EXTENSION_REGISTRY,
+    )
+    assert projection.signed_cloud_layer is not None
+
+
+@pytest.mark.parametrize(
+    ("mutate", "expected_code"),
+    [
+        (
+            lambda document: document.__setitem__(
+                "x-hol-extension-controls",
+                [
+                    {
+                        "authorityMode": "managed-restrictive",
+                        "operation": "disable_permission",
+                        "extensionId": _GIT_EXTENSION,
+                        "permissionId": _GIT_PERMISSION,
+                    }
+                ],
+            ),
+            "invalid_shape",
+        ),
+        (
+            lambda document: cast_controls(document)["controls"][0].__setitem__(
+                "targetId", "git.push.force"
+            ),
+            "invalid_permission_id",
+        ),
+        (
+            lambda document: cast_controls(document).__setitem__(
+                "schemaVersion", "guard.extension-controls.v2"
+            ),
+            "unsupported_control_schema",
+        ),
+        (
+            lambda document: cast_controls(document)["controls"][0].__setitem__(
+                "state", "enabled"
+            ),
+            "managed_restrictive_broadening",
+        ),
+        (
+            lambda document: cast_controls(document).__setitem__("unexpected", True),
+            "unknown_field",
+        ),
+    ],
+)
+def test_malformed_or_broadening_control_envelopes_fail_closed(mutate: object, expected_code: str) -> None:
+    document = _extension_document()
+    callable_mutate = mutate
+    assert callable(callable_mutate)
+    callable_mutate(document)
+    with pytest.raises(PolicyExtensionFieldError) as caught:
+        parse_policy_extension_fields(document)
+    assert caught.value.code == expected_code
+
+
+def cast_controls(document: dict[str, object]) -> dict[str, object]:
+    controls = document["x-hol-extension-controls"]
+    assert isinstance(controls, dict)
+    raw_controls = controls.get("controls")
+    assert isinstance(raw_controls, list)
+    assert isinstance(raw_controls[0], dict)
+    return controls
+
+
+def test_global_lockdown_requires_managed_restrictive_authority() -> None:
+    document = _extension_document(authority_mode="workspace-shared")
+    cast_controls(document)["globalLockdown"] = True
+    with pytest.raises(PolicyExtensionFieldError) as caught:
+        parse_policy_extension_fields(document)
+    assert caught.value.code == "invalid_authority"
+
+
+def test_unknown_and_alias_targets_are_rejected_against_local_registry() -> None:
+    unknown = _extension_document()
+    cast_controls(unknown)["controls"][0]["targetId"] = "command.git.permission.not-real"
+    with pytest.raises(PolicyExtensionFieldError) as caught:
+        validate_and_project_policy_extension_fields(
+            unknown,
+            negotiated_capabilities=_REQUIRED_CAPABILITIES,
+            registry=BUILT_IN_COMMAND_EXTENSION_REGISTRY,
+        )
+    assert caught.value.code == "unknown_permission_target"
+
+    duplicate = deepcopy(_extension_document())
+    controls = cast_controls(duplicate)["controls"]
+    assert isinstance(controls, list)
+    controls.append(deepcopy(controls[0]))
+    with pytest.raises(PolicyExtensionFieldError) as caught_duplicate:
+        parse_policy_extension_fields(duplicate)
+    assert caught_duplicate.value.code == "duplicate_target"


### PR DESCRIPTION
## Managed Controls contract correction

The checklist audit found that the merged Cloud compiler used a flat experimental Extension field shape rather than the approved signed envelope. This Local PR implements the approved contract before any managed write can be accepted.

- parses `x-hol-extension-controls` as a versioned document envelope
- parses rule-level `x-hol-extension-targets` as a versioned target envelope
- accepts only canonical Local `command.*` Extension IDs and `command.*.permission.*` permission IDs
- requires negotiated `extension-control-layer.v1`, `policy-extension-targets.v1`, and `managed-controls-atomic-apply.v1` capabilities, with temporary compatibility aliases
- validates every target against the current Local registry
- rejects unknown, aliased, duplicate, conflicting, oversized, broadening, and unnegotiated semantics
- projects a validated signed-cloud `ExtensionControlLayer` without changing detector ownership
- integrates validation into signed Guard Policy Bundle v2 after hash and signature verification
- preserves existing v2 replay, rollback, expiry, key trust, and acknowledgement behavior
- adds a byte-identical cross-repository contract fixture and focused adversarial coverage

Targets `release/3.0` only. Local protection remains available without Cloud and no raw command data is synchronized.