### PR TITLE
fix(dashboard): validate cloud recovery links

### DIFF
--- a/dashboard/src/approval-center-primitives.tsx
+++ b/dashboard/src/approval-center-primitives.tsx
@@ -470,7 +470,7 @@ export const ActionButton = forwardRef<HTMLButtonElement | HTMLAnchorElement, Ac
           ref={ref as Ref<HTMLAnchorElement>}
           href={guardAwareHref(href)}
           target={/^https?:\/\//i.test(href) ? "_blank" : undefined}
-          rel={/^https?:\/\//i.test(href) ? "noreferrer" : undefined}
+          rel={/^https?:\/\//i.test(href) ? "noopener noreferrer" : undefined}
           onClick={onClick}
           className={className}
           {...anchorPropsFromButtonProps(buttonProps)}

--- a/dashboard/src/fleet-protection-recovery.tsx
+++ b/dashboard/src/fleet-protection-recovery.tsx
@@ -202,7 +202,11 @@ function safeCloudConnectUrl(value: string | null | undefined): string | null {
   if (!value) return null;
   try {
     const url = new URL(value);
-    if (!["http:", "https:"].includes(url.protocol)) return null;
+    if (!url.hostname || url.username || url.password) return null;
+    const loopbackHosts = ["localhost", "127.0.0.1", "[::1]"];
+    const secureRemote = url.protocol === "https:";
+    const localHttp = url.protocol === "http:" && loopbackHosts.includes(url.hostname);
+    if (!secureRemote && !localHttp) return null;
     return url.toString();
   } catch {
     return null;

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/fleet-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/fleet-workspace.js
@@ -205,7 +205,11 @@ function safeCloudConnectUrl(value) {
   if (!value) return null;
   try {
     const url = new URL(value);
-    if (!["http:", "https:"].includes(url.protocol)) return null;
+    if (!url.hostname || url.username || url.password) return null;
+    const loopbackHosts = ["localhost", "127.0.0.1", "[::1]"];
+    const secureRemote = url.protocol === "https:";
+    const localHttp = url.protocol === "http:" && loopbackHosts.includes(url.hostname);
+    if (!secureRemote && !localHttp) return null;
     return url.toString();
   } catch {
     return null;

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -19011,7 +19011,7 @@ const ActionButton = reactExports.forwardRef(
           ref,
           href: guardAwareHref(href),
           target: /^https?:\/\//i.test(href) ? "_blank" : void 0,
-          rel: /^https?:\/\//i.test(href) ? "noreferrer" : void 0,
+          rel: /^https?:\/\//i.test(href) ? "noopener noreferrer" : void 0,
           onClick,
           className,
           ...anchorPropsFromButtonProps(buttonProps),


### PR DESCRIPTION
## Summary

- reject credential-bearing or non-HTTP(S) daemon sign-in URLs
- allow HTTPS enterprise endpoints and loopback-only HTTP development endpoints
- prevent opener access for external sign-in tabs

## Verification

- focused fleet workspace tests
- authoritative action-surface tests
- `cd dashboard && bun run build`

Release parity for #2534.
