### PR TITLE
feat(extensions): replace custom-extension modal with a full-page enroll flow

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 15335,
-  "maximum_test_source_lines": 330835,
+  "maximum_test_source_lines": 330845,
   "schema_version": 1
 }

--- a/dashboard/src/local-cli-api.test.ts
+++ b/dashboard/src/local-cli-api.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   addedCustomExtensions,
   filterExtensionSuggestions,
+  enrollmentCommandStates,
   filterPackageScriptCommands,
   isLocalCliId,
   normalizeLocalCliItem,
@@ -17,7 +18,7 @@ import {
   suggestedPackageScriptExtensions,
   suggestedSeenExtensions,
 } from "./local-cli-api";
-import { parseProtectionRoute, localCliHref } from "./local-cli-links";
+import { parseProtectionRoute, localCliHref, addCustomExtensionHref } from "./local-cli-links";
 
 assert.equal(isLocalCliId("local-cli.cwv-py-abcdef12"), true);
 assert.equal(isLocalCliId("command.git"), false);
@@ -99,6 +100,8 @@ assert.deepEqual(parseProtectionRoute("/extensions/local-cli/local-cli.cwv-py-ab
   kind: "local-cli",
   cliId: "local-cli.cwv-py-abcdef12",
 });
+assert.equal(parseProtectionRoute("/extensions/add").kind, "add-custom");
+assert.equal(addCustomExtensionHref(), "/extensions/add");
 assert.equal(parseProtectionRoute("/extensions/command.git").kind, "detail");
 assert.equal(localCliHref("local-cli.cwv-py-abcdef12"), "/extensions/local-cli/local-cli.cwv-py-abcdef12");
 assert.equal(addedCustomExtensions(list.items).length, 1);
@@ -236,6 +239,10 @@ assert.deepEqual(
   ["guard:reddit-targeting:audit"],
 );
 assert.deepEqual(
+  filterPackageScriptCommands(packageScripts.commands, "guard:audit").map((entry) => entry.name),
+  ["guard:reddit-targeting:audit"],
+);
+assert.deepEqual(
   filterPackageScriptCommands(packageScripts.commands, "npm run").map((entry) => entry.name),
   ["guard:reddit-targeting:audit", "build"],
 );
@@ -245,8 +252,13 @@ assert.equal(looksLikeProjectRelocatePaste("guard:audit"), false);
 assert.equal(looksLikeProjectRelocatePaste("/proj/My App"), true);
 assert.equal(looksLikeProjectRelocatePaste("C:\\\\My App\\\\package.json"), true);
 assert.equal(keepsPackageScriptCatalog("guard:reddit", packageScripts.commands), true);
+assert.equal(keepsPackageScriptCatalog("guard:audit", packageScripts.commands), true);
 assert.equal(keepsPackageScriptCatalog("my-cli", packageScripts.commands), false);
 assert.equal(keepsPackageScriptCatalog("npx -y @scope/mcp-server", packageScripts.commands), false);
+assert.deepEqual(
+  enrollmentCommandStates(packageScripts.commands, "allowed", "package-scripts").map((entry) => entry.state),
+  ["allow", "allow"],
+);
 assert.equal(seenSuggestionMeta(frequentTool), "Seen 4 times");
 assert.equal(seenSuggestionMeta(rareTool), "Seen once");
 

