### PR TITLE
docs(guard): complete managed controls operations guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Added the HOL Guard 3.0 Managed Controls user, operator, migration, recovery,
+  incident, rollback, support, and release documentation set.
 - Persistent menu-bar and system-tray ownership moved to the separate
   `hashgraph-online/hol-guard-desktop` application.
 - HOL Guard Core remains headless and continues to own policy enforcement,

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 15658,
-  "maximum_test_source_lines": 337531,
+  "maximum_collected_cases": 15662,
+  "maximum_test_source_lines": 337652,
   "schema_version": 1
 }

--- a/docs/guard/local-vs-cloud.md
+++ b/docs/guard/local-vs-cloud.md
@@ -173,6 +173,9 @@ Local tightening remains valid.
 
 - [Extension-First Managed Controls ADR](./adr/0011-extension-first-managed-controls.md)
 - [Managed Controls Product Glossary](./managed-controls-glossary.md)
+- [Local Extensions and protection settings](./managed-controls-local-extensions.md)
+- [Managed Controls release notes](./managed-controls-release-notes.md)
+- [Managed Controls support runbook](./managed-controls-support-runbook.md)
 - [Get started](./get-started.md)
 - [Harness support](./harness-support.md)
 - [Remediation](./remediation.md)

--- a/docs/guard/managed-controls-catalog-mismatch-recovery.md
+++ b/docs/guard/managed-controls-catalog-mismatch-recovery.md
@@ -1,0 +1,43 @@
+# Managed Controls catalog-mismatch recovery
+
+Use this runbook when trusted runtime-session or deployment evidence reports a different Extension catalog digest from the affected device. A mismatch blocks Managed Controls compatibility; Guard must not silently drop Extension targets or translate them into broader rules.
+
+Catalog authority is defined in [ADR 0011](adr/0011-extension-first-managed-controls.md), and the authenticated local API boundary is documented in [Protection Center](protection-center.md).
+
+## What the current Local CLI can prove
+
+The following commands expose only the installed version and device-local catalog metadata:
+
+```bash
+hol-guard --version
+set -o pipefail
+hol-guard command controls status | jq -e '{revision, catalog_digest, health}'
+hol-guard command controls list | jq -e '{schema_version, control_schema_version, catalog_digest}'
+```
+
+`command controls status` does not advertise negotiated capabilities or schema compatibility. `connect status` also does not prove them. The Local catalog endpoint supplies a catalog digest and local control schema; capability negotiation requires the bounded `managedControlsCapabilities`, `extensionControlSchemaVersions`, and `extensionCatalogDigest` evidence carried by the runtime-session sync contract.
+
+The current repository does not expose that negotiated runtime-session evidence through a supported Local operator command. Until the corresponding Cloud implementation provides and validates it, record the mismatch as digest-only observation and keep Managed Controls Cloud deployment blocked.
+
+## Diagnose without mutation
+
+1. Record time, HOL Guard version, local authority health/revision, and the local catalog digest using the projections above.
+2. Obtain the expected catalog digest and capability/schema evidence only from the shipped, authenticated runtime-session/deployment surface. If that surface is not available, compatibility is unproven.
+3. Classify only what the evidence supports:
+   - different released versions: expected mixed-version candidate;
+   - equal versions and different digests: release or integrity defect;
+   - matching digest without runtime-session capability/schema evidence: digest match only, not compatibility;
+   - explicit missing capability or unsupported schema from authenticated runtime-session evidence: incompatible.
+
+Do not attach raw commands, local paths, environment values, credentials, daemon authentication material, or private Cloud payloads.
+
+## Recover
+
+1. Keep the affected device out of Managed Controls rollout. If no shipped Cloud rollout surface exists, keep the feature disabled rather than inventing pause or reassign operations.
+2. Confirm the expected digest was built from the intended released Local catalog.
+3. If the device is behind and user-managed, preview the supported update with `hol-guard update --dry-run --json`. Managed installations must use their approved MDM update policy.
+4. Do not delete local state, authority data, trusted keyrings, or last-known-good material.
+5. Re-run the bounded local projections after the approved update.
+6. Require fresh authenticated runtime-session capability/schema/digest evidence before declaring compatibility. A matching local digest alone is insufficient.
+
+Escalate equal-version digest divergence, digest change without a version change, or built-in ID divergence to release engineering. Use the [support runbook](managed-controls-support-runbook.md) for the bounded handoff.

