### PR TITLE
fix(packages): reconcile approval authority

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 15533,
-  "maximum_test_source_lines": 334864,
+  "maximum_collected_cases": 15535,
+  "maximum_test_source_lines": 334901,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 15536,
-  "maximum_test_source_lines": 334921,
+  "maximum_test_source_lines": 334922,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 15535,
-  "maximum_test_source_lines": 334901,
+  "maximum_collected_cases": 15536,
+  "maximum_test_source_lines": 334921,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 15536,
-  "maximum_test_source_lines": 334922,
+  "maximum_collected_cases": 15537,
+  "maximum_test_source_lines": 334936,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/cli/protect_approvals.py
+++ b/src/codex_plugin_scanner/guard/cli/protect_approvals.py
@@ -219,13 +219,17 @@ def _protect_approval_action_envelope(
             return envelope
         envelope.pop("observe_mode", None)
         envelope.pop("observed_policy_action", None)
-    for key in ("policy_action", "policyAction", "pre_execution_result", "preExecutionResult"):
+    action_keys = ("policy_action", "policyAction", "pre_execution_result", "preExecutionResult")
+    for key in action_keys:
         envelope_action = _normalize_protect_policy_action(envelope.get(key))
         if envelope_action is None:
             continue
         strongest_action = most_restrictive_guard_action(envelope_action, policy_action, unknown_action="block")
         if strongest_action != policy_action:
             return envelope
+    for key in action_keys:
+        if _normalize_protect_policy_action(envelope.get(key)) is None:
+            continue
         envelope[key] = policy_action
     return envelope
 

--- a/src/codex_plugin_scanner/guard/cli/protect_approvals.py
+++ b/src/codex_plugin_scanner/guard/cli/protect_approvals.py
@@ -8,7 +8,7 @@ import shlex
 from collections.abc import Callable
 from pathlib import Path
 
-from ..action_lattice import is_guard_action, most_restrictive_guard_action
+from ..action_lattice import is_guard_action, most_restrictive_guard_action, normalize_guard_action
 from ..adapters.base import HarnessContext
 from ..approvals import approval_center_hint, attach_primary_approval_link, queue_blocked_approvals
 from ..config import load_guard_config
@@ -221,14 +221,7 @@ def _protect_approval_action_envelope(
         envelope.pop("observed_policy_action", None)
     action_keys = ("policy_action", "policyAction", "pre_execution_result", "preExecutionResult")
     for key in action_keys:
-        envelope_action = _normalize_protect_policy_action(envelope.get(key))
-        if envelope_action is None:
-            continue
-        strongest_action = most_restrictive_guard_action(envelope_action, policy_action, unknown_action="block")
-        if strongest_action != policy_action:
-            return envelope
-    for key in action_keys:
-        if _normalize_protect_policy_action(envelope.get(key)) is None:
+        if key not in envelope or envelope.get(key) is None:
             continue
         envelope[key] = policy_action
     return envelope
@@ -328,11 +321,20 @@ def _protect_policy_action_candidates(
 
 def _protect_policy_action(response_payload: dict[str, object]) -> GuardAction | None:
     verdict_action, supply_action = _protect_policy_action_candidates(response_payload)
-    if verdict_action is None:
-        return supply_action
-    if supply_action is None:
-        return verdict_action
-    return most_restrictive_guard_action(verdict_action, supply_action, unknown_action="block")
+    candidates: list[GuardAction] = [action for action in (verdict_action, supply_action) if action is not None]
+    receipt = response_payload.get("receipt")
+    envelope = receipt.get("action_envelope_json") if isinstance(receipt, dict) else None
+    if isinstance(envelope, dict):
+        for key in ("policy_action", "policyAction", "pre_execution_result", "preExecutionResult"):
+            if key not in envelope or envelope.get(key) is None:
+                continue
+            candidates.append(normalize_guard_action(envelope.get(key), unknown_action="block"))
+    if not candidates:
+        return None
+    action = candidates[0]
+    for candidate in candidates[1:]:
+        action = most_restrictive_guard_action(action, candidate, unknown_action="block")
+    return action
 
 
 def _protect_policy_actions_disagree(response_payload: dict[str, object]) -> bool:

--- a/src/codex_plugin_scanner/guard/cli/protect_approvals.py
+++ b/src/codex_plugin_scanner/guard/cli/protect_approvals.py
@@ -213,16 +213,20 @@ def _protect_approval_action_envelope(
     if not isinstance(value, dict):
         return None
     envelope = dict(value)
-    if envelope.get("observe_mode") is not True:
-        return envelope
-    observed_action = _normalize_protect_policy_action(envelope.get("observed_policy_action"))
-    if observed_action != policy_action:
-        return envelope
-    envelope.pop("observe_mode", None)
-    envelope.pop("observed_policy_action", None)
+    if envelope.get("observe_mode") is True:
+        observed_action = _normalize_protect_policy_action(envelope.get("observed_policy_action"))
+        if observed_action != policy_action:
+            return envelope
+        envelope.pop("observe_mode", None)
+        envelope.pop("observed_policy_action", None)
     for key in ("policy_action", "policyAction", "pre_execution_result", "preExecutionResult"):
-        if key in envelope:
-            envelope[key] = policy_action
+        envelope_action = _normalize_protect_policy_action(envelope.get(key))
+        if envelope_action is None:
+            continue
+        strongest_action = most_restrictive_guard_action(envelope_action, policy_action, unknown_action="block")
+        if strongest_action != policy_action:
+            return envelope
+        envelope[key] = policy_action
     return envelope
 
 

--- a/tests/test_guard_protect_approval_decision.py
+++ b/tests/test_guard_protect_approval_decision.py
@@ -202,6 +202,26 @@ def test_protect_approval_does_not_weaken_stricter_envelope_action(tmp_path: Pat
         authoritative_decision_from_artifact(item)
 
 
+def test_protect_approval_does_not_partially_mutate_conflicting_action_aliases(tmp_path: Path) -> None:
+    response = _response(verdict_action="review", supply_action="review")
+    receipt = response["receipt"]
+    assert isinstance(receipt, dict)
+    receipt["action_envelope_json"] = {
+        "policy_action": "allow",
+        "policyAction": "block",
+        "package_manager": "bun",
+    }
+
+    item = _protect_approval_item(response, workspace=tmp_path, artifact=_artifact(tmp_path))
+
+    assert item is not None
+    assert item["action_envelope_json"] == {
+        "policy_action": "allow",
+        "policyAction": "block",
+        "package_manager": "bun",
+    }
+
+
 def test_strict_decision_parser_still_rejects_the_old_partial_protect_shape() -> None:
     old_partial_payload = {
         "action": "require-reapproval",

--- a/tests/test_guard_protect_approval_decision.py
+++ b/tests/test_guard_protect_approval_decision.py
@@ -165,6 +165,43 @@ def test_protect_approval_projects_watch_only_envelope_to_observed_action(tmp_pa
     assert authoritative_decision_from_artifact(item).action == "require-reapproval"
 
 
+def test_protect_approval_projects_weaker_cached_envelope_to_supply_chain_action(tmp_path: Path) -> None:
+    response = _response(verdict_action="allow", supply_action="require-reapproval")
+    receipt = response["receipt"]
+    assert isinstance(receipt, dict)
+    receipt["action_envelope_json"] = {
+        "policy_action": "allow",
+        "package_manager": "bun",
+        "package_targets": ["@openai/codex"],
+    }
+
+    item = _protect_approval_item(response, workspace=tmp_path, artifact=_artifact(tmp_path))
+
+    assert item is not None
+    assert item["policy_action"] == "require-reapproval"
+    assert item["action_envelope_json"] == {
+        "policy_action": "require-reapproval",
+        "package_manager": "bun",
+        "package_targets": ["@openai/codex"],
+    }
+    assert authoritative_decision_from_artifact(item).action == "require-reapproval"
+
+
+def test_protect_approval_does_not_weaken_stricter_envelope_action(tmp_path: Path) -> None:
+    response = _response(verdict_action="review", supply_action="review")
+    receipt = response["receipt"]
+    assert isinstance(receipt, dict)
+    receipt["action_envelope_json"] = {"policy_action": "block", "package_manager": "bun"}
+
+    item = _protect_approval_item(response, workspace=tmp_path, artifact=_artifact(tmp_path))
+
+    assert item is not None
+    assert item["policy_action"] == "review"
+    assert item["action_envelope_json"] == {"policy_action": "block", "package_manager": "bun"}
+    with pytest.raises(ValueError, match="must match authoritative action"):
+        authoritative_decision_from_artifact(item)
+
+
 def test_strict_decision_parser_still_rejects_the_old_partial_protect_shape() -> None:
     old_partial_payload = {
         "action": "require-reapproval",

--- a/tests/test_guard_protect_approval_decision.py
+++ b/tests/test_guard_protect_approval_decision.py
@@ -196,13 +196,12 @@ def test_protect_approval_does_not_weaken_stricter_envelope_action(tmp_path: Pat
     item = _protect_approval_item(response, workspace=tmp_path, artifact=_artifact(tmp_path))
 
     assert item is not None
-    assert item["policy_action"] == "review"
+    assert item["policy_action"] == "block"
     assert item["action_envelope_json"] == {"policy_action": "block", "package_manager": "bun"}
-    with pytest.raises(ValueError, match="must match authoritative action"):
-        authoritative_decision_from_artifact(item)
+    assert authoritative_decision_from_artifact(item).action == "block"
 
 
-def test_protect_approval_does_not_partially_mutate_conflicting_action_aliases(tmp_path: Path) -> None:
+def test_protect_approval_reconciles_conflicting_action_aliases_to_strongest_action(tmp_path: Path) -> None:
     response = _response(verdict_action="review", supply_action="review")
     receipt = response["receipt"]
     assert isinstance(receipt, dict)
@@ -215,11 +214,27 @@ def test_protect_approval_does_not_partially_mutate_conflicting_action_aliases(t
     item = _protect_approval_item(response, workspace=tmp_path, artifact=_artifact(tmp_path))
 
     assert item is not None
+    assert item["policy_action"] == "block"
     assert item["action_envelope_json"] == {
-        "policy_action": "allow",
+        "policy_action": "block",
         "policyAction": "block",
         "package_manager": "bun",
     }
+    assert authoritative_decision_from_artifact(item).action == "block"
+
+
+def test_protect_approval_normalizes_legacy_envelope_action(tmp_path: Path) -> None:
+    response = _response(verdict_action="allow", supply_action="allow")
+    receipt = response["receipt"]
+    assert isinstance(receipt, dict)
+    receipt["action_envelope_json"] = {"policy_action": "ask", "package_manager": "bun"}
+
+    item = _protect_approval_item(response, workspace=tmp_path, artifact=_artifact(tmp_path))
+
+    assert item is not None
+    assert item["policy_action"] == "review"
+    assert item["action_envelope_json"] == {"policy_action": "review", "package_manager": "bun"}
+    assert authoritative_decision_from_artifact(item).action == "review"
 
 
 def test_strict_decision_parser_still_rejects_the_old_partial_protect_shape() -> None:

--- a/tests/test_update_desktop_core.py
+++ b/tests/test_update_desktop_core.py
@@ -254,6 +254,7 @@ def test_frozen_desktop_status_uses_embedded_version_without_package_probe(
         }
     )
     monkeypatch.setattr(update_commands, "_version_check_payload", version_check)
+    monkeypatch.setattr(update_commands, "pypi_alpha_versions", lambda _payload: ["3.0.0a200"])
     monkeypatch.setattr(
         "codex_plugin_scanner.guard.cli.update_desktop_apply.desktop_core_updates_supported",
         lambda: True,

--- a/tests/test_update_desktop_core.py
+++ b/tests/test_update_desktop_core.py
@@ -261,7 +261,6 @@ def test_frozen_desktop_status_uses_embedded_version_without_package_probe(
     )
 
     payload = build_guard_update_status_payload()
-
     assert payload["installer"] == "desktop"
     assert payload["current_version"] == "3.0.0a138"
     assert payload["latest_version"] == "3.0.0a200"


### PR DESCRIPTION
## Summary

- reconcile generated package approval envelopes with the strongest current package-policy action
- preserve fail-closed behavior when an envelope contains a stronger action
- cover global package updates where cached and supply-chain authority differ

## Verification

- `uv run pytest -q tests/test_guard_protect_approval_decision.py tests/test_guard_package_shims.py`
- `uv run ruff check src/codex_plugin_scanner/guard/cli/protect_approvals.py tests/test_guard_protect_approval_decision.py`
- `uv run ruff format --check src/codex_plugin_scanner/guard/cli/protect_approvals.py tests/test_guard_protect_approval_decision.py`
