### PR TITLE
fix(daemon): adopt signed frozen peers

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 15536,
-  "maximum_test_source_lines": 334942,
+  "maximum_collected_cases": 15537,
+  "maximum_test_source_lines": 334965,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 15535,
-  "maximum_test_source_lines": 334920,
+  "maximum_collected_cases": 15536,
+  "maximum_test_source_lines": 334942,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 15533,
-  "maximum_test_source_lines": 334864,
+  "maximum_collected_cases": 15535,
+  "maximum_test_source_lines": 334920,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 15537,
-  "maximum_test_source_lines": 334965,
+  "maximum_collected_cases": 15541,
+  "maximum_test_source_lines": 335037,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/cli/update_desktop_core.py
+++ b/src/codex_plugin_scanner/guard/cli/update_desktop_core.py
@@ -9,7 +9,6 @@ import platform
 import re
 import shutil
 import stat
-import subprocess
 import sys
 import tempfile
 import urllib.error
@@ -22,6 +21,7 @@ from typing import TypedDict
 
 from packaging.version import InvalidVersion, Version
 
+from ..macos_code_signing import verified_macos_signing_team
 from ..mdm.contracts import ManagedNetworkPolicy
 from ..mdm.network import ManagedNetworkError, managed_urlopen
 
@@ -364,28 +364,14 @@ def _verify_candidate(path: Path, *, expected_team: str | None, expected_sha256:
 
 
 def _macos_codesign_ok(path: Path) -> bool:
-    result = subprocess.run(
-        ["/usr/bin/codesign", "--verify", "--strict", "--verbose=2", str(path)],
-        check=False,
-        capture_output=True,
-    )
-    return result.returncode == 0
+    return verified_macos_signing_team(path) is not None
 
 
 def _macos_signing_team(path: Path) -> str:
-    result = subprocess.run(
-        ["/usr/bin/codesign", "--display", "--verbose=4", str(path)],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
+    team = verified_macos_signing_team(path)
+    if team is None:
         raise DesktopCoreUpdateError("desktop_core_signature_invalid")
-    for line in result.stderr.splitlines():
-        team = line.strip().removeprefix("TeamIdentifier=").strip()
-        if line.strip().startswith("TeamIdentifier=") and team and team != "not set":
-            return team
-    raise DesktopCoreUpdateError("desktop_core_signature_invalid")
+    return team
 
 
 def _reject_symlink(path: Path) -> None:

--- a/src/codex_plugin_scanner/guard/frozen_daemon_runtime.py
+++ b/src/codex_plugin_scanner/guard/frozen_daemon_runtime.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 import hashlib
 import os
+import subprocess
 import sys
+from collections.abc import Callable
 from pathlib import Path
 
 from .daemon import manager
 
 _frozen_runtime_installed = False
 _frozen_runtime_fingerprint_cache: tuple[Path, str] | None = None
+_frozen_runtime_state_matcher: Callable[[dict[str, object]], bool] | None = None
 
 
 def _trusted_frozen_executable() -> Path:
@@ -48,6 +51,65 @@ def _frozen_runtime_fingerprint() -> str:
     fingerprint = digest.hexdigest()
     _frozen_runtime_fingerprint_cache = (executable, fingerprint)
     return fingerprint
+
+
+def _macos_signing_team(executable: Path) -> str | None:
+    if sys.platform != "darwin":
+        return None
+    try:
+        verified = subprocess.run(
+            ["/usr/bin/codesign", "--verify", "--deep", "--strict", str(executable)],
+            check=False,
+            capture_output=True,
+            timeout=5,
+        )
+        details = subprocess.run(
+            ["/usr/bin/codesign", "--display", "--verbose=4", str(executable)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if verified.returncode != 0 or details.returncode != 0:
+        return None
+    for line in details.stderr.splitlines():
+        if not line.startswith("TeamIdentifier="):
+            continue
+        team = line.partition("=")[2].strip()
+        return team if team and team != "not set" else None
+    return None
+
+
+def _trusted_frozen_peer_state(payload: dict[str, object]) -> bool:
+    """Accept a same-release macOS peer only when Apple verifies one publisher."""
+
+    if (
+        payload.get("compatibility_version") != manager.GUARD_DAEMON_COMPATIBILITY_VERSION
+        or payload.get("package_version") != manager.__version__
+    ):
+        return False
+    source_root = payload.get("source_root")
+    fingerprint = payload.get("runtime_fingerprint")
+    if not isinstance(source_root, str) or not manager._is_sha256_hex(fingerprint):
+        return False
+    try:
+        peer = Path(source_root).expanduser().resolve(strict=True)
+        current = _trusted_frozen_executable()
+    except (OSError, RuntimeError):
+        return False
+    if not peer.is_file():
+        return False
+    current_team = _macos_signing_team(current)
+    return current_team is not None and _macos_signing_team(peer) == current_team
+
+
+def _frozen_runtime_state_matches(payload: dict[str, object]) -> bool:
+    matcher = _frozen_runtime_state_matcher
+    if matcher is None:
+        return False
+    return matcher(payload) or _trusted_frozen_peer_state(payload)
 
 
 def _same_guard_home(left: Path, right: Path) -> bool:
@@ -121,7 +183,7 @@ def _filter_frozen_bootloader_parent(
 def install_frozen_daemon_runtime() -> None:
     """Install one-file daemon identity and process-inventory adaptations."""
 
-    global _frozen_runtime_installed
+    global _frozen_runtime_installed, _frozen_runtime_state_matcher
     if not bool(getattr(sys, "frozen", False)):
         return
 
@@ -132,6 +194,7 @@ def install_frozen_daemon_runtime() -> None:
     if _frozen_runtime_installed:
         return
     current_inventory = manager._guard_daemon_process_inventory_for_guard_home
+    _frozen_runtime_state_matcher = manager._guard_daemon_state_matches_current_runtime
 
     def filtered_inventory(guard_home: Path) -> list[tuple[int, int]] | None:
         return _filter_frozen_bootloader_parent(guard_home, current_inventory(guard_home))
@@ -139,4 +202,5 @@ def install_frozen_daemon_runtime() -> None:
     manager._guard_daemon_process_inventory_for_guard_home = filtered_inventory
     manager._current_guard_daemon_source_root = _frozen_runtime_source_root
     manager._current_guard_daemon_runtime_fingerprint = _frozen_runtime_fingerprint
+    manager._guard_daemon_state_matches_current_runtime = _frozen_runtime_state_matches
     _frozen_runtime_installed = True

--- a/src/codex_plugin_scanner/guard/frozen_daemon_runtime.py
+++ b/src/codex_plugin_scanner/guard/frozen_daemon_runtime.py
@@ -88,7 +88,11 @@ def _trusted_frozen_peer_state(payload: dict[str, object]) -> bool:
         return False
     source_root = payload.get("source_root")
     fingerprint = payload.get("runtime_fingerprint")
-    if not isinstance(source_root, str) or not manager._is_sha256_hex(fingerprint):
+    if (
+        not isinstance(source_root, str)
+        or not isinstance(fingerprint, str)
+        or not manager._is_sha256_hex(fingerprint)
+    ):
         return False
     try:
         peer = Path(source_root).expanduser().resolve(strict=True)

--- a/src/codex_plugin_scanner/guard/frozen_daemon_runtime.py
+++ b/src/codex_plugin_scanner/guard/frozen_daemon_runtime.py
@@ -88,11 +88,7 @@ def _trusted_frozen_peer_state(payload: dict[str, object]) -> bool:
         return False
     source_root = payload.get("source_root")
     fingerprint = payload.get("runtime_fingerprint")
-    if (
-        not isinstance(source_root, str)
-        or not isinstance(fingerprint, str)
-        or not manager._is_sha256_hex(fingerprint)
-    ):
+    if not isinstance(source_root, str) or not isinstance(fingerprint, str) or not manager._is_sha256_hex(fingerprint):
         return False
     try:
         peer = Path(source_root).expanduser().resolve(strict=True)

--- a/src/codex_plugin_scanner/guard/frozen_daemon_runtime.py
+++ b/src/codex_plugin_scanner/guard/frozen_daemon_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import secrets
 import subprocess
 import sys
 from collections.abc import Callable
@@ -41,6 +42,12 @@ def _frozen_runtime_fingerprint() -> str:
     if cached is not None and cached[0] == executable:
         return cached[1]
 
+    fingerprint = _executable_sha256(executable)
+    _frozen_runtime_fingerprint_cache = (executable, fingerprint)
+    return fingerprint
+
+
+def _executable_sha256(executable: Path) -> str:
     digest = hashlib.sha256()
     try:
         with executable.open("rb") as handle:
@@ -48,9 +55,7 @@ def _frozen_runtime_fingerprint() -> str:
                 digest.update(chunk)
     except OSError as error:
         raise RuntimeError("Frozen Guard daemon executable identity could not be read.") from error
-    fingerprint = digest.hexdigest()
-    _frozen_runtime_fingerprint_cache = (executable, fingerprint)
-    return fingerprint
+    return digest.hexdigest()
 
 
 def _macos_signing_team(executable: Path) -> str | None:
@@ -100,6 +105,12 @@ def _trusted_frozen_peer_state(payload: dict[str, object]) -> bool:
     except (OSError, RuntimeError):
         return False
     if not peer.is_file():
+        return False
+    try:
+        peer_fingerprint = _executable_sha256(peer)
+    except RuntimeError:
+        return False
+    if not secrets.compare_digest(peer_fingerprint, fingerprint):
         return False
     current_team = _macos_signing_team(current)
     return current_team is not None and _macos_signing_team(peer) == current_team

--- a/src/codex_plugin_scanner/guard/frozen_daemon_runtime.py
+++ b/src/codex_plugin_scanner/guard/frozen_daemon_runtime.py
@@ -5,16 +5,18 @@ from __future__ import annotations
 import hashlib
 import os
 import secrets
-import subprocess
 import sys
 from collections.abc import Callable
 from pathlib import Path
 
 from .daemon import manager
+from .macos_code_signing import verified_macos_signing_team
 
 _frozen_runtime_installed = False
 _frozen_runtime_fingerprint_cache: tuple[Path, str] | None = None
 _frozen_runtime_state_matcher: Callable[[dict[str, object]], bool] | None = None
+_signing_team_cache: dict[tuple[Path, int, int], str] = {}
+_SIGNING_TEAM_CACHE_LIMIT = 8
 
 
 def _trusted_frozen_executable() -> Path:
@@ -58,33 +60,22 @@ def _executable_sha256(executable: Path) -> str:
     return digest.hexdigest()
 
 
-def _macos_signing_team(executable: Path) -> str | None:
-    if sys.platform != "darwin":
-        return None
+def _cached_macos_signing_team(executable: Path) -> str | None:
     try:
-        verified = subprocess.run(
-            ["/usr/bin/codesign", "--verify", "--deep", "--strict", str(executable)],
-            check=False,
-            capture_output=True,
-            timeout=5,
-        )
-        details = subprocess.run(
-            ["/usr/bin/codesign", "--display", "--verbose=4", str(executable)],
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-    except (OSError, subprocess.SubprocessError):
+        stat_result = executable.stat()
+    except OSError:
         return None
-    if verified.returncode != 0 or details.returncode != 0:
+    cache_key = (executable, stat_result.st_mtime_ns, stat_result.st_size)
+    cached = _signing_team_cache.get(cache_key)
+    if cached is not None:
+        return cached
+    team = verified_macos_signing_team(executable, deep=True)
+    if team is None:
         return None
-    for line in details.stderr.splitlines():
-        if not line.startswith("TeamIdentifier="):
-            continue
-        team = line.partition("=")[2].strip()
-        return team if team and team != "not set" else None
-    return None
+    if len(_signing_team_cache) >= _SIGNING_TEAM_CACHE_LIMIT:
+        _signing_team_cache.clear()
+    _signing_team_cache[cache_key] = team
+    return team
 
 
 def _trusted_frozen_peer_state(payload: dict[str, object]) -> bool:
@@ -112,8 +103,8 @@ def _trusted_frozen_peer_state(payload: dict[str, object]) -> bool:
         return False
     if not secrets.compare_digest(peer_fingerprint, fingerprint):
         return False
-    current_team = _macos_signing_team(current)
-    return current_team is not None and _macos_signing_team(peer) == current_team
+    current_team = _cached_macos_signing_team(current)
+    return current_team is not None and _cached_macos_signing_team(peer) == current_team
 
 
 def _frozen_runtime_state_matches(payload: dict[str, object]) -> bool:

--- a/src/codex_plugin_scanner/guard/macos_code_signing.py
+++ b/src/codex_plugin_scanner/guard/macos_code_signing.py
@@ -1,0 +1,43 @@
+"""Shared macOS publisher-signature verification."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def verified_macos_signing_team(executable: Path, *, deep: bool = False, timeout: float = 5.0) -> str | None:
+    if sys.platform != "darwin":
+        return None
+    verify_command = ["/usr/bin/codesign", "--verify"]
+    if deep:
+        verify_command.append("--deep")
+    verify_command.extend(("--strict", str(executable)))
+    try:
+        verified = subprocess.run(
+            verify_command,
+            check=False,
+            capture_output=True,
+            timeout=timeout,
+        )
+        details = subprocess.run(
+            ["/usr/bin/codesign", "--display", "--verbose=4", str(executable)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if verified.returncode != 0 or details.returncode != 0:
+        return None
+    for line in details.stderr.splitlines():
+        if not line.startswith("TeamIdentifier="):
+            continue
+        team = line.partition("=")[2].strip()
+        return team if team and team != "not set" else None
+    return None
+
+
+__all__ = ["verified_macos_signing_team"]

--- a/tests/test_guard_frozen_daemon_runtime.py
+++ b/tests/test_guard_frozen_daemon_runtime.py
@@ -137,16 +137,72 @@ def test_frozen_runtime_fingerprint_binds_exact_executable_bytes(
     assert frozen_daemon_runtime._frozen_runtime_fingerprint() == hashlib.sha256(payload).hexdigest()
 
 
+def test_frozen_runtime_accepts_same_release_from_same_macos_publisher(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    current = tmp_path / "desktop-core"
+    peer = tmp_path / "managed-core"
+    current.write_bytes(b"desktop-wrapper")
+    peer.write_bytes(b"managed-wrapper")
+    monkeypatch.setattr(frozen_daemon_runtime.sys, "executable", str(current))
+    monkeypatch.setattr(frozen_daemon_runtime, "_macos_signing_team", lambda _path: "TEAM123")
+    monkeypatch.setattr(frozen_daemon_runtime, "_frozen_runtime_state_matcher", lambda _payload: False)
+
+    assert frozen_daemon_runtime._frozen_runtime_state_matches(
+        {
+            "compatibility_version": manager.GUARD_DAEMON_COMPATIBILITY_VERSION,
+            "package_version": manager.__version__,
+            "source_root": str(peer),
+            "runtime_fingerprint": hashlib.sha256(peer.read_bytes()).hexdigest(),
+        }
+    )
+
+
+def test_frozen_runtime_rejects_same_release_from_different_macos_publisher(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    current = tmp_path / "desktop-core"
+    peer = tmp_path / "untrusted-core"
+    current.write_bytes(b"desktop-wrapper")
+    peer.write_bytes(b"different-wrapper")
+    monkeypatch.setattr(frozen_daemon_runtime.sys, "executable", str(current))
+    monkeypatch.setattr(
+        frozen_daemon_runtime,
+        "_macos_signing_team",
+        lambda path: "TEAM123" if path == current else "OTHER456",
+    )
+    monkeypatch.setattr(frozen_daemon_runtime, "_frozen_runtime_state_matcher", lambda _payload: False)
+
+    assert not frozen_daemon_runtime._frozen_runtime_state_matches(
+        {
+            "compatibility_version": manager.GUARD_DAEMON_COMPATIBILITY_VERSION,
+            "package_version": manager.__version__,
+            "source_root": str(peer),
+            "runtime_fingerprint": hashlib.sha256(peer.read_bytes()).hexdigest(),
+        }
+    )
+
+
 def test_frozen_runtime_consumes_pyinstaller_reset_environment(monkeypatch: pytest.MonkeyPatch) -> None:
     inventory = manager._guard_daemon_process_inventory_for_guard_home
+    source_root = manager._current_guard_daemon_source_root
+    fingerprint = manager._current_guard_daemon_runtime_fingerprint
+    state_matcher = manager._guard_daemon_state_matches_current_runtime
     monkeypatch.setattr(frozen_daemon_runtime.sys, "frozen", True, raising=False)
     monkeypatch.setattr(frozen_daemon_runtime, "_frozen_runtime_installed", False)
     monkeypatch.setenv("PYINSTALLER_RESET_ENVIRONMENT", "1")
 
-    frozen_daemon_runtime.install_frozen_daemon_runtime()
+    try:
+        frozen_daemon_runtime.install_frozen_daemon_runtime()
 
-    assert "PYINSTALLER_RESET_ENVIRONMENT" not in frozen_daemon_runtime.os.environ
-    monkeypatch.setattr(manager, "_guard_daemon_process_inventory_for_guard_home", inventory)
+        assert "PYINSTALLER_RESET_ENVIRONMENT" not in frozen_daemon_runtime.os.environ
+    finally:
+        manager._guard_daemon_process_inventory_for_guard_home = inventory
+        manager._current_guard_daemon_source_root = source_root
+        manager._current_guard_daemon_runtime_fingerprint = fingerprint
+        manager._guard_daemon_state_matches_current_runtime = state_matcher
 
 
 def test_frozen_daemon_launcher_preserves_pyinstaller_reset(

--- a/tests/test_guard_frozen_daemon_runtime.py
+++ b/tests/test_guard_frozen_daemon_runtime.py
@@ -146,7 +146,7 @@ def test_frozen_runtime_accepts_same_release_from_same_macos_publisher(
     current.write_bytes(b"desktop-wrapper")
     peer.write_bytes(b"managed-wrapper")
     monkeypatch.setattr(frozen_daemon_runtime.sys, "executable", str(current))
-    monkeypatch.setattr(frozen_daemon_runtime, "_macos_signing_team", lambda _path: "TEAM123")
+    monkeypatch.setattr(frozen_daemon_runtime, "_cached_macos_signing_team", lambda _path: "TEAM123")
     monkeypatch.setattr(frozen_daemon_runtime, "_frozen_runtime_state_matcher", lambda _payload: False)
 
     assert frozen_daemon_runtime._frozen_runtime_state_matches(
@@ -170,7 +170,7 @@ def test_frozen_runtime_rejects_same_release_from_different_macos_publisher(
     monkeypatch.setattr(frozen_daemon_runtime.sys, "executable", str(current))
     monkeypatch.setattr(
         frozen_daemon_runtime,
-        "_macos_signing_team",
+        "_cached_macos_signing_team",
         lambda path: "TEAM123" if path == current else "OTHER456",
     )
     monkeypatch.setattr(frozen_daemon_runtime, "_frozen_runtime_state_matcher", lambda _payload: False)
@@ -194,7 +194,7 @@ def test_frozen_runtime_rejects_same_team_peer_with_mismatched_fingerprint(
     current.write_bytes(b"desktop-wrapper")
     peer.write_bytes(b"managed-wrapper")
     monkeypatch.setattr(frozen_daemon_runtime.sys, "executable", str(current))
-    monkeypatch.setattr(frozen_daemon_runtime, "_macos_signing_team", lambda _path: "TEAM123")
+    monkeypatch.setattr(frozen_daemon_runtime, "_cached_macos_signing_team", lambda _path: "TEAM123")
     monkeypatch.setattr(frozen_daemon_runtime, "_frozen_runtime_state_matcher", lambda _payload: False)
 
     assert not frozen_daemon_runtime._frozen_runtime_state_matches(
@@ -205,6 +205,29 @@ def test_frozen_runtime_rejects_same_team_peer_with_mismatched_fingerprint(
             "runtime_fingerprint": hashlib.sha256(b"other-bytes").hexdigest(),
         }
     )
+
+
+def test_frozen_runtime_caches_verified_team_until_executable_changes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = tmp_path / "managed-core"
+    executable.write_bytes(b"first")
+    calls: list[Path] = []
+
+    def verify(path: Path, *, deep: bool = False) -> str:
+        assert deep is True
+        calls.append(path)
+        return "TEAM123"
+
+    frozen_daemon_runtime._signing_team_cache.clear()
+    monkeypatch.setattr(frozen_daemon_runtime, "verified_macos_signing_team", verify)
+
+    assert frozen_daemon_runtime._cached_macos_signing_team(executable) == "TEAM123"
+    assert frozen_daemon_runtime._cached_macos_signing_team(executable) == "TEAM123"
+    executable.write_bytes(b"second-version")
+    assert frozen_daemon_runtime._cached_macos_signing_team(executable) == "TEAM123"
+    assert calls == [executable, executable]
 
 
 def test_frozen_runtime_consumes_pyinstaller_reset_environment(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_guard_frozen_daemon_runtime.py
+++ b/tests/test_guard_frozen_daemon_runtime.py
@@ -185,6 +185,28 @@ def test_frozen_runtime_rejects_same_release_from_different_macos_publisher(
     )
 
 
+def test_frozen_runtime_rejects_same_team_peer_with_mismatched_fingerprint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    current = tmp_path / "desktop-core"
+    peer = tmp_path / "managed-core"
+    current.write_bytes(b"desktop-wrapper")
+    peer.write_bytes(b"managed-wrapper")
+    monkeypatch.setattr(frozen_daemon_runtime.sys, "executable", str(current))
+    monkeypatch.setattr(frozen_daemon_runtime, "_macos_signing_team", lambda _path: "TEAM123")
+    monkeypatch.setattr(frozen_daemon_runtime, "_frozen_runtime_state_matcher", lambda _payload: False)
+
+    assert not frozen_daemon_runtime._frozen_runtime_state_matches(
+        {
+            "compatibility_version": manager.GUARD_DAEMON_COMPATIBILITY_VERSION,
+            "package_version": manager.__version__,
+            "source_root": str(peer),
+            "runtime_fingerprint": hashlib.sha256(b"other-bytes").hexdigest(),
+        }
+    )
+
+
 def test_frozen_runtime_consumes_pyinstaller_reset_environment(monkeypatch: pytest.MonkeyPatch) -> None:
     inventory = manager._guard_daemon_process_inventory_for_guard_home
     source_root = manager._current_guard_daemon_source_root


### PR DESCRIPTION
## Summary
- let signed macOS Desktop and managed Core runtimes from the same Guard release share one daemon
- retain exact artifact matching and reject unsigned, differently signed, version-mismatched, or protocol-mismatched peers
- isolate frozen-runtime patching in tests so later daemon fingerprint tests remain deterministic

## Testing
- `uv run pytest -q tests/test_guard_frozen_daemon_runtime.py tests/test_guard_daemon_manager.py`
- `uv run pytest -q tests/test_guard_frozen_daemon_runtime.py tests/test_guard_daemon_manager.py tests/test_guard_daemon_wake.py tests/test_guard_daemon_recovery_resilience.py tests/test_guard_approvals.py`
- `uv run ruff check src/codex_plugin_scanner/guard/frozen_daemon_runtime.py tests/test_guard_frozen_daemon_runtime.py`
- `uv run --no-sync basedpyright --level error`
- `uv run python3 scripts/stress_guard_daemon.py --requests 16 --receipts 5000 --settle-seconds 2`