--- a/docs/guard/managed-controls-cloud-operator-guide.md
+++ b/docs/guard/managed-controls-cloud-operator-guide.md
@@ -1,0 +1,57 @@
+# Guard Cloud Managed Controls availability and operator boundary
+
+This document separates the HOL Guard 3.0 Local contract from Cloud functionality that is not yet shipped by the corresponding Guard Cloud Managed Controls PR.
+
+[ADR 0011](adr/0011-extension-first-managed-controls.md) and the [Managed Controls glossary](managed-controls-glossary.md) define the intended product model. [Policy Extension fields v1](policy-extension-fields-v1.md) defines fields the Local runtime can validate. These contracts do not prove that a Cloud authoring, simulation, review, signing, deployment, acknowledgement, drift, or rollback UI/API is available.
+
+## Current release/3.0 Local boundary
+
+The current Local target provides:
+
+- a canonical privacy-safe Extension catalog and digest;
+- authenticated local catalog/effective-state, preview, proof, apply, history, and recovery APIs behind Protection Center;
+- bounded runtime-session posture fields for catalog digest, control schema versions, authority revision, effective projection digest, and Managed Controls capabilities;
+- fail-closed parsing and atomic Local application of correctly negotiated signed bundle fields;
+- continued Local protection when Cloud is unavailable.
+
+The authenticated local API boundary is documented in [Protection Center](protection-center.md). Catalog payload and telemetry privacy are governed by [Command Activity privacy](command-activity-privacy.md) and [privacy-safe outcome receipts](privacy-safe-outcome-receipts.md).
+
+An operator can inspect only the device-local catalog/control contract with:
+
+```bash
+set -o pipefail
+hol-guard command controls status | jq -e '{revision, catalog_digest, health}'
+hol-guard command controls list | jq -e '{schema_version, control_schema_version, catalog_digest}'
+```
+
+These projections do not prove Cloud negotiation, assignment, delivery, acknowledgement, or deployment.
+
+## Cloud availability boundary
+
+This release/3.0 repository does not provide or verify an executable Cloud Managed Controls author/sign/deploy workflow. Do not use an old route inventory, a historical branch pin, internal service names, or generic policy routes as evidence that the Managed Controls Cloud workflow is current or shipped.
+
+Until the corresponding Guard Cloud PR lands and its exact UI/API is tested against this Local target:
+
+- keep Managed Controls Cloud deployment disabled;
+- do not publish operator steps for authoring, signing, canarying, pausing, or rolling back a Control Set;
+- do not claim a device is compatible from the local CLI alone;
+- do not treat the ADR or wire-field parser as delivery evidence;
+- continue to use Local Extensions and existing policy behavior without implying that local safety requires Cloud.
+
+## Documentation gate after the Cloud PR lands
+
+Before replacing this boundary with executable Cloud instructions, validate and document from the composed release:
+
+1. the exact customer-visible Managed controls route and authorized roles;
+2. the exact author, validate, simulate, review, sign, deploy, pause, and rollback operations;
+3. the runtime-session/catalog evidence consumed for capability, schema, and digest compatibility;
+4. exclusion behavior for missing capability, unsupported schema, and catalog mismatch;
+5. canary acknowledgement and effective-digest evidence;
+6. workspace isolation, signing authority, monotonic revision, and audit behavior;
+7. real failure and rollback recovery through the shipped UI/API.
+
+Add links only to current, versioned, public operator/API documentation produced by that implementation. Never document credentials, private infrastructure, or direct database/cache mutation.
+
+## Local safety remains independent
+
+Cloud absence or unavailability does not remove Local Extensions, blocking, approvals, receipts, Test Lab, settings history, or integrity repair. See [Local Guard vs Guard Cloud](local-vs-cloud.md), the [Local Extensions guide](managed-controls-local-extensions.md), and the [support runbook](managed-controls-support-runbook.md).

