### PR TITLE
fix(release): publish merged alpha source

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -197,18 +197,6 @@ jobs:
               VALIDATOR_ARGS+=(--existing-version "$existing_version")
             done
             VERSION=$(uv run --no-sync python scripts/validate_alpha_release.py "${VALIDATOR_ARGS[@]}")
-          elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
-            CHANNEL="canary"
-            VERSION=$(BASE_VERSION="$BASE_VERSION" PR_NUMBER="$PR_NUMBER" GITHUB_RUN_NUMBER="$GITHUB_RUN_NUMBER" GITHUB_RUN_ATTEMPT="$GITHUB_RUN_ATTEMPT" python - <<'PY'
-          import os
-
-          def pair(left: int, right: int) -> int:
-              total = left + right
-              return total * (total + 1) // 2 + right
-
-          print(f"{os.environ['BASE_VERSION']}.dev{pair(pair(int(os.environ['PR_NUMBER']), int(os.environ['GITHUB_RUN_NUMBER'])), int(os.environ['GITHUB_RUN_ATTEMPT']))}")
-          PY
-            )
           elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/release/3.0" ]] || [[ "$GITHUB_EVENT_NAME" == "pull_request" && "$GITHUB_EVENT_ACTION" == "closed" && "$PR_MERGED" == "true" && "$PR_BASE_REF" == "release/3.0" && "$PR_HEAD_REPO" == "$GITHUB_REPOSITORY" && -n "$PR_MERGE_SHA" ]]; then
             if [[ "$RELEASE_PUBLISHING_ENABLED" != "true" ]]; then
               echo "Release publishing is disabled until protected environments are verified" >&2
@@ -271,6 +259,18 @@ jobs:
               VALIDATOR_ARGS+=(--existing-version "$existing_version")
             done
             VERSION=$(uv run --no-sync python scripts/validate_alpha_release.py "${VALIDATOR_ARGS[@]}")
+          elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            CHANNEL="canary"
+            VERSION=$(BASE_VERSION="$BASE_VERSION" PR_NUMBER="$PR_NUMBER" GITHUB_RUN_NUMBER="$GITHUB_RUN_NUMBER" GITHUB_RUN_ATTEMPT="$GITHUB_RUN_ATTEMPT" python - <<'PY'
+          import os
+
+          def pair(left: int, right: int) -> int:
+              total = left + right
+              return total * (total + 1) // 2 + right
+
+          print(f"{os.environ['BASE_VERSION']}.dev{pair(pair(int(os.environ['PR_NUMBER']), int(os.environ['GITHUB_RUN_NUMBER'])), int(os.environ['GITHUB_RUN_ATTEMPT']))}")
+          PY
+            )
           elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]; then
             CHANNEL="stable"
             PYPI_VERSIONS=$(uv run --no-sync python scripts/verify_release_registry.py \

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 15393,
-  "maximum_test_source_lines": 332115,
+  "maximum_test_source_lines": 332112,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 15393,
-  "maximum_test_source_lines": 332112,
+  "maximum_test_source_lines": 332115,
   "schema_version": 1
 }

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -91,7 +91,7 @@ def test_main_push_build_computes_a_registry_derived_stable_version() -> None:
     assert 'VERSION="$BASE_VERSION"' in compute_run
     assert 'elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/release/3.0" ]]' in compute_run
     assert "pull_request" in compute_run
-    assert "PR_MERGE_SHA" in compute_run
+    assert compute_run.index("PR_MERGE_SHA") < compute_run.index('elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]')
     assert 'SOURCE_SHA="$PR_MERGE_SHA"' in compute_run
     assert 'ACTUAL_REF="$TRAIN_REF"' in compute_run
     assert 'SOURCE_SHA" != "$EXPECTED_SOURCE"' in compute_run
@@ -99,9 +99,6 @@ def test_main_push_build_computes_a_registry_derived_stable_version() -> None:
     assert "compute_alpha_release_version.py" in compute_run
     assert "validate_alpha_release.py" in compute_run
     assert 'elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]' in compute_run
-    assert compute_run.index('"$GITHUB_EVENT_ACTION" == "closed"') < compute_run.index(
-        'elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]'
-    )
     assert 'elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]' in compute_run
     assert 'CHANNEL="stable"' in compute_run
     assert "verify_release_registry.py" in compute_run

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -99,6 +99,9 @@ def test_main_push_build_computes_a_registry_derived_stable_version() -> None:
     assert "compute_alpha_release_version.py" in compute_run
     assert "validate_alpha_release.py" in compute_run
     assert 'elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]' in compute_run
+    assert compute_run.index('"$GITHUB_EVENT_ACTION" == "closed"') < compute_run.index(
+        'elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]'
+    )
     assert 'elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]' in compute_run
     assert 'CHANNEL="stable"' in compute_run
     assert "verify_release_registry.py" in compute_run


### PR DESCRIPTION
## Summary
- classify merged release pull requests before generic pull-request canaries
- preserve immutable merge-SHA alpha publication when serialized workflow events replace a push run
- pin the branch ordering with a release workflow contract test

## Testing
- `uv run --no-sync pytest -q tests/test_release_train_workflow.py tests/test_pr_testpypi_canary_workflow.py tests/test_installed_canary_workflow.py tests/test_alpha_container_workflow.py --tb=short`
- `uv run --no-sync ruff check tests/test_release_train_workflow.py`
- `uv run --no-sync ruff format --check tests/test_release_train_workflow.py`
- `actionlint .github/workflows/publish.yml`
- `git diff --check`
