### PR TITLE
fix(runtime): preserve Desktop owner in daemon

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 15750,
-  "maximum_test_source_lines": 339717,
+  "maximum_collected_cases": 15751,
+  "maximum_test_source_lines": 339733,
   "schema_version": 1
 }

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -103,6 +103,7 @@ _GUARD_DAEMON_ENV_KEYS = frozenset(
         "COMSPEC",
         "HOME",
         "HOL_GUARD_DESKTOP",
+        "HOL_GUARD_DESKTOP_RUNTIME_OWNER",
         "HOL_GUARD_DESKTOP_VERSION",
         "LANG",
         "LC_ALL",

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -125,7 +125,6 @@ _GUARD_DAEMON_ENV_KEYS = frozenset(
         "WINDIR",
     }
 )
-
 _START_LOCKS: dict[str, threading.Lock] = {}
 _START_LOCKS_GUARD = threading.Lock()
 _RECOVERY_LOCKS: dict[str, threading.Lock] = {}

--- a/tests/test_guard_frozen_daemon_runtime.py
+++ b/tests/test_guard_frozen_daemon_runtime.py
@@ -264,6 +264,22 @@ def test_frozen_daemon_launcher_preserves_pyinstaller_reset(
     assert child_env["HOL_GUARD_DESKTOP"] == "1"
 
 
+def test_frozen_daemon_launcher_preserves_persistent_desktop_runtime_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime_owner = tmp_path / "desktop-core" / "bin" / "hol-guard"
+    runtime_owner.parent.mkdir(parents=True)
+    runtime_owner.write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.setattr(manager.sys, "frozen", True, raising=False)
+    monkeypatch.setenv("HOL_GUARD_DESKTOP", "1")
+    monkeypatch.setenv("HOL_GUARD_DESKTOP_RUNTIME_OWNER", str(runtime_owner))
+
+    child_env = manager._daemon_launcher_env(home_dir=tmp_path)
+
+    assert child_env["HOL_GUARD_DESKTOP_RUNTIME_OWNER"] == str(runtime_owner)
+
+
 def test_non_frozen_daemon_launcher_drops_pyinstaller_environment(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- preserve the verified persistent Desktop Core owner across detached daemon startup
- keep generated Pi-family hooks bound to the persistent runtime after an AppImage exits
- add regression coverage for the daemon environment boundary

## Verification
- `python3 -m ruff check src/codex_plugin_scanner/guard/daemon/manager.py tests/test_guard_frozen_daemon_runtime.py`
- `python3 -m pytest tests/test_guard_frozen_daemon_runtime.py tests/test_pi_extension_runtime_ownership.py -q`
- `git diff --check`