--- a/docs/guard/managed-controls-invalid-bundle-incident-runbook.md
+++ b/docs/guard/managed-controls-invalid-bundle-incident-runbook.md
@@ -1,0 +1,37 @@
+# Invalid Managed Controls bundle incident runbook
+
+Use this runbook when Local Guard rejects a signed policy bundle containing Managed Controls fields. Validation is fail-closed: an invalid candidate never replaces current state. A still-valid, previously verified last-known-good bundle may remain effective; expired or invalid cached material is not reactivated.
+
+See [Policy Extension fields v1](policy-extension-fields-v1.md), [Local Policy + Cloud Exceptions](policy-cloud-exceptions-boundary.md), and the [Cloud availability boundary](managed-controls-cloud-operator-guide.md).
+
+## Contain
+
+1. Stop any experimental delivery path. If no shipped Managed Controls Cloud rollout surface exists, record an integration defect rather than claiming an operator pause.
+2. Record detection time, Local version, bounded rejection reason, bundle identity/digest when safe, and last confirmed effective Local state.
+3. Confirm whether Local blocking and approvals remain active. A Cloud sync failure does not mean protection expired.
+4. Do not weaken fields, remove unknown targets, bypass verification, edit keyrings, clear local state, or replay an older revision.
+
+## Collect bounded evidence
+
+```bash
+set -o pipefail
+hol-guard command controls status | jq -e '{revision, catalog_digest, health}'
+hol-guard policy explain --json | jq -e '{digest, rules, compiled_rows, actions, scopes}'
+```
+
+Record the visible bounded rejection reason separately. Apply every redaction step in the [support runbook](managed-controls-support-runbook.md); do not attach broad status, connect, or doctor output.
+
+## Classify
+
+- **Envelope/trust:** signature, algorithm, key state/purpose/workspace/fingerprint, workspace binding, or trusted-key configuration.
+- **Integrity/order:** bundle/payload hash, expiry, inactive state, replay, unordered replacement, or downgrade.
+- **Contract:** schema/capability, required field, explicit `null`, authority/action, duplicate/conflict, or limit.
+- **Catalog/projection:** unknown target, digest mismatch, Package Firewall delegation, canonical shadow, or atomic projection.
+
+## Source remediation boundary
+
+The current Local repository proves rejection and last-known-good behavior; it does not provide a Cloud Managed Controls author/sign/deploy repair API. Do not invent one from historical route inventories or generic policy services.
+
+After the corresponding Cloud PR lands, remediate through its tested source workflow: correct the source/assignment/signing input, create a new monotonic identity, validate and review it, then use the shipped canary/delivery evidence. Update this runbook with the exact executable UI/API at that time.
+
+Until then, keep Managed Controls Cloud delivery disabled. Existing Local policy and protection remain the supported state. Close only when the invalid candidate is not effective, Local authority is healthy, and the integration defect preserves the bounded rejection evidence and prevention owner.

--- a/docs/guard/managed-controls-local-extensions.md
+++ b/docs/guard/managed-controls-local-extensions.md
@@ -1,0 +1,55 @@
+# Local Extensions and protection settings
+
+Local Extensions describe the tools and capabilities HOL Guard protects on this device. They remain available without Guard Cloud, a subscription, or a network connection. The product contract reserves Control Sets for future Cloud coordination, but the corresponding Cloud author/sign/deploy workflow is not shipped by this Local documentation change. Local Guard remains the enforcement authority.
+
+For canonical terms and authority rules, see the [Managed Controls glossary](managed-controls-glossary.md) and [ADR 0011](adr/0011-extension-first-managed-controls.md). The authenticated local API and presentation boundary are documented in [Protection Center](protection-center.md).
+
+## View protection
+
+Open **Protection Center** from **Modules** in the local dashboard. The compatibility routes remain `/extensions` and `/extensions/:id`.
+
+Read-only CLI equivalents are:
+
+```bash
+hol-guard command controls status
+hol-guard command controls list
+hol-guard command controls show command.git
+hol-guard command controls patterns --tool command.git
+```
+
+`status` reports the effective revision, catalog digest, authority health, and source layers. `list` and `show` expose the canonical catalog. `patterns` shows configurable permissions and their device state. These commands inspect local state; they do not contact Guard Cloud or change protection.
+
+## Change a device setting
+
+Use **Change settings** on a protection module. Select **Use recommended**, **Block matching actions**, or **Allow when Guard would otherwise permit**, then review **What will change**. Guard previews the change, requests the existing local approval proof, applies it, and refreshes effective state.
+
+To inspect an equivalent change without applying it:
+
+```bash
+hol-guard command controls preview command.git --target-kind extension --state disabled
+```
+
+A device setting can preserve or tighten protection. It cannot lower an immutable HOL Guard floor, override Emergency Lockdown, or weaken a workspace managed restriction. Package-manager Extensions delegated to Package Firewall must be configured through that surface.
+
+## Understand the sources
+
+- **Built into HOL Guard** owns canonical Extension and permission identities and detector facts.
+- **On this device** is the local-admin layer.
+- **Synced from Guard Cloud** identifies a negotiated signed shared layer when one is delivered by a supported implementation.
+- **Managed by a workspace** identifies a negotiated non-weakenable `managed-restrictive` floor when one is delivered by a supported implementation.
+- **Required by HOL Guard** is an immutable protection floor.
+
+The complete vocabulary is in the [glossary](managed-controls-glossary.md). Precedence and mutation semantics are in [ADR 0004](adr/0004-extension-control-center-semantics.md).
+
+These source labels and Local parser support do not prove that the Cloud Managed Controls authoring/deployment surface is available. See the [Cloud availability boundary](managed-controls-cloud-operator-guide.md).
+
+## Privacy
+
+Catalog and control status are bounded security metadata. Command text, prompts, output, local paths, environment values, and secrets are not catalog fields and must not be added to support evidence. Test Lab also keeps its command local and does not persist it. See [Command Activity privacy](command-activity-privacy.md) and [privacy-safe outcome receipts](privacy-safe-outcome-receipts.md).
+
+## If protection needs attention
+
+- A changed catalog or stale revision requires a fresh review; Guard never silently rebases a settings write.
+- A catalog mismatch excludes the device from that Cloud rollout. Follow [catalog-mismatch recovery](managed-controls-catalog-mismatch-recovery.md).
+- Tampered or recovery-required authority state uses the approval-bound **Settings integrity repair** flow. Do not edit the authority database.
+- An invalid signed bundle follows the [invalid-bundle incident runbook](managed-controls-invalid-bundle-incident-runbook.md); local protection must not be described as disabled merely because Cloud sync failed.

