### PR TITLE
fix(update): keep Desktop Core updates on the current 3.Y train

### DIFF
--- a/ci/code-quality-baseline.json
+++ b/ci/code-quality-baseline.json
@@ -735,7 +735,7 @@
     "tests/test_policy_bundle_v2.py": 534,
     "tests/test_policy_document_io.py": 679,
     "tests/test_release_train_workflow.py": 568,
-    "tests/test_update_desktop_core.py": 553,
+    "tests/test_update_desktop_core.py": 669,
     "tests/test_verify_release_registry.py": 567
   },
   "schema_version": 2,

--- a/ci/code-quality-baseline.json
+++ b/ci/code-quality-baseline.json
@@ -514,7 +514,7 @@
     "src/codex_plugin_scanner/guard/cli/product.py": 636,
     "src/codex_plugin_scanner/guard/cli/render.py": 2914,
     "src/codex_plugin_scanner/guard/cli/update_artifact.py": 1279,
-    "src/codex_plugin_scanner/guard/cli/update_commands.py": 2838,
+    "src/codex_plugin_scanner/guard/cli/update_commands.py": 2842,
     "src/codex_plugin_scanner/guard/cli/update_subprocess.py": 2087,
     "src/codex_plugin_scanner/guard/codex_app_server.py": 627,
     "src/codex_plugin_scanner/guard/config.py": 1394,

--- a/ci/code-quality-baseline.json
+++ b/ci/code-quality-baseline.json
@@ -735,7 +735,7 @@
     "tests/test_policy_bundle_v2.py": 534,
     "tests/test_policy_document_io.py": 679,
     "tests/test_release_train_workflow.py": 568,
-    "tests/test_update_desktop_core.py": 669,
+    "tests/test_update_desktop_core.py": 716,
     "tests/test_verify_release_registry.py": 567
   },
   "schema_version": 2,

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 15524,
-  "maximum_test_source_lines": 334727,
+  "maximum_collected_cases": 15531,
+  "maximum_test_source_lines": 334746,
   "schema_version": 1
 }

--- a/dashboard/src/approval-center-layout.tsx
+++ b/dashboard/src/approval-center-layout.tsx
@@ -262,6 +262,7 @@ export function ApprovalCenterLayout(props: LayoutProps) {
     guardVersion,
     updateStatus,
     updatePhase,
+    updateError,
     onUpdateGuard,
     onReinstallGuard,
   } = useGuardUpdate({ onReconnected: props.onGuardReconnected, enabled: props.enableUpdateStatus });
