### PR TITLE
fix(update): retain verified newer desktop runtime

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12848,
-  "maximum_test_source_lines": 292967,
+  "maximum_collected_cases": 12857,
+  "maximum_test_source_lines": 293355,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -824,13 +824,17 @@ def run_guard_update(
         daemon_refresh, daemon_refresh_note = refresh_guard_daemon_after_update(
             context,
             update_context=update_context,
+            minimum_version=resulting_version,
         )
         if daemon_refresh is not None:
             payload["daemon_refresh"] = daemon_refresh
         _append_payload_note(payload, daemon_refresh_note)
-        if daemon_refresh_required and not (
-            isinstance(daemon_refresh, dict) and daemon_refresh.get("status") == "restarted"
-        ):
+        daemon_refresh_succeeded = (
+            isinstance(daemon_refresh, dict)
+            and daemon_refresh.get("status") in {"restarted", "retained_newer_runtime"}
+            and daemon_refresh.get("runtime_verified") is True
+        )
+        if daemon_refresh_required and not daemon_refresh_succeeded:
             payload.update(
                 {
                     "status": "failed",
@@ -2055,11 +2059,21 @@ def refresh_guard_daemon_after_update(
     context: HarnessContext,
     *,
     update_context: TrustedUpdateContext | None = None,
+    minimum_version: str | None = None,
 ) -> tuple[dict[str, object] | None, str | None]:
     """Restart a resident daemon in a fresh interpreter after a CLI package update."""
 
     if not (context.guard_home / "daemon-state.json").is_file():
         return None, None
+    newer_runtime = _verified_newer_guard_daemon(
+        context.guard_home,
+        minimum_version=minimum_version,
+    )
+    if newer_runtime is not None:
+        return (
+            newer_runtime,
+            "Kept the newer HOL Guard runtime active while updating the shell CLI.",
+        )
     active_context: TrustedUpdateContext | None = None
     try:
         active_context = update_context or _standalone_update_context(context)
@@ -2119,6 +2133,78 @@ def refresh_guard_daemon_after_update(
             cleanup_verified=cleanup_verified,
         )
     return payload, "Restarted the Guard daemon to load the updated package."
+
+
+def _verified_newer_guard_daemon(
+    guard_home: Path,
+    *,
+    minimum_version: str | None = None,
+) -> dict[str, object] | None:
+    """Retain a live newer runtime only after signed-state and loopback health agree."""
+
+    from ..daemon.discovery import load_authenticated_daemon_state
+    from ..daemon.manager import load_guard_daemon_auth_token
+
+    state = load_authenticated_daemon_state(guard_home)
+    if state is None:
+        return None
+    daemon_version_text = state.get("package_version")
+    host = state.get("host")
+    port = state.get("port")
+    token = load_guard_daemon_auth_token(guard_home)
+    if (
+        not isinstance(daemon_version_text, str)
+        or host not in {"127.0.0.1", "::1"}
+        or not isinstance(port, int)
+        or not 1 <= port <= 65535
+        or not isinstance(token, str)
+        or not token
+    ):
+        return None
+    try:
+        daemon_version = Version(daemon_version_text)
+        required_version_text = minimum_version or package_version.__version__
+        required_version = Version(required_version_text)
+    except InvalidVersion:
+        return None
+    if daemon_version <= required_version:
+        return None
+
+    daemon_url = f"http://{f'[{host}]' if host == '::1' else host}:{port}"
+    request = urllib.request.Request(
+        f"{daemon_url}/v1/healthz/details",
+        headers={"X-Guard-Token": token},
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=1.0) as response:
+            if response.status != 200:
+                return None
+            response_bytes = response.read(65_537)
+            if len(response_bytes) > 65_536:
+                return None
+            details = json.loads(response_bytes.decode("utf-8"))
+    except (OSError, ValueError, json.JSONDecodeError, urllib.error.URLError):
+        return None
+    if not isinstance(details, dict) or details.get("ok") is not True:
+        return None
+    try:
+        details_guard_home = Path(str(details.get("guard_home"))).expanduser().resolve()
+    except (OSError, RuntimeError, ValueError):
+        return None
+    identity_fields = ("package_version", "compatibility_version", "runtime_fingerprint", "pid")
+    if (
+        details_guard_home != guard_home.expanduser().resolve()
+        or any(details.get(field) != state.get(field) for field in identity_fields)
+    ):
+        return None
+    return {
+        "status": "retained_newer_runtime",
+        "daemon_url": daemon_url,
+        "daemon_version": daemon_version_text,
+        "cli_version": required_version_text,
+        "runtime_verified": True,
+    }
 
 
 def _cleanup_failed_guard_daemon_refresh(

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -2154,6 +2154,7 @@ def _verified_newer_guard_daemon(
     token = load_guard_daemon_auth_token(guard_home)
     if (
         not isinstance(daemon_version_text, str)
+        or not isinstance(host, str)
         or host not in {"127.0.0.1", "::1"}
         or not isinstance(port, int)
         or not 1 <= port <= 65535

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -2143,7 +2143,10 @@ def _verified_newer_guard_daemon(
     """Retain a live newer runtime only after signed-state and loopback health agree."""
 
     from ..daemon.discovery import load_authenticated_daemon_state
-    from ..daemon.manager import load_guard_daemon_auth_token
+    from ..daemon.manager import (
+        GUARD_DAEMON_COMPATIBILITY_VERSION,
+        load_guard_daemon_auth_token,
+    )
 
     state = load_authenticated_daemon_state(guard_home)
     if state is None:
@@ -2151,6 +2154,9 @@ def _verified_newer_guard_daemon(
     daemon_version_text = state.get("package_version")
     host = state.get("host")
     port = state.get("port")
+    compatibility_version = state.get("compatibility_version")
+    runtime_fingerprint = state.get("runtime_fingerprint")
+    daemon_pid = state.get("pid")
     token = load_guard_daemon_auth_token(guard_home)
     if (
         not isinstance(daemon_version_text, str)
@@ -2158,6 +2164,11 @@ def _verified_newer_guard_daemon(
         or host not in {"127.0.0.1", "::1"}
         or not isinstance(port, int)
         or not 1 <= port <= 65535
+        or compatibility_version != GUARD_DAEMON_COMPATIBILITY_VERSION
+        or not isinstance(runtime_fingerprint, str)
+        or not runtime_fingerprint
+        or not isinstance(daemon_pid, int)
+        or daemon_pid <= 0
         or not isinstance(token, str)
         or not token
     ):
@@ -2178,7 +2189,8 @@ def _verified_newer_guard_daemon(
         method="GET",
     )
     try:
-        with urllib.request.urlopen(request, timeout=1.0) as response:
+        opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+        with opener.open(request, timeout=1.0) as response:
             if response.status != 200:
                 return None
             response_bytes = response.read(65_537)
@@ -2196,6 +2208,7 @@ def _verified_newer_guard_daemon(
     identity_fields = ("package_version", "compatibility_version", "runtime_fingerprint", "pid")
     if (
         details_guard_home != guard_home.expanduser().resolve()
+        or any(field not in state or field not in details for field in identity_fields)
         or any(details.get(field) != state.get(field) for field in identity_fields)
     ):
         return None

--- a/src/codex_plugin_scanner/guard/daemon/dashboard_update_runner.py
+++ b/src/codex_plugin_scanner/guard/daemon/dashboard_update_runner.py
@@ -137,7 +137,11 @@ def _isolated_daemon_refresh(
 
 
 def _daemon_refresh_restarted(payload: object) -> bool:
-    return isinstance(payload, dict) and payload.get("status") == "restarted"
+    return (
+        isinstance(payload, dict)
+        and payload.get("status") in {"restarted", "retained_newer_runtime"}
+        and payload.get("runtime_verified") is True
+    )
 
 
 def _parse_args(argv: list[str] | None) -> argparse.Namespace:

--- a/tests/test_dashboard_update.py
+++ b/tests/test_dashboard_update.py
@@ -1195,9 +1195,7 @@ def test_dashboard_update_runner_blocks_install_when_daemon_retirement_is_unprov
     update_token = "9" * 64
     written_payload: dict[str, object] = {}
     run_update = MagicMock()
-    isolated_refresh = MagicMock(
-        return_value=({"status": "restarted", "runtime_verified": True}, None)
-    )
+    isolated_refresh = MagicMock(return_value=({"status": "restarted", "runtime_verified": True}, None))
 
     monkeypatch.setattr(runner_module.time, "sleep", lambda _seconds: None)
     monkeypatch.setattr(runner_module, "claim_dashboard_update_lock", lambda _home, *, token: True)
@@ -1253,9 +1251,7 @@ def test_dashboard_update_runner_exit_zero_requires_embedded_daemon_restart(
         "run_guard_update",
         lambda **kwargs: ({"status": "skipped"}, 0),
     )
-    isolated_refresh = MagicMock(
-        return_value=({"status": "restarted", "runtime_verified": True}, "restarted")
-    )
+    isolated_refresh = MagicMock(return_value=({"status": "restarted", "runtime_verified": True}, "restarted"))
     legacy_restart = MagicMock()
     monkeypatch.setattr(runner_module.update_commands, "refresh_guard_daemon_after_update", isolated_refresh)
     monkeypatch.setattr(runner_module, "ensure_guard_daemon_after_update", legacy_restart)
@@ -1369,9 +1365,7 @@ def test_dashboard_update_runner_failure_stderr_never_renders_payload_details(
         "run_guard_update",
         lambda **kwargs: ({"status": "failed", **failure_detail}, 1),
     )
-    isolated_refresh = MagicMock(
-        return_value=({"status": "restarted", "runtime_verified": True}, "restarted")
-    )
+    isolated_refresh = MagicMock(return_value=({"status": "restarted", "runtime_verified": True}, "restarted"))
     legacy_restart = MagicMock()
     clear_lock = MagicMock(return_value=True)
     monkeypatch.setattr(runner_module.update_commands, "refresh_guard_daemon_after_update", isolated_refresh)

--- a/tests/test_dashboard_update.py
+++ b/tests/test_dashboard_update.py
@@ -1082,7 +1082,10 @@ def test_dashboard_update_runner_preserves_state_for_trusted_successful_restart(
         assert state_path.read_text(encoding="utf-8") == state_text
         calls.append("run_update")
         update_kwargs.update(kwargs)
-        return {"status": "updated", "daemon_refresh": {"status": "restarted"}}, 0
+        return {
+            "status": "updated",
+            "daemon_refresh": {"status": "restarted", "runtime_verified": True},
+        }, 0
 
     monkeypatch.setattr(runner_module.update_commands, "run_guard_update", fake_run_guard_update)
     isolated_refresh = MagicMock()
@@ -1128,6 +1131,59 @@ def test_dashboard_update_runner_preserves_state_for_trusted_successful_restart(
     ]
 
 
+def test_dashboard_update_runner_accepts_verified_retained_newer_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codex_plugin_scanner.guard.daemon import dashboard_update_runner as runner_module
+
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    update_token = "d" * 64
+    written_payload: dict[str, object] = {}
+    monkeypatch.setattr(runner_module.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(runner_module, "claim_dashboard_update_lock", lambda _home, *, token: True)
+    monkeypatch.setattr(runner_module, "retire_all_guard_daemons_for_home", lambda _home: [])
+    monkeypatch.setattr(runner_module, "_retire_guard_daemon_pid", lambda _pid, **_kwargs: True)
+    monkeypatch.setattr(runner_module, "guard_daemon_retirement_is_complete", lambda _home: True)
+    monkeypatch.setattr(
+        runner_module.update_commands,
+        "run_guard_update",
+        lambda **_kwargs: (
+            {
+                "status": "updated",
+                "daemon_refresh": {
+                    "status": "retained_newer_runtime",
+                    "runtime_verified": True,
+                },
+            },
+            0,
+        ),
+    )
+    monkeypatch.setattr(
+        runner_module,
+        "write_dashboard_update_outcome",
+        lambda _home, payload: written_payload.update(payload),
+    )
+    monkeypatch.setattr(runner_module, "clear_dashboard_update_lock", MagicMock(return_value=True))
+
+    exit_code = runner_module.main(
+        [
+            "--guard-home",
+            str(guard_home),
+            "--daemon-pid",
+            "5151",
+            "--daemon-port",
+            "5474",
+            "--update-token",
+            update_token,
+        ]
+    )
+
+    assert exit_code == 0
+    assert written_payload["status"] == "updated"
+
+
 def test_dashboard_update_runner_blocks_install_when_daemon_retirement_is_unproven(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1139,7 +1195,9 @@ def test_dashboard_update_runner_blocks_install_when_daemon_retirement_is_unprov
     update_token = "9" * 64
     written_payload: dict[str, object] = {}
     run_update = MagicMock()
-    isolated_refresh = MagicMock(return_value=({"status": "restarted"}, None))
+    isolated_refresh = MagicMock(
+        return_value=({"status": "restarted", "runtime_verified": True}, None)
+    )
 
     monkeypatch.setattr(runner_module.time, "sleep", lambda _seconds: None)
     monkeypatch.setattr(runner_module, "claim_dashboard_update_lock", lambda _home, *, token: True)
@@ -1195,7 +1253,9 @@ def test_dashboard_update_runner_exit_zero_requires_embedded_daemon_restart(
         "run_guard_update",
         lambda **kwargs: ({"status": "skipped"}, 0),
     )
-    isolated_refresh = MagicMock(return_value=({"status": "restarted"}, "restarted"))
+    isolated_refresh = MagicMock(
+        return_value=({"status": "restarted", "runtime_verified": True}, "restarted")
+    )
     legacy_restart = MagicMock()
     monkeypatch.setattr(runner_module.update_commands, "refresh_guard_daemon_after_update", isolated_refresh)
     monkeypatch.setattr(runner_module, "ensure_guard_daemon_after_update", legacy_restart)
@@ -1309,7 +1369,9 @@ def test_dashboard_update_runner_failure_stderr_never_renders_payload_details(
         "run_guard_update",
         lambda **kwargs: ({"status": "failed", **failure_detail}, 1),
     )
-    isolated_refresh = MagicMock(return_value=({"status": "restarted"}, "restarted"))
+    isolated_refresh = MagicMock(
+        return_value=({"status": "restarted", "runtime_verified": True}, "restarted")
+    )
     legacy_restart = MagicMock()
     clear_lock = MagicMock(return_value=True)
     monkeypatch.setattr(runner_module.update_commands, "refresh_guard_daemon_after_update", isolated_refresh)

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -119,13 +119,18 @@ def test_daemon_refresh_retains_verified_newer_desktop_runtime(
             assert limit == 65_537
             return json.dumps({**state, "ok": True}).encode("utf-8")
 
-    def urlopen(request: urllib.request.Request, *, timeout: float) -> Response:
-        assert request.full_url == "http://127.0.0.1:5245/v1/healthz/details"
-        assert request.headers["X-guard-token"] == "daemon-token"
-        assert timeout == 1.0
-        return Response()
+    class Opener:
+        def open(self, request: urllib.request.Request, *, timeout: float) -> Response:
+            assert request.full_url == "http://127.0.0.1:5245/v1/healthz/details"
+            assert request.headers["X-guard-token"] == "daemon-token"
+            assert timeout == 1.0
+            return Response()
 
-    monkeypatch.setattr(update_commands.urllib.request, "urlopen", urlopen)
+    def build_opener(handler: urllib.request.ProxyHandler) -> Opener:
+        assert handler.proxies == {}
+        return Opener()
+
+    monkeypatch.setattr(update_commands.urllib.request, "build_opener", build_opener)
 
     payload, note = update_commands.refresh_guard_daemon_after_update(
         context,
@@ -176,7 +181,8 @@ def test_daemon_refresh_restarts_runtime_older_than_installed_target(
             assert limit == 65_537
             return json.dumps({**state, "ok": True}).encode("utf-8")
 
-    monkeypatch.setattr(update_commands.urllib.request, "urlopen", lambda *_args, **_kwargs: Response())
+    opener = SimpleNamespace(open=lambda *_args, **_kwargs: Response())
+    monkeypatch.setattr(update_commands.urllib.request, "build_opener", lambda *_args: opener)
     restart = SimpleNamespace(
         returncode=0,
         stdout='{"status":"restarted","runtime_verified":true}',
@@ -234,11 +240,10 @@ def test_daemon_refresh_does_not_trust_newer_state_when_live_identity_differs(
 
         def read(self, limit: int) -> bytes:
             assert limit == 65_537
-            return json.dumps(
-                {**state, "ok": True, "runtime_fingerprint": "different-live-fingerprint"}
-            ).encode()
+            return json.dumps({**state, "ok": True, "runtime_fingerprint": "different-live-fingerprint"}).encode()
 
-    monkeypatch.setattr(update_commands.urllib.request, "urlopen", lambda *_args, **_kwargs: Response())
+    opener = SimpleNamespace(open=lambda *_args, **_kwargs: Response())
+    monkeypatch.setattr(update_commands.urllib.request, "build_opener", lambda *_args: opener)
     restart = SimpleNamespace(
         returncode=0,
         stdout='{"status":"restarted","runtime_verified":true}',
@@ -282,8 +287,8 @@ def test_daemon_refresh_falls_back_when_authenticated_host_is_malformed(
     }
     monkeypatch.setattr(discovery, "load_authenticated_daemon_state", lambda _home: state)
     monkeypatch.setattr(manager, "load_guard_daemon_auth_token", lambda _home: "daemon-token")
-    urlopen = MagicMock()
-    monkeypatch.setattr(update_commands.urllib.request, "urlopen", urlopen)
+    build_opener = MagicMock()
+    monkeypatch.setattr(update_commands.urllib.request, "build_opener", build_opener)
     restart = SimpleNamespace(
         returncode=0,
         stdout='{"status":"restarted","runtime_verified":true}',
@@ -303,7 +308,65 @@ def test_daemon_refresh_falls_back_when_authenticated_host_is_malformed(
 
     assert payload == {"status": "restarted", "runtime_verified": True}
     assert note == "Restarted the Guard daemon to load the updated package."
-    urlopen.assert_not_called()
+    build_opener.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("compatibility_version", 3),
+        ("runtime_fingerprint", None),
+        ("pid", None),
+    ],
+)
+def test_daemon_refresh_falls_back_for_incomplete_or_incompatible_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    value: object,
+) -> None:
+    from codex_plugin_scanner.guard.daemon import discovery, manager
+
+    context = _context(tmp_path)
+    context.guard_home.mkdir(parents=True)
+    (context.guard_home / "daemon-state.json").write_text("signed", encoding="utf-8")
+    state: dict[str, object] = {
+        "guard_home": str(context.guard_home.resolve()),
+        "host": "127.0.0.1",
+        "port": 5245,
+        "pid": 4242,
+        "compatibility_version": 2,
+        "package_version": "3.0.0a253",
+        "runtime_fingerprint": "desktop-core-fingerprint",
+    }
+    if value is None:
+        state.pop(field)
+    else:
+        state[field] = value
+    monkeypatch.setattr(discovery, "load_authenticated_daemon_state", lambda _home: state)
+    monkeypatch.setattr(manager, "load_guard_daemon_auth_token", lambda _home: "daemon-token")
+    build_opener = MagicMock()
+    monkeypatch.setattr(update_commands.urllib.request, "build_opener", build_opener)
+    restart = SimpleNamespace(
+        returncode=0,
+        stdout='{"status":"restarted","runtime_verified":true}',
+        stderr="",
+        output_limited=False,
+    )
+
+    class RestartContext:
+        def python_command(self, script: str, *_args: str) -> list[str]:
+            return ["/trusted/python", "-c", script]
+
+        def run(self, *_args: object, **_kwargs: object) -> SimpleNamespace:
+            return restart
+
+    monkeypatch.setattr(update_commands, "_standalone_update_context", lambda _context: RestartContext())
+    payload, note = update_commands.refresh_guard_daemon_after_update(context)
+
+    assert payload == {"status": "restarted", "runtime_verified": True}
+    assert note == "Restarted the Guard daemon to load the updated package."
+    build_opener.assert_not_called()
 
 
 def test_daemon_refresh_authorizes_breakaway_only_for_restart_child(tmp_path: Path) -> None:

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -7,6 +7,7 @@ import io
 import json
 import os
 import subprocess
+import urllib.request
 import zipfile
 from pathlib import Path
 from types import SimpleNamespace
@@ -80,6 +81,184 @@ def test_daemon_refresh_after_update_skips_when_daemon_is_not_running(tmp_path: 
 
     assert payload is None
     assert note is None
+
+
+def test_daemon_refresh_retains_verified_newer_desktop_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codex_plugin_scanner.guard.daemon import discovery, manager
+
+    context = _context(tmp_path)
+    context.guard_home.mkdir(parents=True)
+    (context.guard_home / "daemon-state.json").write_text("signed", encoding="utf-8")
+    state: dict[str, object] = {
+        "guard_home": str(context.guard_home.resolve()),
+        "host": "127.0.0.1",
+        "port": 5245,
+        "pid": 4242,
+        "compatibility_version": 2,
+        "package_version": "3.0.0a253",
+        "runtime_fingerprint": "desktop-core-fingerprint",
+    }
+    monkeypatch.setattr(discovery, "load_authenticated_daemon_state", lambda _home: state)
+    monkeypatch.setattr(manager, "load_guard_daemon_auth_token", lambda _home: "daemon-token")
+    monkeypatch.setattr(update_commands.package_version, "__version__", "2.2.123")
+
+    class Response:
+        status = 200
+
+        def __enter__(self) -> Response:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def read(self, limit: int) -> bytes:
+            assert limit == 65_537
+            return json.dumps({**state, "ok": True}).encode("utf-8")
+
+    def urlopen(request: urllib.request.Request, *, timeout: float) -> Response:
+        assert request.full_url == "http://127.0.0.1:5245/v1/healthz/details"
+        assert request.headers["X-guard-token"] == "daemon-token"
+        assert timeout == 1.0
+        return Response()
+
+    monkeypatch.setattr(update_commands.urllib.request, "urlopen", urlopen)
+
+    payload, note = update_commands.refresh_guard_daemon_after_update(
+        context,
+    )
+
+    assert payload == {
+        "status": "retained_newer_runtime",
+        "daemon_url": "http://127.0.0.1:5245",
+        "daemon_version": "3.0.0a253",
+        "cli_version": "2.2.123",
+        "runtime_verified": True,
+    }
+    assert note == "Kept the newer HOL Guard runtime active while updating the shell CLI."
+
+
+def test_daemon_refresh_restarts_runtime_older_than_installed_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codex_plugin_scanner.guard.daemon import discovery, manager
+
+    context = _context(tmp_path)
+    context.guard_home.mkdir(parents=True)
+    (context.guard_home / "daemon-state.json").write_text("signed", encoding="utf-8")
+    state: dict[str, object] = {
+        "guard_home": str(context.guard_home.resolve()),
+        "host": "127.0.0.1",
+        "port": 5245,
+        "pid": 4242,
+        "compatibility_version": 2,
+        "package_version": "2.2.123",
+        "runtime_fingerprint": "old-runtime-fingerprint",
+    }
+    monkeypatch.setattr(discovery, "load_authenticated_daemon_state", lambda _home: state)
+    monkeypatch.setattr(manager, "load_guard_daemon_auth_token", lambda _home: "daemon-token")
+    monkeypatch.setattr(update_commands.package_version, "__version__", "2.2.122")
+
+    class Response:
+        status = 200
+
+        def __enter__(self) -> Response:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def read(self, limit: int) -> bytes:
+            assert limit == 65_537
+            return json.dumps({**state, "ok": True}).encode("utf-8")
+
+    monkeypatch.setattr(update_commands.urllib.request, "urlopen", lambda *_args, **_kwargs: Response())
+    restart = SimpleNamespace(
+        returncode=0,
+        stdout='{"status":"restarted","runtime_verified":true}',
+        stderr="",
+        output_limited=False,
+    )
+
+    class RestartContext:
+        def python_command(self, script: str, *_args: str) -> list[str]:
+            return ["/trusted/python", "-c", script]
+
+        def run(self, *_args: object, **_kwargs: object) -> SimpleNamespace:
+            return restart
+
+    monkeypatch.setattr(update_commands, "_standalone_update_context", lambda _context: RestartContext())
+    payload, note = update_commands.refresh_guard_daemon_after_update(
+        context,
+        minimum_version="2.2.124",
+    )
+
+    assert payload == {"status": "restarted", "runtime_verified": True}
+    assert note == "Restarted the Guard daemon to load the updated package."
+
+
+def test_daemon_refresh_does_not_trust_newer_state_when_live_identity_differs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codex_plugin_scanner.guard.daemon import discovery, manager
+
+    context = _context(tmp_path)
+    context.guard_home.mkdir(parents=True)
+    (context.guard_home / "daemon-state.json").write_text("signed", encoding="utf-8")
+    state: dict[str, object] = {
+        "guard_home": str(context.guard_home.resolve()),
+        "host": "127.0.0.1",
+        "port": 5245,
+        "pid": 4242,
+        "compatibility_version": 2,
+        "package_version": "3.0.0a253",
+        "runtime_fingerprint": "signed-state-fingerprint",
+    }
+    monkeypatch.setattr(discovery, "load_authenticated_daemon_state", lambda _home: state)
+    monkeypatch.setattr(manager, "load_guard_daemon_auth_token", lambda _home: "daemon-token")
+    monkeypatch.setattr(update_commands.package_version, "__version__", "2.2.123")
+
+    class Response:
+        status = 200
+
+        def __enter__(self) -> Response:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def read(self, limit: int) -> bytes:
+            assert limit == 65_537
+            return json.dumps(
+                {**state, "ok": True, "runtime_fingerprint": "different-live-fingerprint"}
+            ).encode()
+
+    monkeypatch.setattr(update_commands.urllib.request, "urlopen", lambda *_args, **_kwargs: Response())
+    restart = SimpleNamespace(
+        returncode=0,
+        stdout='{"status":"restarted","runtime_verified":true}',
+        stderr="",
+        output_limited=False,
+    )
+
+    class RestartContext:
+        def python_command(self, script: str, *_args: str) -> list[str]:
+            return ["/trusted/python", "-c", script]
+
+        def run(self, *_args: object, **_kwargs: object) -> SimpleNamespace:
+            return restart
+
+    monkeypatch.setattr(update_commands, "_standalone_update_context", lambda _context: RestartContext())
+    payload, note = update_commands.refresh_guard_daemon_after_update(
+        context,
+    )
+
+    assert payload == {"status": "restarted", "runtime_verified": True}
+    assert note == "Restarted the Guard daemon to load the updated package."
 
 
 def test_daemon_refresh_authorizes_breakaway_only_for_restart_child(tmp_path: Path) -> None:
@@ -1854,6 +2033,51 @@ def test_update_fails_closed_when_required_same_context_daemon_refresh_fails(
     assert payload["status"] == "failed"
     assert payload["reason_code"] == "update_daemon_refresh_failed"
     assert "trusted refresh failed" in payload["notes"]
+
+
+def test_update_succeeds_when_verified_newer_desktop_runtime_is_retained(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    context.guard_home.mkdir(parents=True)
+    (context.guard_home / "daemon-state.json").write_text("signed", encoding="utf-8")
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.2.122")
+    monkeypatch.setattr(update_commands, "_current_version_from_subprocess", lambda *_args, **_kwargs: "2.2.123")
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.2.123")
+    monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+    monkeypatch.setattr(update_commands, "_refresh_package_shims_after_update", lambda **_: (None, None))
+    monkeypatch.setattr(
+        update_commands,
+        "refresh_guard_daemon_after_update",
+        lambda *_args, **_kwargs: (
+            {
+                "status": "retained_newer_runtime",
+                "daemon_version": "3.0.0a253",
+                "cli_version": "2.2.123",
+                "runtime_verified": True,
+            },
+            "Kept the newer HOL Guard runtime active while updating the shell CLI.",
+        ),
+    )
+    monkeypatch.setattr(
+        update_commands.subprocess,
+        "run",
+        lambda command, **_kwargs: subprocess.CompletedProcess(command, 0, "installed", ""),
+    )
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=False, context=context)
+
+    assert exit_code == 0
+    assert payload["status"] == "updated"
+    assert payload["daemon_refresh"] == {
+        "status": "retained_newer_runtime",
+        "daemon_version": "3.0.0a253",
+        "cli_version": "2.2.123",
+        "runtime_verified": True,
+    }
+    assert any("Kept the newer HOL Guard runtime active" in note for note in payload["notes"])
 
 
 def test_required_daemon_refresh_failure_never_deletes_unreceipted_local_wheel_staging(

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -11,6 +11,7 @@ import urllib.request
 import zipfile
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -259,6 +260,50 @@ def test_daemon_refresh_does_not_trust_newer_state_when_live_identity_differs(
 
     assert payload == {"status": "restarted", "runtime_verified": True}
     assert note == "Restarted the Guard daemon to load the updated package."
+
+
+def test_daemon_refresh_falls_back_when_authenticated_host_is_malformed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codex_plugin_scanner.guard.daemon import discovery, manager
+
+    context = _context(tmp_path)
+    context.guard_home.mkdir(parents=True)
+    (context.guard_home / "daemon-state.json").write_text("signed", encoding="utf-8")
+    state: dict[str, object] = {
+        "guard_home": str(context.guard_home.resolve()),
+        "host": ["127.0.0.1"],
+        "port": 5245,
+        "pid": 4242,
+        "compatibility_version": 2,
+        "package_version": "3.0.0a253",
+        "runtime_fingerprint": "desktop-core-fingerprint",
+    }
+    monkeypatch.setattr(discovery, "load_authenticated_daemon_state", lambda _home: state)
+    monkeypatch.setattr(manager, "load_guard_daemon_auth_token", lambda _home: "daemon-token")
+    urlopen = MagicMock()
+    monkeypatch.setattr(update_commands.urllib.request, "urlopen", urlopen)
+    restart = SimpleNamespace(
+        returncode=0,
+        stdout='{"status":"restarted","runtime_verified":true}',
+        stderr="",
+        output_limited=False,
+    )
+
+    class RestartContext:
+        def python_command(self, script: str, *_args: str) -> list[str]:
+            return ["/trusted/python", "-c", script]
+
+        def run(self, *_args: object, **_kwargs: object) -> SimpleNamespace:
+            return restart
+
+    monkeypatch.setattr(update_commands, "_standalone_update_context", lambda _context: RestartContext())
+    payload, note = update_commands.refresh_guard_daemon_after_update(context)
+
+    assert payload == {"status": "restarted", "runtime_verified": True}
+    assert note == "Restarted the Guard daemon to load the updated package."
+    urlopen.assert_not_called()
 
 
 def test_daemon_refresh_authorizes_breakaway_only_for_restart_child(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- retain an authenticated newer Desktop Core when the shell CLI updates
- require signed state, private-token loopback health, bounded output, and exact runtime identity agreement
- restart normally when the resident runtime is stale or cannot be verified

## Testing

- `uv run ruff check src/codex_plugin_scanner/guard/cli/update_commands.py tests/test_guard_phase03_local_install.py`
- `uv run --no-sync basedpyright --level error src/codex_plugin_scanner/guard/cli/update_commands.py`
- `uv run pytest -q tests/test_guard_phase03_local_install.py tests/test_dashboard_update.py tests/test_guard_update_daemon_handoff.py`
- Codex Security diff scan: no findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updates now retain a healthy, verified newer runtime instead of unnecessarily restarting it.
  * Older or mismatched runtimes are restarted to ensure the installed update is active.
  * Runtime identity and health checks improve update reliability and security.
  * Updates now complete successfully when a verified newer runtime is retained.

* **Tests**
  * Added coverage for newer, older, and mismatched runtime scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->