--- a/docs/guard/managed-controls-policy-migration.md
+++ b/docs/guard/managed-controls-policy-migration.md
@@ -1,0 +1,56 @@
+# Migrating existing policies to Managed Controls
+
+HOL Guard 3.0 preserves existing `GuardPolicy` documents, `/policy` routes, remembered rules, and policy bundle names. The Local runtime can validate namespaced Extension fields without requiring a destructive rewrite. Unmapped legacy rules remain advanced contextual rules.
+
+Start with [ADR 0011](adr/0011-extension-first-managed-controls.md), the [glossary](managed-controls-glossary.md), and [Policy Extension fields v1](policy-extension-fields-v1.md). These are Local/product contracts, not proof of a shipped Cloud migration workflow.
+
+## Prepare locally
+
+Export the active local policy with provenance to an operator-controlled private file. This is required for workspace-scoped rows and ensures `policy diff` compares the same canonical representation. The CLI requires a separate high-risk approval before it writes this export:
+
+```bash
+hol-guard policy export --include-provenance --output ./guard-policy-backup.yaml
+hol-guard policy validate ./guard-policy-backup.yaml
+hol-guard policy fmt ./guard-policy-backup.yaml --check
+```
+
+The export contains provenance plus policy scope, workspace, owner, reason, source, and artifact identifiers. Store it under the organization's restricted evidence policy, keep its private file permissions, and do not share it as a support attachment. If high-risk approval is unavailable, stop: a provenance-redacted export cannot represent workspace-scoped rows and is not a valid `policy diff` baseline.
+
+Inventory canonical targets without changing state:
+
+```bash
+hol-guard command controls list
+hol-guard command controls show command.git
+```
+
+## Classify legacy rules
+
+- Keep contextual allow, review, block, routing, and exception behavior as policy rules.
+- Map only exact known canonical Extension or permission IDs.
+- Keep an unmapped rule as an advanced raw rule; never guess a broader target.
+- Keep Package Firewall delegated protection in its existing contract.
+- Do not replace remembered decisions with Extension controls.
+
+Documents with neither new field retain existing behavior. Present-but-`null`, malformed, unknown, or unsupported Extension fields fail closed.
+
+## Validate existing contextual policy locally
+
+```bash
+hol-guard policy validate ./guard-policy-backup.yaml
+hol-guard policy fmt ./guard-policy-backup.yaml --check
+hol-guard policy diff ./guard-policy-backup.yaml
+```
+
+These commands validate and compare the same provenance-inclusive canonical contextual policy document exported above. `policy diff` exits nonzero when semantic changes exist. Review additions, removals, broadened rules, action changes, scopes, and conflicts. Do not compare a provenance-redacted export to the active provenance-inclusive policy because redaction-only differences are not migration changes.
+
+They do not prove semantic validation, negotiation, signing, or deployability of Managed Controls Extension fields. The current Local CLI has no supported operator command that validates a proposed Cloud Control Set end to end. Do not add or activate those fields through this workflow.
+
+Local policy import remains behind an explicit feature gate and approval. This guide does not enable or bypass it.
+
+## Cloud migration availability gate
+
+Stop after Local backup, classification notes, canonical-policy validation, and diff unless the corresponding Guard Cloud Managed Controls PR has landed and its executable author/simulate/review/sign/deploy path has been verified against this release. The current Local target does not document that Cloud workflow.
+
+After that Cloud implementation ships, update this guide with its exact UI/API, authenticated compatibility evidence, canary acknowledgement, and rollback procedure. Until then, keep existing policies authoritative and Local protection active; do not claim migration completion.
+
+See [Local Guard vs Guard Cloud](local-vs-cloud.md) and the [Cloud availability boundary](managed-controls-cloud-operator-guide.md).