@@ -277,6 +278,7 @@ export function ApprovalCenterLayout(props: LayoutProps) {
         guardVersion={guardVersion}
         updateStatus={updateStatus}
         updatePhase={updatePhase}
+        updateError={updateError}
         onUpdateGuard={onUpdateGuard}
         onReinstallGuard={onReinstallGuard}
         approvalGate={props.approvalGate ?? null}

--- a/dashboard/src/approval-center-primitives.tsx
+++ b/dashboard/src/approval-center-primitives.tsx
@@ -62,6 +62,7 @@ export function ShellHeader(props: {
   onUpdateGuard?: () => void;
   onReinstallGuard?: () => void;
   updatePhase?: GuardUpdatePhase;
+  updateError?: string | null;
 }) {
   function handleMobileNavigationChange(event: ChangeEvent<HTMLSelectElement>) {
     props.onNavigate(event.target.value);
@@ -184,6 +185,7 @@ export function ShellSidebar(props: {
   approvalGate?: GuardApprovalGatePublicConfig | null;
   onSetUpdateChannel?: (channel: "stable" | "alpha", proof?: GuardUpdateChannelProof) => void | Promise<void>;
   updatePhase?: GuardUpdatePhase;
+  updateError?: string | null;
   cloudUserProfile?: GuardCloudUserProfile | null;
   workspaceId?: string | null;
   planId?: string | null;
@@ -303,6 +305,7 @@ export function ShellSidebar(props: {
                   guardVersion={props.guardVersion}
                   updateStatus={props.updateStatus}
                   updatePhase={props.updatePhase}
+                  updateError={props.updateError}
                   onUpdateGuard={props.onUpdateGuard}
                   onReinstallGuard={props.onReinstallGuard}
                   onSetUpdateChannel={props.onSetUpdateChannel}

--- a/dashboard/src/approval-center-primitives.tsx
+++ b/dashboard/src/approval-center-primitives.tsx
@@ -62,7 +62,6 @@ export function ShellHeader(props: {
   onUpdateGuard?: () => void;
   onReinstallGuard?: () => void;
   updatePhase?: GuardUpdatePhase;
-  updateError?: string | null;
 }) {
   function handleMobileNavigationChange(event: ChangeEvent<HTMLSelectElement>) {
     props.onNavigate(event.target.value);
@@ -185,7 +184,6 @@ export function ShellSidebar(props: {
   approvalGate?: GuardApprovalGatePublicConfig | null;
   onSetUpdateChannel?: (channel: "stable" | "alpha", proof?: GuardUpdateChannelProof) => void | Promise<void>;
   updatePhase?: GuardUpdatePhase;
-  updateError?: string | null;
   cloudUserProfile?: GuardCloudUserProfile | null;
   workspaceId?: string | null;
   planId?: string | null;
@@ -305,7 +303,6 @@ export function ShellSidebar(props: {
                   guardVersion={props.guardVersion}
                   updateStatus={props.updateStatus}
                   updatePhase={props.updatePhase}
-                  updateError={props.updateError}
                   onUpdateGuard={props.onUpdateGuard}
                   onReinstallGuard={props.onReinstallGuard}
                   onSetUpdateChannel={props.onSetUpdateChannel}

--- a/dashboard/src/guard-update-panel.tsx
+++ b/dashboard/src/guard-update-panel.tsx
@@ -30,6 +30,7 @@ export type GuardUpdatePanelProps = {
   guardVersion?: string | null;
   updateStatus?: GuardUpdateStatus | null;
   updatePhase?: GuardUpdatePhase;
+  updateError?: string | null;
   onUpdateGuard?: () => void;
   onReinstallGuard?: () => void;
   approvalGate?: GuardApprovalGatePublicConfig | null;
@@ -69,7 +70,11 @@ function recoveryReinstallHelpCopy(status: GuardUpdateStatus | null | undefined)
   return "This install came from a local folder, so automatic updates are off. Reinstall from PyPI to switch it back to a normal package; Guard restarts briefly and saved approvals stay.";
 }
 
-function updateHelpCopy(status: GuardUpdateStatus | null | undefined, phase: GuardUpdatePhase): string | null {
+function updateHelpCopy(
+  status: GuardUpdateStatus | null | undefined,
+  phase: GuardUpdatePhase,
+  errorMessage?: string | null,
+): string | null {
   if (phase === "updating") {
     return "Guard is installing the update. The dashboard will pause briefly and reopen when ready.";
   }
@@ -77,7 +82,7 @@ function updateHelpCopy(status: GuardUpdateStatus | null | undefined, phase: Gua
     return "Reconnecting to Guard after the update…";
   }
   if (phase === "error") {
-    return "The update did not finish. Try again or run hol-guard update from your terminal.";
+    return errorMessage?.trim() || "The update did not finish. The installed version stays in place. Try again, or run hol-guard update from your terminal.";
   }
   if (status?.update_suppressed) {
     if (status.retry_command) {
@@ -103,7 +108,7 @@ function updateHelpCopy(status: GuardUpdateStatus | null | undefined, phase: Gua
 export function GuardUpdatePanel(props: GuardUpdatePanelProps) {
   const version = props.guardVersion ?? props.updateStatus?.current_version ?? null;
   const phase = props.updatePhase ?? "idle";
-  const helpCopy = updateHelpCopy(props.updateStatus, phase);
+  const helpCopy = updateHelpCopy(props.updateStatus, phase, props.updateError);
   const showUpdateButton =
     props.updateStatus?.update_available === true &&
     props.updateStatus.auto_updatable &&
@@ -260,6 +265,7 @@ export function useGuardUpdate(options?: { onReconnected?: () => void; enabled?:
   const enabled = options?.enabled !== false;
   const [updateStatus, setUpdateStatus] = useState<GuardUpdateStatus | null>(null);
   const [updatePhase, setUpdatePhase] = useState<GuardUpdatePhase>(enabled ? "checking" : "idle");
+  const [updateError, setUpdateError] = useState<string | null>(null);
   const reconnectStartedAt = useRef<number | null>(null);
   const updatePhaseRef = useRef<GuardUpdatePhase>("checking");
   const updateStatusEpoch = useRef(0);
@@ -395,6 +401,7 @@ export function useGuardUpdate(options?: { onReconnected?: () => void; enabled?:
       expectedLatestVersion: string | null;
     }): Promise<void> => {
       setUpdatePhase("updating");
+      setUpdateError(null);
       try {
         const reconnectAuthorization = await prepareGuardDaemonReconnect();
         const scheduleResult = await scheduleGuardUpdate(
@@ -413,7 +420,9 @@ export function useGuardUpdate(options?: { onReconnected?: () => void; enabled?:
           return;
         }
         if (scheduleResult.scheduled !== true) {
-          throw new Error(scheduleResult.message ?? scheduleResult.error ?? "Guard update was not scheduled.");
+          throw new Error(
+            scheduleResult.message ?? scheduleResult.error ?? "Guard update was not scheduled. The installed version stays in place.",
+          );
         }
         setUpdatePhase("reconnecting");
         const redirected = await waitForReconnect(
@@ -424,8 +433,9 @@ export function useGuardUpdate(options?: { onReconnected?: () => void; enabled?:
         if (!redirected) {
           window.location.reload();
         }
-      } catch {
+      } catch (error) {
         setUpdatePhase("error");
+        setUpdateError(error instanceof Error ? error.message : "The update did not finish. The installed version stays in place.");
       }
     },
     [waitForReconnect],
@@ -478,6 +488,7 @@ export function useGuardUpdate(options?: { onReconnected?: () => void; enabled?:
     guardVersion: updateStatus?.current_version ?? null,
     updateStatus,
     updatePhase,
+    updateError,
     onUpdateGuard,
     onReinstallGuard,
     onSetUpdateChannel,

--- a/dashboard/src/guard-update.test.ts
+++ b/dashboard/src/guard-update.test.ts
@@ -326,4 +326,50 @@ const suppressed = normalizeGuardUpdateStatus({
 assert(suppressed.update_suppressed === true, "update_suppressed should normalize");
 assert(suppressed.retry_command === "pipx install --force hol-guard", "retry_command should normalize");
 
+const currentSeriesMarkup = renderToStaticMarkup(
+  createElement(GuardUpdatePanel, {
+    updateStatus: normalizeGuardUpdateStatus({
+      current_version: "3.0.0a239",
+      latest_version: "3.0.0a239",
+      installer: "desktop",
+      version_check: {
+        source: "desktop_core",
+        status: "current",
+        current_version: "3.0.0a239",
+        latest_version: "3.0.0a239",
+        update_available: false,
+      },
+      auto_updatable: true,
+      update_available: false,
+      blocked_reason: null,
+      release_channel: "alpha",
+    }),
+    onUpdateGuard: () => undefined,
+  }),
+);
+assert(currentSeriesMarkup.includes("v3.0.0a239"), "desktop current version should stay visible");
+assert(!currentSeriesMarkup.includes("Update Guard"), "desktop should not offer Update Guard when this train is current");
+
+const failedUpdateMarkup = renderToStaticMarkup(
+  createElement(GuardUpdatePanel, {
+    updatePhase: "error",
+    updateError: "This Core build is not available for Desktop yet. The installed version stays in place.",
+    updateStatus: normalizeGuardUpdateStatus({
+      current_version: "3.0.0a239",
+      latest_version: "3.0.0a239",
+      installer: "desktop",
+      auto_updatable: true,
+      update_available: false,
+    }),
+  }),
+);
+assert(
+  failedUpdateMarkup.includes("This Core build is not available for Desktop yet"),
+  "failed desktop updates should show the recovery copy",
+);
+assert(
+  failedUpdateMarkup.includes("The installed version stays in place"),
+  "failed desktop updates should say the current install remains",
+);
+
 console.log("guard-update.test.ts: all tests passed");

--- a/dashboard/src/shell-navigation-drawer.tsx
+++ b/dashboard/src/shell-navigation-drawer.tsx
@@ -212,6 +212,7 @@ export function NavigationDrawer(
               guardVersion={props.guardVersion}
               updateStatus={props.updateStatus}
               updatePhase={props.updatePhase}
+              updateError={props.updateError}
               onUpdateGuard={props.onUpdateGuard}
               onReinstallGuard={props.onReinstallGuard}
               approvalGate={props.approvalGate}

--- a/dashboard/src/shell-navigation-model.ts
+++ b/dashboard/src/shell-navigation-model.ts
@@ -43,6 +43,7 @@ export type ShellNavigationProps = {
   onUpdateGuard?: () => void;
   onReinstallGuard?: () => void;
   updatePhase?: GuardUpdatePhase;
+  updateError?: string | null;
   approvalGate?: GuardApprovalGatePublicConfig | null;
   cloudUserProfile?: GuardCloudUserProfile | null;
   workspaceId?: string | null;

--- a/dashboard/src/shell-navigation.tsx
+++ b/dashboard/src/shell-navigation.tsx
@@ -220,6 +220,7 @@ function PersistentSidebar(
               guardVersion={props.guardVersion}
               updateStatus={props.updateStatus}
               updatePhase={props.updatePhase}
+              updateError={props.updateError}
               onUpdateGuard={props.onUpdateGuard}
               onReinstallGuard={props.onReinstallGuard}
               approvalGate={props.approvalGate}

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -57,7 +57,11 @@ from .update_artifact import (
     recover_local_wheel_original,
     stage_trusted_wheel,
 )
-from .update_desktop_apply import desktop_update_status_state, run_desktop_managed_update
+from .update_desktop_apply import (
+    desktop_update_status_state,
+    refine_desktop_version_check,
+    run_desktop_managed_update,
+)
 from .update_desktop_core import is_desktop_managed_runtime
 from .update_grok_repair import append_grok_repair
 from .update_install_verify import verify_installed_distribution
@@ -1364,6 +1368,28 @@ def _latest_alpha_version_from_pypi(current_version: str) -> str | None:
     if not candidates:
         return None
     return max(candidates, key=lambda candidate: candidate[0])[1]
+
+
+def _cached_pypi_alpha_versions() -> list[str]:
+    payload = _last_pypi_payload
+    if not isinstance(payload, dict):
+        return []
+    releases = payload.get("releases")
+    if not isinstance(releases, dict):
+        return []
+    versions: list[str] = []
+    for version_text, files in releases.items():
+        if not isinstance(version_text, str) or not version_text.strip():
+            continue
+        try:
+            parsed_version = Version(version_text)
+        except InvalidVersion:
+            continue
+        if parsed_version.pre is None or parsed_version.pre[0] != "a":
+            continue
+        if _release_has_non_yanked_file(files):
+            versions.append(version_text.strip())
+    return versions
 
 
 def already_current_update_message(version_check: Mapping[str, object] | None) -> str:
@@ -2757,6 +2783,12 @@ def build_guard_update_status_payload(*, guard_home: Path | None = None) -> dict
             "update_available": None,
         }
     )
+    if installer == "desktop" and installed_distribution is not None:
+        version_check = refine_desktop_version_check(
+            current_version,
+            version_check,
+            candidates=_cached_pypi_alpha_versions(),
+        )
 
     if installer != "desktop" and auto_updatable and _python_runtime_blocks_update(version_check):
         auto_updatable = False

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -57,7 +57,11 @@ from .update_artifact import (
     recover_local_wheel_original,
     stage_trusted_wheel,
 )
-from .update_desktop_apply import desktop_update_status_state, finalize_desktop_update_status, run_desktop_managed_update
+from .update_desktop_apply import (
+    desktop_update_status_state,
+    finalize_desktop_update_status,
+    run_desktop_managed_update,
+)
 from .update_desktop_core import is_desktop_managed_runtime, pypi_alpha_versions
 from .update_grok_repair import append_grok_repair
 from .update_install_verify import verify_installed_distribution

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -57,12 +57,8 @@ from .update_artifact import (
     recover_local_wheel_original,
     stage_trusted_wheel,
 )
-from .update_desktop_apply import (
-    desktop_update_status_state,
-    refine_desktop_version_check,
-    run_desktop_managed_update,
-)
-from .update_desktop_core import is_desktop_managed_runtime
+from .update_desktop_apply import desktop_update_status_state, finalize_desktop_update_status, run_desktop_managed_update
+from .update_desktop_core import is_desktop_managed_runtime, pypi_alpha_versions
 from .update_grok_repair import append_grok_repair
 from .update_install_verify import verify_installed_distribution
 from .update_subprocess import (
@@ -1368,28 +1364,6 @@ def _latest_alpha_version_from_pypi(current_version: str) -> str | None:
     if not candidates:
         return None
     return max(candidates, key=lambda candidate: candidate[0])[1]
-
-
-def _cached_pypi_alpha_versions() -> list[str]:
-    payload = _last_pypi_payload
-    if not isinstance(payload, dict):
-        return []
-    releases = payload.get("releases")
-    if not isinstance(releases, dict):
-        return []
-    versions: list[str] = []
-    for version_text, files in releases.items():
-        if not isinstance(version_text, str) or not version_text.strip():
-            continue
-        try:
-            parsed_version = Version(version_text)
-        except InvalidVersion:
-            continue
-        if parsed_version.pre is None or parsed_version.pre[0] != "a":
-            continue
-        if _release_has_non_yanked_file(files):
-            versions.append(version_text.strip())
-    return versions
 
 
 def already_current_update_message(version_check: Mapping[str, object] | None) -> str:
@@ -2783,12 +2757,6 @@ def build_guard_update_status_payload(*, guard_home: Path | None = None) -> dict
             "update_available": None,
         }
     )
-    if installer == "desktop" and installed_distribution is not None:
-        version_check = refine_desktop_version_check(
-            current_version,
-            version_check,
-            candidates=_cached_pypi_alpha_versions(),
-        )
 
     if installer != "desktop" and auto_updatable and _python_runtime_blocks_update(version_check):
         auto_updatable = False
@@ -2843,7 +2811,7 @@ def build_guard_update_status_payload(*, guard_home: Path | None = None) -> dict
     }
     if trusted_failure_reason is not None:
         payload["reason_code"] = trusted_failure_reason
-    return payload
+    return finalize_desktop_update_status(payload, candidates=pypi_alpha_versions(_last_pypi_payload))
 
 
 def _status_installed_distribution(

--- a/src/codex_plugin_scanner/guard/cli/update_desktop_apply.py
+++ b/src/codex_plugin_scanner/guard/cli/update_desktop_apply.py
@@ -64,13 +64,18 @@ def refine_desktop_version_check(
     *,
     candidates: list[str],
 ) -> dict[str, object]:
+    status = str(version_check.get("status") or "")
+    source = str(version_check.get("source") or "")
+    if status == "unavailable" or source not in {"pypi", "desktop_core"}:
+        return version_check
     known = [item.strip() for item in candidates if item.strip()]
     latest = version_check.get("latest_version")
     if isinstance(latest, str) and latest.strip() and latest.strip() not in known:
         known.append(latest.strip())
+    current = current_version.strip()
+    if current and current not in known:
+        known.append(current)
     selected = select_desktop_core_latest(current_version, known)
-    if selected is None and str(version_check.get("status") or "") == "unavailable":
-        return version_check
     refined = dict(version_check)
     refined["source"] = "desktop_core"
     if selected is None:

--- a/src/codex_plugin_scanner/guard/cli/update_desktop_apply.py
+++ b/src/codex_plugin_scanner/guard/cli/update_desktop_apply.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+from packaging.version import InvalidVersion, Version
+
 from ..adapters.base import HarnessContext
 from ..mdm.contracts import ManagedNetworkPolicy
 from ..store import GuardStore
@@ -13,10 +15,29 @@ from .update_desktop_core import (
     apply_desktop_core_update,
     desktop_core_updates_supported,
     desktop_core_uses_alpha_channel,
+    select_desktop_core_latest,
 )
 
 _STABLE_CORE_FEED_MESSAGE = "Stable Core updates are not published yet. Switch the update channel to alpha."
 _DAEMON_REFRESH_FAILED = "HOL Guard was updated, but its daemon could not be restarted safely."
+_APPLY_FAILURE_FALLBACK = "HOL Guard could not apply the signed Core update. The installed version stays in place."
+_APPLY_FAILURE_MESSAGES = {
+    "desktop_core_download_failed": (
+        "This Core build is not available for Desktop yet. The installed version stays in place."
+    ),
+    "desktop_core_integrity_mismatch": (
+        "The downloaded Core did not match its signed manifest. The installed version stays in place."
+    ),
+    "desktop_core_signature_invalid": (
+        "Desktop could not verify the Core signature. The installed version stays in place."
+    ),
+    "desktop_core_signature_mismatch": (
+        "Desktop could not verify the Core signature. The installed version stays in place."
+    ),
+    "desktop_core_desktop_too_old": (
+        "This Desktop app is too old for the latest Core. Install the newest Desktop, then update Guard again."
+    ),
+}
 
 
 def desktop_update_status_state(
@@ -34,6 +55,40 @@ def desktop_update_status_state(
     if include_alpha:
         return True, True, None
     return False, False, _STABLE_CORE_FEED_MESSAGE
+
+
+def refine_desktop_version_check(
+    current_version: str,
+    version_check: dict[str, object],
+    *,
+    candidates: list[str],
+) -> dict[str, object]:
+    known = [item.strip() for item in candidates if item.strip()]
+    latest = version_check.get("latest_version")
+    if isinstance(latest, str) and latest.strip() and latest.strip() not in known:
+        known.append(latest.strip())
+    selected = select_desktop_core_latest(current_version, known)
+    if selected is None and str(version_check.get("status") or "") == "unavailable":
+        return version_check
+    refined = dict(version_check)
+    refined["source"] = "desktop_core"
+    if selected is None:
+        refined["latest_version"] = current_version
+        refined["update_available"] = False
+        refined["status"] = "current"
+        return refined
+    try:
+        newer = Version(selected) > Version(current_version)
+    except InvalidVersion:
+        newer = False
+    refined["latest_version"] = selected
+    refined["update_available"] = newer
+    refined["status"] = "stale" if newer else "current"
+    return refined
+
+
+def desktop_core_apply_failure_message(reason_code: str) -> str:
+    return _APPLY_FAILURE_MESSAGES.get(reason_code, _APPLY_FAILURE_FALLBACK)
 
 
 def run_desktop_managed_update(
@@ -62,11 +117,15 @@ def run_desktop_managed_update(
 
     include_alpha = payload.get("release_channel") == "alpha"
     current_version = str(payload["current_version"])
-    version_check = commands._version_check_payload(
+    version_check = refine_desktop_version_check(
         current_version,
-        source_kind="pypi",
-        network_policy=network_policy,
-        include_alpha=include_alpha,
+        commands._version_check_payload(
+            current_version,
+            source_kind="pypi",
+            network_policy=network_policy,
+            include_alpha=include_alpha,
+        ),
+        candidates=commands._cached_pypi_alpha_versions(),
     )
     payload["version_check"] = version_check
     already_current = (
@@ -222,7 +281,7 @@ def _desktop_apply_target(
                 "changed": False,
                 "reason_code": error.reason_code,
                 "error": str(error),
-                "message": "HOL Guard could not apply the signed Core update.",
+                "message": desktop_core_apply_failure_message(error.reason_code),
             }
         )
         return payload, 1

--- a/src/codex_plugin_scanner/guard/cli/update_desktop_apply.py
+++ b/src/codex_plugin_scanner/guard/cli/update_desktop_apply.py
@@ -15,6 +15,7 @@ from .update_desktop_core import (
     apply_desktop_core_update,
     desktop_core_updates_supported,
     desktop_core_uses_alpha_channel,
+    pypi_alpha_versions,
     select_desktop_core_latest,
 )
 
@@ -91,6 +92,29 @@ def desktop_core_apply_failure_message(reason_code: str) -> str:
     return _APPLY_FAILURE_MESSAGES.get(reason_code, _APPLY_FAILURE_FALLBACK)
 
 
+def finalize_desktop_update_status(
+    payload: dict[str, object],
+    *,
+    candidates: list[str],
+) -> dict[str, object]:
+    if payload.get("installer") != "desktop":
+        return payload
+    version_check = payload.get("version_check")
+    if not isinstance(version_check, dict):
+        return payload
+    current_version = str(payload.get("current_version") or "")
+    refined = refine_desktop_version_check(
+        current_version,
+        version_check,
+        candidates=candidates,
+    )
+    latest_version = refined.get("latest_version")
+    payload["version_check"] = refined
+    payload["latest_version"] = latest_version if isinstance(latest_version, str) else None
+    payload["update_available"] = payload.get("auto_updatable") is True and refined.get("update_available") is True
+    return payload
+
+
 def run_desktop_managed_update(
     payload: dict[str, object],
     *,
@@ -125,7 +149,7 @@ def run_desktop_managed_update(
             network_policy=network_policy,
             include_alpha=include_alpha,
         ),
-        candidates=commands._cached_pypi_alpha_versions(),
+        candidates=pypi_alpha_versions(commands._last_pypi_payload),
     )
     payload["version_check"] = version_check
     already_current = (

--- a/src/codex_plugin_scanner/guard/cli/update_desktop_core.py
+++ b/src/codex_plugin_scanner/guard/cli/update_desktop_core.py
@@ -88,8 +88,6 @@ def desktop_core_release_series(version: str) -> tuple[int, int] | None:
         parsed = Version(version)
     except InvalidVersion:
         return None
-    if parsed.major != 3:
-        return None
     return (parsed.major, parsed.minor)
 
 

--- a/src/codex_plugin_scanner/guard/cli/update_desktop_core.py
+++ b/src/codex_plugin_scanner/guard/cli/update_desktop_core.py
@@ -93,6 +93,33 @@ def desktop_core_release_series(version: str) -> tuple[int, int] | None:
     return (parsed.major, parsed.minor)
 
 
+def pypi_alpha_versions(payload: object) -> list[str]:
+    if not isinstance(payload, dict):
+        return []
+    releases = payload.get("releases")
+    if not isinstance(releases, dict):
+        return []
+    versions: list[str] = []
+    for version_text, files in releases.items():
+        if not isinstance(version_text, str) or not version_text.strip():
+            continue
+        try:
+            parsed_version = Version(version_text)
+        except InvalidVersion:
+            continue
+        if parsed_version.pre is None or parsed_version.pre[0] != "a":
+            continue
+        if _release_files_are_available(files):
+            versions.append(version_text.strip())
+    return versions
+
+
+def _release_files_are_available(files: object) -> bool:
+    if not isinstance(files, list):
+        return False
+    return any(isinstance(item, dict) and not item.get("yanked") for item in files)
+
+
 def select_desktop_core_latest(current_version: str, candidates: list[str]) -> str | None:
     series = desktop_core_release_series(current_version)
     if series is None:
@@ -420,5 +447,6 @@ __all__ = [
     "is_desktop_managed_runtime",
     "is_frozen_runtime",
     "platform_target",
+    "pypi_alpha_versions",
     "select_desktop_core_latest",
 ]

--- a/src/codex_plugin_scanner/guard/cli/update_desktop_core.py
+++ b/src/codex_plugin_scanner/guard/cli/update_desktop_core.py
@@ -83,6 +83,39 @@ def desktop_core_uses_alpha_channel(current_version: str, *, requested_alpha: bo
     return requested_alpha or _version_is_prerelease(current_version)
 
 
+def desktop_core_release_series(version: str) -> tuple[int, int] | None:
+    try:
+        parsed = Version(version)
+    except InvalidVersion:
+        return None
+    if parsed.major != 3:
+        return None
+    return (parsed.major, parsed.minor)
+
+
+def select_desktop_core_latest(current_version: str, candidates: list[str]) -> str | None:
+    series = desktop_core_release_series(current_version)
+    if series is None:
+        return None
+    matching: list[tuple[Version, str]] = []
+    for text in candidates:
+        candidate = text.strip()
+        if not candidate:
+            continue
+        try:
+            parsed = Version(candidate)
+        except InvalidVersion:
+            continue
+        if (parsed.major, parsed.minor) != series:
+            continue
+        if parsed.pre is None or parsed.pre[0] != "a":
+            continue
+        matching.append((parsed, candidate))
+    if not matching:
+        return None
+    return max(matching, key=lambda item: item[0])[1]
+
+
 def platform_target() -> str | None:
     system = sys.platform
     machine = platform.machine().lower()
@@ -379,6 +412,7 @@ __all__ = [
     "DesktopCoreApplyResult",
     "DesktopCoreUpdateError",
     "apply_desktop_core_update",
+    "desktop_core_release_series",
     "desktop_core_root",
     "desktop_core_updates_supported",
     "desktop_core_uses_alpha_channel",
@@ -386,4 +420,5 @@ __all__ = [
     "is_desktop_managed_runtime",
     "is_frozen_runtime",
     "platform_target",
+    "select_desktop_core_latest",
 ]

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -19578,7 +19578,7 @@ function recoveryReinstallHelpCopy(status) {
   }
   return "This install came from a local folder, so automatic updates are off. Reinstall from PyPI to switch it back to a normal package; Guard restarts briefly and saved approvals stay.";
 }
-function updateHelpCopy(status, phase) {
+function updateHelpCopy(status, phase, errorMessage) {
   if (phase === "updating") {
     return "Guard is installing the update. The dashboard will pause briefly and reopen when ready.";
   }
@@ -19586,7 +19586,7 @@ function updateHelpCopy(status, phase) {
     return "Reconnecting to Guard after the update…";
   }
   if (phase === "error") {
-    return "The update did not finish. Try again or run hol-guard update from your terminal.";
+    return errorMessage?.trim() || "The update did not finish. The installed version stays in place. Try again, or run hol-guard update from your terminal.";
   }
   if (status?.update_suppressed) {
     if (status.retry_command) {
@@ -19611,7 +19611,7 @@ function updateHelpCopy(status, phase) {
 function GuardUpdatePanel(props) {
   const version = props.guardVersion ?? props.updateStatus?.current_version ?? null;
   const phase = props.updatePhase ?? "idle";
-  const helpCopy = updateHelpCopy(props.updateStatus, phase);
+  const helpCopy = updateHelpCopy(props.updateStatus, phase, props.updateError);
   const showUpdateButton = props.updateStatus?.update_available === true && props.updateStatus.auto_updatable && props.updateStatus.update_suppressed !== true && phase !== "updating" && phase !== "reconnecting";
   const showReinstallButton = shouldPromptRecoveryReinstall(props.updateStatus) && phase !== "updating" && phase !== "reconnecting";
   const busy = phase === "updating" || phase === "reconnecting";
@@ -19754,6 +19754,7 @@ function useGuardUpdate(options) {
   const enabled = options?.enabled !== false;
   const [updateStatus, setUpdateStatus] = reactExports.useState(null);
   const [updatePhase, setUpdatePhase] = reactExports.useState(enabled ? "checking" : "idle");
+  const [updateError, setUpdateError] = reactExports.useState(null);
   const reconnectStartedAt = reactExports.useRef(null);
   const updatePhaseRef = reactExports.useRef("checking");
   const updateStatusEpoch = reactExports.useRef(0);
@@ -19863,6 +19864,7 @@ function useGuardUpdate(options) {
   const scheduleAndWait = reactExports.useCallback(
     async (params) => {
       setUpdatePhase("updating");
+      setUpdateError(null);
       try {
         const reconnectAuthorization = await prepareGuardDaemonReconnect();
         const scheduleResult = await scheduleGuardUpdate(
@@ -19881,7 +19883,9 @@ function useGuardUpdate(options) {
           return;
         }
         if (scheduleResult.scheduled !== true) {
-          throw new Error(scheduleResult.message ?? scheduleResult.error ?? "Guard update was not scheduled.");
+          throw new Error(
+            scheduleResult.message ?? scheduleResult.error ?? "Guard update was not scheduled. The installed version stays in place."
+          );
         }
         setUpdatePhase("reconnecting");
         const redirected = await waitForReconnect(
@@ -19892,8 +19896,9 @@ function useGuardUpdate(options) {
         if (!redirected) {
           window.location.reload();
         }
-      } catch {
+      } catch (error) {
         setUpdatePhase("error");
+        setUpdateError(error instanceof Error ? error.message : "The update did not finish. The installed version stays in place.");
       }
     },
     [waitForReconnect]
@@ -19940,6 +19945,7 @@ function useGuardUpdate(options) {
     guardVersion: updateStatus?.current_version ?? null,
     updateStatus,
     updatePhase,
+    updateError,
     onUpdateGuard,
     onReinstallGuard,
     onSetUpdateChannel,
@@ -20308,6 +20314,7 @@ function NavigationDrawer(props) {
                       guardVersion: props.guardVersion,
                       updateStatus: props.updateStatus,
                       updatePhase: props.updatePhase,
+                      updateError: props.updateError,
                       onUpdateGuard: props.onUpdateGuard,
                       onReinstallGuard: props.onReinstallGuard,
                       approvalGate: props.approvalGate
@@ -20523,6 +20530,7 @@ function PersistentSidebar(props) {
                   guardVersion: props.guardVersion,
                   updateStatus: props.updateStatus,
                   updatePhase: props.updatePhase,
+                  updateError: props.updateError,
                   onUpdateGuard: props.onUpdateGuard,
                   onReinstallGuard: props.onReinstallGuard,
                   approvalGate: props.approvalGate
@@ -30475,6 +30483,7 @@ function ApprovalCenterLayout(props) {
     guardVersion,
     updateStatus,
     updatePhase,
+    updateError,
     onUpdateGuard,
     onReinstallGuard
   } = useGuardUpdate({ onReconnected: props.onGuardReconnected, enabled: props.enableUpdateStatus });
@@ -30490,6 +30499,7 @@ function ApprovalCenterLayout(props) {
         guardVersion,
         updateStatus,
         updatePhase,
+        updateError,
         onUpdateGuard,
         onReinstallGuard,
         approvalGate: props.approvalGate ?? null,

--- a/tests/test_update_desktop_core.py
+++ b/tests/test_update_desktop_core.py
@@ -537,6 +537,123 @@ def test_wait_for_updated_core_binds_spawned_pid(
     assert seen["expected_pid"] == 4242
 
 
+def test_select_desktop_core_latest_stays_on_current_series() -> None:
+    selected = update_desktop_core.select_desktop_core_latest(
+        "3.0.0a239",
+        ["3.1.0a13", "3.1.0a5", "3.0.0a239", "3.0.0a238", "2.2.122"],
+    )
+    assert selected == "3.0.0a239"
+
+
+def test_select_desktop_core_latest_picks_newer_same_series() -> None:
+    selected = update_desktop_core.select_desktop_core_latest(
+        "3.0.0a230",
+        ["3.1.0a13", "3.0.0a239", "3.0.0a231"],
+    )
+    assert selected == "3.0.0a239"
+
+
+def test_desktop_status_does_not_advertise_newer_train(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(update_desktop_core, "is_frozen_runtime", lambda: True)
+    monkeypatch.setattr(update_commands, "_is_frozen_runtime", lambda: True)
+    monkeypatch.setenv("HOL_GUARD_DESKTOP", "1")
+    monkeypatch.setattr(update_commands.package_version, "__version__", "3.0.0a239")
+    monkeypatch.setattr(
+        update_commands.importlib.metadata,
+        "version",
+        MagicMock(side_effect=importlib.metadata.PackageNotFoundError),
+    )
+    monkeypatch.setattr(
+        update_commands,
+        "_status_installed_distribution",
+        MagicMock(side_effect=AssertionError("frozen Desktop must not probe package metadata")),
+    )
+    monkeypatch.setattr(
+        update_commands,
+        "_version_check_payload",
+        lambda current_version, **_kwargs: {
+            "source": "pypi",
+            "status": "stale",
+            "current_version": current_version,
+            "latest_version": "3.1.0a13",
+            "update_available": True,
+        },
+    )
+    monkeypatch.setattr(
+        update_commands,
+        "_cached_pypi_alpha_versions",
+        lambda: ["3.1.0a13", "3.1.0a5", "3.0.0a239", "3.0.0a238"],
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.update_desktop_apply.desktop_core_updates_supported",
+        lambda: True,
+    )
+
+    payload = build_guard_update_status_payload()
+
+    assert payload["installer"] == "desktop"
+    assert payload["current_version"] == "3.0.0a239"
+    assert payload["latest_version"] == "3.0.0a239"
+    assert payload["update_available"] is False
+    assert payload["auto_updatable"] is True
+    assert payload["version_check"]["latest_version"] == "3.0.0a239"
+    assert payload["version_check"]["update_available"] is False
+
+
+def test_desktop_cli_update_does_not_apply_newer_train(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(update_commands, "_is_desktop_managed_runtime", lambda: True)
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "3.0.0a239")
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.update_desktop_apply.desktop_core_updates_supported",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        update_commands,
+        "_version_check_payload",
+        lambda current_version, **_kwargs: {
+            "source": "pypi",
+            "status": "stale",
+            "current_version": current_version,
+            "latest_version": "3.1.0a13",
+            "update_available": True,
+        },
+    )
+    monkeypatch.setattr(
+        update_commands,
+        "_cached_pypi_alpha_versions",
+        lambda: ["3.1.0a13", "3.0.0a239"],
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.update_desktop_apply.apply_desktop_core_update",
+        MagicMock(side_effect=AssertionError("must not apply a newer 3.Y train")),
+    )
+
+    payload, exit_code = update_commands.run_guard_update(
+        dry_run=False,
+        include_alpha=True,
+        guard_home=tmp_path / "guard-home",
+    )
+
+    assert exit_code == 0
+    assert payload["status"] == "current"
+    assert payload["resulting_version"] == "3.0.0a239"
+    assert payload["changed"] is False
+    assert payload["version_check"]["latest_version"] == "3.0.0a239"
+
+
+def test_desktop_apply_download_failure_explains_missing_core() -> None:
+    from codex_plugin_scanner.guard.cli.update_desktop_apply import desktop_core_apply_failure_message
+
+    message = desktop_core_apply_failure_message("desktop_core_download_failed")
+    assert "not available for Desktop" in message
+    assert "stays in place" in message
+
+
 def test_dashboard_runner_and_daemon_env_preserve_desktop_version(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_update_desktop_core.py
+++ b/tests/test_update_desktop_core.py
@@ -543,6 +543,13 @@ def test_select_desktop_core_latest_stays_on_current_series() -> None:
         ["3.1.0a13", "3.1.0a5", "3.0.0a239", "3.0.0a238", "2.2.122"],
     )
     assert selected == "3.0.0a239"
+    assert (
+        update_desktop_core.select_desktop_core_latest(
+            "4.0.0a2",
+            ["4.0.0a2", "4.0.0a1", "3.0.0a239"],
+        )
+        == "4.0.0a2"
+    )
 
 
 def test_select_desktop_core_latest_picks_newer_same_series() -> None:
@@ -643,6 +650,46 @@ def test_desktop_cli_update_does_not_apply_newer_train(
     assert payload["resulting_version"] == "3.0.0a239"
     assert payload["changed"] is False
     assert payload["version_check"]["latest_version"] == "3.0.0a239"
+
+
+def test_refine_keeps_current_when_older_same_series_is_listed() -> None:
+    from codex_plugin_scanner.guard.cli.update_desktop_apply import refine_desktop_version_check
+
+    refined = refine_desktop_version_check(
+        "3.0.0a239",
+        {
+            "source": "pypi",
+            "status": "stale",
+            "current_version": "3.0.0a239",
+            "latest_version": "3.1.0a13",
+            "update_available": True,
+        },
+        candidates=["3.1.0a13", "3.0.0a238"],
+    )
+    assert refined["latest_version"] == "3.0.0a239"
+    assert refined["update_available"] is False
+    assert refined["status"] == "current"
+
+
+def test_refine_preserves_unavailable_and_managed_sources() -> None:
+    from codex_plugin_scanner.guard.cli.update_desktop_apply import refine_desktop_version_check
+
+    unavailable = {
+        "source": "pypi",
+        "status": "unavailable",
+        "current_version": "3.0.0a239",
+        "latest_version": None,
+        "update_available": None,
+    }
+    managed = {
+        "source": "managed_index",
+        "status": "stale",
+        "current_version": "3.0.0a239",
+        "latest_version": "3.0.0a240",
+        "update_available": True,
+    }
+    assert refine_desktop_version_check("3.0.0a239", unavailable, candidates=["3.0.0a239"]) == unavailable
+    assert refine_desktop_version_check("3.0.0a239", managed, candidates=["3.1.0a13"]) == managed
 
 
 def test_desktop_apply_download_failure_explains_missing_core() -> None:

--- a/tests/test_update_desktop_core.py
+++ b/tests/test_update_desktop_core.py
@@ -583,8 +583,8 @@ def test_desktop_status_does_not_advertise_newer_train(
     )
     monkeypatch.setattr(
         update_commands,
-        "_cached_pypi_alpha_versions",
-        lambda: ["3.1.0a13", "3.1.0a5", "3.0.0a239", "3.0.0a238"],
+        "pypi_alpha_versions",
+        lambda _payload: ["3.1.0a13", "3.1.0a5", "3.0.0a239", "3.0.0a238"],
     )
     monkeypatch.setattr(
         "codex_plugin_scanner.guard.cli.update_desktop_apply.desktop_core_updates_supported",
@@ -624,9 +624,8 @@ def test_desktop_cli_update_does_not_apply_newer_train(
         },
     )
     monkeypatch.setattr(
-        update_commands,
-        "_cached_pypi_alpha_versions",
-        lambda: ["3.1.0a13", "3.0.0a239"],
+        "codex_plugin_scanner.guard.cli.update_desktop_apply.pypi_alpha_versions",
+        lambda _payload: ["3.1.0a13", "3.0.0a239"],
     )
     monkeypatch.setattr(
         "codex_plugin_scanner.guard.cli.update_desktop_apply.apply_desktop_core_update",


### PR DESCRIPTION
## Summary
- Desktop-managed Core updates stay on the installed 3.Y train instead of following a newer global alpha that has no signed Core build.
- Update status no longer advertises that later train as ready to install.
- Failed Core downloads tell the operator that the installed version stays in place.

## Testing
- `.venv/bin/python -m pytest tests/test_update_desktop_core.py --tb=short`
- `npx tsx src/guard-update.test.ts` from `dashboard/`
