### PR TITLE
fix(scanner): reduce secret and shell false positives

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 15519,
-  "maximum_test_source_lines": 334697,
+  "maximum_collected_cases": 15521,
+  "maximum_test_source_lines": 334713,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 15510,
-  "maximum_test_source_lines": 334559,
+  "maximum_collected_cases": 15519,
+  "maximum_test_source_lines": 334697,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 15521,
-  "maximum_test_source_lines": 334713,
+  "maximum_collected_cases": 15524,
+  "maximum_test_source_lines": 334727,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/checks/code_quality.py
+++ b/src/codex_plugin_scanner/checks/code_quality.py
@@ -13,10 +13,24 @@ EXCLUDED_DIRS = {"node_modules", ".git", "dist", ".next", "coverage", "__pycache
 
 EVAL_RE = re.compile(r"\beval\s*\(")
 FUNCTION_RE = re.compile(r"new\s+Function\s*\(")
-SHELL_INJECT_RE = re.compile(
-    r"`[^`]*\$\{[^}]+\}[^`]*`"
-    r"[\s\S]{0,30}"
-    r"\b(exec|spawn|execSync|spawnSync|os\.system|subprocess)\b"
+INTERPOLATED_TEMPLATE_PATTERN = r"`[^`]*\$\{[^}]+\}[^`]*`"
+SHELL_CALL_PATTERN = r"(?:execSync|spawnSync|exec|spawn)"
+SHELL_RECEIVER_PATTERN = (
+    r"(?:child_process|childProcess|cp|"
+    r"require\s*\(\s*['\"](?:node:)?child_process['\"]\s*\))"
+)
+DIRECT_SHELL_TEMPLATE_RE = re.compile(
+    rf"(?<![\w.]){SHELL_CALL_PATTERN}\s*\(\s*{INTERPOLATED_TEMPLATE_PATTERN}",
+    re.S,
+)
+MEMBER_SHELL_TEMPLATE_RE = re.compile(
+    rf"{SHELL_RECEIVER_PATTERN}\s*\.\s*{SHELL_CALL_PATTERN}\s*\(\s*{INTERPOLATED_TEMPLATE_PATTERN}",
+    re.S,
+)
+INTERPOLATED_TEMPLATE_ASSIGNMENT_RE = re.compile(
+    rf"\b(?:export\s+)?(?:const|let|var)\s+(?P<name>[A-Za-z_$][\w$]*)"
+    rf"(?:\s*:\s*[^=;\n]+)?\s*=\s*{INTERPOLATED_TEMPLATE_PATTERN}\s*;?",
+    re.S,
 )
 
 
@@ -31,6 +45,29 @@ def _find_code_files(plugin_dir: Path) -> list[Path]:
             continue
         files.append(p)
     return files
+
+
+def _shell_call_uses_variable(content: str, variable: str) -> bool:
+    escaped_variable = re.escape(variable)
+    variable_boundary = r"(?![\w$])"
+    direct_call = re.compile(
+        rf"(?<![\w.]){SHELL_CALL_PATTERN}\s*\(\s*{escaped_variable}{variable_boundary}"
+    )
+    member_call = re.compile(
+        rf"{SHELL_RECEIVER_PATTERN}\s*\.\s*{SHELL_CALL_PATTERN}\s*\(\s*"
+        rf"{escaped_variable}{variable_boundary}"
+    )
+    return bool(direct_call.search(content) or member_call.search(content))
+
+
+def _has_shell_injection_pattern(content: str) -> bool:
+    if DIRECT_SHELL_TEMPLATE_RE.search(content) or MEMBER_SHELL_TEMPLATE_RE.search(content):
+        return True
+
+    for assignment in INTERPOLATED_TEMPLATE_ASSIGNMENT_RE.finditer(content):
+        if _shell_call_uses_variable(content[assignment.end() :], assignment.group("name")):
+            return True
+    return False
 
 
 def check_no_eval(plugin_dir: Path) -> CheckResult:
@@ -80,7 +117,7 @@ def check_no_shell_injection(plugin_dir: Path) -> CheckResult:
             content = fpath.read_text(encoding="utf-8", errors="ignore")
         except OSError:
             continue
-        if SHELL_INJECT_RE.search(content):
+        if _has_shell_injection_pattern(content):
             findings.append(str(fpath.relative_to(plugin_dir)))
     if not findings:
         return CheckResult(

--- a/src/codex_plugin_scanner/checks/code_quality.py
+++ b/src/codex_plugin_scanner/checks/code_quality.py
@@ -14,6 +14,7 @@ EXCLUDED_DIRS = {"node_modules", ".git", "dist", ".next", "coverage", "__pycache
 EVAL_RE = re.compile(r"\beval\s*\(")
 FUNCTION_RE = re.compile(r"new\s+Function\s*\(")
 INTERPOLATED_TEMPLATE_PATTERN = r"`[^`]*\$\{[^}]+\}[^`]*`"
+TS_TEMPLATE_SUFFIX_PATTERN = r"(?:[ \t]+(?:as|satisfies)[ \t]+[^;\n]+)?"
 SHELL_CALL_PATTERN = r"(?:execSync|spawnSync|exec|spawn)"
 SHELL_RECEIVER_PATTERN = (
     r"(?:child_process|childProcess|cp|"
@@ -29,7 +30,8 @@ MEMBER_SHELL_TEMPLATE_RE = re.compile(
 )
 INTERPOLATED_TEMPLATE_ASSIGNMENT_RE = re.compile(
     rf"\b(?:export\s+)?(?:const|let|var)\s+(?P<name>[A-Za-z_$][\w$]*)"
-    rf"(?:\s*:\s*[^=;\n]+)?\s*=\s*{INTERPOLATED_TEMPLATE_PATTERN}\s*;?",
+    rf"(?:\s*:\s*[^=;\n]+)?\s*=\s*{INTERPOLATED_TEMPLATE_PATTERN}"
+    rf"{TS_TEMPLATE_SUFFIX_PATTERN}[ \t]*;?",
     re.S,
 )
 
@@ -50,9 +52,7 @@ def _find_code_files(plugin_dir: Path) -> list[Path]:
 def _shell_call_uses_variable(content: str, variable: str) -> bool:
     escaped_variable = re.escape(variable)
     variable_boundary = r"(?![\w$])"
-    direct_call = re.compile(
-        rf"(?<![\w.]){SHELL_CALL_PATTERN}\s*\(\s*{escaped_variable}{variable_boundary}"
-    )
+    direct_call = re.compile(rf"(?<![\w.]){SHELL_CALL_PATTERN}\s*\(\s*{escaped_variable}{variable_boundary}")
     member_call = re.compile(
         rf"{SHELL_RECEIVER_PATTERN}\s*\.\s*{SHELL_CALL_PATTERN}\s*\(\s*"
         rf"{escaped_variable}{variable_boundary}"

--- a/src/codex_plugin_scanner/checks/code_quality.py
+++ b/src/codex_plugin_scanner/checks/code_quality.py
@@ -17,7 +17,7 @@ INTERPOLATED_TEMPLATE_PATTERN = r"`[^`]*\$\{[^}]+\}[^`]*`"
 TS_TEMPLATE_SUFFIX_PATTERN = r"(?:[ \t]+(?:as|satisfies)[ \t]+[^;\n]+)?"
 SHELL_CALL_PATTERN = r"(?:execSync|spawnSync|exec|spawn)"
 SHELL_RECEIVER_PATTERN = (
-    r"(?:child_process|childProcess|cp|"
+    r"(?<![\w$])(?:child_process|childProcess|cp|"
     r"require\s*\(\s*['\"](?:node:)?child_process['\"]\s*\))"
 )
 DIRECT_SHELL_TEMPLATE_RE = re.compile(

--- a/src/codex_plugin_scanner/checks/security.py
+++ b/src/codex_plugin_scanner/checks/security.py
@@ -49,7 +49,7 @@ SECRET_PATTERNS: tuple[SecretPattern, ...] = (
     SecretPattern(re.compile(r"xoxe-[A-Za-z0-9\-]{10,}")),
     SecretPattern(re.compile(r"xoxr-[A-Za-z0-9\-]{10,}")),
     SecretPattern(re.compile(r"xapp-[A-Za-z0-9\-]{10,}")),
-    SecretPattern(re.compile(r"sk-(?:proj-|ant-)?[A-Za-z0-9_-]{20,}")),
+    SecretPattern(re.compile(r"(?<![A-Za-z0-9])sk-(?:proj-|ant-)?[A-Za-z0-9_-]{20,}")),
 )
 
 EXCLUDED_DIRS = {"node_modules", ".git", "dist", ".next", "coverage", ".turbo", "__pycache__", ".venv", "venv"}

--- a/tests/test_code_quality.py
+++ b/tests/test_code_quality.py
@@ -61,6 +61,108 @@ class TestCheckNoShellInjection:
             r = check_no_shell_injection(Path(tmpdir))
             assert r.passed and r.points == 5
 
+    def test_ignores_template_literal_near_spawn_switch_label(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "dispatcher.ts").write_text(
+                "const message = `failed ${reason}`;\n"
+                "switch (kind) {\n"
+                "  case 'spawn':\n"
+                "    return message;\n"
+                "}\n",
+                encoding="utf-8",
+            )
+
+            result = check_no_shell_injection(root)
+
+            assert result.passed is True
+            assert result.points == 5
+
+    def test_ignores_regexp_exec_with_interpolated_template(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "matcher.ts").write_text(
+                "const match = new RegExp(pattern).exec(`value ${candidate}`);\n",
+                encoding="utf-8",
+            )
+
+            result = check_no_shell_injection(root)
+
+            assert result.passed is True
+            assert result.points == 5
+
+    def test_detects_interpolated_template_passed_directly_to_exec(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "runner.js").write_text(
+                "exec(`echo ${userInput}`);\n",
+                encoding="utf-8",
+            )
+
+            result = check_no_shell_injection(root)
+
+            assert result.passed is False
+            assert result.points == 0
+            assert result.findings[0].file_path == "runner.js"
+
+    def test_detects_interpolated_template_passed_to_required_child_process(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "runner.js").write_text(
+                "require('child_process').exec(`echo ${userInput}`);\n",
+                encoding="utf-8",
+            )
+
+            result = check_no_shell_injection(root)
+
+            assert result.passed is False
+            assert result.points == 0
+            assert result.findings[0].file_path == "runner.js"
+
+    def test_detects_one_hop_variable_passed_to_required_node_child_process(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "runner.js").write_text(
+                "const cmd = `echo ${userInput}`;\n"
+                'require("node:child_process").exec(cmd);\n',
+                encoding="utf-8",
+            )
+
+            result = check_no_shell_injection(root)
+
+            assert result.passed is False
+            assert result.points == 0
+            assert result.findings[0].file_path == "runner.js"
+
+    def test_detects_typed_interpolated_template_variable_in_typescript(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "runner.ts").write_text(
+                "export const command: string = `echo ${userInput}`;\n"
+                "child_process.exec(command);\n",
+                encoding="utf-8",
+            )
+
+            result = check_no_shell_injection(root)
+
+            assert result.passed is False
+            assert result.points == 0
+            assert result.findings[0].file_path == "runner.ts"
+
+    def test_detects_interpolated_template_dollar_variable_passed_to_child_process_exec(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "runner.js").write_text(
+                "const cmd$ = `echo ${userInput}`;\nchild_process.exec(cmd$);\n",
+                encoding="utf-8",
+            )
+
+            result = check_no_shell_injection(root)
+
+            assert result.passed is False
+            assert result.points == 0
+            assert result.findings[0].file_path == "runner.js"
+
 
 class TestFindCodeFiles:
     def test_finds_js_files(self):

--- a/tests/test_code_quality.py
+++ b/tests/test_code_quality.py
@@ -149,6 +149,22 @@ class TestCheckNoShellInjection:
             assert result.points == 0
             assert result.findings[0].file_path == "runner.ts"
 
+    @pytest.mark.parametrize("suffix", ("as const", "satisfies string"))
+    def test_detects_typescript_template_assertion_suffixes(self, suffix: str):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "runner.ts").write_text(
+                f"const cmd = `echo ${{userInput}}` {suffix};\n"
+                "child_process.exec(cmd);\n",
+                encoding="utf-8",
+            )
+
+            result = check_no_shell_injection(root)
+
+            assert result.passed is False
+            assert result.points == 0
+            assert result.findings[0].file_path == "runner.ts"
+
     def test_detects_interpolated_template_dollar_variable_passed_to_child_process_exec(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/tests/test_code_quality.py
+++ b/tests/test_code_quality.py
@@ -91,6 +91,20 @@ class TestCheckNoShellInjection:
             assert result.passed is True
             assert result.points == 5
 
+    @pytest.mark.parametrize("receiver", ("mycp", "scp", "foochild_process"))
+    def test_ignores_shell_receiver_identifier_suffixes(self, receiver: str):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "runner.js").write_text(
+                f"{receiver}.exec(`echo ${{userInput}}`);\n",
+                encoding="utf-8",
+            )
+
+            result = check_no_shell_injection(root)
+
+            assert result.passed is True
+            assert result.points == 5
+
     def test_detects_interpolated_template_passed_directly_to_exec(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/tests/test_scanner_false_positive_regressions.py
+++ b/tests/test_scanner_false_positive_regressions.py
@@ -1,0 +1,36 @@
+"""Regression tests for scanner false positives reported by downstream users."""
+
+import tempfile
+from pathlib import Path
+
+from codex_plugin_scanner.checks.security import check_no_hardcoded_secrets
+
+
+def test_openai_secret_prefix_does_not_match_inside_hyphenated_identifier():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        (root / "state.ts").write_text(
+            "const marker = 'task-base-untracked-guard';\n",
+            encoding="utf-8",
+        )
+
+        result = check_no_hardcoded_secrets(root)
+
+        assert result.passed is True
+        assert result.points == 7
+
+
+def test_openai_secret_prefix_still_detects_a_standalone_token():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        token = "".join(("sk-proj-", "A1b2C3d4", "E5f6G7h8", "I9j0K1l2"))
+        (root / "config.ts").write_text(
+            f"const apiKey = '{token}';\n",
+            encoding="utf-8",
+        )
+
+        result = check_no_hardcoded_secrets(root)
+
+        assert result.passed is False
+        assert result.points == 0
+        assert result.findings[0].file_path == "config.ts"


### PR DESCRIPTION
## Summary

- require a token boundary before the OpenAI `sk-` provider prefix so ordinary identifiers such as `task-base-untracked-guard` are not treated as secrets
- replace the shell-injection proximity heuristic with call-aware matching
- keep detection for direct interpolated shell calls and the existing one-hop `const cmd = `...${...}`; child_process.exec(cmd)` pattern
- add regressions for switch-label proximity, `RegExp.prototype.exec`, embedded `sk-` text, and real shell/token positives

## Validation

- regression tests added for both reported false-positive classes
- existing dangerous shell fixture remains covered

Targets `release/3.0`.