### PR TITLE
fix(extensions): let MCP enroll confirm and bulk-set tools

### DIFF
--- a/dashboard/src/local-cli-api.test.ts
+++ b/dashboard/src/local-cli-api.test.ts
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 import {
   addedCustomExtensions,
   filterExtensionSuggestions,
+  applyBulkCommandState,
+  bulkCommandState,
   enrollmentCommandStates,
   filterPackageScriptCommands,
   isLocalCliId,
@@ -259,6 +261,12 @@ assert.deepEqual(
   enrollmentCommandStates(packageScripts.commands, "allowed", "package-scripts").map((entry) => entry.state),
   ["allow", "allow"],
 );
+assert.equal(bulkCommandState(packageScripts.commands), "inherit");
+assert.deepEqual(
+  applyBulkCommandState(packageScripts.commands, "allow").map((entry) => entry.state),
+  ["allow", "allow"],
+);
+assert.equal(bulkCommandState(applyBulkCommandState(packageScripts.commands, "block")), "block");
 assert.equal(seenSuggestionMeta(frequentTool), "Seen 4 times");
 assert.equal(seenSuggestionMeta(rareTool), "Seen once");
 

--- a/dashboard/src/local-cli-api.test.ts
+++ b/dashboard/src/local-cli-api.test.ts
@@ -267,6 +267,14 @@ assert.deepEqual(
   ["allow", "allow"],
 );
 assert.equal(bulkCommandState(applyBulkCommandState(packageScripts.commands, "block")), "block");
+const withSynthetic = [
+  { command_id: "root", name: "pnpm run", usage: "pnpm run", description: "", parent_id: null, state: "inherit" as const },
+  ...packageScripts.commands,
+];
+assert.equal(
+  applyBulkCommandState(withSynthetic, "allow", new Set(["root", "other"])).find((entry) => entry.command_id === "root")?.state,
+  "inherit",
+);
 assert.equal(seenSuggestionMeta(frequentTool), "Seen 4 times");
 assert.equal(seenSuggestionMeta(rareTool), "Seen once");
 

--- a/dashboard/src/local-cli-api.ts
+++ b/dashboard/src/local-cli-api.ts
@@ -205,6 +205,19 @@ export function enrollmentCommandStates(
   }));
 }
 
