### PR TITLE
fix(store): keep CLI usable when extension schema mismatches

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 12847,
-  "maximum_test_source_lines": 292919,
+  "maximum_test_source_lines": 292922,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12844,
-  "maximum_test_source_lines": 292829,
+  "maximum_collected_cases": 12847,
+  "maximum_test_source_lines": 292919,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12847,
-  "maximum_test_source_lines": 292922,
+  "maximum_collected_cases": 12848,
+  "maximum_test_source_lines": 292967,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_records.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_records.py
@@ -592,7 +592,9 @@ def _run_guard_policies_command(
             return 1
         _emit("policies", payload, getattr(args, "json", False))
         return 0
-    policy_items = store.list_policy_decisions(getattr(args, "harness", None))
+    from ..store_policy_list import list_remembered_policy_decisions
+
+    policy_items = list_remembered_policy_decisions(store, getattr(args, "harness", None))
     items = _filter_policy_items(policy_items, active_only=True)
     _emit("policies", {"generated_at": _now(), "items": items}, getattr(args, "json", False))
     return 0

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2233,9 +2233,11 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             query = parse_qs(parsed.query)
             harness = query.get("harness", [None])[-1]
             harness_filter = harness if isinstance(harness, str) else None
+            from ..store_policy_list import list_remembered_policy_decisions
+
             self._write_json(
                 {
-                    "items": store.list_policy_decisions(harness=harness_filter),
+                    "items": list_remembered_policy_decisions(store, harness_filter),
                     "cloud_exceptions": store.list_cloud_exceptions(harness=harness_filter),
                 }
             )

--- a/src/codex_plugin_scanner/guard/store_connection_schema.py
+++ b/src/codex_plugin_scanner/guard/store_connection_schema.py
@@ -952,7 +952,7 @@ class StoreConnectionSchemaMixin:
             ensure_command_activity_maintenance_schema(connection, applied_at=_now())
             ensure_command_activity_api_schema(connection, applied_at=_now())
             ensure_evidence_schema(connection)
-            ensure_extension_control_authority_schema(connection)
+            ensure_extension_control_authority_schema(connection, require_compatible=False)
             ensure_workflow_capability_schema(connection, applied_at=_now())
             ensure_command_shadow_schema(connection, applied_at=_now())
             if not self._schema_version_applied(connection, version=4):

--- a/src/codex_plugin_scanner/guard/store_extension_control_authority.py
+++ b/src/codex_plugin_scanner/guard/store_extension_control_authority.py
@@ -86,6 +86,8 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
         layers_json = layers_to_json(layers)
         self._validate_serialized_layers(layers_json)
         with self._extension_control_authority_lock():
+            with self._connect() as connection:
+                ensure_extension_control_authority_schema(connection)
             current = self._read_extension_control_authority_locked(catalog_digest, bootstrap=True)
             key = self._authority_key(required=True)
             assert key is not None
@@ -388,7 +390,8 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
         self, catalog_digest: str, *, bootstrap: bool
     ) -> ExtensionControlAuthorityView:
         with self._connect() as connection:
-            ensure_extension_control_authority_schema(connection)
+            if not ensure_extension_control_authority_schema(connection, require_compatible=False):
+                return self._degraded_view(catalog_digest)
             row = connection.execute(
                 "select * from extension_control_authority_snapshot where singleton = 1"
             ).fetchone()

