### PR TITLE
fix(codex): preserve launcher trust across repair

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 15559,
-  "maximum_test_source_lines": 335252,
+  "maximum_collected_cases": 15560,
+  "maximum_test_source_lines": 335280,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 15560,
-  "maximum_test_source_lines": 335280,
+  "maximum_test_source_lines": 335310,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -468,8 +468,12 @@ def _hook_manifest_spec(context: HarnessContext) -> CodexHookManifestSpec:
     )
 
 
-def _build_authenticated_hook_manifest(context: HarnessContext) -> dict[str, object]:
-    return build_authenticated_hook_manifest(_hook_manifest_spec(context))
+def _build_authenticated_hook_manifest(
+    context: HarnessContext,
+    *,
+    previous_manifest: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    return build_authenticated_hook_manifest(_hook_manifest_spec(context), previous_manifest=previous_manifest)
 
 
 def _current_install_legacy_bindings(context: HarnessContext, hooks: dict[str, object]) -> list[dict[str, object]]:
@@ -1705,7 +1709,7 @@ class CodexHarnessAdapter(HarnessAdapter):
         original_manifest = snapshot_regular_file(manifest_path)
         original_secret = snapshot_regular_file(secret_path)
         try:
-            manifest = _build_authenticated_hook_manifest(context)
+            manifest = _build_authenticated_hook_manifest(context, previous_manifest=previous_manifest)
             _assert_package_reauthentication_is_safe(previous_manifest, manifest)
             write_hook_manifest(context.guard_home, config_path, manifest)
             atomic_write_text(config_path, dump_toml(payload), mode=0o600)

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -468,14 +468,6 @@ def _hook_manifest_spec(context: HarnessContext) -> CodexHookManifestSpec:
     )
 
 
-def _build_authenticated_hook_manifest(
-    context: HarnessContext,
-    *,
-    previous_manifest: Mapping[str, object] | None = None,
-) -> dict[str, object]:
-    return build_authenticated_hook_manifest(_hook_manifest_spec(context), previous_manifest=previous_manifest)
-
-
 def _current_install_legacy_bindings(context: HarnessContext, hooks: dict[str, object]) -> list[dict[str, object]]:
     """Select exact current bridge entries for explicit legacy re-adoption only."""
 
@@ -1709,7 +1701,9 @@ class CodexHarnessAdapter(HarnessAdapter):
         original_manifest = snapshot_regular_file(manifest_path)
         original_secret = snapshot_regular_file(secret_path)
         try:
-            manifest = _build_authenticated_hook_manifest(context, previous_manifest=previous_manifest)
+            manifest = build_authenticated_hook_manifest(
+                _hook_manifest_spec(context), previous_manifest=previous_manifest
+            )
             _assert_package_reauthentication_is_safe(previous_manifest, manifest)
             write_hook_manifest(context.guard_home, config_path, manifest)
             atomic_write_text(config_path, dump_toml(payload), mode=0o600)