--- a/dashboard/src/local-cli-api.ts
+++ b/dashboard/src/local-cli-api.ts
@@ -182,7 +182,55 @@ export function filterPackageScriptCommands(
 }
 
 export function commandMatchesQuery(command: LocalCliCommand, needle: string): boolean {
-  return [command.name, command.usage, command.description].some((value) => value.toLowerCase().includes(needle));
+  const haystacks = [command.name, command.usage, command.description];
+  if (haystacks.some((value) => value.toLowerCase().includes(needle))) return true;
+  return colonPartsMatch(command.name, needle);
+}
+
+export function enrollablePackageScriptCommands(
+  commands: readonly LocalCliCommand[],
+): LocalCliCommand[] {
+  return commands.filter((command) => command.command_id !== "root" && command.command_id !== "other");
+}
+
+export function enrollmentCommandStates(
+  commands: readonly LocalCliCommand[],
+  pending: LocalCliState,
+  surface: LocalCliSurface,
+): Array<{ command_id: string; state: LocalCliCommandState }> {
+  if (surface !== "package-scripts") return commandStatesFrom(commands);
+  return commands.map((command) => ({
+    command_id: command.command_id,
+    state: packageScriptEnrollmentState(command, pending),
+  }));
+}
+
+function commandStatesFrom(
+  commands: readonly LocalCliCommand[],
+): Array<{ command_id: string; state: LocalCliCommandState }> {
+  return commands.map((command) => ({ command_id: command.command_id, state: command.state }));
+}
+
+function packageScriptEnrollmentState(
+  command: LocalCliCommand,
+  pending: LocalCliState,
+): LocalCliCommandState {
+  if (command.command_id === "root" || command.command_id === "other") return command.state;
+  if (pending === "blocked") return "block";
+  if (command.state === "block") return "block";
+  if (pending === "allowed") return "allow";
+  return command.state;
+}
+
+function colonPartsMatch(name: string, needle: string): boolean {
+  const queryParts = needle.split(":").map((part) => part.trim()).filter(Boolean);
+  if (queryParts.length < 2) return false;
+  const nameParts = name.toLowerCase().split(":");
+  let index = 0;
+  for (const part of nameParts) {
+    if (index < queryParts.length && part.includes(queryParts[index]!)) index += 1;
+  }
+  return index === queryParts.length;
 }
 
 function packageScriptFilterNeedle(query: string): string {

--- a/dashboard/src/local-cli-links.ts
+++ b/dashboard/src/local-cli-links.ts
@@ -2,9 +2,19 @@ import { parseExtensionRoute, type ExtensionRoute } from "./extension-control-ce
 
 const LOCAL_CLI_ID_PATTERN = /^local-cli\.[a-z0-9]+(?:-[a-z0-9]+){0,8}$/;
 
-export type ProtectionRoute = ExtensionRoute | { kind: "local-cli"; cliId: string };
+export type ProtectionRoute =
+  | ExtensionRoute
+  | { kind: "local-cli"; cliId: string }
+  | { kind: "add-custom" };
+
+export function addCustomExtensionHref(): string {
+  return "/extensions/add";
+}
 
 export function parseProtectionRoute(pathname: string): ProtectionRoute {
+  if (pathname === "/extensions/add" || pathname === "/extensions/add/") {
+    return { kind: "add-custom" };
+  }
   if (pathname.startsWith("/extensions/local-cli/")) {
     try {
       const cliId = decodeURIComponent(pathname.slice("/extensions/local-cli/".length)).trim().toLowerCase();

--- a/dashboard/src/protection-center/add-custom-extension-dialog.tsx
+++ b/dashboard/src/protection-center/add-custom-extension-dialog.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ChangeEvent, FormEvent } from "react";
+import { HiMiniArrowLeft } from "react-icons/hi2";
 
 import {
   ApprovalProofFieldInputs,
@@ -8,6 +9,8 @@ import {
 } from "../approval-proof-inline";
 import {
   applyLocalCliMutation,
+  enrollablePackageScriptCommands,
+  enrollmentCommandStates,
   filterExtensionSuggestions,
   filterPackageScriptCommands,
   LocalCliApiError,
@@ -32,10 +35,8 @@ import {
   ProjectSwitcher,
   SuggestionPanel,
   suggestionSummary,
-  surfaceBadge,
 } from "./add-custom-extension-support";
-import { CustomExtensionCommandList, commandStatesPayload, withCommandState } from "./custom-extension-commands";
-import { useModalDialog } from "../use-modal-dialog";
+import { CustomExtensionCommandList, withCommandState } from "./custom-extension-commands";
 import { useResolvedApprovalGate } from "../use-resolved-approval-gate";
 import { InlineError } from "./components/protection-primitives";
 
@@ -43,10 +44,10 @@ function randomToken(): string {
   return crypto.randomUUID().replaceAll("-", "");
 }
 
-export function AddCustomExtensionDialog(props: {
+export function AddCustomExtensionWorkspace(props: {
   items: LocalCliItem[];
   revision: number;
-  onClose: () => void;
+  onBack: () => void;
   onAdded: (cliId: string) => void;
 }) {
   const { resolvedApprovalGate, resolveApprovalGate } = useResolvedApprovalGate(null);
@@ -59,23 +60,14 @@ export function AddCustomExtensionDialog(props: {
   const [totp, setTotp] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const dialogRef = useModalDialog<HTMLFormElement>(props.onClose, !busy);
+  const [reviewingScripts, setReviewingScripts] = useState(false);
   const recognizeGeneration = useRef(0);
   const autoRecognizedCommand = useRef("");
   const didAutoSelect = useRef(false);
   const rememberedProjects = suggestedPackageScriptExtensions(props.items);
-  const packageScriptSuggestions = filterExtensionSuggestions(
-    rememberedProjects,
-    command,
-  ).slice(0, 6);
-  const harnessSuggestions = filterExtensionSuggestions(
-    suggestedHarnessExtensions(props.items),
-    command,
-  ).slice(0, 8);
-  const seenSuggestions = filterExtensionSuggestions(
-    suggestedSeenExtensions(props.items),
-    command,
-  ).slice(0, 6);
+  const packageScriptSuggestions = filterExtensionSuggestions(rememberedProjects, command).slice(0, 8);
+  const harnessSuggestions = filterExtensionSuggestions(suggestedHarnessExtensions(props.items), command).slice(0, 8);
+  const seenSuggestions = filterExtensionSuggestions(suggestedSeenExtensions(props.items), command).slice(0, 6);
   const hasSuggestions = packageScriptSuggestions.length > 0
     || harnessSuggestions.length > 0
     || seenSuggestions.length > 0;
@@ -99,6 +91,7 @@ export function AddCustomExtensionDialog(props: {
     setCommands([]);
     setSummary(null);
     setPending(null);
+    setReviewingScripts(false);
   }, [commands, recognized]);
   const handlePassword = useCallback((event: ChangeEvent<HTMLInputElement>) => {
     setPassword(event.target.value);
@@ -145,6 +138,7 @@ export function AddCustomExtensionDialog(props: {
     setCommands(item.commands);
     setSummary(suggestionSummary(item));
     setPending(item.surface === "package-scripts" && item.commands.length > 0 ? "allowed" : null);
+    setReviewingScripts(false);
   }, [runRecognize]);
   const findTool = useCallback(async () => {
     await runRecognize(command);
@@ -168,6 +162,8 @@ export function AddCustomExtensionDialog(props: {
   }, [busy, command, recognized, runRecognize]);
   const requestAllow = useCallback(() => setPending("allowed"), []);
   const requestBlock = useCallback(() => setPending("blocked"), []);
+  const openScriptReview = useCallback(() => setReviewingScripts(true), []);
+  const closeScriptReview = useCallback(() => setReviewingScripts(false), []);
   const handleSubmit = useCallback(async (event: FormEvent) => {
     event.preventDefault();
     if (recognized === null) {
@@ -188,7 +184,7 @@ export function AddCustomExtensionDialog(props: {
         state: pending,
         previous_revision: props.revision,
         session_nonce: randomToken(),
-        commands: commandStatesPayload(commands),
+        commands: enrollmentCommandStates(commands, pending, recognized.surface),
         ...buildApprovalProofCredentials(resolvedApprovalGate, {
           approvalPassword: password,
           approvalTotpCode: totp,
@@ -215,98 +211,89 @@ export function AddCustomExtensionDialog(props: {
       { approvalPassword: password, approvalTotpCode: totp },
       busy,
     );
-  const submitLabel = addDialogSubmitLabel({
-    recognized,
-    busy,
-    pending,
-  });
   const showingPackageCatalog = recognized?.surface === "package-scripts";
+  const enrollable = enrollablePackageScriptCommands(commands);
   const visibleCommands = showingPackageCatalog
-    ? filterPackageScriptCommands(commands, command)
+    ? filterPackageScriptCommands(enrollable, command)
     : commands;
-  const commandLabel = showingPackageCatalog ? "Filter scripts" : "Command";
-  const commandPlaceholder = showingPackageCatalog
-    ? "guard:audit"
-    : "npm run guard:audit";
+  const previewNames = visibleCommands.slice(0, 8).map((entry) => entry.name);
 
   return (
-    <div className="fixed inset-0 z-50 grid place-items-center bg-slate-950/45 p-4 backdrop-blur-sm">
-      <form
-        ref={dialogRef}
-        tabIndex={-1}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="add-custom-extension-title"
-        onSubmit={handleSubmit}
-        className="w-full max-w-lg rounded-3xl bg-white p-6 shadow-2xl focus:outline-none"
-      >
-        <h2 id="add-custom-extension-title" className="text-xl font-semibold text-brand-dark">Add a custom extension</h2>
-        <p className="mt-2 text-sm leading-6 text-brand-dark/80">
+    <form
+      data-testid="add-custom-extension"
+      onSubmit={handleSubmit}
+      className="flex min-h-[70vh] w-full flex-col"
+    >
+      <button type="button" onClick={props.onBack} className="inline-flex min-h-11 w-fit items-center gap-2 rounded-lg px-1 text-sm font-semibold text-brand-dark/80 hover:text-brand-dark">
+        <HiMiniArrowLeft className="size-4" aria-hidden="true" />
+        Extensions
+      </button>
+      <header className="mt-4 max-w-2xl border-b border-slate-200 pb-6">
+        <h1 id="add-custom-extension-title" className="text-2xl font-semibold tracking-tight text-brand-dark">Add a custom extension</h1>
+        <p className="mt-2 text-sm leading-6 text-slate-500">
           {dialogIntro(rememberedProjects.length > 0, showingPackageCatalog === true)}
         </p>
-        <label htmlFor="custom-extension-command" className="mt-5 block text-sm font-semibold text-brand-dark">{commandLabel}</label>
-        <input
-          id="custom-extension-command"
-          value={command}
-          onChange={handleCommand}
-          spellCheck={false}
-          autoComplete="off"
-          placeholder={commandPlaceholder}
-          className="mt-2 min-h-11 w-full rounded-xl border border-slate-300 px-3 text-sm text-brand-dark placeholder:text-brand-dark/40 focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/30"
+      </header>
+      <label htmlFor="custom-extension-command" className="mt-6 block text-sm font-semibold text-brand-dark">
+        {showingPackageCatalog ? "Find a script" : "Command"}
+      </label>
+      <input
+        id="custom-extension-command"
+        value={command}
+        onChange={handleCommand}
+        spellCheck={false}
+        autoComplete="off"
+        placeholder={showingPackageCatalog ? "guard:audit" : "npm run guard:audit"}
+        className="mt-2 min-h-11 w-full max-w-xl rounded-xl border border-slate-300 bg-white px-3 text-sm text-brand-dark placeholder:text-brand-dark/40 focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/30"
+      />
+      {recognized !== null && showingPackageCatalog ? (
+        <ProjectSwitcher items={rememberedProjects} currentId={recognized.cli_id} onSelect={selectSuggestion} />
+      ) : null}
+      {recognized ? (
+        <section className="mt-8 max-w-3xl" aria-labelledby="custom-extension-selected">
+          <h2 id="custom-extension-selected" className="text-xl font-semibold tracking-tight text-brand-dark">
+            {recognized.name}
+          </h2>
+          <p className="mt-1 font-mono text-xs text-brand-dark/70">
+            {recognized.source_label ? `${recognized.source_label} · ${recognized.example_label}` : recognized.example_label}
+          </p>
+          {summary ? <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-500">{summary}</p> : null}
+          {showingPackageCatalog ? (
+            <PackageScriptPreview
+              query={command}
+              previewNames={previewNames}
+              visibleCount={visibleCommands.length}
+              totalCount={enrollable.length}
+              reviewing={reviewingScripts}
+              onOpenReview={openScriptReview}
+              onCloseReview={closeScriptReview}
+            />
+          ) : null}
+          {(!showingPackageCatalog || reviewingScripts) && visibleCommands.length > 0 ? (
+            <div className="mt-4 overflow-auto rounded-2xl border border-slate-200 bg-white">
+              <CustomExtensionCommandList
+                commands={visibleCommands}
+                disabled={busy}
+                surface={recognized.surface}
+                onChange={handleCommandState}
+              />
+            </div>
+          ) : null}
+        </section>
+      ) : (
+        <SuggestionPanel
+          query={command}
+          hasSuggestions={hasSuggestions}
+          packageScriptSuggestions={packageScriptSuggestions}
+          harnessSuggestions={harnessSuggestions}
+          seenSuggestions={seenSuggestions}
+          onSelect={selectSuggestion}
         />
-        <p className="mt-2 text-sm leading-6 text-brand-dark/70">
-          {showingPackageCatalog
-            ? "Typing filters nested names. Allow still enrolls every script in this project."
-            : <>One command. A script, a binary, <span className="font-medium">npm run</span>, a project folder, or an MCP launch. Not a pipeline.</>}
-        </p>
-        {recognized !== null && showingPackageCatalog ? (
-          <ProjectSwitcher
-            items={rememberedProjects}
-            currentId={recognized.cli_id}
-            onSelect={selectSuggestion}
-          />
-        ) : null}
-        {recognized ? (
-          <div className="mt-5 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
-            <div className="flex flex-wrap items-center gap-2">
-              <p className="text-sm font-semibold text-brand-dark">{recognized.name}</p>
-              {surfaceBadge(recognized.surface) ? (
-                <span className="rounded-full bg-white px-2 py-0.5 text-[11px] font-semibold tracking-wide text-brand-dark/70 ring-1 ring-slate-200">
-                  {surfaceBadge(recognized.surface)}
-                </span>
-              ) : null}
-            </div>
-            <p className="mt-1 font-mono text-xs text-brand-dark/70">
-              {recognized.source_label ? `${recognized.source_label} · ${recognized.example_label}` : recognized.example_label}
-            </p>
-            {summary ? <p className="mt-2 text-sm leading-6 text-brand-dark/80">{summary}</p> : null}
-            {showingPackageCatalog && command.trim() !== "" ? (
-              <p className="mt-2 text-xs leading-5 text-brand-dark/60">
-                {filterCountCopy(visibleCommands.length, commands.length)}
-              </p>
-            ) : null}
-            {visibleCommands.length > 0 ? (
-              <div className={`mt-4 overflow-auto rounded-2xl bg-white ${showingPackageCatalog ? "max-h-96" : "max-h-72"}`}>
-                <CustomExtensionCommandList
-                  commands={visibleCommands}
-                  disabled={busy}
-                  surface={recognized.surface}
-                  onChange={handleCommandState}
-                />
-              </div>
-            ) : null}
-            <div className="mt-4 flex flex-wrap gap-2">
-              <button type="button" onClick={requestAllow} className={`min-h-11 rounded-xl px-4 text-sm font-semibold ${pending === "allowed" ? "bg-brand-blue text-white" : "border border-slate-300 text-brand-dark"}`}>
-                {allowActionLabel(recognized.surface)}
-              </button>
-              <button type="button" onClick={requestBlock} className={`min-h-11 rounded-xl px-4 text-sm font-semibold ${pending === "blocked" ? "bg-brand-dark text-white" : "border border-slate-300 text-brand-dark"}`}>
-                {blockActionLabel(recognized.surface)}
-              </button>
-            </div>
-          </div>
-        ) : null}
+      )}
+      {error ? <div className="mt-4 max-w-xl"><InlineError message={error} /></div> : null}
+      <div className="sticky bottom-0 mt-auto border-t border-slate-200 bg-white py-4">
         {proofReady ? (
-          <div className="mt-5">
+          <div className="mb-4 max-w-sm">
             <ApprovalProofFieldInputs
               approvalGate={resolvedApprovalGate}
               approvalPassword={password}
@@ -316,24 +303,61 @@ export function AddCustomExtensionDialog(props: {
             />
           </div>
         ) : null}
-        {recognized === null ? (
-          <SuggestionPanel
-            query={command}
-            hasSuggestions={hasSuggestions}
-            packageScriptSuggestions={packageScriptSuggestions}
-            harnessSuggestions={harnessSuggestions}
-            seenSuggestions={seenSuggestions}
-            onSelect={selectSuggestion}
-          />
-        ) : null}
-        {error ? <div className="mt-4"><InlineError message={error} /></div> : null}
-        <div className="mt-6 flex justify-end gap-3">
-          <button type="button" disabled={busy} onClick={props.onClose} className="min-h-11 rounded-xl px-4 text-sm font-semibold text-brand-dark">Cancel</button>
+        <div className="flex flex-wrap items-center gap-3">
           <button type="submit" disabled={submitDisabled} className="min-h-11 rounded-xl bg-brand-blue px-5 text-sm font-semibold text-white disabled:opacity-60">
-            {submitLabel}
+            {addDialogSubmitLabel({ recognized, busy, pending })}
           </button>
+          {recognized && showingPackageCatalog && pending === "allowed" ? (
+            <button type="button" onClick={requestBlock} className="min-h-11 rounded-xl px-4 text-sm font-semibold text-brand-dark">
+              {blockActionLabel(recognized.surface)}
+            </button>
+          ) : null}
+          {recognized && showingPackageCatalog && pending === "blocked" ? (
+            <button type="button" onClick={requestAllow} className="min-h-11 rounded-xl px-4 text-sm font-semibold text-brand-dark">
+              {allowActionLabel(recognized.surface)}
+            </button>
+          ) : null}
         </div>
-      </form>
+      </div>
+    </form>
+  );
+}
+
+function PackageScriptPreview(props: {
+  query: string;
+  previewNames: string[];
+  visibleCount: number;
+  totalCount: number;
+  reviewing: boolean;
+  onOpenReview: () => void;
+  onCloseReview: () => void;
+}) {
+  return (
+    <div className="mt-5">
+      {props.query.trim() !== "" ? (
+        <p className="text-xs leading-5 text-brand-dark/60">{filterCountCopy(props.visibleCount, props.totalCount)}</p>
+      ) : null}
+      {props.previewNames.length > 0 && !props.reviewing ? (
+        <ul className="mt-3 flex flex-wrap gap-2">
+          {props.previewNames.map((name) => (
+            <li key={name} className="rounded-full bg-slate-100 px-3 py-1.5 font-mono text-xs text-brand-dark">
+              {name}
+            </li>
+          ))}
+          {props.visibleCount > props.previewNames.length ? (
+            <li className="rounded-full px-3 py-1.5 text-xs font-semibold text-brand-dark/60">
+              +{props.visibleCount - props.previewNames.length} more
+            </li>
+          ) : null}
+        </ul>
+      ) : null}
+      <button
+        type="button"
+        onClick={props.reviewing ? props.onCloseReview : props.onOpenReview}
+        className="mt-4 min-h-11 text-sm font-semibold text-brand-blue"
+      >
+        {props.reviewing ? "Hide individual settings" : "Adjust individual scripts"}
+      </button>
     </div>
   );
 }

--- a/dashboard/src/protection-center/add-custom-extension-support.test.ts
+++ b/dashboard/src/protection-center/add-custom-extension-support.test.ts
@@ -40,12 +40,9 @@ const packageItem: LocalCliItem = {
   ],
 };
 
-assert.equal(
-  dialogIntro(true, true),
-  "Confirm these project scripts, or type a nested name to find one fast.",
-);
-assert.match(filterCountCopy(1, 8), /Showing 1 of 8/);
-assert.match(suggestionSummary(packageItem), /Ready to enroll 1 script from ads-app/);
+assert.match(dialogIntro(true, true), /Allow these scripts/);
+assert.match(filterCountCopy(1, 8), /1 of 8 scripts match/);
+assert.match(suggestionSummary(packageItem), /1 script from ads-app/);
 assert.equal(
   addDialogSubmitLabel({ recognized: packageItem, busy: false, pending: "allowed" }),
   "Allow these scripts",

--- a/dashboard/src/protection-center/add-custom-extension-support.tsx
+++ b/dashboard/src/protection-center/add-custom-extension-support.tsx
@@ -1,6 +1,10 @@
 import { useCallback } from "react";
 
-import { seenSuggestionMeta, type LocalCliItem, type LocalCliState } from "../local-cli-api";
+import { enrollablePackageScriptCommands, seenSuggestionMeta, type LocalCliItem, type LocalCliState } from "../local-cli-api";
+
+function enrollableCount(item: LocalCliItem): number {
+  return Math.max(enrollablePackageScriptCommands(item.commands).length, 0);
+}
 
 export function addDialogSubmitLabel(input: {
   recognized: LocalCliItem | null;
@@ -39,7 +43,7 @@ export function blockActionLabel(surface: LocalCliItem["surface"]): string {
 
 export function dialogIntro(hasProjects: boolean, showingCatalog: boolean): string {
   if (showingCatalog) {
-    return "Confirm these project scripts, or type a nested name to find one fast.";
+    return "Allow these scripts so Protect can stop asking about them. Type a nested name such as guard:audit to inspect one.";
   }
   if (hasProjects) {
     return "Guard already found project scripts on this device. Pick a project, or paste another folder.";
@@ -48,16 +52,16 @@ export function dialogIntro(hasProjects: boolean, showingCatalog: boolean): stri
 }
 
 export function filterCountCopy(visible: number, total: number): string {
-  if (visible === 0) return "No scripts match that name. Try another nested name, or paste a different project folder.";
+  if (visible === 0) return "No scripts match that name. Try another nested name, or pick a different project.";
   if (visible === total) return `${visible} scripts in this project.`;
-  return `Showing ${visible} of ${total} scripts. Allow still covers the whole project.`;
+  return `${visible} of ${total} scripts match. Allow still enrolls the whole project.`;
 }
 
 export function suggestionSummary(item: LocalCliItem): string {
   if (item.surface === "package-scripts" && item.commands.length > 0) {
-    const count = item.commands.length;
+    const count = enrollableCount(item);
     const unit = count === 1 ? "script" : "scripts";
-    return `Ready to enroll ${count} ${unit} from ${item.source_label ?? item.name}. Nested names stay grouped. Recommended keeps the usual review.`;
+    return `${count} ${unit} from ${item.source_label ?? item.name}. Allow lets this project's scripts run. Nested names stay grouped.`;
   }
   if (item.surface === "package-scripts") {
     return `Find this tool to list npm scripts from ${item.name}.`;

--- a/dashboard/src/protection-center/extensions-overview.tsx
+++ b/dashboard/src/protection-center/extensions-overview.tsx
@@ -9,7 +9,6 @@ import { addedCustomExtensions, type LocalCliItem } from "../local-cli-api";
 import { WorkspacePageHeader } from "../workspace-page-header";
 import {
   AddCustomExtensionButton,
-  AddCustomExtensionDialog,
   CustomExtensionsSection,
 } from "./local-clis-panel";
 import { PatternSearchConsole } from "./components/pattern-search-console";
@@ -68,20 +67,16 @@ export function ExtensionsOverview(props: {
   catalogExtensions: ExtensionCatalogItem[];
   effective: EffectiveExtensionControls;
   localCliItems: LocalCliItem[];
-  localCliRevision: number;
   mutationError: string | null;
   recoveryStatus: string | null;
   healthBroken: boolean;
   status: ProtectionStatusView;
-  addingCustom: boolean;
   active: boolean;
   onPrimaryStatusAction?: () => void;
   onRefresh: () => Promise<void> | void;
   onOpenExtension: (extension: ExtensionCatalogItem) => void;
   onOpenLocalCli: (cliId: string) => void;
   onAddCustom: () => void;
-  onCloseAddCustom: () => void;
-  onCustomExtensionAdded: (cliId: string) => void;
 }) {
   const [query, setQuery] = useState("");
   // An active search replaces the catalogs below it: results, then the Tools
@@ -160,14 +155,6 @@ export function ExtensionsOverview(props: {
         </>
       )}
 
-      {props.addingCustom ? (
-        <AddCustomExtensionDialog
-          items={props.localCliItems}
-          revision={props.localCliRevision}
-          onClose={props.onCloseAddCustom}
-          onAdded={props.onCustomExtensionAdded}
-        />
-      ) : null}
     </div>
   );
 }

--- a/dashboard/src/protection-center/local-clis-panel.tsx
+++ b/dashboard/src/protection-center/local-clis-panel.tsx
@@ -24,7 +24,7 @@ import { useModalDialog } from "../use-modal-dialog";
 import { useResolvedApprovalGate } from "../use-resolved-approval-gate";
 import { InlineError, ProtectionModuleRow } from "./components/protection-primitives";
 
-export { AddCustomExtensionDialog } from "./add-custom-extension-dialog";
+export { AddCustomExtensionWorkspace } from "./add-custom-extension-dialog";
 
 function randomToken(): string {
   return crypto.randomUUID().replaceAll("-", "");

--- a/dashboard/src/protection-center/protection-center-workspace.tsx
+++ b/dashboard/src/protection-center/protection-center-workspace.tsx
@@ -13,8 +13,8 @@ import {
   readExtensionDetailUrlState,
   type ExtensionDetailUrlState,
 } from "../extension-control-center-model";
-import { parseProtectionRoute, localCliHref, type ProtectionRoute } from "../local-cli-links";
-import { LocalCliDetail, useLocalCliCatalog } from "./local-clis-panel";
+import { parseProtectionRoute, localCliHref, addCustomExtensionHref, type ProtectionRoute } from "../local-cli-links";
+import { AddCustomExtensionWorkspace, LocalCliDetail, useLocalCliCatalog } from "./local-clis-panel";
 import {
   acknowledgeDegradedExtensionControlAuthority,
   applyExtensionMutation,
@@ -218,8 +218,6 @@ export function ProtectionCenterWorkspace() {
   const aliasRedirected = useRef<string | null>(null);
   const overviewKeepAlive = useRef(false);
   const localClis = useLocalCliCatalog();
-  const [addingCustom, setAddingCustom] = useState(false);
-
   const load = useCallback(async (): Promise<EffectiveExtensionControls | null> => {
     // Keep the already-rendered protection data mounted while a refresh is in
     // flight so an applied change's confirmation toast survives the reload.
@@ -273,24 +271,22 @@ export function ProtectionCenterWorkspace() {
   }, []);
 
   const openLocalCliDetail = useCallback((cliId: string) => {
-    setAddingCustom(false);
     pushExtensionHistory(localCliHref(cliId));
     setRouteState({ route: { kind: "local-cli", cliId }, detail: DEFAULT_EXTENSION_DETAIL_URL_STATE });
     window.scrollTo({ top: 0, behavior: "auto" });
   }, []);
-  const openAddCustom = useCallback(() => setAddingCustom(true), []);
-  const closeAddCustom = useCallback(() => setAddingCustom(false), []);
+  const openAddCustom = useCallback(() => {
+    pushExtensionHistory(addCustomExtensionHref());
+    setRouteState({ route: { kind: "add-custom" }, detail: DEFAULT_EXTENSION_DETAIL_URL_STATE });
+    window.scrollTo({ top: 0, behavior: "auto" });
+  }, []);
   const handleCustomExtensionAdded = useCallback((cliId: string) => {
     void localClis.load();
-    closeAddCustom();
     openLocalCliDetail(cliId);
-  }, [closeAddCustom, localClis.load, openLocalCliDetail]);
-  const retryLocalClis = useCallback(() => {
-    void localClis.load();
-  }, [localClis.load]);
-  const retryLoad = useCallback(() => {
-    void load();
-  }, [load]);
+  }, [localClis.load, openLocalCliDetail]);
+
+  const retryLocalClis = useCallback(() => { void localClis.load(); }, [localClis.load]);
+  const retryLoad = useCallback(() => { void load(); }, [load]);
   const refreshProtection = useCallback(async () => {
     await load();
   }, [load]);
@@ -392,9 +388,7 @@ export function ProtectionCenterWorkspace() {
   }, [authorityNeedsAttention, resolveApprovalGate]);
 
   const showOverview = state.kind === "ready" && routeState.route.kind === "overview";
-  if (showOverview) {
-    overviewKeepAlive.current = true;
-  }
+  if (showOverview) overviewKeepAlive.current = true;
   const keepOverviewMounted = state.kind === "ready" && (showOverview || overviewKeepAlive.current);
   const localCliRoute = routeState.route.kind === "local-cli" ? routeState.route : null;
   const selectedLocalCli = localCliRoute
@@ -439,20 +433,16 @@ export function ProtectionCenterWorkspace() {
           catalogExtensions={catalogExtensions}
           effective={state.effective}
           localCliItems={localClis.data?.items ?? []}
-          localCliRevision={localClis.data?.revision ?? 0}
           mutationError={mutationError && !pending ? mutationError : null}
           recoveryStatus={recoveryStatus}
           healthBroken={healthBroken}
           status={status}
-          addingCustom={addingCustom && showOverview}
           active={showOverview}
           onPrimaryStatusAction={handlePrimaryStatusAction}
           onRefresh={refreshProtection}
           onOpenExtension={openExtension}
           onOpenLocalCli={openLocalCliDetail}
           onAddCustom={openAddCustom}
-          onCloseAddCustom={closeAddCustom}
-          onCustomExtensionAdded={handleCustomExtensionAdded}
         />
       ) : null}
       {showLocalCli && localClis.error && !localClis.data ? (
@@ -464,6 +454,14 @@ export function ProtectionCenterWorkspace() {
       ) : null}
       {showLocalCli && !localClis.data && !localClis.error ? (
         <ExtensionsLoadingState label="Loading custom extension" />
+      ) : null}
+      {routeState.route.kind === "add-custom" && state.kind === "ready" ? (
+        <AddCustomExtensionWorkspace
+          items={localClis.data?.items ?? []}
+          revision={localClis.data?.revision ?? 0}
+          onBack={closeExtension}
+          onAdded={handleCustomExtensionAdded}
+        />
       ) : null}
       {showLocalCli && selectedLocalCli && localClis.data ? (
         <LocalCliDetail

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
@@ -182,7 +182,13 @@ function groupPermissionsByFamily(permissions) {
   return { ungrouped, families };
 }
 const LOCAL_CLI_ID_PATTERN = /^local-cli\.[a-z0-9]+(?:-[a-z0-9]+){0,8}$/;
+function addCustomExtensionHref() {
+  return "/extensions/add";
+}
 function parseProtectionRoute(pathname) {
+  if (pathname === "/extensions/add" || pathname === "/extensions/add/") {
+    return { kind: "add-custom" };
+  }
   if (pathname.startsWith("/extensions/local-cli/")) {
     try {
       const cliId = decodeURIComponent(pathname.slice("/extensions/local-cli/".length)).trim().toLowerCase();
@@ -286,7 +292,39 @@ function filterPackageScriptCommands(commands, query) {
   return commands.filter((command) => commandMatchesQuery(command, needle));
 }
 function commandMatchesQuery(command, needle) {
-  return [command.name, command.usage, command.description].some((value) => value.toLowerCase().includes(needle));
+  const haystacks = [command.name, command.usage, command.description];
+  if (haystacks.some((value) => value.toLowerCase().includes(needle))) return true;
+  return colonPartsMatch(command.name, needle);
+}
+function enrollablePackageScriptCommands(commands) {
+  return commands.filter((command) => command.command_id !== "root" && command.command_id !== "other");
+}
+function enrollmentCommandStates(commands, pending, surface) {
+  if (surface !== "package-scripts") return commandStatesFrom(commands);
+  return commands.map((command) => ({
+    command_id: command.command_id,
+    state: packageScriptEnrollmentState(command, pending)
+  }));
+}
+function commandStatesFrom(commands) {
+  return commands.map((command) => ({ command_id: command.command_id, state: command.state }));
+}
+function packageScriptEnrollmentState(command, pending) {
+  if (command.command_id === "root" || command.command_id === "other") return command.state;
+  if (pending === "blocked") return "block";
+  if (command.state === "block") return "block";
+  if (pending === "allowed") return "allow";
+  return command.state;
+}
+function colonPartsMatch(name, needle) {
+  const queryParts = needle.split(":").map((part) => part.trim()).filter(Boolean);
+  if (queryParts.length < 2) return false;
+  const nameParts = name.toLowerCase().split(":");
+  let index = 0;
+  for (const part of nameParts) {
+    if (index < queryParts.length && part.includes(queryParts[index])) index += 1;
+  }
+  return index === queryParts.length;
 }
 function packageScriptFilterNeedle(query) {
   const trimmed = query.trim().toLowerCase();
@@ -2716,6 +2754,9 @@ function TechnicalDetails(props) {
 function InlineError({ message }) {
   return /* @__PURE__ */ jsxRuntimeExports.jsx("p", { role: "alert", className: "rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800", children: message });
 }
+function enrollableCount(item) {
+  return Math.max(enrollablePackageScriptCommands(item.commands).length, 0);
+}
 function addDialogSubmitLabel(input) {
   if (input.recognized === null) {
     return input.busy ? "Looking…" : "Find this tool";
@@ -2727,11 +2768,6 @@ function addDialogSubmitLabel(input) {
     return blockActionLabel(input.recognized.surface);
   }
   return allowActionLabel(input.recognized.surface);
-}
-function surfaceBadge(surface) {
-  if (surface === "mcp") return "MCP server";
-  if (surface === "package-scripts") return "Package scripts";
-  return null;
 }
 function allowActionLabel(surface) {
   if (surface === "mcp") return "Allow this server";
@@ -2745,7 +2781,7 @@ function blockActionLabel(surface) {
 }
 function dialogIntro(hasProjects, showingCatalog) {
   if (showingCatalog) {
-    return "Confirm these project scripts, or type a nested name to find one fast.";
+    return "Allow these scripts so Protect can stop asking about them. Type a nested name such as guard:audit to inspect one.";
   }
   if (hasProjects) {
     return "Guard already found project scripts on this device. Pick a project, or paste another folder.";
@@ -2753,15 +2789,15 @@ function dialogIntro(hasProjects, showingCatalog) {
   return "Paste a script, binary, MCP launch, or package scripts such as npm run. Everyday commands such as rg, grep, and whoami are not custom extensions.";
 }
 function filterCountCopy(visible, total) {
-  if (visible === 0) return "No scripts match that name. Try another nested name, or paste a different project folder.";
+  if (visible === 0) return "No scripts match that name. Try another nested name, or pick a different project.";
   if (visible === total) return `${visible} scripts in this project.`;
-  return `Showing ${visible} of ${total} scripts. Allow still covers the whole project.`;
+  return `${visible} of ${total} scripts match. Allow still enrolls the whole project.`;
 }
 function suggestionSummary(item) {
   if (item.surface === "package-scripts" && item.commands.length > 0) {
-    const count = item.commands.length;
+    const count = enrollableCount(item);
     const unit = count === 1 ? "script" : "scripts";
-    return `Ready to enroll ${count} ${unit} from ${item.source_label ?? item.name}. Nested names stay grouped. Recommended keeps the usual review.`;
+    return `${count} ${unit} from ${item.source_label ?? item.name}. Allow lets this project's scripts run. Nested names stay grouped.`;
   }
   if (item.surface === "package-scripts") {
     return `Find this tool to list npm scripts from ${item.name}.`;
@@ -2867,7 +2903,7 @@ function SuggestionButton(props) {
 function randomToken$2() {
   return crypto.randomUUID().replaceAll("-", "");
 }
-function AddCustomExtensionDialog(props) {
+function AddCustomExtensionWorkspace(props) {
   const { resolvedApprovalGate, resolveApprovalGate } = useResolvedApprovalGate(null);
   const [command, setCommand] = reactExports.useState("");
   const [recognized, setRecognized] = reactExports.useState(null);
@@ -2878,23 +2914,14 @@ function AddCustomExtensionDialog(props) {
   const [totp, setTotp] = reactExports.useState("");
   const [busy, setBusy] = reactExports.useState(false);
   const [error, setError] = reactExports.useState(null);
-  const dialogRef = useModalDialog(props.onClose, !busy);
+  const [reviewingScripts, setReviewingScripts] = reactExports.useState(false);
   const recognizeGeneration = reactExports.useRef(0);
   const autoRecognizedCommand = reactExports.useRef("");
   const didAutoSelect = reactExports.useRef(false);
   const rememberedProjects = suggestedPackageScriptExtensions(props.items);
-  const packageScriptSuggestions = filterExtensionSuggestions(
-    rememberedProjects,
-    command
-  ).slice(0, 6);
-  const harnessSuggestions = filterExtensionSuggestions(
-    suggestedHarnessExtensions(props.items),
-    command
-  ).slice(0, 8);
-  const seenSuggestions = filterExtensionSuggestions(
-    suggestedSeenExtensions(props.items),
-    command
-  ).slice(0, 6);
+  const packageScriptSuggestions = filterExtensionSuggestions(rememberedProjects, command).slice(0, 8);
+  const harnessSuggestions = filterExtensionSuggestions(suggestedHarnessExtensions(props.items), command).slice(0, 8);
+  const seenSuggestions = filterExtensionSuggestions(suggestedSeenExtensions(props.items), command).slice(0, 6);
   const hasSuggestions = packageScriptSuggestions.length > 0 || harnessSuggestions.length > 0 || seenSuggestions.length > 0;
   reactExports.useEffect(() => {
     void resolveApprovalGate({ failClosed: true }).catch(() => {
@@ -2914,6 +2941,7 @@ function AddCustomExtensionDialog(props) {
     setCommands([]);
     setSummary(null);
     setPending(null);
+    setReviewingScripts(false);
   }, [commands, recognized]);
   const handlePassword = reactExports.useCallback((event) => {
     setPassword(event.target.value);
@@ -2960,6 +2988,7 @@ function AddCustomExtensionDialog(props) {
     setCommands(item.commands);
     setSummary(suggestionSummary(item));
     setPending(item.surface === "package-scripts" && item.commands.length > 0 ? "allowed" : null);
+    setReviewingScripts(false);
   }, [runRecognize]);
   const findTool = reactExports.useCallback(async () => {
     await runRecognize(command);
@@ -2983,6 +3012,8 @@ function AddCustomExtensionDialog(props) {
   }, [busy, command, recognized, runRecognize]);
   const requestAllow = reactExports.useCallback(() => setPending("allowed"), []);
   const requestBlock = reactExports.useCallback(() => setPending("blocked"), []);
+  const openScriptReview = reactExports.useCallback(() => setReviewingScripts(true), []);
+  const closeScriptReview = reactExports.useCallback(() => setReviewingScripts(false), []);
   const handleSubmit = reactExports.useCallback(async (event) => {
     event.preventDefault();
     if (recognized === null) {
@@ -3003,7 +3034,7 @@ function AddCustomExtensionDialog(props) {
         state: pending,
         previous_revision: props.revision,
         session_nonce: randomToken$2(),
-        commands: commandStatesPayload(commands),
+        commands: enrollmentCommandStates(commands, pending, recognized.surface),
         ...buildApprovalProofCredentials(resolvedApprovalGate, {
           approvalPassword: password,
           approvalTotpCode: totp
@@ -3027,29 +3058,26 @@ function AddCustomExtensionDialog(props) {
     { approvalPassword: password, approvalTotpCode: totp },
     busy
   );
-  const submitLabel = addDialogSubmitLabel({
-    recognized,
-    busy,
-    pending
-  });
   const showingPackageCatalog = recognized?.surface === "package-scripts";
-  const visibleCommands = showingPackageCatalog ? filterPackageScriptCommands(commands, command) : commands;
-  const commandLabel = showingPackageCatalog ? "Filter scripts" : "Command";
-  const commandPlaceholder = showingPackageCatalog ? "guard:audit" : "npm run guard:audit";
-  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "fixed inset-0 z-50 grid place-items-center bg-slate-950/45 p-4 backdrop-blur-sm", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(
+  const enrollable = enrollablePackageScriptCommands(commands);
+  const visibleCommands = showingPackageCatalog ? filterPackageScriptCommands(enrollable, command) : commands;
+  const previewNames = visibleCommands.slice(0, 8).map((entry) => entry.name);
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs(
     "form",
     {
-      ref: dialogRef,
-      tabIndex: -1,
-      role: "dialog",
-      "aria-modal": "true",
-      "aria-labelledby": "add-custom-extension-title",
+      "data-testid": "add-custom-extension",
       onSubmit: handleSubmit,
-      className: "w-full max-w-lg rounded-3xl bg-white p-6 shadow-2xl focus:outline-none",
+      className: "flex min-h-[70vh] w-full flex-col",
       children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { id: "add-custom-extension-title", className: "text-xl font-semibold text-brand-dark", children: "Add a custom extension" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm leading-6 text-brand-dark/80", children: dialogIntro(rememberedProjects.length > 0, showingPackageCatalog === true) }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("label", { htmlFor: "custom-extension-command", className: "mt-5 block text-sm font-semibold text-brand-dark", children: commandLabel }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("button", { type: "button", onClick: props.onBack, className: "inline-flex min-h-11 w-fit items-center gap-2 rounded-lg px-1 text-sm font-semibold text-brand-dark/80 hover:text-brand-dark", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowLeft, { className: "size-4", "aria-hidden": "true" }),
+          "Extensions"
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("header", { className: "mt-4 max-w-2xl border-b border-slate-200 pb-6", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("h1", { id: "add-custom-extension-title", className: "text-2xl font-semibold tracking-tight text-brand-dark", children: "Add a custom extension" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm leading-6 text-slate-500", children: dialogIntro(rememberedProjects.length > 0, showingPackageCatalog === true) })
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("label", { htmlFor: "custom-extension-command", className: "mt-6 block text-sm font-semibold text-brand-dark", children: showingPackageCatalog ? "Find a script" : "Command" }),
         /* @__PURE__ */ jsxRuntimeExports.jsx(
           "input",
           {
@@ -3058,32 +3086,28 @@ function AddCustomExtensionDialog(props) {
             onChange: handleCommand,
             spellCheck: false,
             autoComplete: "off",
-            placeholder: commandPlaceholder,
-            className: "mt-2 min-h-11 w-full rounded-xl border border-slate-300 px-3 text-sm text-brand-dark placeholder:text-brand-dark/40 focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/30"
+            placeholder: showingPackageCatalog ? "guard:audit" : "npm run guard:audit",
+            className: "mt-2 min-h-11 w-full max-w-xl rounded-xl border border-slate-300 bg-white px-3 text-sm text-brand-dark placeholder:text-brand-dark/40 focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/30"
           }
         ),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm leading-6 text-brand-dark/70", children: showingPackageCatalog ? "Typing filters nested names. Allow still enrolls every script in this project." : /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
-          "One command. A script, a binary, ",
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-medium", children: "npm run" }),
-          ", a project folder, or an MCP launch. Not a pipeline."
-        ] }) }),
-        recognized !== null && showingPackageCatalog ? /* @__PURE__ */ jsxRuntimeExports.jsx(
-          ProjectSwitcher,
-          {
-            items: rememberedProjects,
-            currentId: recognized.cli_id,
-            onSelect: selectSuggestion
-          }
-        ) : null,
-        recognized ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark", children: recognized.name }),
-            surfaceBadge(recognized.surface) ? /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "rounded-full bg-white px-2 py-0.5 text-[11px] font-semibold tracking-wide text-brand-dark/70 ring-1 ring-slate-200", children: surfaceBadge(recognized.surface) }) : null
-          ] }),
+        recognized !== null && showingPackageCatalog ? /* @__PURE__ */ jsxRuntimeExports.jsx(ProjectSwitcher, { items: rememberedProjects, currentId: recognized.cli_id, onSelect: selectSuggestion }) : null,
+        recognized ? /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { className: "mt-8 max-w-3xl", "aria-labelledby": "custom-extension-selected", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { id: "custom-extension-selected", className: "text-xl font-semibold tracking-tight text-brand-dark", children: recognized.name }),
           /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 font-mono text-xs text-brand-dark/70", children: recognized.source_label ? `${recognized.source_label} · ${recognized.example_label}` : recognized.example_label }),
-          summary ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm leading-6 text-brand-dark/80", children: summary }) : null,
-          showingPackageCatalog && command.trim() !== "" ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-xs leading-5 text-brand-dark/60", children: filterCountCopy(visibleCommands.length, commands.length) }) : null,
-          visibleCommands.length > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: `mt-4 overflow-auto rounded-2xl bg-white ${showingPackageCatalog ? "max-h-96" : "max-h-72"}`, children: /* @__PURE__ */ jsxRuntimeExports.jsx(
+          summary ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-3 max-w-2xl text-sm leading-6 text-slate-500", children: summary }) : null,
+          showingPackageCatalog ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+            PackageScriptPreview,
+            {
+              query: command,
+              previewNames,
+              visibleCount: visibleCommands.length,
+              totalCount: enrollable.length,
+              reviewing: reviewingScripts,
+              onOpenReview: openScriptReview,
+              onCloseReview: closeScriptReview
+            }
+          ) : null,
+          (!showingPackageCatalog || reviewingScripts) && visibleCommands.length > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 overflow-auto rounded-2xl border border-slate-200 bg-white", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
             CustomExtensionCommandList,
             {
               commands: visibleCommands,
@@ -3091,23 +3115,8 @@ function AddCustomExtensionDialog(props) {
               surface: recognized.surface,
               onChange: handleCommandState
             }
-          ) }) : null,
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 flex flex-wrap gap-2", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", onClick: requestAllow, className: `min-h-11 rounded-xl px-4 text-sm font-semibold ${pending === "allowed" ? "bg-brand-blue text-white" : "border border-slate-300 text-brand-dark"}`, children: allowActionLabel(recognized.surface) }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", onClick: requestBlock, className: `min-h-11 rounded-xl px-4 text-sm font-semibold ${pending === "blocked" ? "bg-brand-dark text-white" : "border border-slate-300 text-brand-dark"}`, children: blockActionLabel(recognized.surface) })
-          ] })
-        ] }) : null,
-        proofReady ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-5", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
-          ApprovalProofFieldInputs,
-          {
-            approvalGate: resolvedApprovalGate,
-            approvalPassword: password,
-            approvalTotpCode: totp,
-            onApprovalPasswordChange: handlePassword,
-            onApprovalTotpCodeChange: handleTotp
-          }
-        ) }) : null,
-        recognized === null ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+          ) }) : null
+        ] }) : /* @__PURE__ */ jsxRuntimeExports.jsx(
           SuggestionPanel,
           {
             query: command,
@@ -3117,15 +3126,50 @@ function AddCustomExtensionDialog(props) {
             seenSuggestions,
             onSelect: selectSuggestion
           }
-        ) : null,
-        error ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4", children: /* @__PURE__ */ jsxRuntimeExports.jsx(InlineError, { message: error }) }) : null,
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-6 flex justify-end gap-3", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", disabled: busy, onClick: props.onClose, className: "min-h-11 rounded-xl px-4 text-sm font-semibold text-brand-dark", children: "Cancel" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "submit", disabled: submitDisabled, className: "min-h-11 rounded-xl bg-brand-blue px-5 text-sm font-semibold text-white disabled:opacity-60", children: submitLabel })
+        ),
+        error ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 max-w-xl", children: /* @__PURE__ */ jsxRuntimeExports.jsx(InlineError, { message: error }) }) : null,
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sticky bottom-0 mt-auto border-t border-slate-200 bg-white py-4", children: [
+          proofReady ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mb-4 max-w-sm", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
+            ApprovalProofFieldInputs,
+            {
+              approvalGate: resolvedApprovalGate,
+              approvalPassword: password,
+              approvalTotpCode: totp,
+              onApprovalPasswordChange: handlePassword,
+              onApprovalTotpCodeChange: handleTotp
+            }
+          ) }) : null,
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-3", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "submit", disabled: submitDisabled, className: "min-h-11 rounded-xl bg-brand-blue px-5 text-sm font-semibold text-white disabled:opacity-60", children: addDialogSubmitLabel({ recognized, busy, pending }) }),
+            recognized && showingPackageCatalog && pending === "allowed" ? /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", onClick: requestBlock, className: "min-h-11 rounded-xl px-4 text-sm font-semibold text-brand-dark", children: blockActionLabel(recognized.surface) }) : null,
+            recognized && showingPackageCatalog && pending === "blocked" ? /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", onClick: requestAllow, className: "min-h-11 rounded-xl px-4 text-sm font-semibold text-brand-dark", children: allowActionLabel(recognized.surface) }) : null
+          ] })
         ] })
       ]
     }
-  ) });
+  );
+}
+function PackageScriptPreview(props) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5", children: [
+    props.query.trim() !== "" ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs leading-5 text-brand-dark/60", children: filterCountCopy(props.visibleCount, props.totalCount) }) : null,
+    props.previewNames.length > 0 && !props.reviewing ? /* @__PURE__ */ jsxRuntimeExports.jsxs("ul", { className: "mt-3 flex flex-wrap gap-2", children: [
+      props.previewNames.map((name) => /* @__PURE__ */ jsxRuntimeExports.jsx("li", { className: "rounded-full bg-slate-100 px-3 py-1.5 font-mono text-xs text-brand-dark", children: name }, name)),
+      props.visibleCount > props.previewNames.length ? /* @__PURE__ */ jsxRuntimeExports.jsxs("li", { className: "rounded-full px-3 py-1.5 text-xs font-semibold text-brand-dark/60", children: [
+        "+",
+        props.visibleCount - props.previewNames.length,
+        " more"
+      ] }) : null
+    ] }) : null,
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "button",
+      {
+        type: "button",
+        onClick: props.reviewing ? props.onCloseReview : props.onOpenReview,
+        className: "mt-4 min-h-11 text-sm font-semibold text-brand-blue",
+        children: props.reviewing ? "Hide individual settings" : "Adjust individual scripts"
+      }
+    )
+  ] });
 }
 function randomToken$1() {
   return crypto.randomUUID().replaceAll("-", "");
@@ -3920,16 +3964,7 @@ function ExtensionsOverview(props) {
           extension2.extension_id
         )) })
       ] })
-    ] }),
-    props.addingCustom ? /* @__PURE__ */ jsxRuntimeExports.jsx(
-      AddCustomExtensionDialog,
-      {
-        items: props.localCliItems,
-        revision: props.localCliRevision,
-        onClose: props.onCloseAddCustom,
-        onAdded: props.onCustomExtensionAdded
-      }
-    ) : null
+    ] })
   ] });
 }
 function pushExtensionHistory(href) {
@@ -4541,7 +4576,6 @@ function ProtectionCenterWorkspace() {
   const aliasRedirected = reactExports.useRef(null);
   const overviewKeepAlive = reactExports.useRef(false);
   const localClis = useLocalCliCatalog();
-  const [addingCustom, setAddingCustom] = reactExports.useState(false);
   const load = reactExports.useCallback(async () => {
     setState((current) => current.kind === "ready" ? current : { kind: "loading" });
     try {
@@ -4586,18 +4620,19 @@ function ProtectionCenterWorkspace() {
     window.scrollTo({ top: 0, behavior: "auto" });
   }, []);
   const openLocalCliDetail = reactExports.useCallback((cliId) => {
-    setAddingCustom(false);
     pushExtensionHistory(localCliHref(cliId));
     setRouteState({ route: { kind: "local-cli", cliId }, detail: DEFAULT_EXTENSION_DETAIL_URL_STATE });
     window.scrollTo({ top: 0, behavior: "auto" });
   }, []);
-  const openAddCustom = reactExports.useCallback(() => setAddingCustom(true), []);
-  const closeAddCustom = reactExports.useCallback(() => setAddingCustom(false), []);
+  const openAddCustom = reactExports.useCallback(() => {
+    pushExtensionHistory(addCustomExtensionHref());
+    setRouteState({ route: { kind: "add-custom" }, detail: DEFAULT_EXTENSION_DETAIL_URL_STATE });
+    window.scrollTo({ top: 0, behavior: "auto" });
+  }, []);
   const handleCustomExtensionAdded = reactExports.useCallback((cliId) => {
     void localClis.load();
-    closeAddCustom();
     openLocalCliDetail(cliId);
-  }, [closeAddCustom, localClis.load, openLocalCliDetail]);
+  }, [localClis.load, openLocalCliDetail]);
   const retryLocalClis = reactExports.useCallback(() => {
     void localClis.load();
   }, [localClis.load]);
@@ -4688,9 +4723,7 @@ function ProtectionCenterWorkspace() {
     });
   }, [authorityNeedsAttention, resolveApprovalGate]);
   const showOverview = state.kind === "ready" && routeState.route.kind === "overview";