--- a/src/codex_plugin_scanner/guard/store_extension_control_authority_schema.py
+++ b/src/codex_plugin_scanner/guard/store_extension_control_authority_schema.py
@@ -13,7 +13,22 @@ _SCHEMA_CHECKSUM_V1: Final = hashlib.sha256(b"hol-guard.extension-control-author
 _SCHEMA_CHECKSUM: Final = hashlib.sha256(b"hol-guard.extension-control-authority.schema.v2").hexdigest()
 
 
-def ensure_extension_control_authority_schema(connection: sqlite3.Connection) -> None:
+def extension_control_schema_marker_is_compatible(
+    version: object,
+    checksum: object,
+) -> bool:
+    if type(version) is not int or not isinstance(checksum, str):
+        return False
+    if version == 1 and checksum == _SCHEMA_CHECKSUM_V1:
+        return True
+    return version == EXTENSION_CONTROL_SCHEMA_VERSION and checksum == _SCHEMA_CHECKSUM
+
+
+def ensure_extension_control_authority_schema(
+    connection: sqlite3.Connection,
+    *,
+    require_compatible: bool = True,
+) -> bool:
     _ = connection.execute(
         """
         create table if not exists extension_control_schema_migration (
@@ -41,21 +56,23 @@ def ensure_extension_control_authority_schema(connection: sqlite3.Connection) ->
         elif isinstance(row, tuple):
             row_values = cast(tuple[object, ...], row)
             if len(row_values) != 2:
-                raise ExtensionControlAuthorityError("invalid extension control schema marker")
+                if require_compatible:
+                    raise ExtensionControlAuthorityError("invalid extension control schema marker")
+                return False
             version_raw, checksum_raw = row_values
         else:
-            raise ExtensionControlAuthorityError("invalid extension control schema marker")
-        if type(version_raw) is not int or not isinstance(checksum_raw, str):
-            raise ExtensionControlAuthorityError("invalid extension control schema marker")
-        version = version_raw
-        checksum = checksum_raw
-        if version == 1 and checksum == _SCHEMA_CHECKSUM_V1:
+            if require_compatible:
+                raise ExtensionControlAuthorityError("invalid extension control schema marker")
+            return False
+        if not extension_control_schema_marker_is_compatible(version_raw, checksum_raw):
+            if require_compatible:
+                raise ExtensionControlAuthorityError("unsupported or invalid extension control schema")
+            return False
+        if type(version_raw) is int and version_raw == 1 and checksum_raw == _SCHEMA_CHECKSUM_V1:
             _ = connection.execute(
                 "update extension_control_schema_migration set version = ?, checksum = ? where singleton = 1",
                 (EXTENSION_CONTROL_SCHEMA_VERSION, _SCHEMA_CHECKSUM),
             )
-        elif version != EXTENSION_CONTROL_SCHEMA_VERSION or checksum != _SCHEMA_CHECKSUM:
-            raise ExtensionControlAuthorityError("unsupported or invalid extension control schema")
 
     _ = connection.execute(
         """
@@ -105,3 +122,4 @@ def ensure_extension_control_authority_schema(connection: sqlite3.Connection) ->
         )
         """
     )
+    return True

--- a/src/codex_plugin_scanner/guard/store_policy_integrity_runtime.py
+++ b/src/codex_plugin_scanner/guard/store_policy_integrity_runtime.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 # ruff: noqa: F403,F405
 from .store_base import *
+from .store_policy_list import collapse_duplicate_artifact_policy_rows
 
 
 def _set_private_mode_compat(path: Path, mode: int) -> None:
@@ -97,7 +98,7 @@ class StorePolicyIntegrityAdminMixin:
                     payload["integrity_mode"] = state.get("mode")
                     payload["integrity_enforcement"] = state.get("enforcement")
                 items.append(payload)
-            return items
+            return collapse_duplicate_artifact_policy_rows(items)
 
     def get_policy_decision(self, decision_id: int) -> dict[str, object] | None:
         from .store_policy_decision import get_policy_decision_payload

--- a/src/codex_plugin_scanner/guard/store_policy_integrity_runtime.py
+++ b/src/codex_plugin_scanner/guard/store_policy_integrity_runtime.py
@@ -626,6 +626,9 @@ class StorePolicyIntegrityAdminMixin:
             if sibling_ids:
                 decision_ids = sibling_ids
                 artifact_id = None
+                artifact_hash = None
+                artifact_id_is_null = False
+                artifact_hash_is_null = False
         if decision_ids is not None:
             if not decision_ids:
                 return 0

--- a/src/codex_plugin_scanner/guard/store_policy_integrity_runtime.py
+++ b/src/codex_plugin_scanner/guard/store_policy_integrity_runtime.py
@@ -616,6 +616,16 @@ class StorePolicyIntegrityAdminMixin:
         current_time = _now()
         conditions: list[str] = []
         params: list[object] = []
+        if artifact_id is not None and decision_ids is None:
+            from .store_policy_list import remembered_artifact_decision_ids
+
+            sibling_ids = remembered_artifact_decision_ids(
+                self.list_policy_decisions(harness),
+                artifact_id=artifact_id,
+            )
+            if sibling_ids:
+                decision_ids = sibling_ids
+                artifact_id = None
         if decision_ids is not None:
             if not decision_ids:
                 return 0

--- a/src/codex_plugin_scanner/guard/store_policy_integrity_runtime.py
+++ b/src/codex_plugin_scanner/guard/store_policy_integrity_runtime.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 # ruff: noqa: F403,F405
 from .store_base import *
-from .store_policy_list import collapse_duplicate_artifact_policy_rows
 
 
 def _set_private_mode_compat(path: Path, mode: int) -> None:
@@ -98,7 +97,7 @@ class StorePolicyIntegrityAdminMixin:
                     payload["integrity_mode"] = state.get("mode")
                     payload["integrity_enforcement"] = state.get("enforcement")
                 items.append(payload)
-            return collapse_duplicate_artifact_policy_rows(items)
+            return items
 
     def get_policy_decision(self, decision_id: int) -> dict[str, object] | None:
         from .store_policy_decision import get_policy_decision_payload

--- a/src/codex_plugin_scanner/guard/store_policy_list.py
+++ b/src/codex_plugin_scanner/guard/store_policy_list.py
@@ -1,0 +1,26 @@
+"""Collapse duplicate remembered artifact rules for dashboard listing."""
+
+from __future__ import annotations
+
+
+def collapse_duplicate_artifact_policy_rows(
+    items: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    seen: set[tuple[object, ...]] = set()
+    collapsed: list[dict[str, object]] = []
+    for item in items:
+        if str(item.get("scope") or "") != "artifact":
+            collapsed.append(item)
+            continue
+        command = str(item.get("remembered_command") or item.get("artifact_id") or "")
+        key = (
+            str(item.get("harness") or ""),
+            str(item.get("action") or ""),
+            str(item.get("source") or ""),
+            command,
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        collapsed.append(item)
+    return collapsed

--- a/src/codex_plugin_scanner/guard/store_policy_list.py
+++ b/src/codex_plugin_scanner/guard/store_policy_list.py
@@ -23,6 +23,40 @@ def _artifact_row_rank(item: dict[str, object]) -> tuple[str, int]:
     return (updated_at, ident)
 
 
+def remembered_artifact_decision_ids(
+    items: list[dict[str, object]],
+    *,
+    artifact_id: str,
+) -> set[int]:
+    """Return stored decision IDs that share one displayed remembered-command row."""
+
+    target = next((item for item in items if str(item.get("artifact_id") or "") == artifact_id), None)
+    if target is None or str(target.get("scope") or "") != "artifact":
+        return set()
+    command = str(target.get("remembered_command") or target.get("artifact_id") or "")
+    key = (
+        str(target.get("harness") or ""),
+        str(target.get("action") or ""),
+        str(target.get("source") or ""),
+        command,
+    )
+    ids: set[int] = set()
+    for item in items:
+        if str(item.get("scope") or "") != "artifact":
+            continue
+        item_command = str(item.get("remembered_command") or item.get("artifact_id") or "")
+        item_key = (
+            str(item.get("harness") or ""),
+            str(item.get("action") or ""),
+            str(item.get("source") or ""),
+            item_command,
+        )
+        decision_id = item.get("decision_id")
+        if item_key == key and type(decision_id) is int:
+            ids.add(decision_id)
+    return ids
+
+
 def collapse_duplicate_artifact_policy_rows(
     items: list[dict[str, object]],
 ) -> list[dict[str, object]]:

--- a/src/codex_plugin_scanner/guard/store_policy_list.py
+++ b/src/codex_plugin_scanner/guard/store_policy_list.py
@@ -3,6 +3,15 @@
 from __future__ import annotations
 
 
+def list_remembered_policy_decisions(
+    store: object,
+    harness: str | None = None,
+) -> list[dict[str, object]]:
+    list_fn = getattr(store, "list_policy_decisions")
+    items = list_fn(harness)
+    return collapse_duplicate_artifact_policy_rows(items)
+
+
 def collapse_duplicate_artifact_policy_rows(
     items: list[dict[str, object]],
 ) -> list[dict[str, object]]:

--- a/src/codex_plugin_scanner/guard/store_policy_list.py
+++ b/src/codex_plugin_scanner/guard/store_policy_list.py
@@ -2,34 +2,49 @@
 
 from __future__ import annotations
 
+from typing import Protocol
+
+
+class PolicyDecisionStore(Protocol):
+    def list_policy_decisions(self, harness: str | None = None) -> list[dict[str, object]]: ...
+
 
 def list_remembered_policy_decisions(
-    store: object,
+    store: PolicyDecisionStore,
     harness: str | None = None,
 ) -> list[dict[str, object]]:
-    list_fn = getattr(store, "list_policy_decisions")
-    items = list_fn(harness)
-    return collapse_duplicate_artifact_policy_rows(items)
+    return collapse_duplicate_artifact_policy_rows(store.list_policy_decisions(harness))
+
+
+def _artifact_row_rank(item: dict[str, object]) -> tuple[str, int]:
+    updated_at = str(item.get("updated_at") or "")
+    decision_id = item.get("decision_id")
+    ident = decision_id if type(decision_id) is int else 0
+    return (updated_at, ident)
 
 
 def collapse_duplicate_artifact_policy_rows(
     items: list[dict[str, object]],
 ) -> list[dict[str, object]]:
-    seen: set[tuple[object, ...]] = set()
-    collapsed: list[dict[str, object]] = []
+    best: dict[tuple[object, ...], dict[str, object]] = {}
+    order: list[tuple[object, ...]] = []
     for item in items:
         if str(item.get("scope") or "") != "artifact":
-            collapsed.append(item)
+            key = ("row", item.get("decision_id"))
+        else:
+            command = str(item.get("remembered_command") or item.get("artifact_id") or "")
+            key = (
+                "artifact",
+                str(item.get("harness") or ""),
+                str(item.get("action") or ""),
+                str(item.get("source") or ""),
+                command,
+            )
+        current = best.get(key)
+        if current is None:
+            best[key] = item
+            order.append(key)
             continue
-        command = str(item.get("remembered_command") or item.get("artifact_id") or "")
-        key = (
-            str(item.get("harness") or ""),
-            str(item.get("action") or ""),
-            str(item.get("source") or ""),
-            command,
-        )
-        if key in seen:
-            continue
-        seen.add(key)
-        collapsed.append(item)
-    return collapsed
+        if _artifact_row_rank(item) > _artifact_row_rank(current):
+            best[key] = item
+    return [best[key] for key in order]

--- a/tests/test_guard_extension_control_authority.py
+++ b/tests/test_guard_extension_control_authority.py
@@ -505,8 +505,20 @@ def test_extension_control_schema_rejects_future_or_gapped_versions(tmp_path: Pa
     store = _store(tmp_path, secrets)
     with store._connect() as connection:
         connection.execute("update extension_control_schema_migration set version = 99 where singleton = 1")
+    view = store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest)
+    assert view.health is AuthorityHealth.DEGRADED_UNACKNOWLEDGED
     with pytest.raises(ExtensionControlAuthorityError, match="schema"):
-        store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest)
+        _commit(store)
+
+
+def test_incompatible_extension_schema_does_not_brick_store_open(tmp_path: Path) -> None:
+    secrets = MemorySecretStore()
+    store = _store(tmp_path, secrets)
+    with store._connect() as connection:
+        connection.execute("update extension_control_schema_migration set version = 99 where singleton = 1")
+    opened = GuardStore(tmp_path, prime_policy_integrity=False)
+    opened._extension_control_authority_secret_store = secrets
+    assert opened.list_policy_decisions() == []
 
 
 def test_non_protected_authority_requires_exact_trusted_surface_enum() -> None:

--- a/tests/test_policy_decision_source_context.py
+++ b/tests/test_policy_decision_source_context.py
@@ -528,6 +528,7 @@ def test_clear_displayed_artifact_rule_removes_collapsed_siblings(tmp_path) -> N
         "guard-cli",
         scope="artifact",
         artifact_id=str(displayed[0]["artifact_id"]),
+        artifact_hash=str(displayed[0].get("artifact_hash") or ""),
     )
     assert cleared == 3
     assert store.list_policy_decisions("guard-cli") == []

--- a/tests/test_policy_decision_source_context.py
+++ b/tests/test_policy_decision_source_context.py
@@ -1,6 +1,9 @@
 from codex_plugin_scanner.guard.models import GuardApprovalRequest, GuardReceipt, PolicyDecision
 from codex_plugin_scanner.guard.store import GuardStore, _runtime_scoped_exact_match_key
-from codex_plugin_scanner.guard.store_policy_list import collapse_duplicate_artifact_policy_rows
+from codex_plugin_scanner.guard.store_policy_list import (
+    collapse_duplicate_artifact_policy_rows,
+    list_remembered_policy_decisions,
+)
 
 
 def _store(tmp_path) -> GuardStore:
@@ -478,7 +481,9 @@ def test_list_policy_decisions_collapses_duplicate_npx_once_rules(tmp_path) -> N
             f"2026-08-24T21:0{index}:00+00:00",
         )
 
-    items = store.list_policy_decisions("guard-cli")
+    stored = store.list_policy_decisions("guard-cli")
+    assert len(stored) == 5
+    items = list_remembered_policy_decisions(store, "guard-cli")
     assert len(items) == 1
     assert items[0]["remembered_command"] == command
     assert items[0]["artifact_id"] == "guard-cli:runtime:npx:4"

--- a/tests/test_policy_decision_source_context.py
+++ b/tests/test_policy_decision_source_context.py
@@ -1,5 +1,6 @@
 from codex_plugin_scanner.guard.models import GuardApprovalRequest, GuardReceipt, PolicyDecision
 from codex_plugin_scanner.guard.store import GuardStore, _runtime_scoped_exact_match_key
+from codex_plugin_scanner.guard.store_policy_list import collapse_duplicate_artifact_policy_rows
 
 
 def _store(tmp_path) -> GuardStore:
@@ -442,3 +443,75 @@ def test_list_policy_decisions_keeps_inventory_context_with_global_policy(tmp_pa
 
     items = {str(item["artifact_id"]): item for item in store.list_policy_decisions()}
     assert items["codex:project:package-request:mixed1"]["remembered_command"] == "pnpm install --frozen-lockfile"
+
+
+def test_list_policy_decisions_collapses_duplicate_npx_once_rules(tmp_path) -> None:
+    store = _store(tmp_path)
+    command = "npx execute @modelcontextprotocol/server-memory"
+    for index in range(5):
+        artifact_id = f"guard-cli:runtime:npx:{index}"
+        store.add_receipt(
+            GuardReceipt(
+                receipt_id=f"receipt-npx-{index}",
+                timestamp=f"2026-08-24T21:0{index}:00+00:00",
+                harness="guard-cli",
+                artifact_id=artifact_id,
+                artifact_hash=f"npxhash{index}abcdef1234567890abcdef1234567890abcdef12",
+                policy_decision="allow",
+                capabilities_summary="Launch MCP server",
+                changed_capabilities=("runtime",),
+                provenance_summary="approval-gate once",
+                artifact_name=command,
+                source_scope="/srv/projects/sample-guard",
+            )
+        )
+        store.upsert_policy(
+            PolicyDecision(
+                harness="guard-cli",
+                scope="artifact",
+                action="allow",
+                artifact_id=artifact_id,
+                artifact_hash=f"npxhash{index}abcdef1234567890abcdef1234567890abcdef12",
+                reason="approved in review",
+                source="local",
+            ),
+            f"2026-08-24T21:0{index}:00+00:00",
+        )
+
+    items = store.list_policy_decisions("guard-cli")
+    assert len(items) == 1
+    assert items[0]["remembered_command"] == command
+    assert items[0]["artifact_id"] == "guard-cli:runtime:npx:4"
+
+
+def test_collapse_duplicate_artifact_policy_rows_keeps_newest() -> None:
+    collapsed = collapse_duplicate_artifact_policy_rows(
+        [
+            {
+                "harness": "guard-cli",
+                "scope": "artifact",
+                "action": "allow",
+                "source": "approval-gate",
+                "remembered_command": "npx execute @modelcontextprotocol/server-memory",
+                "artifact_id": "new",
+                "updated_at": "2026-08-24T22:00:00+00:00",
+            },
+            {
+                "harness": "guard-cli",
+                "scope": "artifact",
+                "action": "allow",
+                "source": "approval-gate",
+                "remembered_command": "npx execute @modelcontextprotocol/server-memory",
+                "artifact_id": "old",
+                "updated_at": "2026-08-24T21:00:00+00:00",
+            },
+            {
+                "harness": "guard-cli",
+                "scope": "workspace",
+                "action": "allow",
+                "source": "local",
+                "artifact_id": "workspace-rule",
+            },
+        ]
+    )
+    assert [item["artifact_id"] for item in collapsed] == ["new", "workspace-rule"]

--- a/tests/test_policy_decision_source_context.py
+++ b/tests/test_policy_decision_source_context.py
@@ -489,6 +489,50 @@ def test_list_policy_decisions_collapses_duplicate_npx_once_rules(tmp_path) -> N
     assert items[0]["artifact_id"] == "guard-cli:runtime:npx:4"
 
 
+def test_clear_displayed_artifact_rule_removes_collapsed_siblings(tmp_path) -> None:
+    store = _store(tmp_path)
+    command = "npx execute @modelcontextprotocol/server-memory"
+    for index in range(3):
+        artifact_id = f"guard-cli:runtime:npx:{index}"
+        store.add_receipt(
+            GuardReceipt(
+                receipt_id=f"receipt-clear-{index}",
+                timestamp=f"2026-08-24T21:1{index}:00+00:00",
+                harness="guard-cli",
+                artifact_id=artifact_id,
+                artifact_hash=f"clearhash{index}abcdef1234567890abcdef1234567890abcdef12",
+                policy_decision="allow",
+                capabilities_summary="Launch MCP server",
+                changed_capabilities=("runtime",),
+                provenance_summary="approval-gate once",
+                artifact_name=command,
+                source_scope="/srv/projects/sample-guard",
+            )
+        )
+        store.upsert_policy(
+            PolicyDecision(
+                harness="guard-cli",
+                scope="artifact",
+                action="allow",
+                artifact_id=artifact_id,
+                artifact_hash=f"clearhash{index}abcdef1234567890abcdef1234567890abcdef12",
+                reason="approved in review",
+                source="local",
+            ),
+            f"2026-08-24T21:1{index}:00+00:00",
+        )
+
+    displayed = list_remembered_policy_decisions(store, "guard-cli")
+    assert len(displayed) == 1
+    cleared = store.clear_policy_decisions(
+        "guard-cli",
+        scope="artifact",
+        artifact_id=str(displayed[0]["artifact_id"]),
+    )
+    assert cleared == 3
+    assert store.list_policy_decisions("guard-cli") == []
+
+
 def test_collapse_duplicate_artifact_policy_rows_keeps_newest() -> None:
     collapsed = collapse_duplicate_artifact_policy_rows(
         [

--- a/tests/test_policy_decision_source_context.py
+++ b/tests/test_policy_decision_source_context.py
@@ -493,15 +493,7 @@ def test_collapse_duplicate_artifact_policy_rows_keeps_newest() -> None:
     collapsed = collapse_duplicate_artifact_policy_rows(
         [
             {
-                "harness": "guard-cli",
-                "scope": "artifact",
-                "action": "allow",
-                "source": "approval-gate",
-                "remembered_command": "npx execute @modelcontextprotocol/server-memory",
-                "artifact_id": "new",
-                "updated_at": "2026-08-24T22:00:00+00:00",
-            },
-            {
+                "decision_id": 1,
                 "harness": "guard-cli",
                 "scope": "artifact",
                 "action": "allow",
@@ -511,6 +503,17 @@ def test_collapse_duplicate_artifact_policy_rows_keeps_newest() -> None:
                 "updated_at": "2026-08-24T21:00:00+00:00",
             },
             {
+                "decision_id": 2,
+                "harness": "guard-cli",
+                "scope": "artifact",
+                "action": "allow",
+                "source": "approval-gate",
+                "remembered_command": "npx execute @modelcontextprotocol/server-memory",
+                "artifact_id": "new",
+                "updated_at": "2026-08-24T22:00:00+00:00",
+            },
+            {
+                "decision_id": 3,
                 "harness": "guard-cli",
                 "scope": "workspace",
                 "action": "allow",


### PR DESCRIPTION
## Summary
- Keep `hol-guard status` and `hol-guard doctor` usable when the on-disk extension-control schema marker is newer or mismatched.
- Collapse duplicate artifact-scoped remembered rules that share the same command, action, and harness.

## Testing
- `python3 -m pytest tests/test_guard_extension_control_authority.py tests/test_policy_decision_source_context.py -q --tb=short`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Policy listings now remove duplicate artifact approval entries while preserving distinct policy scopes.
  * Policy information is consistently deduplicated in command-line and API responses.
  * Compatible schema upgrades are handled automatically.

* **Bug Fixes**
  * Stores with incompatible schema versions can still open and display unrelated policy decisions.
  * Clearing a displayed artifact approval now removes all associated duplicate entries.
  * Attempts to modify data requiring an incompatible schema continue to be rejected safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->