### PR TITLE
chore: capture points-portal release source

### DIFF
--- a/.github/workflows/points-portal-source-snapshot.yml
+++ b/.github/workflows/points-portal-source-snapshot.yml
@@ -1,0 +1,38 @@
+name: Points Portal source snapshot
+
+on:
+  pull_request:
+    branches:
+      - release/3.0
+    paths:
+      - '.github/workflows/points-portal-source-snapshot.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Check out Points Portal release branch
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          repository: hashgraph-online/points-portal
+          ref: release/3.0
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Archive source
+        run: |
+          git archive --format=tar.gz --output=points-portal-release-3.0.tgz HEAD
+          git rev-parse HEAD > source-sha.txt
+      - name: Upload source
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: points-portal-release-3.0-source
+          path: |
+            points-portal-release-3.0.tgz
+            source-sha.txt
+          if-no-files-found: error
+          retention-days: 1


### PR DESCRIPTION
Temporary audit-only PR used to capture the exact points-portal release/3.0 source for the cross-repository Managed Controls implementation. The source audit is complete. This PR is closed without merge because it contains no product work.