### PR TITLE
test(guard): harden managed controls security matrix

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 15635,
-  "maximum_test_source_lines": 337010,
+  "maximum_collected_cases": 15654,
+  "maximum_test_source_lines": 337379,
   "schema_version": 1
 }

--- a/docs/guard/architecture.md
+++ b/docs/guard/architecture.md
@@ -49,6 +49,7 @@ Cisco AIBOM stays out of Guard runtime policy in this phase. If it returns later
 - [Command extension architecture](command-extension-architecture.md)
 - [Command extension precedence](command-extension-precedence.md)
 - [Command extension threat model](command-extension-threat-model.md)
+- [Managed Controls threat model](managed-controls-threat-model.md)
 - [Package command extension coverage](command-package-extension-coverage.md)
 - [Infrastructure command extension coverage](command-domain-extension-coverage.md)
 - [Cloud command extension coverage](command-cloud-extension-coverage.md)

--- a/docs/guard/managed-controls-release-runbook.md
+++ b/docs/guard/managed-controls-release-runbook.md
@@ -16,6 +16,8 @@ This runbook covers the HOL Guard Local side of Extension-First Managed Controls
 10. Confirm local blocks still tighten Cloud permits.
 11. Verify custom Extension copy remains local-only until continuity is real.
 12. Run adversarial, privacy, accessibility, and performance checks.
+13. Complete and record the independent review required by the
+    [Managed Controls threat model](managed-controls-threat-model.md).
 
 From the repository root, run:
 