--- a/docs/guard/managed-controls-release-notes.md
+++ b/docs/guard/managed-controls-release-notes.md
@@ -1,0 +1,34 @@
+# Managed Controls release notes
+
+## Release/3.0 documentation status
+
+This documentation change is not a Cloud Managed Controls availability announcement. The corresponding Guard Cloud author/simulate/review/sign/deploy/acknowledgement/drift/rollback PR has not yet landed in the evidence reviewed for this target.
+
+### Confirmed Local behavior
+
+- Local Extensions, settings, blocking, approvals, receipts, Test Lab, history, and integrity repair remain Cloud-independent.
+- The Local runtime owns the canonical catalog, exposes authenticated local catalog/effective-state APIs, and validates namespaced Extension fields after signed-bundle verification and negotiation.
+- Existing Rules & exceptions routes and `GuardPolicy` documents remain compatible.
+- Existing rules without an exact Extension mapping remain advanced contextual rules.
+- Invalid or incompatible candidates fail closed and do not silently discard Extension semantics.
+- Local device-settings history prepares a current-revision draft and retains the normal proof-bound apply flow.
+
+### Not yet documented as shipped
+
+Do not represent Guard Cloud Control Set authoring, simulation, review, signing, staged rollout, acknowledgement, drift, or rollback as available until the corresponding Cloud PR lands and its exact UI/API passes composed release verification.
+
+[ADR 0011](adr/0011-extension-first-managed-controls.md), the [Managed Controls glossary](managed-controls-glossary.md), and [Policy Extension fields v1](policy-extension-fields-v1.md) define intended product and Local wire contracts. They are not Cloud delivery evidence.
+
+### Local safety boundary
+
+Cloud absence, outage, or plan state does not disable Local Guard. Raw commands, prompts, output, paths, secrets, tokens, and proof material do not belong in catalog/Cloud telemetry or support evidence. See [Local Guard vs Guard Cloud](local-vs-cloud.md), [Command Activity privacy](command-activity-privacy.md), and [privacy-safe outcome receipts](privacy-safe-outcome-receipts.md).
+
+### Documentation
+
+- [Local Extensions and protection settings](managed-controls-local-extensions.md)
+- [Cloud availability and operator boundary](managed-controls-cloud-operator-guide.md)
+- [Existing-policy migration](managed-controls-policy-migration.md)
+- [Catalog-mismatch recovery](managed-controls-catalog-mismatch-recovery.md)
+- [Support runbook](managed-controls-support-runbook.md)
+- [Invalid-bundle incident runbook](managed-controls-invalid-bundle-incident-runbook.md)
+- [Rollback runbook](managed-controls-rollback-runbook.md)

--- a/docs/guard/managed-controls-release-runbook.md
+++ b/docs/guard/managed-controls-release-runbook.md
@@ -2,6 +2,8 @@
 
 This runbook covers the HOL Guard Local side of Extension-First Managed Controls on `release/3.0`.
 
+The gates below are release-contract requirements, not evidence that the corresponding Guard Cloud author/sign/deploy workflow is shipped. Keep Cloud Managed Controls deployment disabled until that PR lands and its composed UI/API evidence satisfies the applicable gates. See the [Cloud availability boundary](managed-controls-cloud-operator-guide.md).
+
 ## Required gates
 
 1. Verify the four negotiated capability markers.
@@ -22,8 +24,27 @@ This runbook covers the HOL Guard Local side of Extension-First Managed Controls
 From the repository root, run:
 
 ```bash
-python scripts/ci/managed_controls_release_gate.py
-pytest tests/managed_controls
+uv run python scripts/ci/managed_controls_release_gate.py
+uv run pytest tests/managed_controls
 ```
 
 No release may silently drop Extension semantics or move detector ownership into Guard Cloud.
+
+## Operator documentation gate
+
+Before release, review and link-check:
+
+- [release notes](managed-controls-release-notes.md)
+- [Local Extensions guide](managed-controls-local-extensions.md)
+- [Guard Cloud operator guide](managed-controls-cloud-operator-guide.md)
+- [existing-policy migration](managed-controls-policy-migration.md)
+- [catalog-mismatch recovery](managed-controls-catalog-mismatch-recovery.md)
+- [support runbook](managed-controls-support-runbook.md)
+- [invalid-bundle incident runbook](managed-controls-invalid-bundle-incident-runbook.md)
+- [rollback runbook](managed-controls-rollback-runbook.md)
+
+Run the focused documentation contract check:
+
+```bash
+uv run pytest tests/test_managed_controls_contract_docs.py
+```

