### PR TITLE
fix(dashboard): validate cloud recovery links

### DIFF
--- a/dashboard/src/approval-center-primitives.tsx
+++ b/dashboard/src/approval-center-primitives.tsx
@@ -459,8 +459,8 @@ export const ActionButton = forwardRef<HTMLButtonElement | HTMLAnchorElement, Ac
         <a
           ref={ref as Ref<HTMLAnchorElement>}
           href={guardAwareHref(href)}
-          target={href.startsWith("https://") ? "_blank" : undefined}
-          rel={href.startsWith("https://") ? "noreferrer" : undefined}
+          target={/^https?:\/\//i.test(href) ? "_blank" : undefined}
+          rel={/^https?:\/\//i.test(href) ? "noopener noreferrer" : undefined}
           onClick={onClick}
           className={className}
           {...anchorPropsFromButtonProps(buttonProps)}

--- a/dashboard/src/fleet-protection-recovery.tsx
+++ b/dashboard/src/fleet-protection-recovery.tsx
@@ -189,6 +189,30 @@ function cloudConnectPendingMessage(hasAuthorizeUrl: boolean, opened: boolean): 
   return "Your browser blocked the sign-in window. Open the secure sign-in link below.";
 }
 
+function cloudConnectButtonLabel(
+  state: CloudConnectState | null,
+  defaultLabel: string,
+): string {
+  if (state?.status === "working") return "Starting sign-in…";
+  if (state?.status === "success") return "Guard Cloud connected";
+  return defaultLabel;
+}
+
+function safeCloudConnectUrl(value: string | null | undefined): string | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    if (!url.hostname || url.username || url.password) return null;
+    const loopbackHosts = ["localhost", "127.0.0.1", "[::1]"];
+    const secureRemote = url.protocol === "https:";
+    const localHttp = url.protocol === "http:" && loopbackHosts.includes(url.hostname);
+    if (!secureRemote && !localHttp) return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
 export function FleetProtectionRecovery(props: FleetProtectionRecoveryProps) {
   const [repairState, setRepairState] = useState<RepairState | null>(null);
   const [cloudConnectState, setCloudConnectState] = useState<CloudConnectState | null>(null);
@@ -252,19 +276,20 @@ export function FleetProtectionRecovery(props: FleetProtectionRecoveryProps) {
         return;
       }
       const flow = status.connect_flow;
-      const signInUrl = flow?.authorize_url ?? flow?.connect_url;
+      const authorizeUrl = safeCloudConnectUrl(flow?.authorize_url);
+      const signInUrl = authorizeUrl ?? safeCloudConnectUrl(flow?.connect_url);
       if (!flow || !signInUrl) {
         throw new Error(
           flow?.detail || "Guard could not generate a secure sign-in link. Try again.",
         );
       }
-      const opened = flow.authorize_url
-        ? openPackageFirewallAuthorizeFallback(flow.authorize_url, flow.browser_opened)
+      const opened = authorizeUrl
+        ? openPackageFirewallAuthorizeFallback(authorizeUrl, flow.browser_opened)
         : false;
       if (!isActiveCloudConnect(controller)) return;
       setCloudConnectState({
         authorizeUrl: signInUrl,
-        message: cloudConnectPendingMessage(Boolean(flow.authorize_url), opened),
+        message: cloudConnectPendingMessage(Boolean(authorizeUrl), opened),
         status: "pending",
       });
       const connectedStatus = await waitForCloudConnection(status, {
@@ -282,8 +307,8 @@ export function FleetProtectionRecovery(props: FleetProtectionRecoveryProps) {
       const detail = connectedStatus.connect_flow?.detail;
       setCloudConnectState({
         authorizeUrl:
-          connectedStatus.connect_flow?.authorize_url
-          ?? connectedStatus.connect_flow?.connect_url
+          safeCloudConnectUrl(connectedStatus.connect_flow?.authorize_url)
+          ?? safeCloudConnectUrl(connectedStatus.connect_flow?.connect_url)
           ?? signInUrl,
         message:
           connectedStatus.connect_flow?.state === "failed"
@@ -355,9 +380,7 @@ export function FleetProtectionRecovery(props: FleetProtectionRecoveryProps) {
                 disabled={cloudConnectDisabled}
                 variant="outline"
               >
-                {cloudConnectState?.status === "working"
-                  ? "Starting sign-in…"
-                  : cloudPolicyHint.actionLabel}
+                {cloudConnectButtonLabel(cloudConnectState, cloudPolicyHint.actionLabel)}
               </ActionButton>
               {cloudConnectState?.authorizeUrl ? (
                 <ActionButton href={cloudConnectState.authorizeUrl} variant="quiet">

--- a/dashboard/src/guard-cloud-connect-flow.ts
+++ b/dashboard/src/guard-cloud-connect-flow.ts
@@ -26,7 +26,9 @@ export async function withCloudRequestTimeout<T>(
   try {
     return await request(controller.signal);
   } catch (error: unknown) {
-    if (timedOut && !parentSignal?.aborted) throw new CloudRequestTimeoutError();
+    if (timedOut && !parentSignal?.aborted && error instanceof DOMException && error.name === "AbortError") {
+      throw new CloudRequestTimeoutError();
+    }
     throw error;
   } finally {
     globalThis.clearTimeout(timeout);

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/fleet-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/fleet-workspace.js
@@ -106,6 +106,25 @@ function cloudConnectPendingMessage(hasAuthorizeUrl, opened) {
   }
   return "Your browser blocked the sign-in window. Open the secure sign-in link below.";
 }
+function cloudConnectButtonLabel(state, defaultLabel) {
+  if (state?.status === "working") return "Starting sign-in…";
+  if (state?.status === "success") return "Guard Cloud connected";
+  return defaultLabel;
+}
+function safeCloudConnectUrl(value) {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    if (!url.hostname || url.username || url.password) return null;
+    const loopbackHosts = ["localhost", "127.0.0.1", "[::1]"];
+    const secureRemote = url.protocol === "https:";
+    const localHttp = url.protocol === "http:" && loopbackHosts.includes(url.hostname);
+    if (!secureRemote && !localHttp) return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
 function FleetProtectionRecovery(props) {
   const [repairState, setRepairState] = reactExports.useState(null);
   const [cloudConnectState, setCloudConnectState] = reactExports.useState(null);
@@ -164,17 +183,18 @@ function FleetProtectionRecovery(props) {
         return;
       }
       const flow = status.connect_flow;
-      const signInUrl = flow?.authorize_url ?? flow?.connect_url;
+      const authorizeUrl = safeCloudConnectUrl(flow?.authorize_url);
+      const signInUrl = authorizeUrl ?? safeCloudConnectUrl(flow?.connect_url);
       if (!flow || !signInUrl) {
         throw new Error(
           flow?.detail || "Guard could not generate a secure sign-in link. Try again."
         );
       }
-      const opened = flow.authorize_url ? openPackageFirewallAuthorizeFallback(flow.authorize_url, flow.browser_opened) : false;
+      const opened = authorizeUrl ? openPackageFirewallAuthorizeFallback(authorizeUrl, flow.browser_opened) : false;
       if (!isActiveCloudConnect(controller)) return;
       setCloudConnectState({
         authorizeUrl: signInUrl,
-        message: cloudConnectPendingMessage(Boolean(flow.authorize_url), opened),
+        message: cloudConnectPendingMessage(Boolean(authorizeUrl), opened),
         status: "pending"
       });
       const connectedStatus = await waitForCloudConnection(status, {
@@ -191,7 +211,7 @@ function FleetProtectionRecovery(props) {
       }
       const detail = connectedStatus.connect_flow?.detail;
       setCloudConnectState({
-        authorizeUrl: connectedStatus.connect_flow?.authorize_url ?? connectedStatus.connect_flow?.connect_url ?? signInUrl,
+        authorizeUrl: safeCloudConnectUrl(connectedStatus.connect_flow?.authorize_url) ?? safeCloudConnectUrl(connectedStatus.connect_flow?.connect_url) ?? signInUrl,
         message: connectedStatus.connect_flow?.state === "failed" ? detail || "Guard Cloud sign-in could not finish. Try again." : "Automatic checking stopped before sign-in finished. Complete sign-in, then try again.",
         status: connectedStatus.connect_flow?.state === "failed" ? "error" : "pending"
       });
@@ -251,7 +271,7 @@ function FleetProtectionRecovery(props) {
                 onClick: handleCloudConnectClick,
                 disabled: cloudConnectDisabled,
                 variant: "outline",
-                children: cloudConnectState?.status === "working" ? "Starting sign-in…" : cloudPolicyHint.actionLabel
+                children: cloudConnectButtonLabel(cloudConnectState, cloudPolicyHint.actionLabel)
               }
             ),
             cloudConnectState?.authorizeUrl ? /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: cloudConnectState.authorizeUrl, variant: "quiet", children: "Open secure sign-in" }) : null,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -20160,8 +20160,8 @@ const ActionButton = reactExports.forwardRef(
         {
           ref,
           href: guardAwareHref(href),
-          target: href.startsWith("https://") ? "_blank" : void 0,
-          rel: href.startsWith("https://") ? "noreferrer" : void 0,
+          target: /^https?:\/\//i.test(href) ? "_blank" : void 0,
+          rel: /^https?:\/\//i.test(href) ? "noopener noreferrer" : void 0,
           onClick,
           className,
           ...anchorPropsFromButtonProps(buttonProps),
@@ -28269,7 +28269,9 @@ async function withCloudRequestTimeout(request, parentSignal) {
   try {
     return await request(controller.signal);
   } catch (error) {
-    if (timedOut && !parentSignal?.aborted) throw new CloudRequestTimeoutError();
+    if (timedOut && !parentSignal?.aborted && error instanceof DOMException && error.name === "AbortError") {
+      throw new CloudRequestTimeoutError();
+    }
     throw error;
   } finally {
     globalThis.clearTimeout(timeout);


### PR DESCRIPTION
## Summary

- validate daemon-provided cloud sign-in links before rendering them
- keep HTTP and HTTPS external sign-in links in a new tab so local completion polling continues
- classify only actual aborts as timeouts and show a connected-state action label

## Verification

- `cd dashboard && bun run test`
- `cd dashboard && bun run build`

Parity follow-up for release PR #2533.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Cloud sign-in now validates authorization and fallback URLs, accepting only secure HTTP(S) destinations.
  * Cloud connection flows provide clearer status labels, including a success state and improved retry handling.
  * External HTTP and HTTPS links now open safely in a new tab with referrer information removed.

* **Bug Fixes**
  * Timeout errors are now reported accurately without masking unrelated request failures.
  * Invalid sign-in URLs are rejected or replaced with the last valid destination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->