--- a/docs/guard/managed-controls-threat-model.md
+++ b/docs/guard/managed-controls-threat-model.md
@@ -1,0 +1,126 @@
+# Managed Controls threat model
+
+Status: release 3.0 security-review baseline
+Scope: Local catalog projection, signed Cloud policy delivery, authority composition,
+atomic activation, acknowledgement, telemetry, and Package Firewall delegation.
+
+This model supplements the command Extension threat model. It does not change
+authentication, approval, exception, or remembered-rule semantics.
+
+## Security objectives
+
+Managed Controls must preserve these invariants:
+
+1. A Cloud document is applied only when its signature, workspace, monotonic
+   revision, capabilities, catalog digest, and target identities agree.
+2. Managed restrictions and immutable built-in floors cannot be weakened by a
+   local control, remembered allow, shared Cloud control, downgrade, or replay.
+3. Local administrators may always tighten effective posture.
+4. Policy and Extension authority become visible as one complete activation or
+   the last-known-good state remains visible.
+5. Package controls have exactly one enforcement owner.
+6. Catalog sync, telemetry, diagnostics, and acknowledgements disclose no raw
+   command, source path, secret, authentication material, or unconsented custom
+   identity.
+
+## Trust boundaries and data flow
+
+1. The Local registry produces a canonical, bounded catalog and digest.
+2. Local sends only the privacy-filtered catalog projection to its authenticated
+   workspace.
+3. Cloud compiles Extension targets against that exact catalog and signs the
+   bounded policy envelope with a workspace-scoped key.
+4. Local validates envelope authority and monotonicity before parsing any
+   namespaced Managed Controls fields.
+5. Local stages policy and authority projections, publishes them atomically,
+   persists an authenticated activation and epoch, and retains the authenticated
+   last-known-good state.
+6. Runtime resolution composes Local and signed-Cloud layers with disable
+   dominance. Delegated package targets leave the command plane.
+7. Local acknowledges the exact bundle, catalog, authority revision, and
+   effective projection digest using privacy-safe fields.
+
+The local database is untrusted storage. The authority key, machine-managed
+trust anchors, authenticated transition records, and monotonic external anchor
+form the trust boundary. Cloud administrators are authorized policy authors,
+not authority to weaken required Local floors.
+
+## Adversaries
+
+- A compromised or malicious Cloud administrator.
+- A user with write access to Local configuration or the Guard database.
+- A network attacker replaying, reordering, substituting, or crossing workspace
+  messages.
+- A malicious custom Extension attempting identity confusion or data exfiltration.
+- A policy author supplying pathological sizes, namespaces, or Advanced matchers.
+- A crash or injected failure at any activation phase.
+- An old or capability-incomplete Local client.
+
+## Threat analysis and executable evidence
+
+| Threat | Required control | Executable evidence |
+| --- | --- | --- |
+| Catalog poisoning | Canonical bytes bind every projected field; a changed projection changes the digest; signed layers with a different digest fail closed. | `tests/managed_controls/test_capabilities_catalog.py::test_catalog_poisoning_changes_digest_and_duplicate_permission_ids_fail_closed`; `tests/test_guard_extension_control_resolver.py::test_resolver_failures_are_typed_privacy_safe_and_fail_closed`; `tests/test_guard_extension_control_authority.py::test_catalog_manifest_tamper_is_detected_immediately` |
+| Permission-ID collision | Permission IDs are unique across the whole projection and the runtime permission catalog retains one canonical owner. | `tests/managed_controls/test_capabilities_catalog.py::test_catalog_poisoning_changes_digest_and_duplicate_permission_ids_fail_closed`; `tests/test_guard_extension_control_catalog_detail.py::test_catalog_exposes_deterministic_full_extension_permission_and_rule_contract` |
+| Custom Extension identity spoofing | Cloud identity must exactly match the locally observed ID and version; absence and mismatch never become an applicable identity. | `tests/managed_controls/test_catalog_privacy_identity.py::test_custom_identity_spoofing_requires_exact_id_and_version` |
+| Downgrade to a client that ignores `x-*` | All negotiated Managed Controls capabilities are mandatory; an incomplete client is incompatible and receives no weakened fallback. | `tests/managed_controls/test_compatibility_migration.py::test_unsupported_client_is_excluded_not_silently_downgraded`; `tests/test_managed_controls_policy_fields.py::test_full_capability_negotiation_parses_managed_controls_and_rule_targets` |
+| Signed bundle replay | Bundle versions are monotonic; same-version content substitution fails. Exact acknowledgement replay is idempotent, conflicting replay fails. | `tests/test_policy_bundle_v2.py::test_v2_transition_rejects_replay_and_same_version_substitution`; `tests/test_policy_bundle_v2.py::test_v2_acknowledgement_rejects_sequence_conflicts_and_terminal_reapply` |
+| Out-of-order rollback | A lower bundle version is rejected. Rollback is a newer signed envelope bound to the current and expected last-good hashes. | `tests/test_policy_bundle_v2.py::test_v2_transition_accepts_only_authorized_monotonic_rollback`; `tests/test_managed_controls_activation_integration.py::test_replayed_authenticated_activation_cannot_rollback_durable_epoch` |
+| Cross-workspace application | Workspace identity is checked before rule application and the trusted signing key is scoped to the expected workspace. | `tests/test_policy_bundle_parser.py::test_policy_bundle_rejects_wrong_workspace_before_rule_application`; `tests/test_policy_bundle_parser.py::test_policy_bundle_rejects_revoked_or_wrong_purpose_anchor` |
+| Catalog TOCTOU | Activation validation is bound to the candidate catalog digest; catalog migration and runtime publication are atomic boundaries. A validation failure cannot stage or publish. | `tests/managed_controls/test_atomic_apply.py::test_validation_failure_never_stages_or_changes_state`; `tests/test_guard_extension_control_authority.py::test_catalog_digest_change_requires_trusted_migration_boundary`; `tests/test_managed_controls_activation_integration.py::test_activation_and_epoch_are_read_from_one_sqlite_snapshot` |
+| Partial policy and authority activation | Validation, staging, commit, persistence, runtime publication, and rollback retain one complete prior projection on failure. | `tests/managed_controls/test_atomic_apply.py`; `tests/test_managed_controls_activation_integration.py::test_failed_partial_activation_retains_prior_complete_state`; `tests/test_managed_controls_activation_integration.py::test_runtime_publish_failure_rolls_back_database_activation`; `tests/test_managed_controls_activation_integration.py::test_commit_failure_does_not_publish_staged_runtime` |
+| Local database tamper | Snapshots, transitions, managed activation, and revision epoch are authenticated and externally anchored; tamper yields a fail-closed authority state. | `tests/test_guard_extension_control_authority.py::test_authenticated_snapshot_transition_and_anchor_detect_sqlite_tamper`; `tests/test_guard_extension_control_authority.py::test_database_rollback_against_monotonic_anchor_fails_closed`; `tests/test_managed_controls_activation_integration.py::test_tampered_authenticated_activation_fails_closed` |
+| Malicious administrator weakens a required floor | Managed-restrictive authority can only disable or lock down. Shared enablement is permission-only and requires a configurable permission. Required Extensions cannot be disabled by shared posture. | `tests/test_managed_controls_policy_fields.py::test_managed_restrictive_is_disable_or_lockdown_only`; `tests/test_managed_controls_policy_fields.py::test_shared_enable_respects_configurability_and_required_floors`; `tests/test_guard_extension_control_semantic_preview.py::test_local_draft_cannot_create_fixed_permission_or_required_extension_controls` |
+| Remembered allow bypass | Remembered/local permits are inputs below disable-dominant managed floors; they cannot erase or outrank a managed block. | `tests/managed_controls/test_authority_composition.py::test_remembered_local_allow_cannot_bypass_managed_restriction`; `tests/test_guard_extension_control_semantic_preview.py::test_preview_explains_when_managed_disable_dominates_local_allow` |
+| Oversized catalog or Control Set | Catalog bytes, extension/permission counts, rules, targets, layers, controls, observations, and identity text have explicit bounds and fail closed. | `tests/test_managed_controls_policy_fields.py::test_duplicates_conflicts_and_limits_fail_before_projection`; `tests/test_managed_controls_policy_fields.py::test_targeted_rule_count_limit_is_enforced`; `tests/test_guard_extension_control_resolver.py::test_resolver_input_limits_fail_closed_at_boundary`; `tests/test_guard_extension_control_catalog_wire.py::test_catalog_payload_limit_uses_exact_daemon_wire_encoding` |
+| Regex or matcher denial of service in Advanced mode | Managed namespaced parsing never compiles or executes Advanced matchers. IDs are length-checked before their bounded canonical regex. Advanced-rule execution remains in the existing policy engine and its separate limits. | `tests/test_managed_controls_policy_fields.py::test_oversized_target_and_advanced_regex_are_not_evaluated_by_extension_parser`; `tests/test_managed_controls_policy_fields.py::test_namespaced_control_field_fuzz_rejects_near_matches` |
+| Package Firewall double enforcement | Canonical delegation selects exactly one plane; package targets are returned as delegated targets and omitted from the signed command-control layer. | `tests/managed_controls/test_delegated_package_firewall.py`; `tests/test_managed_controls_policy_fields.py::test_delegated_targets_require_package_firewall_and_do_not_double_materialize` |
+| Custom name or source-path leakage | Catalog export uses an exact allowlist, rejects sensitive/path-like text recursively, and telemetry/diagnostics use separate allowlists and redaction. | `tests/managed_controls/test_catalog_privacy_identity.py::test_custom_catalog_privacy_rejects_names_paths_commands_and_secrets`; `tests/managed_controls/test_flags_telemetry_redaction.py::test_telemetry_is_allowlisted_and_privacy_safe`; `tests/managed_controls/test_flags_telemetry_redaction.py::test_diagnostics_redact_sensitive_values_recursively` |
+
+## Property, fuzz, and fault-injection matrix
+
+The security properties are tested across generated combinations rather than
+only one example:
+
+- Disable dominance and order independence:
+  `test_composition_is_permutation_independent_and_disable_dominates_enable`.
+- Local tightening monotonicity:
+  `test_adding_restrictions_never_reduces_the_resolved_action`.
+- Immutable floors across every non-configurable permission and required
+  Extension are enforced by
+  `test_every_builtin_immutable_floor_rejects_shared_cloud_weakening` and the
+  semantic-preview tests.
+- Namespaced-field fuzzing covers wrong types, nulls, unsupported keys, embedded
+  NUL, Unicode near-matches, regex-shaped keys, oversized IDs, duplicate and
+  conflicting targets.
+- Atomic-apply fault injection covers revision validation, candidate validation,
+  compilation, commit, rollback, last-known-good restoration,
+  database commit, runtime publication, and crash/retry recovery. The production
+  SQLite transaction is terminated in subprocesses after remote-row replacement,
+  before commit after all state writes, and immediately after commit but before
+  runtime installation by
+  `tests/test_managed_controls_activation_integration.py::test_process_crash_restart_never_exposes_partial_managed_activation`.
+
+## Residual risk and review gate
+
+- Custom Extension continuity depends on the workspace-scoped opaque identity
+  contract and authenticated Local observation being enabled end to end. A
+  display name is never identity.
+- Advanced mode remains a separate expert surface. Managed Controls neither
+  interprets nor broadens its matcher language; changes to that engine require
+  its own complexity and denial-of-service review.
+- A rollback failure is reported distinctly and the candidate is not published,
+  but operators must treat it as an incident and repair from authenticated
+  last-known-good state.
+- Tests and this model are author evidence, not independent review. Managed
+  Controls must not leave pilot until a reviewer independent of the implementer
+  examines this model, the named controls, and the exact release diff, records
+  findings, and signs off with no unresolved security findings.
+
+## Review checklist
+
+- [ ] Independent reviewer identified.
+- [ ] Exact release diff reviewed against every threat row.
+- [ ] Focused security matrix and full release CI green at reviewed commit.
+- [ ] No unresolved security findings or review threads.
+- [ ] Pilot exit approval recorded with reviewer, date, and commit SHA.