--- a/docs/guard/managed-controls-rollback-runbook.md
+++ b/docs/guard/managed-controls-rollback-runbook.md
@@ -1,0 +1,32 @@
+# Managed Controls rollback runbook
+
+This document separates real Local settings restore from the future Cloud Control Set rollback workflow.
+
+Definitions and authority are in [ADR 0011](adr/0011-extension-first-managed-controls.md) and the [Managed Controls glossary](managed-controls-glossary.md). Local settings history is documented in [Protection Center Local Tools](protection-center-local-tools.md).
+
+## Cloud rollback availability gate
+
+The current release/3.0 Local repository does not provide or verify an executable Cloud Managed Controls rollback UI/API. Do not claim that selecting, signing, canarying, deploying, acknowledging, or auditing a rollback is available from this target. Do not infer it from the intended product lifecycle in the ADR or from historical/generic Cloud policy routes.
+
+Until the corresponding Guard Cloud PR lands, keep Managed Controls Cloud rollout disabled. If Local Guard rejects an invalid candidate, record rejection/last-known-good behavior under the [incident runbook](managed-controls-invalid-bundle-incident-runbook.md); that rejection is not an operator-executed rollback.
+
+After the Cloud implementation ships, replace this gate with tested instructions that prove:
+
+1. a rollback creates a new monotonic Control Set identity rather than replaying an older bundle;
+2. workspace, signing, catalog, schema, capability, and review requirements remain enforced;
+3. the exact source and destination identities plus reason are auditable;
+4. canary delivery produces authenticated acknowledgement and matching effective evidence;
+5. failures stop expansion without weakening Local protection.
+
+## Available Local device-settings restore
+
+Protection Center settings history can prepare a historical **device** layer as a draft against the current revision. It does not immediately roll back settings and does not remove the organization layer.
+
+The user must:
+
+1. choose a historical device settings entry in Protection Center;
+2. review **What will change** against the current revision;
+3. complete the normal preview, proof-bound approval, and apply flow;
+4. wait for refreshed effective state before treating the restore as complete.
+
+Do not mutate local persistence, replay an old revision, or use device settings history to evade a managed restriction. This Local restore remains available independently of Cloud.

--- a/docs/guard/managed-controls-support-runbook.md
+++ b/docs/guard/managed-controls-support-runbook.md
@@ -1,0 +1,52 @@
+# Managed Controls support runbook
+
+Use this runbook for Local Extension settings and for pre-release Managed Controls contract reports. Cloud authoring/deployment support begins only after the corresponding Guard Cloud PR lands and publishes a tested operator surface.
+
+## Preserve the boundary
+
+Local Guard enforces on the device. Cloud outage, sign-out, plan state, or sync failure does not mean local protection expired. Use the [glossary](managed-controls-glossary.md), [ADR 0011](adr/0011-extension-first-managed-controls.md), and the [Cloud availability boundary](managed-controls-cloud-operator-guide.md).
+
+## Collect a bounded diagnostic projection
+
+Record time/timezone, `hol-guard --version`, operating system, installation ownership, customer-visible symptom, and the exact visible bounded reason code.
+
+These commands project only the fields needed for Managed Controls triage:
+
+```bash
+set -o pipefail
+hol-guard command controls status | jq -e '{revision, catalog_digest, health}'
+hol-guard command controls list | jq -e '{schema_version, control_schema_version, catalog_digest}'
+hol-guard policy explain --json | jq -e \
+  '{digest, rules, compiled_rows, actions, scope_rule_counts: ([.scopes | to_entries[] | .value])}'
+```
+
+`pipefail` preserves a failing HOL Guard exit status, and `jq -e` rejects invalid JSON, so a stopped daemon or malformed response cannot become an empty successful evidence file.
+
+Do not attach unfiltered `hol-guard status --json`, `hol-guard connect status --json`, or `hol-guard doctor --json`; those broader diagnostics can include local paths, configured URLs, or identifiers outside this incident's minimum scope.
+
+Before sharing the projected output:
+
+1. verify that it contains only the keys shown above;
+2. verify that `scope_rule_counts` contains counts only; the command deliberately discards every scope identifier key before capture;
+3. keep digests only when the approved support channel needs correlation;
+4. remove workspace/device identifiers from prose unless the channel is authorized for them;
+5. never include raw commands, prompts, output, paths, environment values, secret-file content, access/refresh tokens, approval credentials, daemon authentication material, private signing keys, or raw Cloud responses.
+
+See [Command Activity privacy](command-activity-privacy.md) and [privacy-safe outcome receipts](privacy-safe-outcome-receipts.md).
+
+## Triage
+
+| Symptom | Evidence-supported classification | Next action |
+|---|---|---|
+| Local blocking and approvals work; Cloud is unavailable | Cloud availability only | Keep Local protection active. |
+| Local and expected catalog digests differ | Digest mismatch | Follow [catalog-mismatch recovery](managed-controls-catalog-mismatch-recovery.md). |
+| Digest matches but capability/schema evidence is absent | Compatibility unproven | Keep Cloud deployment disabled; obtain authenticated runtime-session evidence after the Cloud PR ships. |
+| Local bundle rejection reason reports signature, hash, workspace, expiry, schema, or rollback failure | Invalid bundle | Follow the [invalid-bundle incident runbook](managed-controls-invalid-bundle-incident-runbook.md). |
+| Local settings authority is tampered or recovery-required | Local integrity | Use approval-bound Settings integrity repair; never edit persistence directly. |
+| Legacy rules do not map exactly | Migration incomplete | Preserve them and follow the [migration guide](managed-controls-policy-migration.md). |
+
+## Escalation and closure
+
+Escalate equal-version catalog divergence to release engineering; signature, trust-anchor, wrong-workspace, replay, or rollback rejection to security incident response; and local authority tamper to Local runtime owners. Do not repair by deleting caches, databases, keyrings, or receipts.
+
+State which evidence was observed and which was unavailable. Do not close a Cloud Managed Controls case as deployed, acknowledged, compatible, or rolled back until the shipped Cloud implementation provides the corresponding authenticated evidence.