-  if (showOverview) {
-    overviewKeepAlive.current = true;
-  }
+  if (showOverview) overviewKeepAlive.current = true;
   const keepOverviewMounted = state.kind === "ready" && (showOverview || overviewKeepAlive.current);
   const localCliRoute = routeState.route.kind === "local-cli" ? routeState.route : null;
   const selectedLocalCli = localCliRoute ? localClis.data?.items.find((item) => item.cli_id === localCliRoute.cliId) ?? null : null;
@@ -4725,20 +4758,16 @@ function ProtectionCenterWorkspace() {
         catalogExtensions,
         effective: state.effective,
         localCliItems: localClis.data?.items ?? [],
-        localCliRevision: localClis.data?.revision ?? 0,
         mutationError: mutationError && !pending ? mutationError : null,
         recoveryStatus,
         healthBroken,
         status,
-        addingCustom: addingCustom && showOverview,
         active: showOverview,
         onPrimaryStatusAction: handlePrimaryStatusAction,
         onRefresh: refreshProtection,
         onOpenExtension: openExtension,
         onOpenLocalCli: openLocalCliDetail,
-        onAddCustom: openAddCustom,
-        onCloseAddCustom: closeAddCustom,
-        onCustomExtensionAdded: handleCustomExtensionAdded
+        onAddCustom: openAddCustom
       }
     ) : null,
     showLocalCli && localClis.error && !localClis.data ? /* @__PURE__ */ jsxRuntimeExports.jsx(
@@ -4750,6 +4779,15 @@ function ProtectionCenterWorkspace() {
       }
     ) : null,
     showLocalCli && !localClis.data && !localClis.error ? /* @__PURE__ */ jsxRuntimeExports.jsx(ExtensionsLoadingState, { label: "Loading custom extension" }) : null,