--- a/src/codex_plugin_scanner/guard/managed_controls/catalog.py
+++ b/src/codex_plugin_scanner/guard/managed_controls/catalog.py
@@ -97,6 +97,8 @@ class CatalogExtension:
         permission_ids = [item.permission_id for item in self.permissions]
         if len(permission_ids) != len(set(permission_ids)):
             raise CatalogValidationError("duplicate permission id")
+        if any(not permission_id.startswith(f"{self.extension_id}.permission.") for permission_id in permission_ids):
+            raise CatalogValidationError("permission owner mismatch")
 
     def to_dict(self) -> dict[str, object]:
         ordered_permissions = sorted(
@@ -130,6 +132,11 @@ class CatalogProjection:
         extension_ids = [item.extension_id for item in self.extensions]
         if len(extension_ids) != len(set(extension_ids)):
             raise CatalogValidationError("duplicate extension id")
+        permission_ids = [
+            permission.permission_id for extension in self.extensions for permission in extension.permissions
+        ]
+        if len(permission_ids) != len(set(permission_ids)):
+            raise CatalogValidationError("duplicate permission id")
         if len(self.canonical_bytes()) > MAX_CATALOG_PAYLOAD_BYTES:
             raise CatalogValidationError("catalog payload limit exceeded")
 

--- a/tests/managed_controls/test_atomic_apply.py
+++ b/tests/managed_controls/test_atomic_apply.py
@@ -78,3 +78,48 @@ def test_failed_commit_rolls_back_external_projection() -> None:
 def test_initial_negative_revision_is_rejected() -> None:
     with pytest.raises(AtomicApplyError):
         _state(-1, "invalid")
+
+
+def test_validation_failure_never_stages_or_changes_state() -> None:
+    previous = _state(1, "old")
+    store = AtomicManagedControlsStore(previous)
+    compiled = False
+
+    def reject(_: AppliedManagedControls[str]) -> None:
+        raise ValueError("catalog changed")
+
+    def compile_projection(_: AppliedManagedControls[str]) -> PreparedProjection:
+        nonlocal compiled
+        compiled = True
+        return PreparedProjection(lambda: None, lambda: None)
+
+    with pytest.raises(AtomicApplyError, match="apply failed"):
+        store.apply(_state(2, "new"), validate=reject, compile_projection=compile_projection)
+    assert not compiled
+    assert store.current == previous
+    assert store.last_known_good == previous
+
+
+def test_rollback_failure_is_distinct_and_does_not_publish_candidate() -> None:
+    previous = _state(1, "old")
+    store = AtomicManagedControlsStore(previous)
+
+    def stage(_: AppliedManagedControls[str]) -> PreparedProjection:
+        def commit() -> None:
+            raise ValueError("commit failed")
+
+        def rollback() -> None:
+            raise ValueError("rollback failed")
+
+        return PreparedProjection(commit, rollback)
+
+    with pytest.raises(AtomicApplyError, match="apply and rollback failed"):
+        store.apply(_state(2, "new"), validate=lambda _: None, compile_projection=stage)
+    assert store.current == previous
+    assert store.last_known_good == previous
+
+
+def test_restore_without_last_known_good_fails_closed() -> None:
+    store: AtomicManagedControlsStore[str] = AtomicManagedControlsStore()
+    with pytest.raises(AtomicApplyError, match="no last-known-good"):
+        store.restore_last_known_good()

--- a/tests/managed_controls/test_authority_composition.py
+++ b/tests/managed_controls/test_authority_composition.py
@@ -54,6 +54,25 @@ def test_managed_block_cannot_be_weakened_by_local_permit() -> None:
     assert result.managed_floor
 
 
+def test_remembered_local_allow_cannot_bypass_managed_restriction() -> None:
+    result = compose_control_instructions(
+        (
+            _control(
+                ControlEffect.PERMIT,
+                AuthorityMode.PERSONAL_SHARED,
+                "remembered-allow:exact-command-context",
+            ),
+            _control(
+                ControlEffect.BLOCK,
+                AuthorityMode.MANAGED_RESTRICTIVE,
+                "managed-control-set",
+            ),
+        )
+    )
+    assert result.effect is ControlEffect.BLOCK
+    assert result.managed_floor
+
+
 def test_managed_authority_cannot_publish_permit() -> None:
     with pytest.raises(AuthorityValidationError):
         _control(

--- a/tests/managed_controls/test_capabilities_catalog.py
+++ b/tests/managed_controls/test_capabilities_catalog.py
@@ -119,3 +119,38 @@ def test_unknown_targets_fail_instead_of_disappearing() -> None:
             "command.missing",
             "command.missing.permission.push",
         )
+
+
+def test_catalog_poisoning_changes_digest_and_duplicate_permission_ids_fail_closed() -> None:
+    original = _catalog()
+    poisoned = CatalogProjection(
+        1,
+        (
+            CatalogExtension(
+                "command.git",
+                "Git (poisoned label)",
+                "1",
+                original.extensions[0].permissions,
+            ),
+        ),
+    )
+    assert poisoned.digest != original.digest
+
+    colliding_permission = CatalogPermission(
+        "command.git.permission.push",
+        "Impersonated push",
+        configurable=False,
+    )
+    with pytest.raises(CatalogValidationError, match="permission owner mismatch"):
+        CatalogProjection(
+            1,
+            (
+                original.extensions[0],
+                CatalogExtension(
+                    "command.other",
+                    "Other",
+                    "1",
+                    (colliding_permission,),
+                ),
+            ),
+        )

--- a/tests/managed_controls/test_catalog_privacy_identity.py
+++ b/tests/managed_controls/test_catalog_privacy_identity.py
@@ -62,3 +62,49 @@ def test_catalog_projection_excludes_commands_paths_and_secrets() -> None:
 def test_custom_identity_is_truthfully_local_only_without_cloud_match() -> None:
     local = ExtensionIdentity("custom.acme", "1", custom=True)
     assert compare_extension_identity(local, None) is CatalogIdentityState.CUSTOM_LOCAL_ONLY
+
+
+@pytest.mark.parametrize(
+    ("cloud", "expected"),
+    (
+        (ExtensionIdentity("custom.attacker", "1", custom=True), CatalogIdentityState.MISSING),
+        (ExtensionIdentity("custom.acme", "2", custom=True), CatalogIdentityState.VERSION_DIFFERENT),
+    ),
+)
+def test_custom_identity_spoofing_requires_exact_id_and_version(
+    cloud: ExtensionIdentity,
+    expected: CatalogIdentityState,
+) -> None:
+    local = ExtensionIdentity("custom.acme", "1", custom=True)
+    assert compare_extension_identity(local, cloud) is expected
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("name", "/Users/alice/private/custom-tool"),
+        ("name", "token=super-secret"),
+        ("source_path", "/private/custom-tool"),
+        ("raw_command", "custom-tool --credential secret"),
+    ),
+)
+def test_custom_catalog_privacy_rejects_names_paths_commands_and_secrets(
+    field: str,
+    value: str,
+) -> None:
+    extension = {
+        "extension_id": "command.custom-tool",
+        "name": "Custom tool",
+        "version": "1",
+        "custom": True,
+        "permissions": [],
+        field: value,
+    }
+    with pytest.raises(CatalogPrivacyError):
+        privacy_safe_catalog_payload(
+            {
+                "schema_version": 1,
+                "catalog_digest": "a" * 64,
+                "extensions": [extension],
+            }
+        )