--- a/src/codex_plugin_scanner/guard/codex_hook_compatibility.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_compatibility.py
@@ -1,0 +1,33 @@
+"""Bounded authenticated identities for Codex hooks loaded before repair."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+
+_MAX_COMPATIBLE_BRIDGE_GENERATIONS = 8
+
+
+def bridge_argv_sha256(argv: Sequence[object]) -> str:
+    payload = json.dumps(list(argv), ensure_ascii=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def compatible_bridge_argv_hashes(previous_manifest: Mapping[str, object] | None) -> list[str]:
+    if previous_manifest is None:
+        return []
+    candidates: list[str] = []
+    previous_hashes = previous_manifest.get("compatible_bridge_argv_sha256")
+    if isinstance(previous_hashes, list):
+        candidates.extend(value for value in previous_hashes if isinstance(value, str) and len(value) == 64)
+    events = previous_manifest.get("events")
+    if isinstance(events, list):
+        for event in events:
+            argv = event.get("argv") if isinstance(event, Mapping) else None
+            if isinstance(argv, list) and argv and all(isinstance(value, str) for value in argv):
+                candidates.append(bridge_argv_sha256(argv))
+    return list(dict.fromkeys(candidates))[-_MAX_COMPATIBLE_BRIDGE_GENERATIONS:]
+
+
+__all__ = ["bridge_argv_sha256", "compatible_bridge_argv_hashes"]

--- a/src/codex_plugin_scanner/guard/codex_hook_manifest.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_manifest.py
@@ -7,7 +7,9 @@ construction at the harness boundary and prevents a circular dependency.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -44,6 +46,7 @@ _TRANSPORT_PACKAGE_ROLES = (
     "runtime_trust",
     "windows_job",
 )
+_MAX_COMPATIBLE_BRIDGE_GENERATIONS = 8
 
 
 @dataclass(frozen=True, slots=True)
@@ -64,7 +67,11 @@ class CodexHookManifestSpec:
     workspace_rebinding_allowed: bool = False
 
 
-def build_authenticated_hook_manifest(spec: CodexHookManifestSpec) -> dict[str, object]:
+def build_authenticated_hook_manifest(
+    spec: CodexHookManifestSpec,
+    *,
+    previous_manifest: Mapping[str, object] | None = None,
+) -> dict[str, object]:
     secret = load_or_create_hook_secret(spec.guard_home)
     interpreter = describe_executable_file(spec.interpreter_path, role="interpreter")
     packaged_files = [
@@ -84,6 +91,7 @@ def build_authenticated_hook_manifest(spec: CodexHookManifestSpec) -> dict[str, 
     generated_at = datetime.now(timezone.utc).isoformat()
     unsigned_manifest: dict[str, object] = {
         "config": {"scope": "global", "target": canonical_path(spec.config_path)},
+        "compatible_bridge_argv_sha256": _compatible_bridge_argv_hashes(previous_manifest),
         "context": _expected_context(spec),
         "daemon_start": {
             "argv": list(spec.daemon_start_argv),
@@ -106,6 +114,27 @@ def build_authenticated_hook_manifest(spec: CodexHookManifestSpec) -> dict[str, 
         "transport": {**transport, "wrapper": None},
     }
     return sign_hook_manifest(unsigned_manifest, secret)
+
+
+def bridge_argv_sha256(argv: Sequence[object]) -> str:
+    payload = json.dumps(list(argv), ensure_ascii=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _compatible_bridge_argv_hashes(previous_manifest: Mapping[str, object] | None) -> list[str]:
+    if previous_manifest is None:
+        return []
+    candidates: list[str] = []
+    previous_hashes = previous_manifest.get("compatible_bridge_argv_sha256")
+    if isinstance(previous_hashes, list):
+        candidates.extend(value for value in previous_hashes if isinstance(value, str) and len(value) == 64)
+    events = previous_manifest.get("events")
+    if isinstance(events, list):
+        for event in events:
+            argv = event.get("argv") if isinstance(event, Mapping) else None
+            if isinstance(argv, list) and argv and all(isinstance(value, str) for value in argv):
+                candidates.append(bridge_argv_sha256(argv))
+    return list(dict.fromkeys(candidates))[-_MAX_COMPATIBLE_BRIDGE_GENERATIONS:]
 
 
 def load_hook_manifest_baseline(spec: CodexHookManifestSpec) -> dict[str, object] | None:
@@ -478,6 +507,7 @@ __all__ = [
     "CodexHookManifestSpec",
     "assert_package_reauthentication_is_safe",
     "authenticated_manifest_for_ownership",
+    "bridge_argv_sha256",
     "build_authenticated_hook_manifest",
     "load_hook_manifest_baseline",
     "manifest_bindings",

--- a/src/codex_plugin_scanner/guard/codex_hook_manifest.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_manifest.py
@@ -7,14 +7,13 @@ construction at the harness boundary and prevents a circular dependency.
 
 from __future__ import annotations
 
-import hashlib
-import json
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import NoReturn
 
+from .codex_hook_compatibility import compatible_bridge_argv_hashes
 from .codex_hook_file_integrity import (
     CodexHookIntegrityError,
     canonical_path,
@@ -46,7 +45,6 @@ _TRANSPORT_PACKAGE_ROLES = (
     "runtime_trust",
     "windows_job",
 )
-_MAX_COMPATIBLE_BRIDGE_GENERATIONS = 8
 
 
 @dataclass(frozen=True, slots=True)
@@ -91,7 +89,7 @@ def build_authenticated_hook_manifest(
     generated_at = datetime.now(timezone.utc).isoformat()
     unsigned_manifest: dict[str, object] = {
         "config": {"scope": "global", "target": canonical_path(spec.config_path)},
-        "compatible_bridge_argv_sha256": _compatible_bridge_argv_hashes(previous_manifest),
+        "compatible_bridge_argv_sha256": compatible_bridge_argv_hashes(previous_manifest),
         "context": _expected_context(spec),
         "daemon_start": {
             "argv": list(spec.daemon_start_argv),
@@ -114,27 +112,6 @@ def build_authenticated_hook_manifest(
         "transport": {**transport, "wrapper": None},
     }
     return sign_hook_manifest(unsigned_manifest, secret)
-
-
-def bridge_argv_sha256(argv: Sequence[object]) -> str:
-    payload = json.dumps(list(argv), ensure_ascii=True, separators=(",", ":")).encode("utf-8")
-    return hashlib.sha256(payload).hexdigest()
-
-
-def _compatible_bridge_argv_hashes(previous_manifest: Mapping[str, object] | None) -> list[str]:
-    if previous_manifest is None:
-        return []
-    candidates: list[str] = []
-    previous_hashes = previous_manifest.get("compatible_bridge_argv_sha256")
-    if isinstance(previous_hashes, list):
-        candidates.extend(value for value in previous_hashes if isinstance(value, str) and len(value) == 64)
-    events = previous_manifest.get("events")
-    if isinstance(events, list):
-        for event in events:
-            argv = event.get("argv") if isinstance(event, Mapping) else None
-            if isinstance(argv, list) and argv and all(isinstance(value, str) for value in argv):
-                candidates.append(bridge_argv_sha256(argv))
-    return list(dict.fromkeys(candidates))[-_MAX_COMPATIBLE_BRIDGE_GENERATIONS:]
 
 
 def load_hook_manifest_baseline(spec: CodexHookManifestSpec) -> dict[str, object] | None:
@@ -507,7 +484,6 @@ __all__ = [
     "CodexHookManifestSpec",
     "assert_package_reauthentication_is_safe",
     "authenticated_manifest_for_ownership",
-    "bridge_argv_sha256",
     "build_authenticated_hook_manifest",
     "load_hook_manifest_baseline",
     "manifest_bindings",

--- a/src/codex_plugin_scanner/guard/codex_hook_runtime_trust.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_runtime_trust.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
+from .codex_hook_compatibility import bridge_argv_sha256
 from .codex_hook_file_integrity import (
     canonical_path,
     verify_executable_file_identity,
@@ -24,7 +25,6 @@ from .codex_hook_launch_runtime import (
     private_hook_runtime_cwd,
     run_isolated_hook_process,
 )
-from .codex_hook_manifest import bridge_argv_sha256
 
 _REQUIRED_PACKAGE_ROLES = frozenset(
     {

--- a/src/codex_plugin_scanner/guard/codex_hook_runtime_trust.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_runtime_trust.py
@@ -24,6 +24,7 @@ from .codex_hook_launch_runtime import (
     private_hook_runtime_cwd,
     run_isolated_hook_process,
 )
+from .codex_hook_manifest import bridge_argv_sha256
 
 _REQUIRED_PACKAGE_ROLES = frozenset(
     {
@@ -279,10 +280,18 @@ def _verify_registered_bridge_argv(
     events = manifest.get("events")
     if not isinstance(events, list) or not events:
         raise ValueError("managed Codex hook event identity is invalid")
+    if all(_mapping(event, label="event").get("argv") == expected_argv for event in events):
+        return
+    compatible_hashes = manifest.get("compatible_bridge_argv_sha256")
+    if not isinstance(compatible_hashes, list) or bridge_argv_sha256(expected_argv) not in compatible_hashes:
+        raise ValueError("managed Codex hook bridge config changed after authentication")
+    for value in compatible_hashes:
+        if not isinstance(value, str) or len(value) != 64:
+            raise ValueError("managed Codex hook bridge compatibility identity is invalid")
     for event in events:
         binding = _mapping(event, label="event")
-        if binding.get("argv") != expected_argv:
-            raise ValueError("managed Codex hook bridge config changed after authentication")
+        if not isinstance(binding.get("argv"), list):
+            raise ValueError("managed Codex hook event identity is invalid")
 
 
 def _mapping(value: object, *, label: str) -> dict[str, object]:

--- a/tests/test_codex_hook_fallback_isolation.py
+++ b/tests/test_codex_hook_fallback_isolation.py
@@ -197,6 +197,34 @@ def test_runtime_rejects_a_manifest_changed_after_install(tmp_path: Path) -> Non
         _trusted_launch(bridge_command, config)
 
 
+def test_repaired_manifest_keeps_an_open_codex_session_authenticated(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(codex_adapter, "_post_tool_hook_timeout_seconds", lambda _context: 35)
+    context, old_bridge_command, old_config = _installed_launch(tmp_path)
+
+    monkeypatch.setattr(codex_adapter, "_post_tool_hook_timeout_seconds", lambda _context: 65)
+    CodexHarnessAdapter().install(context)
+
+    trusted = _trusted_launch(old_bridge_command, old_config)
+    assert trusted.cwd == Path(str(old_config["manifest_path"])).parent.resolve(strict=True)
+
+    changed_config = dict(old_config)
+    changed_timeouts = dict(changed_config["hook_timeouts"])
+    changed_timeouts["PreToolUse"] = 34
+    changed_config["hook_timeouts"] = changed_timeouts
+    changed_json = json.dumps(changed_config, separators=(",", ":"))
+    with pytest.raises(ValueError, match="bridge config changed after authentication"):
+        validate_codex_hook_launch(
+            manifest_path=str(changed_config["manifest_path"]),
+            state_path=str(changed_config["state_path"]),
+            fallback_command=_config_command(changed_config, "fallback_command"),
+            start_command=_config_command(changed_config, "start_command"),
+            config_json=changed_json,
+        )
+
+
 @pytest.mark.skipif(os.name == "nt", reason="symlink replacement semantics differ on Windows")
 def test_signed_runtime_guard_home_is_canonical_across_directory_aliases(tmp_path: Path) -> None:
     real_root = tmp_path / "real"

--- a/tests/test_codex_hook_fallback_isolation.py
+++ b/tests/test_codex_hook_fallback_isolation.py
@@ -197,34 +197,6 @@ def test_runtime_rejects_a_manifest_changed_after_install(tmp_path: Path) -> Non
         _trusted_launch(bridge_command, config)
 
 
-def test_repaired_manifest_keeps_an_open_codex_session_authenticated(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(codex_adapter, "_post_tool_hook_timeout_seconds", lambda _context: 35)
-    context, old_bridge_command, old_config = _installed_launch(tmp_path)
-
-    monkeypatch.setattr(codex_adapter, "_post_tool_hook_timeout_seconds", lambda _context: 65)
-    CodexHarnessAdapter().install(context)
-
-    trusted = _trusted_launch(old_bridge_command, old_config)
-    assert trusted.cwd == Path(str(old_config["manifest_path"])).parent.resolve(strict=True)
-
-    changed_config = dict(old_config)
-    changed_timeouts = dict(changed_config["hook_timeouts"])
-    changed_timeouts["PreToolUse"] = 34
-    changed_config["hook_timeouts"] = changed_timeouts
-    changed_json = json.dumps(changed_config, separators=(",", ":"))
-    with pytest.raises(ValueError, match="bridge config changed after authentication"):
-        validate_codex_hook_launch(
-            manifest_path=str(changed_config["manifest_path"]),
-            state_path=str(changed_config["state_path"]),
-            fallback_command=_config_command(changed_config, "fallback_command"),
-            start_command=_config_command(changed_config, "start_command"),
-            config_json=changed_json,
-        )
-
-
 @pytest.mark.skipif(os.name == "nt", reason="symlink replacement semantics differ on Windows")
 def test_signed_runtime_guard_home_is_canonical_across_directory_aliases(tmp_path: Path) -> None:
     real_root = tmp_path / "real"

--- a/tests/test_codex_hook_repair_compatibility.py
+++ b/tests/test_codex_hook_repair_compatibility.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters import codex as codex_adapter
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.codex import CodexHarnessAdapter
+from codex_plugin_scanner.guard.codex_hook_runtime_trust import validate_codex_hook_launch
+
+
+def _command(config: dict[str, object], name: str) -> list[str]:
+    value = config[name]
+    assert isinstance(value, list) and all(isinstance(token, str) for token in value)
+    return [token for token in value if isinstance(token, str)]
+
+
+def _validate(config: dict[str, object], config_json: str):
+    return validate_codex_hook_launch(
+        manifest_path=str(config["manifest_path"]),
+        state_path=str(config["state_path"]),
+        fallback_command=_command(config, "fallback_command"),
+        start_command=_command(config, "start_command"),
+        config_json=config_json,
+    )
+
+
+def test_repair_keeps_an_open_codex_session_authenticated(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=tmp_path / "workspace",
+        guard_home=tmp_path / "guard-home",
+        home_override_explicit=True,
+    )
+    context.workspace_dir.mkdir(parents=True)
+    monkeypatch.setattr(codex_adapter, "_post_tool_hook_timeout_seconds", lambda _context: 35)
+    CodexHarnessAdapter().install(context)
+    old_bridge_command = codex_adapter._hook_command_parts(context)
+    old_config_json = old_bridge_command[3]
+    old_config = json.loads(old_config_json)
+
+    monkeypatch.setattr(codex_adapter, "_post_tool_hook_timeout_seconds", lambda _context: 65)
+    CodexHarnessAdapter().install(context)
+
+    trusted = _validate(old_config, old_config_json)
+    assert trusted.cwd == Path(str(old_config["manifest_path"])).parent.resolve(strict=True)
+
+    changed_config = dict(old_config)
+    changed_timeouts = dict(changed_config["hook_timeouts"])
+    changed_timeouts["PreToolUse"] = 34
+    changed_config["hook_timeouts"] = changed_timeouts
+    with pytest.raises(ValueError, match="bridge config changed after authentication"):
+        _validate(changed_config, json.dumps(changed_config, separators=(",", ":")))


### PR DESCRIPTION
## Summary

- retain a bounded signed identity set for Codex launcher generations replaced by repair
- let already-open Codex sessions recover through the current trusted runtime after repair
- continue rejecting altered hook commands and validating current package, fallback, and daemon-start identities

## Root cause

Repair replaced the authenticated hook manifest. A Codex session that had already loaded the previous valid hook command could use the daemon while it remained available, but could not authenticate local recovery after a daemon interruption because only the newest command identity remained signed.

## Verification

- `uv run pytest -q tests/test_codex_hook_fallback_isolation.py tests/test_frozen_codex_runtime.py tests/test_guard_codex_install.py` (85 passed)
- `uv run pytest -q tests/test_codex_daemon_hook_bridge.py::test_bridge_real_daemon_reviews_git_fetch_without_repository_bound_cwd` (14 passed)
- focused Ruff lint and format checks (passed)
- broader suite sampling (437 passed, no failures before stopping the long serial run)

## Security boundary

Compatibility is limited to eight exact, previously authenticated launcher argv hashes. Runtime recovery still verifies the current package bytes and exact current fallback and daemon-start contracts. An altered prior command remains rejected.