+export function applyBulkCommandState(
+  commands: readonly LocalCliCommand[],
+  state: LocalCliCommandState,
+): LocalCliCommand[] {
+  return commands.map((command) => ({ ...command, state }));
+}
+
+export function bulkCommandState(commands: readonly LocalCliCommand[]): LocalCliCommandState | "mixed" {
+  if (commands.length === 0) return "inherit";
+  const first = commands[0]!.state;
+  return commands.every((command) => command.state === first) ? first : "mixed";
+}
+
 function commandStatesFrom(
   commands: readonly LocalCliCommand[],
 ): Array<{ command_id: string; state: LocalCliCommandState }> {

--- a/dashboard/src/local-cli-api.ts
+++ b/dashboard/src/local-cli-api.ts
@@ -208,8 +208,11 @@ export function enrollmentCommandStates(
 export function applyBulkCommandState(
   commands: readonly LocalCliCommand[],
   state: LocalCliCommandState,
+  skipIds: ReadonlySet<string> = new Set(),
 ): LocalCliCommand[] {
-  return commands.map((command) => ({ ...command, state }));
+  return commands.map((command) => (
+    skipIds.has(command.command_id) ? command : { ...command, state }
+  ));
 }
 
 export function bulkCommandState(commands: readonly LocalCliCommand[]): LocalCliCommandState | "mixed" {

--- a/dashboard/src/protection-center/add-custom-extension-dialog.tsx
+++ b/dashboard/src/protection-center/add-custom-extension-dialog.tsx
@@ -172,9 +172,13 @@ export function AddCustomExtensionWorkspace(props: {
   const openScriptReview = useCallback(() => setReviewingScripts(true), []);
   const closeScriptReview = useCallback(() => setReviewingScripts(false), []);
   const applyBulk = useCallback((state: LocalCliCommandState) => {
-    setCommands((current) => applyBulkCommandState(current, state));
+    setCommands((current) => applyBulkCommandState(
+      current,
+      state,
+      recognized?.surface === "package-scripts" ? new Set(["root", "other"]) : new Set(),
+    ));
     setPending(state === "block" ? "blocked" : "allowed");
-  }, []);
+  }, [recognized]);
   const handleSubmit = useCallback(async (event: FormEvent) => {
     event.preventDefault();
     if (recognized === null) {

--- a/dashboard/src/protection-center/add-custom-extension-dialog.tsx
+++ b/dashboard/src/protection-center/add-custom-extension-dialog.tsx
@@ -32,6 +32,7 @@ import {
   addDialogSubmitLabel,
   allowActionLabel,
   blockActionLabel,
+  commandFieldLabel,
   dialogIntro,
   filterCountCopy,
   ProjectSwitcher,
@@ -39,6 +40,10 @@ import {
   suggestionSummary,
 } from "./add-custom-extension-support";
 import { CustomExtensionCommandList, withCommandState } from "./custom-extension-commands";
+import {
+  extensionPolicyRadioTabStop,
+  nextExtensionPolicyRadioIndex,
+} from "../extension-policy-panel";
 import { useResolvedApprovalGate } from "../use-resolved-approval-gate";
 import { InlineError } from "./components/protection-primitives";
 
@@ -244,7 +249,7 @@ export function AddCustomExtensionWorkspace(props: {
         </p>
       </header>
       <label htmlFor="custom-extension-command" className="mt-4 block text-sm font-semibold text-brand-dark">
-        {showingPackageCatalog ? "Find a script" : showingMcpCatalog ? "Launch command" : "Command"}
+        {commandFieldLabel(recognized?.surface ?? null)}
       </label>
       <input
         id="custom-extension-command"
@@ -390,17 +395,41 @@ function BulkPolicyPicker(props: {
     { value: "allow", label: "Allow all" },
     { value: "block", label: "Block all" },
   ];
+  const selected = props.value === "mixed" ? "inherit" : props.value;
+  const tabStopIndex = extensionPolicyRadioTabStop(choices, selected, props.disabled);
+  const chooseAdjacent = (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+    const next = nextExtensionPolicyRadioIndex(choices, index, event.key, props.disabled);
+    if (next < 0) return;
+    event.preventDefault();
+    props.onChange(choices[next]!.value);
+    event.currentTarget.parentElement?.querySelectorAll<HTMLButtonElement>('[role="radio"]')[next]?.focus();
+  };
   return (
-    <div role="radiogroup" aria-label="All tools protection setting" className="guard-segmented mt-4 w-fit">
-      {choices.map((choice) => (
-        <BulkPolicyChoice
-          key={choice.value}
-          choice={choice}
-          checked={props.value === choice.value}
-          disabled={props.disabled}
-          onChoose={props.onChange}
-        />
-      ))}
+    <div className="mt-4">
+      <div
+        role="radiogroup"
+        aria-label="All tools protection setting"
+        aria-describedby={props.value === "mixed" ? "bulk-policy-mixed" : undefined}
+        className="guard-segmented w-fit"
+      >
+        {choices.map((choice, index) => (
+          <BulkPolicyChoice
+            key={choice.value}
+            choice={choice}
+            checked={props.value === choice.value}
+            tabIndex={!props.disabled && index === tabStopIndex ? 0 : -1}
+            disabled={props.disabled}
+            index={index}
+            onChoose={props.onChange}
+            onAdjacent={chooseAdjacent}
+          />
+        ))}
+      </div>
+      {props.value === "mixed" ? (
+        <p id="bulk-policy-mixed" className="mt-2 text-xs leading-5 text-brand-dark/70">
+          Custom mix. Pick Recommended, Allow all, or Block all to reset every tool.
+        </p>
+      ) : null}
     </div>
   );
 }
@@ -408,18 +437,26 @@ function BulkPolicyPicker(props: {
 function BulkPolicyChoice(props: {
   choice: { value: LocalCliCommandState; label: string };
   checked: boolean;
+  tabIndex: number;
   disabled: boolean;
+  index: number;
   onChoose: (state: LocalCliCommandState) => void;
+  onAdjacent: (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => void;
 }) {
   const handleClick = useCallback(() => {
     props.onChoose(props.choice.value);
+  }, [props]);
+  const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLButtonElement>) => {
+    props.onAdjacent(event, props.index);
   }, [props]);
   return (
     <button
       type="button"
       role="radio"
       aria-checked={props.checked}
+      tabIndex={props.tabIndex}
       disabled={props.disabled}
+      onKeyDown={handleKeyDown}
       onClick={handleClick}
       className="min-h-11 px-4 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-45"
     >

--- a/dashboard/src/protection-center/add-custom-extension-dialog.tsx
+++ b/dashboard/src/protection-center/add-custom-extension-dialog.tsx
@@ -8,7 +8,9 @@ import {
   isApprovalProofSubmitDisabled,
 } from "../approval-proof-inline";
 import {
+  applyBulkCommandState,
   applyLocalCliMutation,
+  bulkCommandState,
   enrollablePackageScriptCommands,
   enrollmentCommandStates,
   filterExtensionSuggestions,
@@ -110,7 +112,7 @@ export function AddCustomExtensionWorkspace(props: {
       setRecognized(result.item);
       setCommands(result.item.commands);
       setSummary(result.summary);
-      setPending(result.item.surface === "package-scripts" ? "allowed" : null);
+      setPending("allowed");
       setError(null);
     } catch (caught) {
       if (recognizeGeneration.current !== generation) return;
@@ -137,7 +139,7 @@ export function AddCustomExtensionWorkspace(props: {
     setRecognized(item);
     setCommands(item.commands);
     setSummary(suggestionSummary(item));
-    setPending(item.surface === "package-scripts" && item.commands.length > 0 ? "allowed" : null);
+    setPending("allowed");
     setReviewingScripts(false);
   }, [runRecognize]);
   const findTool = useCallback(async () => {
@@ -164,6 +166,10 @@ export function AddCustomExtensionWorkspace(props: {
   const requestBlock = useCallback(() => setPending("blocked"), []);
   const openScriptReview = useCallback(() => setReviewingScripts(true), []);
   const closeScriptReview = useCallback(() => setReviewingScripts(false), []);
+  const applyBulk = useCallback((state: LocalCliCommandState) => {
+    setCommands((current) => applyBulkCommandState(current, state));
+    setPending(state === "block" ? "blocked" : "allowed");
+  }, []);
   const handleSubmit = useCallback(async (event: FormEvent) => {
     event.preventDefault();
     if (recognized === null) {
@@ -212,11 +218,14 @@ export function AddCustomExtensionWorkspace(props: {
       busy,
     );
   const showingPackageCatalog = recognized?.surface === "package-scripts";
-  const enrollable = enrollablePackageScriptCommands(commands);
+  const showingMcpCatalog = recognized?.surface === "mcp";
+  const showingCatalog = showingPackageCatalog || showingMcpCatalog;
+  const enrollable = showingPackageCatalog ? enrollablePackageScriptCommands(commands) : commands;
   const visibleCommands = showingPackageCatalog
     ? filterPackageScriptCommands(enrollable, command)
     : commands;
   const previewNames = visibleCommands.slice(0, 8).map((entry) => entry.name);
+  const bulkState = bulkCommandState(enrollable);
 
   return (
     <form
@@ -228,14 +237,14 @@ export function AddCustomExtensionWorkspace(props: {
         <HiMiniArrowLeft className="size-4" aria-hidden="true" />
         Extensions
       </button>
-      <header className="mt-4 max-w-2xl border-b border-slate-200 pb-6">
+      <header className="mt-3 max-w-2xl pb-4">
         <h1 id="add-custom-extension-title" className="text-2xl font-semibold tracking-tight text-brand-dark">Add a custom extension</h1>
         <p className="mt-2 text-sm leading-6 text-slate-500">
-          {dialogIntro(rememberedProjects.length > 0, showingPackageCatalog === true)}
+          {dialogIntro(rememberedProjects.length > 0, recognized?.surface ?? null)}
         </p>
       </header>
-      <label htmlFor="custom-extension-command" className="mt-6 block text-sm font-semibold text-brand-dark">
-        {showingPackageCatalog ? "Find a script" : "Command"}
+      <label htmlFor="custom-extension-command" className="mt-4 block text-sm font-semibold text-brand-dark">
+        {showingPackageCatalog ? "Find a script" : showingMcpCatalog ? "Launch command" : "Command"}
       </label>
       <input
         id="custom-extension-command"
@@ -250,27 +259,33 @@ export function AddCustomExtensionWorkspace(props: {
         <ProjectSwitcher items={rememberedProjects} currentId={recognized.cli_id} onSelect={selectSuggestion} />
       ) : null}
       {recognized ? (
-        <section className="mt-8 max-w-3xl" aria-labelledby="custom-extension-selected">
+        <section className="mt-5 max-w-3xl" aria-labelledby="custom-extension-selected">
           <h2 id="custom-extension-selected" className="text-xl font-semibold tracking-tight text-brand-dark">
             {recognized.name}
           </h2>
           <p className="mt-1 font-mono text-xs text-brand-dark/70">
             {recognized.source_label ? `${recognized.source_label} · ${recognized.example_label}` : recognized.example_label}
           </p>
-          {summary ? <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-500">{summary}</p> : null}
-          {showingPackageCatalog ? (
-            <PackageScriptPreview
+          {summary ? <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-500">{summary}</p> : null}
+          {showingCatalog && enrollable.length > 0 ? (
+            <BulkPolicyPicker value={bulkState} disabled={busy} onChange={applyBulk} />
+          ) : null}
+          {showingCatalog ? (
+            <CatalogPreview
               query={command}
+              showFilterCount={showingPackageCatalog}
               previewNames={previewNames}
               visibleCount={visibleCommands.length}
               totalCount={enrollable.length}
               reviewing={reviewingScripts}
+              adjustLabel={showingMcpCatalog ? "Adjust individual tools" : "Adjust individual scripts"}
+              hideLabel="Hide individual settings"
               onOpenReview={openScriptReview}
               onCloseReview={closeScriptReview}
             />
           ) : null}
-          {(!showingPackageCatalog || reviewingScripts) && visibleCommands.length > 0 ? (
-            <div className="mt-4 overflow-auto rounded-2xl border border-slate-200 bg-white">
+          {(!showingCatalog || reviewingScripts) && visibleCommands.length > 0 ? (
+            <div className="mt-3 overflow-auto rounded-2xl border border-slate-200 bg-white">
               <CustomExtensionCommandList
                 commands={visibleCommands}
                 disabled={busy}
@@ -307,12 +322,12 @@ export function AddCustomExtensionWorkspace(props: {
           <button type="submit" disabled={submitDisabled} className="min-h-11 rounded-xl bg-brand-blue px-5 text-sm font-semibold text-white disabled:opacity-60">
             {addDialogSubmitLabel({ recognized, busy, pending })}
           </button>
-          {recognized && showingPackageCatalog && pending === "allowed" ? (
+          {recognized && pending === "allowed" ? (
             <button type="button" onClick={requestBlock} className="min-h-11 rounded-xl px-4 text-sm font-semibold text-brand-dark">
               {blockActionLabel(recognized.surface)}
             </button>
           ) : null}
-          {recognized && showingPackageCatalog && pending === "blocked" ? (
+          {recognized && pending === "blocked" ? (
             <button type="button" onClick={requestAllow} className="min-h-11 rounded-xl px-4 text-sm font-semibold text-brand-dark">
               {allowActionLabel(recognized.surface)}
             </button>
@@ -323,18 +338,21 @@ export function AddCustomExtensionWorkspace(props: {
   );
 }
 
-function PackageScriptPreview(props: {
+function CatalogPreview(props: {
   query: string;
+  showFilterCount: boolean;
   previewNames: string[];
   visibleCount: number;
   totalCount: number;
   reviewing: boolean;
+  adjustLabel: string;
+  hideLabel: string;
   onOpenReview: () => void;
   onCloseReview: () => void;
 }) {
   return (
-    <div className="mt-5">
-      {props.query.trim() !== "" ? (
+    <div className="mt-4">
+      {props.showFilterCount && props.query.trim() !== "" ? (
         <p className="text-xs leading-5 text-brand-dark/60">{filterCountCopy(props.visibleCount, props.totalCount)}</p>
       ) : null}
       {props.previewNames.length > 0 && !props.reviewing ? (
@@ -354,10 +372,58 @@ function PackageScriptPreview(props: {
       <button
         type="button"
         onClick={props.reviewing ? props.onCloseReview : props.onOpenReview}
-        className="mt-4 min-h-11 text-sm font-semibold text-brand-blue"
+        className="mt-3 min-h-11 text-sm font-semibold text-brand-blue"
       >
-        {props.reviewing ? "Hide individual settings" : "Adjust individual scripts"}
+        {props.reviewing ? props.hideLabel : props.adjustLabel}
       </button>
     </div>
+  );
+}
+
+function BulkPolicyPicker(props: {
+  value: LocalCliCommandState | "mixed";
+  disabled: boolean;
+  onChange: (state: LocalCliCommandState) => void;
+}) {
+  const choices: Array<{ value: LocalCliCommandState; label: string }> = [
+    { value: "inherit", label: "Recommended" },
+    { value: "allow", label: "Allow all" },
+    { value: "block", label: "Block all" },
+  ];
+  return (
+    <div role="radiogroup" aria-label="All tools protection setting" className="guard-segmented mt-4 w-fit">
+      {choices.map((choice) => (
+        <BulkPolicyChoice
+          key={choice.value}
+          choice={choice}
+          checked={props.value === choice.value}
+          disabled={props.disabled}
+          onChoose={props.onChange}
+        />
+      ))}
+    </div>
+  );
+}
+
+function BulkPolicyChoice(props: {
+  choice: { value: LocalCliCommandState; label: string };
+  checked: boolean;
+  disabled: boolean;
+  onChoose: (state: LocalCliCommandState) => void;
+}) {
+  const handleClick = useCallback(() => {
+    props.onChoose(props.choice.value);
+  }, [props]);
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={props.checked}
+      disabled={props.disabled}
+      onClick={handleClick}
+      className="min-h-11 px-4 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-45"
+    >
+      {props.choice.label}
+    </button>
   );
 }

--- a/dashboard/src/protection-center/add-custom-extension-support.test.ts
+++ b/dashboard/src/protection-center/add-custom-extension-support.test.ts
@@ -40,7 +40,8 @@ const packageItem: LocalCliItem = {
   ],
 };
 
-assert.match(dialogIntro(true, true), /Allow these scripts/);
+assert.match(dialogIntro(true, "package-scripts"), /Allow these scripts/);
+assert.match(dialogIntro(false, "mcp"), /Allow all/);
 assert.match(filterCountCopy(1, 8), /1 of 8 scripts match/);
 assert.match(suggestionSummary(packageItem), /1 script from ads-app/);
 assert.equal(

--- a/dashboard/src/protection-center/add-custom-extension-support.tsx
+++ b/dashboard/src/protection-center/add-custom-extension-support.tsx
@@ -41,9 +41,15 @@ export function blockActionLabel(surface: LocalCliItem["surface"]): string {
   return "Block this tool";
 }
 
-export function dialogIntro(hasProjects: boolean, showingCatalog: boolean): string {
-  if (showingCatalog) {
+export function dialogIntro(
+  hasProjects: boolean,
+  surface: LocalCliItem["surface"] | null,
+): string {
+  if (surface === "package-scripts") {
     return "Allow these scripts so Protect can stop asking about them. Type a nested name such as guard:audit to inspect one.";
+  }
+  if (surface === "mcp") {
+    return "Choose Recommended, Allow all, or Block all, then confirm this server.";
   }
   if (hasProjects) {
     return "Guard already found project scripts on this device. Pick a project, or paste another folder.";
@@ -67,7 +73,7 @@ export function suggestionSummary(item: LocalCliItem): string {
     return `Find this tool to list npm scripts from ${item.name}.`;
   }
   if (item.surface === "mcp" && item.commands.length > 0) {
-    return `Guard listed ${item.commands.length} tools from this MCP server. Recommended keeps the usual review. Allow or block each one.`;
+    return `${item.commands.length} tools from this server. Recommended keeps the usual review. Allow all lets them run.`;
   }
   if (item.surface === "mcp") {
     return `Find this tool to list MCP tools from ${item.name}.`;

--- a/dashboard/src/protection-center/add-custom-extension-support.tsx
+++ b/dashboard/src/protection-center/add-custom-extension-support.tsx
@@ -29,6 +29,12 @@ export function surfaceBadge(surface: LocalCliItem["surface"]): string | null {
   return null;
 }
 
+export function commandFieldLabel(surface: LocalCliItem["surface"] | null): string {
+  if (surface === "package-scripts") return "Find a script";
+  if (surface === "mcp") return "Launch command";
+  return "Command";
+}
+
 export function allowActionLabel(surface: LocalCliItem["surface"]): string {
   if (surface === "mcp") return "Allow this server";
   if (surface === "package-scripts") return "Allow these scripts";

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
@@ -306,8 +306,8 @@ function enrollmentCommandStates(commands, pending, surface) {
     state: packageScriptEnrollmentState(command, pending)
   }));
 }
-function applyBulkCommandState(commands, state) {
-  return commands.map((command) => ({ ...command, state }));
+function applyBulkCommandState(commands, state, skipIds = /* @__PURE__ */ new Set()) {
+  return commands.map((command) => skipIds.has(command.command_id) ? command : { ...command, state });
 }
 function bulkCommandState(commands) {
   if (commands.length === 0) return "inherit";
@@ -3031,9 +3031,13 @@ function AddCustomExtensionWorkspace(props) {
   const openScriptReview = reactExports.useCallback(() => setReviewingScripts(true), []);
   const closeScriptReview = reactExports.useCallback(() => setReviewingScripts(false), []);
   const applyBulk = reactExports.useCallback((state) => {
-    setCommands((current) => applyBulkCommandState(current, state));
+    setCommands((current) => applyBulkCommandState(
+      current,
+      state,
+      recognized?.surface === "package-scripts" ? /* @__PURE__ */ new Set(["root", "other"]) : /* @__PURE__ */ new Set()
+    ));
     setPending(state === "block" ? "blocked" : "allowed");
-  }, []);
+  }, [recognized]);
   const handleSubmit = reactExports.useCallback(async (event) => {
     event.preventDefault();
     if (recognized === null) {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
@@ -306,6 +306,14 @@ function enrollmentCommandStates(commands, pending, surface) {
     state: packageScriptEnrollmentState(command, pending)
   }));
 }
+function applyBulkCommandState(commands, state) {
+  return commands.map((command) => ({ ...command, state }));
+}
+function bulkCommandState(commands) {
+  if (commands.length === 0) return "inherit";
+  const first = commands[0].state;
+  return commands.every((command) => command.state === first) ? first : "mixed";
+}
 function commandStatesFrom(commands) {
   return commands.map((command) => ({ command_id: command.command_id, state: command.state }));
 }
@@ -2779,9 +2787,12 @@ function blockActionLabel(surface) {
   if (surface === "package-scripts") return "Block these scripts";
   return "Block this tool";
 }
-function dialogIntro(hasProjects, showingCatalog) {
-  if (showingCatalog) {
+function dialogIntro(hasProjects, surface) {
+  if (surface === "package-scripts") {
     return "Allow these scripts so Protect can stop asking about them. Type a nested name such as guard:audit to inspect one.";
+  }
+  if (surface === "mcp") {
+    return "Choose Recommended, Allow all, or Block all, then confirm this server.";
   }
   if (hasProjects) {
     return "Guard already found project scripts on this device. Pick a project, or paste another folder.";
@@ -2803,7 +2814,7 @@ function suggestionSummary(item) {
     return `Find this tool to list npm scripts from ${item.name}.`;
   }
   if (item.surface === "mcp" && item.commands.length > 0) {
-    return `Guard listed ${item.commands.length} tools from this MCP server. Recommended keeps the usual review. Allow or block each one.`;
+    return `${item.commands.length} tools from this server. Recommended keeps the usual review. Allow all lets them run.`;
   }
   if (item.surface === "mcp") {
     return `Find this tool to list MCP tools from ${item.name}.`;
@@ -2960,7 +2971,7 @@ function AddCustomExtensionWorkspace(props) {
       setRecognized(result.item);
       setCommands(result.item.commands);
       setSummary(result.summary);
-      setPending(result.item.surface === "package-scripts" ? "allowed" : null);
+      setPending("allowed");
       setError(null);
     } catch (caught) {
       if (recognizeGeneration.current !== generation) return;
@@ -2987,7 +2998,7 @@ function AddCustomExtensionWorkspace(props) {
     setRecognized(item);
     setCommands(item.commands);
     setSummary(suggestionSummary(item));
-    setPending(item.surface === "package-scripts" && item.commands.length > 0 ? "allowed" : null);
+    setPending("allowed");
     setReviewingScripts(false);
   }, [runRecognize]);
   const findTool = reactExports.useCallback(async () => {
@@ -3014,6 +3025,10 @@ function AddCustomExtensionWorkspace(props) {
   const requestBlock = reactExports.useCallback(() => setPending("blocked"), []);
   const openScriptReview = reactExports.useCallback(() => setReviewingScripts(true), []);
   const closeScriptReview = reactExports.useCallback(() => setReviewingScripts(false), []);
+  const applyBulk = reactExports.useCallback((state) => {
+    setCommands((current) => applyBulkCommandState(current, state));
+    setPending(state === "block" ? "blocked" : "allowed");
+  }, []);
   const handleSubmit = reactExports.useCallback(async (event) => {
     event.preventDefault();
     if (recognized === null) {
@@ -3059,9 +3074,12 @@ function AddCustomExtensionWorkspace(props) {
     busy
   );
   const showingPackageCatalog = recognized?.surface === "package-scripts";
-  const enrollable = enrollablePackageScriptCommands(commands);
+  const showingMcpCatalog = recognized?.surface === "mcp";
+  const showingCatalog = showingPackageCatalog || showingMcpCatalog;
+  const enrollable = showingPackageCatalog ? enrollablePackageScriptCommands(commands) : commands;
   const visibleCommands = showingPackageCatalog ? filterPackageScriptCommands(enrollable, command) : commands;
   const previewNames = visibleCommands.slice(0, 8).map((entry) => entry.name);
+  const bulkState = bulkCommandState(enrollable);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs(
     "form",
     {
@@ -3073,11 +3091,11 @@ function AddCustomExtensionWorkspace(props) {
           /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowLeft, { className: "size-4", "aria-hidden": "true" }),
           "Extensions"
         ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("header", { className: "mt-4 max-w-2xl border-b border-slate-200 pb-6", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("header", { className: "mt-3 max-w-2xl pb-4", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("h1", { id: "add-custom-extension-title", className: "text-2xl font-semibold tracking-tight text-brand-dark", children: "Add a custom extension" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm leading-6 text-slate-500", children: dialogIntro(rememberedProjects.length > 0, showingPackageCatalog === true) })
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm leading-6 text-slate-500", children: dialogIntro(rememberedProjects.length > 0, recognized?.surface ?? null) })
         ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("label", { htmlFor: "custom-extension-command", className: "mt-6 block text-sm font-semibold text-brand-dark", children: showingPackageCatalog ? "Find a script" : "Command" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("label", { htmlFor: "custom-extension-command", className: "mt-4 block text-sm font-semibold text-brand-dark", children: showingPackageCatalog ? "Find a script" : showingMcpCatalog ? "Launch command" : "Command" }),
         /* @__PURE__ */ jsxRuntimeExports.jsx(
           "input",
           {
@@ -3091,23 +3109,27 @@ function AddCustomExtensionWorkspace(props) {
           }
         ),
         recognized !== null && showingPackageCatalog ? /* @__PURE__ */ jsxRuntimeExports.jsx(ProjectSwitcher, { items: rememberedProjects, currentId: recognized.cli_id, onSelect: selectSuggestion }) : null,
-        recognized ? /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { className: "mt-8 max-w-3xl", "aria-labelledby": "custom-extension-selected", children: [
+        recognized ? /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { className: "mt-5 max-w-3xl", "aria-labelledby": "custom-extension-selected", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { id: "custom-extension-selected", className: "text-xl font-semibold tracking-tight text-brand-dark", children: recognized.name }),
           /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 font-mono text-xs text-brand-dark/70", children: recognized.source_label ? `${recognized.source_label} · ${recognized.example_label}` : recognized.example_label }),
-          summary ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-3 max-w-2xl text-sm leading-6 text-slate-500", children: summary }) : null,
-          showingPackageCatalog ? /* @__PURE__ */ jsxRuntimeExports.jsx(
-            PackageScriptPreview,
+          summary ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 max-w-2xl text-sm leading-6 text-slate-500", children: summary }) : null,
+          showingCatalog && enrollable.length > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx(BulkPolicyPicker, { value: bulkState, disabled: busy, onChange: applyBulk }) : null,
+          showingCatalog ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+            CatalogPreview,
             {
               query: command,
+              showFilterCount: showingPackageCatalog,
               previewNames,
               visibleCount: visibleCommands.length,
               totalCount: enrollable.length,
               reviewing: reviewingScripts,
+              adjustLabel: showingMcpCatalog ? "Adjust individual tools" : "Adjust individual scripts",
+              hideLabel: "Hide individual settings",
               onOpenReview: openScriptReview,
               onCloseReview: closeScriptReview
             }
           ) : null,
-          (!showingPackageCatalog || reviewingScripts) && visibleCommands.length > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 overflow-auto rounded-2xl border border-slate-200 bg-white", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
+          (!showingCatalog || reviewingScripts) && visibleCommands.length > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3 overflow-auto rounded-2xl border border-slate-200 bg-white", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
             CustomExtensionCommandList,
             {
               commands: visibleCommands,
@@ -3141,17 +3163,17 @@ function AddCustomExtensionWorkspace(props) {
           ) }) : null,
           /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-3", children: [
             /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "submit", disabled: submitDisabled, className: "min-h-11 rounded-xl bg-brand-blue px-5 text-sm font-semibold text-white disabled:opacity-60", children: addDialogSubmitLabel({ recognized, busy, pending }) }),
-            recognized && showingPackageCatalog && pending === "allowed" ? /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", onClick: requestBlock, className: "min-h-11 rounded-xl px-4 text-sm font-semibold text-brand-dark", children: blockActionLabel(recognized.surface) }) : null,
-            recognized && showingPackageCatalog && pending === "blocked" ? /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", onClick: requestAllow, className: "min-h-11 rounded-xl px-4 text-sm font-semibold text-brand-dark", children: allowActionLabel(recognized.surface) }) : null
+            recognized && pending === "allowed" ? /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", onClick: requestBlock, className: "min-h-11 rounded-xl px-4 text-sm font-semibold text-brand-dark", children: blockActionLabel(recognized.surface) }) : null,
+            recognized && pending === "blocked" ? /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", onClick: requestAllow, className: "min-h-11 rounded-xl px-4 text-sm font-semibold text-brand-dark", children: allowActionLabel(recognized.surface) }) : null
           ] })
         ] })
       ]
     }
   );
 }
-function PackageScriptPreview(props) {
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5", children: [
-    props.query.trim() !== "" ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs leading-5 text-brand-dark/60", children: filterCountCopy(props.visibleCount, props.totalCount) }) : null,
+function CatalogPreview(props) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4", children: [
+    props.showFilterCount && props.query.trim() !== "" ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs leading-5 text-brand-dark/60", children: filterCountCopy(props.visibleCount, props.totalCount) }) : null,
     props.previewNames.length > 0 && !props.reviewing ? /* @__PURE__ */ jsxRuntimeExports.jsxs("ul", { className: "mt-3 flex flex-wrap gap-2", children: [
       props.previewNames.map((name) => /* @__PURE__ */ jsxRuntimeExports.jsx("li", { className: "rounded-full bg-slate-100 px-3 py-1.5 font-mono text-xs text-brand-dark", children: name }, name)),
       props.visibleCount > props.previewNames.length ? /* @__PURE__ */ jsxRuntimeExports.jsxs("li", { className: "rounded-full px-3 py-1.5 text-xs font-semibold text-brand-dark/60", children: [
@@ -3165,11 +3187,45 @@ function PackageScriptPreview(props) {
       {
         type: "button",
         onClick: props.reviewing ? props.onCloseReview : props.onOpenReview,
-        className: "mt-4 min-h-11 text-sm font-semibold text-brand-blue",
-        children: props.reviewing ? "Hide individual settings" : "Adjust individual scripts"
+        className: "mt-3 min-h-11 text-sm font-semibold text-brand-blue",
+        children: props.reviewing ? props.hideLabel : props.adjustLabel
       }
     )
   ] });
+}
+function BulkPolicyPicker(props) {
+  const choices = [
+    { value: "inherit", label: "Recommended" },
+    { value: "allow", label: "Allow all" },
+    { value: "block", label: "Block all" }
+  ];
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { role: "radiogroup", "aria-label": "All tools protection setting", className: "guard-segmented mt-4 w-fit", children: choices.map((choice) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+    BulkPolicyChoice,
+    {
+      choice,
+      checked: props.value === choice.value,
+      disabled: props.disabled,
+      onChoose: props.onChange
+    },
+    choice.value
+  )) });
+}
+function BulkPolicyChoice(props) {
+  const handleClick = reactExports.useCallback(() => {
+    props.onChoose(props.choice.value);
+  }, [props]);
+  return /* @__PURE__ */ jsxRuntimeExports.jsx(
+    "button",
+    {
+      type: "button",
+      role: "radio",
+      "aria-checked": props.checked,
+      disabled: props.disabled,
+      onClick: handleClick,
+      className: "min-h-11 px-4 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-45",
+      children: props.choice.label
+    }
+  );
 }
 function randomToken$1() {
   return crypto.randomUUID().replaceAll("-", "");

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
@@ -2777,6 +2777,11 @@ function addDialogSubmitLabel(input) {
   }
   return allowActionLabel(input.recognized.surface);
 }
+function commandFieldLabel(surface) {
+  if (surface === "package-scripts") return "Find a script";
+  if (surface === "mcp") return "Launch command";
+  return "Command";
+}
 function allowActionLabel(surface) {
   if (surface === "mcp") return "Allow this server";
   if (surface === "package-scripts") return "Allow these scripts";
@@ -3095,7 +3100,7 @@ function AddCustomExtensionWorkspace(props) {
           /* @__PURE__ */ jsxRuntimeExports.jsx("h1", { id: "add-custom-extension-title", className: "text-2xl font-semibold tracking-tight text-brand-dark", children: "Add a custom extension" }),
           /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm leading-6 text-slate-500", children: dialogIntro(rememberedProjects.length > 0, recognized?.surface ?? null) })
         ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("label", { htmlFor: "custom-extension-command", className: "mt-4 block text-sm font-semibold text-brand-dark", children: showingPackageCatalog ? "Find a script" : showingMcpCatalog ? "Launch command" : "Command" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("label", { htmlFor: "custom-extension-command", className: "mt-4 block text-sm font-semibold text-brand-dark", children: commandFieldLabel(recognized?.surface ?? null) }),
         /* @__PURE__ */ jsxRuntimeExports.jsx(
           "input",
           {
@@ -3199,20 +3204,47 @@ function BulkPolicyPicker(props) {
     { value: "allow", label: "Allow all" },
     { value: "block", label: "Block all" }
   ];
-  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { role: "radiogroup", "aria-label": "All tools protection setting", className: "guard-segmented mt-4 w-fit", children: choices.map((choice) => /* @__PURE__ */ jsxRuntimeExports.jsx(
-    BulkPolicyChoice,
-    {
-      choice,
-      checked: props.value === choice.value,
-      disabled: props.disabled,
-      onChoose: props.onChange
-    },
-    choice.value
-  )) });
+  const selected = props.value === "mixed" ? "inherit" : props.value;
+  const tabStopIndex = extensionPolicyRadioTabStop(choices, selected, props.disabled);
+  const chooseAdjacent = (event, index) => {
+    const next = nextExtensionPolicyRadioIndex(choices, index, event.key, props.disabled);
+    if (next < 0) return;
+    event.preventDefault();
+    props.onChange(choices[next].value);
+    event.currentTarget.parentElement?.querySelectorAll('[role="radio"]')[next]?.focus();
+  };
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "div",
+      {
+        role: "radiogroup",
+        "aria-label": "All tools protection setting",
+        "aria-describedby": props.value === "mixed" ? "bulk-policy-mixed" : void 0,
+        className: "guard-segmented w-fit",
+        children: choices.map((choice, index) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+          BulkPolicyChoice,
+          {
+            choice,
+            checked: props.value === choice.value,
+            tabIndex: !props.disabled && index === tabStopIndex ? 0 : -1,
+            disabled: props.disabled,
+            index,
+            onChoose: props.onChange,
+            onAdjacent: chooseAdjacent
+          },
+          choice.value
+        ))
+      }
+    ),
+    props.value === "mixed" ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { id: "bulk-policy-mixed", className: "mt-2 text-xs leading-5 text-brand-dark/70", children: "Custom mix. Pick Recommended, Allow all, or Block all to reset every tool." }) : null
+  ] });
 }
 function BulkPolicyChoice(props) {
   const handleClick = reactExports.useCallback(() => {
     props.onChoose(props.choice.value);
+  }, [props]);
+  const handleKeyDown = reactExports.useCallback((event) => {
+    props.onAdjacent(event, props.index);
   }, [props]);
   return /* @__PURE__ */ jsxRuntimeExports.jsx(
     "button",
@@ -3220,7 +3252,9 @@ function BulkPolicyChoice(props) {
       type: "button",
       role: "radio",
       "aria-checked": props.checked,
+      tabIndex: props.tabIndex,
       disabled: props.disabled,
+      onKeyDown: handleKeyDown,
       onClick: handleClick,
       className: "min-h-11 px-4 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-45",
       children: props.choice.label


### PR DESCRIPTION
## Summary
- Add Custom Extension now confirms an MCP server without dumping every tool as a radio row. Recommended, Allow all, and Block all set the catalog in one control.
- Recognizing a server selects Allow so the authenticator step appears and Confirm is reachable.
- Individual tool radios stay behind Adjust individual tools. Spacing on the enroll page is tighter.

## Testing
- `tsx src/local-cli-api.test.ts`
- `tsx src/protection-center/add-custom-extension-support.test.ts`
- `bun run build`