--- a/tests/test_managed_controls_crash_recovery.py
+++ b/tests/test_managed_controls_crash_recovery.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from types import MethodType
+
+import pytest
+
+from codex_plugin_scanner.guard.managed_controls_policy_bundle import MANAGED_CONTROLS_ACTIVE_STATE_KEY
+from codex_plugin_scanner.guard.runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
+from codex_plugin_scanner.guard.runtime.extension_control_authority import (
+    AuthorityHealth,
+    ExtensionControlAuthorityView,
+)
+from codex_plugin_scanner.guard.store import GuardStore
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "tests"))
+from test_managed_controls_activation_integration import _activate, _bundle  # noqa: E402
+
+
+def _run_activation_crash_child(guard_home: Path, stage: str) -> None:
+    store = GuardStore(guard_home)
+    bundle = _bundle()
+    bundle["bundleVersion"] = 8
+    bundle["bundleHash"] = "sha256:" + "8" * 64
+
+    if stage == "after_remote_rows":
+        original_replace = store._replace_remote_policy_rows_locked  # pyright: ignore[reportPrivateUsage]
+
+        def replace_then_crash(
+            _store: GuardStore,
+            connection: sqlite3.Connection,
+            rows: Sequence[tuple[object, ...]],
+        ) -> None:
+            original_replace(connection, rows)
+            os._exit(91)
+
+        store._replace_remote_policy_rows_locked = MethodType(  # pyright: ignore[reportPrivateUsage]
+            replace_then_crash,
+            store,
+        )
+        _activate(store, bundle)
+        raise AssertionError("crash injection did not terminate")
+
+    def publish_then_crash(
+        _view: ExtensionControlAuthorityView,
+        commit: Callable[[], None],
+    ) -> None:
+        if stage == "after_commit":
+            commit()
+            os._exit(93)
+        if stage == "before_commit":
+            os._exit(92)
+        raise AssertionError(f"unknown crash stage: {stage}")
+
+    _activate(store, bundle, managed_controls_publish=publish_then_crash)
+    raise AssertionError("crash injection did not terminate")
+
+
+@pytest.mark.parametrize(
+    ("stage", "exit_code", "durable_new_state"),
+    (
+        ("after_remote_rows", 91, False),
+        ("before_commit", 92, False),
+        ("after_commit", 93, True),
+    ),
+)
+def test_process_crash_restart_never_exposes_partial_managed_activation(
+    tmp_path: Path,
+    stage: str,
+    exit_code: int,
+    durable_new_state: bool,
+) -> None:
+    guard_home = tmp_path / stage
+    store = GuardStore(guard_home)
+    first = _bundle()
+    assert _activate(store, first)
+    previous_active = store.get_sync_payload(MANAGED_CONTROLS_ACTIVE_STATE_KEY)
+    assert isinstance(previous_active, dict)
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(Path(__file__).resolve()),
+            "--activation-crash-child",
+            str(guard_home),
+            stage,
+        ],
+        cwd=_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert completed.returncode == exit_code, completed.stderr
+
+    restarted = GuardStore(guard_home)
+    active = restarted.get_sync_payload(MANAGED_CONTROLS_ACTIVE_STATE_KEY)
+    assert isinstance(active, dict)
+    expected_version = 8 if durable_new_state else 7
+    assert active["bundleVersion"] == expected_version
+    assert active["complete"] is True
+    restarted_view = restarted.read_extension_control_authority_for_registry(
+        BUILT_IN_COMMAND_EXTENSION_REGISTRY,
+    )
+    assert restarted_view.health is AuthorityHealth.PROTECTED
+    assert restarted_view.managed_revision == (2 if durable_new_state else 1)
+
+    second = _bundle()
+    second["bundleVersion"] = 8
+    second["bundleHash"] = "sha256:" + "8" * 64
+    assert _activate(restarted, second)
+    replayed = restarted.get_sync_payload(MANAGED_CONTROLS_ACTIVE_STATE_KEY)
+    assert isinstance(replayed, dict)
+    assert replayed["complete"] is True
+    assert replayed["bundleVersion"] == 8
+    replayed_view = restarted.read_extension_control_authority_for_registry(
+        BUILT_IN_COMMAND_EXTENSION_REGISTRY,
+    )
+    assert replayed_view.health is AuthorityHealth.PROTECTED
+    assert replayed_view.managed_revision == 2
+
+
+if __name__ == "__main__" and len(sys.argv) == 4 and sys.argv[1] == "--activation-crash-child":
+    _run_activation_crash_child(Path(sys.argv[2]), sys.argv[3])