--- a/tests/test_managed_controls_contract_docs.py
+++ b/tests/test_managed_controls_contract_docs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -32,6 +33,26 @@ POLICY_BUNDLE_PATH = (
     / "assets"
     / "chunks"
     / "policy-workspace-page.js"
+)
+MANAGED_CONTROLS_DOCS = (
+    ROOT / "docs" / "guard" / "managed-controls-local-extensions.md",
+    ROOT / "docs" / "guard" / "managed-controls-cloud-operator-guide.md",
+    ROOT / "docs" / "guard" / "managed-controls-catalog-mismatch-recovery.md",
+    ROOT / "docs" / "guard" / "managed-controls-policy-migration.md",
+    ROOT / "docs" / "guard" / "managed-controls-support-runbook.md",
+    ROOT / "docs" / "guard" / "managed-controls-invalid-bundle-incident-runbook.md",
+    ROOT / "docs" / "guard" / "managed-controls-rollback-runbook.md",
+    ROOT / "docs" / "guard" / "managed-controls-release-notes.md",
+)
+MARKDOWN_LINK = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+EXTENSION_CONTROL_API_PATH = (
+    ROOT / "src" / "codex_plugin_scanner" / "guard" / "daemon" / "extension_control_api.py"
+)
+MANAGED_CONTROLS_API_PATH = (
+    ROOT / "src" / "codex_plugin_scanner" / "guard" / "daemon" / "managed_controls_api.py"
+)
+POLICY_COMMAND_PATH = (
+    ROOT / "src" / "codex_plugin_scanner" / "guard" / "cli" / "commands_dispatch_policy_document.py"
 )
 
 EXPECTED_PRODUCT_DECISION: dict[str, object] = {
@@ -190,3 +211,103 @@ def test_packaged_dashboard_matches_the_reviewed_product_vocabulary() -> None:
     ):
         assert stale_copy not in dashboard_bundle
         assert stale_copy not in policy_bundle
