### PR TITLE
fix(update): preserve newer runtime artifacts

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12857,
-  "maximum_test_source_lines": 293355,
+  "maximum_collected_cases": 12860,
+  "maximum_test_source_lines": 293500,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12860,
-  "maximum_test_source_lines": 293500,
+  "maximum_collected_cases": 12861,
+  "maximum_test_source_lines": 293542,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -580,6 +580,22 @@ def run_guard_update(
         payload["changed"] = False
         payload["resulting_version"] = current_version
         payload["message"] = "HOL Guard is already current."
+        newer_runtime = (
+            _verified_newer_guard_daemon(
+                context.guard_home,
+                minimum_version=current_version,
+            )
+            if context is not None
+            else None
+        )
+        if newer_runtime is not None:
+            payload["daemon_refresh"] = newer_runtime
+            payload["runtime_artifact_owner"] = "newer_runtime"
+            _append_payload_note(
+                payload,
+                "Kept newer-runtime package shims and harness hooks unchanged.",
+            )
+            return payload, 0
         # Skip force-reinstall/upgrade noise when PyPI already reports current.
         package_shims, package_shim_note = _refresh_package_shims_after_update(
             context=context,
@@ -797,7 +813,21 @@ def run_guard_update(
     notes = _success_notes(payload)
     if notes:
         payload["notes"] = [*_payload_notes(payload), *notes]
-    if payload.get("changed") is True or payload.get("status") == "current":
+    newer_runtime_owns_artifacts = (
+        _verified_newer_guard_daemon(
+            context.guard_home,
+            minimum_version=resulting_version,
+        )
+        if context is not None
+        else None
+    )
+    if newer_runtime_owns_artifacts is not None:
+        payload["runtime_artifact_owner"] = "newer_runtime"
+        _append_payload_note(
+            payload,
+            "Deferred package shim and harness hook repair to the verified newer runtime.",
+        )
+    elif payload.get("changed") is True or payload.get("status") == "current":
         package_shims, package_shim_note = _refresh_package_shims_after_update(
             context=context,
             dry_run=dry_run,
@@ -806,20 +836,21 @@ def run_guard_update(
         if package_shims is not None:
             payload["package_shims"] = package_shims
         _append_payload_note(payload, package_shim_note)
-    repaired_installs, repair_notes = _repair_supported_harnesses(
-        context=context,
-        store=store,
-        workspace=workspace,
-        now=now,
-        dry_run=dry_run,
-        update_context=update_context,
-    )
-    if repair_notes:
-        payload["notes"] = [*_payload_notes(payload), *repair_notes]
-    if repaired_installs:
-        payload["managed_installs"] = repaired_installs
-        if len(repaired_installs) == 1:
-            payload["managed_install"] = repaired_installs[0]
+    if newer_runtime_owns_artifacts is None:
+        repaired_installs, repair_notes = _repair_supported_harnesses(
+            context=context,
+            store=store,
+            workspace=workspace,
+            now=now,
+            dry_run=dry_run,
+            update_context=update_context,
+        )
+        if repair_notes:
+            payload["notes"] = [*_payload_notes(payload), *repair_notes]
+        if repaired_installs:
+            payload["managed_installs"] = repaired_installs
+            if len(repaired_installs) == 1:
+                payload["managed_install"] = repaired_installs[0]
     if context is not None:
         daemon_refresh, daemon_refresh_note = refresh_guard_daemon_after_update(
             context,
@@ -843,6 +874,34 @@ def run_guard_update(
                 }
             )
             return payload, 1
+        if (
+            newer_runtime_owns_artifacts is not None
+            and isinstance(daemon_refresh, dict)
+            and daemon_refresh.get("status") != "retained_newer_runtime"
+        ):
+            payload.pop("runtime_artifact_owner", None)
+            package_shims, package_shim_note = _refresh_package_shims_after_update(
+                context=context,
+                dry_run=dry_run,
+                update_context=update_context,
+            )
+            if package_shims is not None:
+                payload["package_shims"] = package_shims
+            _append_payload_note(payload, package_shim_note)
+            repaired_installs, repair_notes = _repair_supported_harnesses(
+                context=context,
+                store=store,
+                workspace=workspace,
+                now=now,
+                dry_run=dry_run,
+                update_context=update_context,
+            )
+            if repair_notes:
+                payload["notes"] = [*_payload_notes(payload), *repair_notes]
+            if repaired_installs:
+                payload["managed_installs"] = repaired_installs
+                if len(repaired_installs) == 1:
+                    payload["managed_install"] = repaired_installs[0]
     return payload, 0
 
 

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -813,15 +813,22 @@ def run_guard_update(
     notes = _success_notes(payload)
     if notes:
         payload["notes"] = [*_payload_notes(payload), *notes]
-    newer_runtime_owns_artifacts = (
-        _verified_newer_guard_daemon(
-            context.guard_home,
+    daemon_refresh: dict[str, object] | None = None
+    if context is not None:
+        daemon_refresh, daemon_refresh_note = refresh_guard_daemon_after_update(
+            context,
+            update_context=update_context,
             minimum_version=resulting_version,
         )
-        if context is not None
-        else None
+        if daemon_refresh is not None:
+            payload["daemon_refresh"] = daemon_refresh
+        _append_payload_note(payload, daemon_refresh_note)
+    newer_runtime_owns_artifacts = (
+        isinstance(daemon_refresh, dict)
+        and daemon_refresh.get("status") == "retained_newer_runtime"
+        and daemon_refresh.get("runtime_verified") is True
     )
-    if newer_runtime_owns_artifacts is not None:
+    if newer_runtime_owns_artifacts:
         payload["runtime_artifact_owner"] = "newer_runtime"
         _append_payload_note(
             payload,
@@ -836,7 +843,7 @@ def run_guard_update(
         if package_shims is not None:
             payload["package_shims"] = package_shims
         _append_payload_note(payload, package_shim_note)
-    if newer_runtime_owns_artifacts is None:
+    if not newer_runtime_owns_artifacts:
         repaired_installs, repair_notes = _repair_supported_harnesses(
             context=context,
             store=store,
@@ -852,14 +859,6 @@ def run_guard_update(
             if len(repaired_installs) == 1:
                 payload["managed_install"] = repaired_installs[0]
     if context is not None:
-        daemon_refresh, daemon_refresh_note = refresh_guard_daemon_after_update(
-            context,
-            update_context=update_context,
-            minimum_version=resulting_version,
-        )
-        if daemon_refresh is not None:
-            payload["daemon_refresh"] = daemon_refresh
-        _append_payload_note(payload, daemon_refresh_note)
         daemon_refresh_succeeded = (
             isinstance(daemon_refresh, dict)
             and daemon_refresh.get("status") in {"restarted", "retained_newer_runtime"}
@@ -874,34 +873,6 @@ def run_guard_update(
                 }
             )
             return payload, 1
-        if (
-            newer_runtime_owns_artifacts is not None
-            and isinstance(daemon_refresh, dict)
-            and daemon_refresh.get("status") != "retained_newer_runtime"
-        ):
-            payload.pop("runtime_artifact_owner", None)
-            package_shims, package_shim_note = _refresh_package_shims_after_update(
-                context=context,
-                dry_run=dry_run,
-                update_context=update_context,
-            )
-            if package_shims is not None:
-                payload["package_shims"] = package_shims
-            _append_payload_note(payload, package_shim_note)
-            repaired_installs, repair_notes = _repair_supported_harnesses(
-                context=context,
-                store=store,
-                workspace=workspace,
-                now=now,
-                dry_run=dry_run,
-                update_context=update_context,
-            )
-            if repair_notes:
-                payload["notes"] = [*_payload_notes(payload), *repair_notes]
-            if repaired_installs:
-                payload["managed_installs"] = repaired_installs
-                if len(repaired_installs) == 1:
-                    payload["managed_install"] = repaired_installs[0]
     return payload, 0
 
 

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -2188,6 +2188,151 @@ def test_update_succeeds_when_verified_newer_desktop_runtime_is_retained(
     assert any("Kept the newer HOL Guard runtime active" in note for note in payload["notes"])
 
 
+def test_update_does_not_replace_artifacts_owned_by_newer_desktop_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    context.guard_home.mkdir(parents=True)
+    (context.guard_home / "daemon-state.json").write_text("signed", encoding="utf-8")
+    retained = {
+        "status": "retained_newer_runtime",
+        "daemon_version": "3.0.0a253",
+        "cli_version": "2.2.123",
+        "runtime_verified": True,
+    }
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.2.122")
+    monkeypatch.setattr(update_commands, "_current_version_from_subprocess", lambda *_args, **_kwargs: "2.2.123")
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.2.123")
+    monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+    monkeypatch.setattr(update_commands, "_verified_newer_guard_daemon", lambda *_args, **_kwargs: retained)
+    monkeypatch.setattr(
+        update_commands,
+        "_refresh_package_shims_after_update",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("newer runtime owns package shims")),
+    )
+    monkeypatch.setattr(
+        update_commands,
+        "_repair_supported_harnesses",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("newer runtime owns harness hooks")),
+    )
+    monkeypatch.setattr(
+        update_commands,
+        "refresh_guard_daemon_after_update",
+        lambda *_args, **_kwargs: (retained, "Kept the newer HOL Guard runtime active."),
+    )
+    monkeypatch.setattr(
+        update_commands.subprocess,
+        "run",
+        lambda command, **_kwargs: subprocess.CompletedProcess(command, 0, "installed", ""),
+    )
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=False, context=context)
+
+    assert exit_code == 0
+    assert payload["status"] == "updated"
+    assert payload["runtime_artifact_owner"] == "newer_runtime"
+    assert payload["daemon_refresh"] == retained
+    assert "managed_installs" not in payload
+    assert "package_shims" not in payload
+
+
+def test_current_update_does_not_repair_artifacts_owned_by_newer_desktop_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    context.guard_home.mkdir(parents=True)
+    (context.guard_home / "daemon-state.json").write_text("signed", encoding="utf-8")
+    retained = {
+        "status": "retained_newer_runtime",
+        "daemon_version": "3.0.0a253",
+        "cli_version": "2.2.123",
+        "runtime_verified": True,
+    }
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.2.123")
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.2.123")
+    monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+    monkeypatch.setattr(update_commands, "_verified_newer_guard_daemon", lambda *_args, **_kwargs: retained)
+    monkeypatch.setattr(
+        update_commands,
+        "_refresh_package_shims_after_update",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("newer runtime owns package shims")),
+    )
+    monkeypatch.setattr(
+        update_commands,
+        "_repair_supported_harnesses",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("newer runtime owns harness hooks")),
+    )
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=False, context=context)
+
+    assert exit_code == 0
+    assert payload["status"] == "current"
+    assert payload["runtime_artifact_owner"] == "newer_runtime"
+    assert payload["daemon_refresh"] == retained
+    assert "managed_installs" not in payload
+    assert "package_shims" not in payload
+
+
+def test_update_repairs_stable_artifacts_when_newer_runtime_disappears(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    context.guard_home.mkdir(parents=True)
+    (context.guard_home / "daemon-state.json").write_text("signed", encoding="utf-8")
+    newer_runtime = {
+        "status": "retained_newer_runtime",
+        "daemon_version": "3.0.0a253",
+        "cli_version": "2.2.123",
+        "runtime_verified": True,
+    }
+    restarted_runtime = {
+        "status": "restarted",
+        "daemon_version": "2.2.123",
+        "runtime_verified": True,
+    }
+    repairs: list[str] = []
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.2.122")
+    monkeypatch.setattr(update_commands, "_current_version_from_subprocess", lambda *_args, **_kwargs: "2.2.123")
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.2.123")
+    monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+    monkeypatch.setattr(update_commands, "_verified_newer_guard_daemon", lambda *_args, **_kwargs: newer_runtime)
+    monkeypatch.setattr(
+        update_commands,
+        "_refresh_package_shims_after_update",
+        lambda **_kwargs: (repairs.append("shims") or {"status": "refreshed"}, None),
+    )
+    monkeypatch.setattr(
+        update_commands,
+        "_repair_supported_harnesses",
+        lambda **_kwargs: (repairs.append("hooks") or [{"harness": "codex"}], []),
+    )
+    monkeypatch.setattr(
+        update_commands,
+        "refresh_guard_daemon_after_update",
+        lambda *_args, **_kwargs: (restarted_runtime, "Restarted stable HOL Guard."),
+    )
+    monkeypatch.setattr(
+        update_commands.subprocess,
+        "run",
+        lambda command, **_kwargs: subprocess.CompletedProcess(command, 0, "installed", ""),
+    )
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=False, context=context)
+
+    assert exit_code == 0
+    assert repairs == ["shims", "hooks"]
+    assert "runtime_artifact_owner" not in payload
+    assert payload["package_shims"] == {"status": "refreshed"}
+    assert payload["managed_install"] == {"harness": "codex"}
+    assert payload["daemon_refresh"] == restarted_runtime
+
+
 def test_required_daemon_refresh_failure_never_deletes_unreceipted_local_wheel_staging(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -2277,19 +2277,13 @@ def test_current_update_does_not_repair_artifacts_owned_by_newer_desktop_runtime
     assert "package_shims" not in payload
 
 
-def test_update_repairs_stable_artifacts_when_newer_runtime_disappears(
+def test_update_repairs_stable_artifacts_from_final_daemon_ownership_decision(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     context = _context(tmp_path)
     context.guard_home.mkdir(parents=True)
     (context.guard_home / "daemon-state.json").write_text("signed", encoding="utf-8")
-    newer_runtime = {
-        "status": "retained_newer_runtime",
-        "daemon_version": "3.0.0a253",
-        "cli_version": "2.2.123",
-        "runtime_verified": True,
-    }
     restarted_runtime = {
         "status": "restarted",
         "daemon_version": "2.2.123",
@@ -2301,7 +2295,11 @@ def test_update_repairs_stable_artifacts_when_newer_runtime_disappears(
     monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.2.123")
     monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
     monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
-    monkeypatch.setattr(update_commands, "_verified_newer_guard_daemon", lambda *_args, **_kwargs: newer_runtime)
+    monkeypatch.setattr(
+        update_commands,
+        "_verified_newer_guard_daemon",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("only daemon refresh decides ownership")),
+    )
     monkeypatch.setattr(
         update_commands,
         "_refresh_package_shims_after_update",
@@ -2331,6 +2329,50 @@ def test_update_repairs_stable_artifacts_when_newer_runtime_disappears(
     assert payload["package_shims"] == {"status": "refreshed"}
     assert payload["managed_install"] == {"harness": "codex"}
     assert payload["daemon_refresh"] == restarted_runtime
+    assert not any("Deferred package shim" in note for note in payload["notes"])
+
+
+def test_update_repairs_stable_artifacts_before_reporting_daemon_refresh_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    context.guard_home.mkdir(parents=True)
+    (context.guard_home / "daemon-state.json").write_text("signed", encoding="utf-8")
+    repairs: list[str] = []
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.2.122")
+    monkeypatch.setattr(update_commands, "_current_version_from_subprocess", lambda *_args, **_kwargs: "2.2.123")
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.2.123")
+    monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+    monkeypatch.setattr(
+        update_commands,
+        "_refresh_package_shims_after_update",
+        lambda **_kwargs: (repairs.append("shims") or {"status": "refreshed"}, None),
+    )
+    monkeypatch.setattr(
+        update_commands,
+        "_repair_supported_harnesses",
+        lambda **_kwargs: (repairs.append("hooks") or [{"harness": "omp"}], []),
+    )
+    monkeypatch.setattr(
+        update_commands,
+        "refresh_guard_daemon_after_update",
+        lambda *_args, **_kwargs: (None, "Could not restart stable HOL Guard."),
+    )
+    monkeypatch.setattr(
+        update_commands.subprocess,
+        "run",
+        lambda command, **_kwargs: subprocess.CompletedProcess(command, 0, "installed", ""),
+    )
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=False, context=context)
+
+    assert exit_code == 1
+    assert payload["reason_code"] == "update_daemon_refresh_failed"
+    assert repairs == ["shims", "hooks"]
+    assert payload["package_shims"] == {"status": "refreshed"}
+    assert payload["managed_install"] == {"harness": "omp"}
 
 
 def test_required_daemon_refresh_failure_never_deletes_unreceipted_local_wheel_staging(


### PR DESCRIPTION
## Summary
- preserve package shims and harness hooks owned by a verified newer Guard runtime during stable CLI updates
- repair stable-managed artifacts if the newer runtime disappears while an update is completing
- cover updated, already-current, and ownership-race paths with regression tests

## Testing
- `uv run ruff check src/codex_plugin_scanner/guard/cli/update_commands.py tests/test_guard_phase03_local_install.py`
- `uv run ruff format --check src/codex_plugin_scanner/guard/cli/update_commands.py tests/test_guard_phase03_local_install.py`
- `uv run python -m pytest tests/test_guard_phase03_local_install.py tests/test_dashboard_update.py -q`
- `uv run basedpyright src/codex_plugin_scanner/guard/cli/update_commands.py`
- `uv run python scripts/ci/test_inventory.py --output <inventory-output>`
- `uv run python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory <inventory-output>`