--- a/tests/test_managed_controls_policy_fields.py
+++ b/tests/test_managed_controls_policy_fields.py
@@ -290,6 +290,53 @@ def test_shared_enable_respects_configurability_and_required_floors() -> None:
     assert _code(document) == "immutable_floor"
 
 
+def test_every_builtin_immutable_floor_rejects_shared_cloud_weakening() -> None:
+    immutable_permissions = tuple(
+        permission
+        for extension in BUILT_IN_COMMAND_EXTENSION_REGISTRY.extensions
+        if extension.delegated_protection is None
+        for permission in extension.permissions
+        if not permission.configurable
+    )
+    required_extensions = tuple(
+        extension for extension in BUILT_IN_COMMAND_EXTENSION_REGISTRY.extensions if extension.required
+    )
+    assert immutable_permissions
+    assert required_extensions
+
+    for permission in immutable_permissions:
+        document = _document()
+        document["spec"]["rules"][0].pop("x-hol-extension-targets")
+        document["x-hol-extension-controls"] = {
+            "schemaVersion": "guard.extension-controls.v1",
+            "authorityMode": "workspace-shared",
+            "controls": [
+                {
+                    "targetKind": "permission",
+                    "targetId": permission.permission_id,
+                    "state": "enabled",
+                }
+            ],
+        }
+        assert _code(document) == "immutable_floor"
+
+    for extension in required_extensions:
+        document = _document()
+        document["spec"]["rules"][0].pop("x-hol-extension-targets")
+        document["x-hol-extension-controls"] = {
+            "schemaVersion": "guard.extension-controls.v1",
+            "authorityMode": "workspace-shared",
+            "controls": [
+                {
+                    "targetKind": "extension",
+                    "targetId": extension.extension_id,
+                    "state": "disabled",
+                }
+            ],
+        }
+        assert _code(document) == "immutable_floor"
+
+
 @pytest.mark.parametrize(
     "bad",
     [
@@ -314,6 +361,53 @@ def test_malformed_field_fuzz_matrix_is_bounded(bad: object) -> None:
         "unsupported_control_schema",
         "invalid_authority",
     }
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected"),
+    (
+        ("x-hol-extension-controls\x00", {}, "unknown_field"),
+        ("x-hol-extension-controls.regex", "(a+)+$", "unknown_field"),
+        ("x-hol-extension-controls-unicode-\N{ZERO WIDTH JOINER}", [], "unknown_field"),
+    ),
+)
+def test_namespaced_control_field_fuzz_rejects_near_matches(
+    field: str,
+    value: object,
+    expected: str,
+) -> None:
+    document = _document()
+    document["x-hol-extension-controls"][field] = value
+    assert _code(document) == expected
+
+
+def test_oversized_target_and_advanced_regex_are_not_evaluated_by_extension_parser() -> None:
+    document = _document()
+    document["x-hol-extension-controls"]["controls"][0]["targetId"] = "command." + ("a" * 100_000)
+    assert _code(document) == "invalid_permission_id"
+
+    matcher_accesses: list[str] = []
+
+    class ObservableRule(dict[str, Any]):
+        def __getitem__(self, key: str) -> Any:
+            if key == "matcher":
+                matcher_accesses.append(key)
+                raise AssertionError("managed-controls parser accessed the advanced matcher")
+            return super().__getitem__(key)
+
+        def get(self, key: str, default: Any = None) -> Any:
+            if key == "matcher":
+                matcher_accesses.append(key)
+                raise AssertionError("managed-controls parser accessed the advanced matcher")
+            return super().get(key, default)
+
+    document = _document()
+    original_rule = document["spec"]["rules"][0]
+    original_rule["matcher"] = {"regex": "(a+)+$"}
+    document["spec"]["rules"][0] = ObservableRule(original_rule)
+    parsed = _parse(document)
+    assert matcher_accesses == []
+    assert parsed.rule_targets[0].permission_ids == ("command.git.permission.force-push",)
 
 
 def test_shared_signature_vector_validates_before_projection() -> None:


### PR DESCRIPTION
## Summary
- add the Managed Controls threat model and release-review linkage
- enforce global permission ownership constraints in the catalog
- add adversarial, property, fault-injection, and subprocess crash/restart coverage
- verify atomic rollback, durable restart, idempotent replay, authority monotonicity, privacy, and policy-field bounds

## Verification
- `uv run pytest -q tests/managed_controls tests/test_managed_controls_activation_integration.py tests/test_managed_controls_policy_fields.py` (129 passed)
- `uv run ruff check src/codex_plugin_scanner/guard/managed_controls/catalog.py tests/managed_controls tests/test_managed_controls_activation_integration.py tests/test_managed_controls_policy_fields.py`
- independent implementation review: approved
- `git diff --check`