+
+
+def test_managed_controls_user_and_operator_documentation_is_complete() -> None:
+    documents = {path.name: path.read_text(encoding="utf-8") for path in MANAGED_CONTROLS_DOCS}
+
+    local_guide = documents["managed-controls-local-extensions.md"]
+    assert "hol-guard command controls status" in local_guide
+    assert "hol-guard command controls preview" in local_guide
+    assert "command-activity-privacy.md" in local_guide
+
+    operator_guide = documents["managed-controls-cloud-operator-guide.md"]
+    assert "does not provide or verify an executable Cloud Managed Controls" in operator_guide
+    assert "release-3-0-cloud-control-inventory.md" not in operator_guide
+    assert "historical branch pin" in operator_guide
+    assert "These projections do not prove Cloud negotiation" in operator_guide
+
+    mismatch = documents["managed-controls-catalog-mismatch-recovery.md"]
+    assert "digest-only observation" in mismatch
+    assert "does not advertise negotiated capabilities" in mismatch
+    assert "`connect status` also does not prove them" in mismatch
+    assert "A matching local digest alone is insufficient" in mismatch
+
+    migration = documents["managed-controls-policy-migration.md"]
+    assert "hol-guard policy export" in migration
+    assert "policy export --include-provenance" in migration
+    assert "provenance-redacted export cannot represent workspace-scoped rows" in migration
+    assert "hol-guard policy validate" in migration
+    assert "hol-guard policy diff" in migration
+    assert "Unmapped legacy rules remain" in migration
+    assert "no supported operator command that validates a proposed Cloud Control Set" in migration
+    assert "Stop after Local backup" in migration
+
+    support = documents["managed-controls-support-runbook.md"]
+    assert "set -o pipefail" in support
+    assert "jq -e '{revision, catalog_digest, health}'" in support
+    assert "cannot become an empty successful evidence file" in support
+    assert "Do not attach unfiltered" in support
+    assert "hol-guard doctor --json" in support
+    assert "scope_rule_counts: ([.scopes | to_entries[] | .value])" in support
+    assert "deliberately discards every scope identifier key" in support
+
+    invalid_bundle = documents["managed-controls-invalid-bundle-incident-runbook.md"]
+    assert "does not provide a Cloud Managed Controls author/sign/deploy repair API" in invalid_bundle
+    assert "keep Managed Controls Cloud delivery disabled" in invalid_bundle
+
+    rollback = documents["managed-controls-rollback-runbook.md"]
+    assert "does not provide or verify an executable Cloud Managed Controls rollback UI/API" in rollback
+    assert "Available Local device-settings restore" in rollback
+
+    release_notes = documents["managed-controls-release-notes.md"]
+    for path in MANAGED_CONTROLS_DOCS[:-1]:
+        assert path.name in release_notes
+
+
+def test_managed_controls_documentation_uses_only_resolvable_local_links() -> None:
+    for document_path in MANAGED_CONTROLS_DOCS:
+        text = document_path.read_text(encoding="utf-8")
+        assert "http://" not in text
+        assert "https://" not in text
+        assert "Authorization:" not in text
+        assert "Bearer " not in text
+        for raw_target in MARKDOWN_LINK.findall(text):
+            target = raw_target.split("#", 1)[0]
+            if not target:
+                continue
+            relative_target = Path(target)
+            assert not relative_target.is_absolute(), f"absolute link in {document_path}: {target}"
+            assert ".." not in relative_target.parts, f"escaping link in {document_path}: {target}"
+            resolved = document_path.parent / relative_target
+            assert resolved.is_file(), f"broken link in {document_path}: {target}"
+
+        if "| jq " in text:
+            assert "set -o pipefail" in text
+            assert "| jq -e " in text
+
+
+def test_support_projection_fields_exist_in_current_local_apis() -> None:
+    extension_api = "\n".join(
+        (
+            EXTENSION_CONTROL_API_PATH.read_text(encoding="utf-8"),
+            MANAGED_CONTROLS_API_PATH.read_text(encoding="utf-8"),
+        )
+    )
+    policy_command = POLICY_COMMAND_PATH.read_text(encoding="utf-8")
+
+    for field in ("schema_version", "control_schema_version", "catalog_digest", "revision", "health"):
+        assert f'"{field}"' in extension_api
+    for field in ("digest", "rules", "compiled_rows", "actions", "scopes"):
+        assert f'"{field}"' in policy_command
+
+
+def test_managed_controls_release_runbook_uses_repository_tooling() -> None:
+    release_runbook = (ROOT / "docs" / "guard" / "managed-controls-release-runbook.md").read_text(
+        encoding="utf-8"
+    )
+    assert "uv run python scripts/ci/managed_controls_release_gate.py" in release_runbook
+    assert "uv run pytest tests/managed_controls" in release_runbook
+    assert "uv run pytest tests/test_managed_controls_contract_docs.py" in release_runbook
+    assert "\npython scripts/ci/managed_controls_release_gate.py" not in release_runbook
+    assert "\npytest tests/" not in release_runbook


### PR DESCRIPTION
## Summary
- document Local Extensions and the current Local/Cloud boundary without implying Cloud is required for safety
- add catalog mismatch recovery, existing-policy migration, support, invalid-bundle incident, and rollback runbooks
- add release notes and cross-links using bounded/redacted diagnostic procedures
- mark Cloud Managed Controls author/sign/deploy workflow as pending until its production PR lands

## Verification
- focused docs, CLI, and Managed Controls suites: 90 passed
- test inventory ratchet: 15,607 cases / 336,148 lines
- Ruff and `git diff --check`
- independent documentation review: approved