+    routeState.route.kind === "add-custom" && state.kind === "ready" ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+      AddCustomExtensionWorkspace,
+      {
+        items: localClis.data?.items ?? [],
+        revision: localClis.data?.revision ?? 0,
+        onBack: closeExtension,
+        onAdded: handleCustomExtensionAdded
+      }
+    ) : null,
     showLocalCli && selectedLocalCli && localClis.data ? /* @__PURE__ */ jsxRuntimeExports.jsx(
       LocalCliDetail,
       {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -1117,10 +1117,6 @@
     max-height: calc(var(--spacing) * 40);
   }
 
-  .max-h-72 {
-    max-height: calc(var(--spacing) * 72);
-  }
-
   .max-h-96 {
     max-height: calc(var(--spacing) * 96);
   }
@@ -1199,6 +1195,10 @@
 
   .min-h-\[60vh\] {
     min-height: 60vh;
+  }
+
+  .min-h-\[70vh\] {
+    min-height: 70vh;
   }
 
   .min-h-\[72px\] {

--- a/src/codex_plugin_scanner/guard/local_cli_trust.py
+++ b/src/codex_plugin_scanner/guard/local_cli_trust.py
@@ -11,6 +11,7 @@ from typing import Literal
 from .models import GuardAction, GuardArtifact
 from .runtime.local_cli_commands import (
     OTHER_COMMAND_ID,
+    ROOT_COMMAND_ID,
     LocalCliCommand,
     resolve_command_id_for_text,
     slug_local_cli_command_id,
@@ -73,6 +74,18 @@ def matching_local_cli_grant(
         return identity, "allowed"
     if command_state == "block":
         return identity, "blocked"
+    if (
+        state == "allowed"
+        and command_state == "inherit"
+        and _package_script_inherit_allows(
+            store,
+            identity,
+            command=command,
+            cwd=cwd,
+            home_dir=home_dir,
+        )
+    ):
+        return identity, "allowed"
     return None
 
 
@@ -220,6 +233,48 @@ def _command_state_for_grant(
         return "inherit"
     raw_state = states.get(command_id, "inherit")
     return raw_state if raw_state in {"inherit", "allow", "block"} else "inherit"
+
+
+def _package_script_inherit_allows(
+    store: object,
+    identity: UnlistedCliIdentity,
+    *,
+    command: str,
+    cwd: Path,
+    home_dir: Path | None,
+) -> bool:
+    if _observation_surface(store, identity.cli_id) != "package-scripts":
+        return False
+    catalog_lookup = getattr(store, "read_local_cli_command_catalog", None)
+    commands: list[LocalCliCommand] = []
+    if callable(catalog_lookup):
+        loaded = catalog_lookup(identity.cli_id)
+        if isinstance(loaded, list):
+            commands = [item for item in loaded if isinstance(item, LocalCliCommand)]
+    if not commands:
+        return False
+    command_id = resolve_command_id_for_text(
+        command,
+        cwd=cwd,
+        home_dir=home_dir,
+        identity=identity,
+        commands=commands,
+    )
+    return command_id not in {ROOT_COMMAND_ID, OTHER_COMMAND_ID}
+
+
+def _observation_surface(store: object, cli_id: str) -> str:
+    lister = getattr(store, "list_local_cli_items", None)
+    if not callable(lister):
+        return "cli"
+    raw = lister()
+    if not isinstance(raw, list):
+        return "cli"
+    for item in raw:
+        if isinstance(item, dict) and item.get("cli_id") == cli_id:
+            surface = item.get("surface")
+            return surface if isinstance(surface, str) else "cli"
+    return "cli"
 
 
 def utc_now() -> str:

--- a/tests/test_guard_package_json_scripts.py
+++ b/tests/test_guard_package_json_scripts.py
@@ -227,6 +227,16 @@ def test_allowed_nested_script_grant_matches_live_command(tmp_path: Path) -> Non
             home_dir=home,
             current_action="review",
         )
+        == "allow"
+    )
+    assert (
+        apply_local_cli_grant(
+            store=store,
+            command="pnpm run not-a-script",
+            cwd=project,
+            home_dir=home,
+            current_action="review",
+        )
         == "review"
     )
 


### PR DESCRIPTION
## Summary
- Replace the Add Custom Extension modal with a full-page `/extensions/add` flow. Project scripts stay collapsed by default; inspect individual names only when needed.
- Nested filters such as `guard:audit` match colon-grouped script names. Allow enrolls those listed scripts so Protect no longer queues every matching project run.
- Unknown leftover commands still follow the usual review. Root and other synthetic entries stay on Recommended.

## Testing
- `uv run pytest tests/test_guard_package_json_scripts.py -q --tb=short`
- `tsx src/local-cli-api.test.ts`
- `tsx src/protection-center/add-custom-extension-support.test.ts`
- `bun run build`
