### PR TITLE
fix(release): allow co-owned prerelease assets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1393,7 +1393,7 @@ jobs:
                 cmp --silent "$local_file" "$remote_file"
               fi
             done
-            python scripts/ci/verify_release_asset_inventory.py "$existing_dir" dist "$VERSION"
+            python scripts/ci/verify_release_asset_inventory.py "$existing_dir" dist "$VERSION" stable
             bundle="$existing_dir/hol-guard-v${VERSION}.intoto.jsonl"
             [[ -s "$bundle" ]]
             shopt -s nullglob
@@ -1500,7 +1500,7 @@ jobs:
                 cmp --silent "$local_file" "$remote_file"
               fi
             done
-            python scripts/ci/verify_release_asset_inventory.py "$existing_dir" dist "$VERSION"
+            python scripts/ci/verify_release_asset_inventory.py "$existing_dir" dist "$VERSION" alpha
             bundle="$existing_dir/hol-guard-v${VERSION}.intoto.jsonl"
             [[ -s "$bundle" ]]
             for remote_file in "$existing_dir"/hol_guard-*; do

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1385,9 +1385,7 @@ jobs:
             existing_dir=$(mktemp -d)
             gh release download "$tag" --dir "$existing_dir"
             mapfile -d '' local_files < <(find dist -maxdepth 1 -type f -print0 | sort -z)
-            mapfile -d '' remote_files < <(find "$existing_dir" -maxdepth 1 -type f -print0 | sort -z)
             [[ "${#local_files[@]}" -gt 0 ]]
-            [[ "${#local_files[@]}" == "${#remote_files[@]}" ]]
             for local_file in "${local_files[@]}"; do
               remote_file="$existing_dir/$(basename "$local_file")"
               [[ -f "$remote_file" ]]
@@ -1493,9 +1491,7 @@ jobs:
             existing_dir=$(mktemp -d)
             gh release download "$tag" --dir "$existing_dir"
             mapfile -d '' local_files < <(find dist -maxdepth 1 -type f -print0 | sort -z)
-            mapfile -d '' remote_files < <(find "$existing_dir" -maxdepth 1 -type f -print0 | sort -z)
             [[ "${#local_files[@]}" -gt 0 ]]
-            [[ "${#local_files[@]}" == "${#remote_files[@]}" ]]
             for local_file in "${local_files[@]}"; do
               remote_file="$existing_dir/$(basename "$local_file")"
               [[ -f "$remote_file" ]]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1393,6 +1393,7 @@ jobs:
                 cmp --silent "$local_file" "$remote_file"
               fi
             done
+            python scripts/ci/verify_release_asset_inventory.py "$existing_dir" dist "$VERSION"
             bundle="$existing_dir/hol-guard-v${VERSION}.intoto.jsonl"
             [[ -s "$bundle" ]]
             shopt -s nullglob
@@ -1499,6 +1500,7 @@ jobs:
                 cmp --silent "$local_file" "$remote_file"
               fi
             done
+            python scripts/ci/verify_release_asset_inventory.py "$existing_dir" dist "$VERSION"
             bundle="$existing_dir/hol-guard-v${VERSION}.intoto.jsonl"
             [[ -s "$bundle" ]]
             for remote_file in "$existing_dir"/hol_guard-*; do

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 15807,
-  "maximum_test_source_lines": 341236,
+  "maximum_collected_cases": 15812,
+  "maximum_test_source_lines": 341300,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 15812,
-  "maximum_test_source_lines": 341300,
+  "maximum_collected_cases": 15815,
+  "maximum_test_source_lines": 341323,
   "schema_version": 1
 }

--- a/scripts/ci/verify_release_asset_inventory.py
+++ b/scripts/ci/verify_release_asset_inventory.py
@@ -10,27 +10,37 @@ import sys
 from pathlib import Path
 
 SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
+CORE_TARGET = "aarch64-apple-darwin"
 
 
 def _regular_file_names(directory: Path) -> set[str]:
     return {entry.name for entry in directory.iterdir() if stat.S_ISREG(entry.lstat().st_mode)}
 
 
-def verify_release_assets(release_dir: Path, dist_dir: Path, version: str) -> None:
-    """Reject unowned assets and verify an optional MCPB/checksum pair."""
+def verify_release_assets(release_dir: Path, dist_dir: Path, version: str, channel: str) -> None:
+    """Reject unowned assets and verify optional co-owned asset sets."""
+    if channel not in {"alpha", "stable"}:
+        raise ValueError(f"Unsupported release channel: {channel}")
     owned_names = _regular_file_names(dist_dir)
     mcpb_name = f"hol-guard-{version}.mcpb"
     checksum_name = f"{mcpb_name}.sha256"
-    allowed_names = owned_names | {mcpb_name, checksum_name}
+    mcpb_names = {mcpb_name, checksum_name}
+    core_base = f"hol-guard-core-{version}-{CORE_TARGET}"
+    core_names = {core_base, f"{core_base}.json", f"{core_base}.attested.json"}
+    co_owned_names = mcpb_names | (core_names if channel == "alpha" else set())
+    allowed_names = owned_names | co_owned_names
     release_names = _regular_file_names(release_dir)
     unexpected_names = sorted(release_names - allowed_names)
     if unexpected_names:
         names = ", ".join(unexpected_names)
         raise ValueError(f"Unexpected release asset: {names}")
 
-    present_mcpb_names = release_names & {mcpb_name, checksum_name}
-    if present_mcpb_names and present_mcpb_names != {mcpb_name, checksum_name}:
+    present_mcpb_names = release_names & mcpb_names
+    if present_mcpb_names and present_mcpb_names != mcpb_names:
         raise ValueError("MCPB release asset and checksum must both be present")
+    present_core_names = release_names & core_names
+    if present_core_names and present_core_names != core_names:
+        raise ValueError("Desktop Core release assets must be a complete set")
     if not present_mcpb_names:
         return
 
@@ -46,11 +56,11 @@ def verify_release_assets(release_dir: Path, dist_dir: Path, version: str) -> No
 
 
 def main() -> int:
-    if len(sys.argv) != 4:
-        print(f"Usage: {Path(sys.argv[0]).name} RELEASE_DIR DIST_DIR VERSION", file=sys.stderr)
+    if len(sys.argv) != 5:
+        print(f"Usage: {Path(sys.argv[0]).name} RELEASE_DIR DIST_DIR VERSION CHANNEL", file=sys.stderr)
         return 2
     try:
-        verify_release_assets(Path(sys.argv[1]), Path(sys.argv[2]), sys.argv[3])
+        verify_release_assets(Path(sys.argv[1]), Path(sys.argv[2]), sys.argv[3], sys.argv[4])
     except (OSError, ValueError) as error:
         print(error, file=sys.stderr)
         return 1

--- a/scripts/ci/verify_release_asset_inventory.py
+++ b/scripts/ci/verify_release_asset_inventory.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Verify retry-safe GitHub release assets owned by Guard workflows."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import stat
+import sys
+from pathlib import Path
+
+SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
+
+
+def _regular_file_names(directory: Path) -> set[str]:
+    return {entry.name for entry in directory.iterdir() if stat.S_ISREG(entry.lstat().st_mode)}
+
+
+def verify_release_assets(release_dir: Path, dist_dir: Path, version: str) -> None:
+    """Reject unowned assets and verify an optional MCPB/checksum pair."""
+    owned_names = _regular_file_names(dist_dir)
+    mcpb_name = f"hol-guard-{version}.mcpb"
+    checksum_name = f"{mcpb_name}.sha256"
+    allowed_names = owned_names | {mcpb_name, checksum_name}
+    release_names = _regular_file_names(release_dir)
+    unexpected_names = sorted(release_names - allowed_names)
+    if unexpected_names:
+        names = ", ".join(unexpected_names)
+        raise ValueError(f"Unexpected release asset: {names}")
+
+    present_mcpb_names = release_names & {mcpb_name, checksum_name}
+    if present_mcpb_names and present_mcpb_names != {mcpb_name, checksum_name}:
+        raise ValueError("MCPB release asset and checksum must both be present")
+    if not present_mcpb_names:
+        return
+
+    checksum_lines = (release_dir / checksum_name).read_text(encoding="utf-8").splitlines()
+    if len(checksum_lines) != 1:
+        raise ValueError("MCPB checksum must contain exactly one line")
+    checksum_fields = checksum_lines[0].split()
+    if not checksum_fields or SHA256_PATTERN.fullmatch(checksum_fields[0]) is None:
+        raise ValueError("MCPB checksum does not contain a valid SHA-256 digest")
+    actual_digest = hashlib.sha256((release_dir / mcpb_name).read_bytes()).hexdigest()
+    if actual_digest != checksum_fields[0]:
+        raise ValueError("MCPB release asset does not match its checksum")
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        print(f"Usage: {Path(sys.argv[0]).name} RELEASE_DIR DIST_DIR VERSION", file=sys.stderr)
+        return 2
+    try:
+        verify_release_assets(Path(sys.argv[1]), Path(sys.argv[2]), sys.argv[3])
+    except (OSError, ValueError) as error:
+        print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -252,7 +252,7 @@ def _nested_trust_result(marker_path: str) -> dict[str, str]:
     context = local_trust_contract_module.multiprocessing.get_context("spawn")
     process = context.Process(target=_write_nested_trust_marker, args=(marker_path,))
     process.start()
-    process.join(timeout=3.0)
+    process.join(timeout=10.0)
     return {"mode": "protected", "nested": str(Path(marker_path).exists())}
 
 
@@ -597,8 +597,8 @@ def test_trust_backend_check_allows_spawned_helper_child_process(tmp_path: Path)
 
     result = run_trust_backend_check(
         partial(_nested_trust_result, str(marker_path)),
-        # This verifies nested containment, while concurrent spawn runners need startup headroom.
-        timeout_seconds=10.0,
+        # Nested spawn gets 10s under runner contention; outer containment keeps cleanup headroom.
+        timeout_seconds=15.0,
         timeout_result={"mode": "degraded", "nested": "False"},
     )
 

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -1012,16 +1012,17 @@ class TestGuardSurfaceServer:
         assert "protect your local secrets" in hook_payload["hookSpecificOutput"]["permissionDecisionReason"].lower()
         assert store.list_guard_sessions() == []
 
-    def test_guard_daemon_pi_hook_endpoint_returns_blocked_runtime_review_payload(self, tmp_path) -> None:
+    def test_guard_daemon_pi_hook_endpoint_returns_blocked_runtime_review_payload(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr(daemon_server_module, "_RUNTIME_HOOK_PROCESS_TIMEOUT_SECONDS", 10.0)
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
         workspace_dir.mkdir(parents=True, exist_ok=True)
         store = GuardStore(home_dir)
         daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        monkeypatch.setattr(daemon._server.hook_process_runner, "_timeout_seconds", 8.0)
         daemon.start()
         assert daemon._server.hook_process_runner.wait_for_capacity(  # pyright: ignore[reportPrivateUsage]
-            minimum_workers=1,
-            timeout_seconds=15,
+            minimum_workers=1, timeout_seconds=15
         )
 
         try:
@@ -1045,16 +1046,15 @@ class TestGuardSurfaceServer:
                 },
                 method="POST",
             )
-            with urllib.request.urlopen(hook_request, timeout=5) as response:
+            with urllib.request.urlopen(hook_request, timeout=15) as response:
                 hook_payload = json.loads(response.read().decode("utf-8"))
             if str(hook_payload.get("reason", "")).startswith(
                 "HOL Guard blocked this action because isolated local review could not complete safely."
             ):
                 assert daemon._server.hook_process_runner.wait_for_capacity(  # pyright: ignore[reportPrivateUsage]
-                    minimum_workers=1,
-                    timeout_seconds=15,
+                    minimum_workers=1, timeout_seconds=15
                 )
-                with urllib.request.urlopen(hook_request, timeout=5) as response:
+                with urllib.request.urlopen(hook_request, timeout=15) as response:
                     hook_payload = json.loads(response.read().decode("utf-8"))
         finally:
             daemon.stop()

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -489,29 +489,25 @@ def test_release_tags_are_bound_to_the_exact_published_source() -> None:
     assert 'gh release view "$tag" --json isDraft,isPrerelease' in release_run
     assert 'gh release download "$tag"' in release_run
     assert 'cmp --silent "$local_file"' in release_run
-    assert "mapfile -d '' local_files" in release_run
-    assert "remote_files" not in release_run
-    assert '[[ -f "$remote_file" ]]' in release_run
+    assert "mapfile -d '' local_files" in release_run and "remote_files" not in release_run
     assert 'gh attestation verify "$remote_file"' in release_run
     assert '--bundle "$bundle" --source-digest "$SOURCE_SHA"' in release_run
     assert "--verify-tag" in release_run
 
-    main_release_run = next(
+    main_run = next(
         step["run"] for step in jobs["release-main"]["steps"] if step.get("name") == "Create discoverable main release"
     )
-    assert 'tag="v${VERSION}"' in main_release_run
-    assert 'gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs"' in main_release_run
-    assert '-f sha="$SOURCE_SHA"' in main_release_run
-    assert 'remote_tag_sha" != "$SOURCE_SHA"' in main_release_run
-    assert 'gh release view "$tag" --json isDraft,isPrerelease' in main_release_run
-    assert "Existing stable release is a draft or prerelease" in main_release_run
-    assert "remote_files" not in main_release_run
-    assert '[[ -f "$remote_file" ]]' in main_release_run
-    assert 'remote_guard_files=("$existing_dir"/hol_guard-*)' in main_release_run
-    assert '[[ "${#remote_guard_files[@]}" -gt 0 ]]' in main_release_run
-    assert 'gh attestation verify "$remote_file"' in main_release_run
-    assert '--bundle "$bundle" --source-digest "$SOURCE_SHA"' in main_release_run
-    assert "--verify-tag" in main_release_run
+    assert 'tag="v${VERSION}"' in main_run
+    assert 'gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs"' in main_run
+    assert '-f sha="$SOURCE_SHA"' in main_run
+    assert 'remote_tag_sha" != "$SOURCE_SHA"' in main_run
+    assert 'gh release view "$tag" --json isDraft,isPrerelease' in main_run
+    assert "Existing stable release is a draft or prerelease" in main_run and "remote_files" not in main_run
+    assert 'remote_guard_files=("$existing_dir"/hol_guard-*)' in main_run
+    assert '[[ "${#remote_guard_files[@]}" -gt 0 ]]' in main_run
+    assert 'gh attestation verify "$remote_file"' in main_run
+    assert '--bundle "$bundle" --source-digest "$SOURCE_SHA"' in main_run
+    assert "--verify-tag" in main_run
 
 
 def test_release_3x_alpha_branches_remain_alpha_while_main_is_stable() -> None:

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -478,36 +478,36 @@ def test_release_tags_are_bound_to_the_exact_published_source() -> None:
     )
     assert '"$remote_alpha_tag_sha" != "$SOURCE_SHA"' in alpha_pypi_run
 
-    release_run = next(
+    alpha_run = next(
         step["run"]
         for step in jobs["release-alpha"]["steps"]
         if step.get("name") == "Create discoverable alpha prerelease"
     )
-    assert 'gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs"' in release_run
-    assert '-f ref="refs/tags/${tag}"' in release_run
-    assert 'remote_tag_sha" != "$SOURCE_SHA"' in release_run
-    assert 'gh release view "$tag" --json isDraft,isPrerelease' in release_run
-    assert 'gh release download "$tag"' in release_run
-    assert 'cmp --silent "$local_file"' in release_run
-    assert "mapfile -d '' local_files" in release_run and "remote_files" not in release_run
-    assert 'gh attestation verify "$remote_file"' in release_run
-    assert '--bundle "$bundle" --source-digest "$SOURCE_SHA"' in release_run
-    assert "--verify-tag" in release_run
+    assert 'gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs"' in alpha_run
+    assert '-f ref="refs/tags/${tag}"' in alpha_run
+    assert 'remote_tag_sha" != "$SOURCE_SHA"' in alpha_run
+    assert 'gh release view "$tag" --json isDraft,isPrerelease' in alpha_run
+    assert 'gh release download "$tag"' in alpha_run and "verify_release_asset_inventory.py" in alpha_run
+    assert 'cmp --silent "$local_file"' in alpha_run
+    assert '"$existing_dir" dist "$VERSION"' in alpha_run
+    assert "mapfile -d '' local_files" in alpha_run
+    assert 'gh attestation verify "$remote_file"' in alpha_run and '--bundle "$bundle"' in alpha_run
+    assert '--source-digest "$SOURCE_SHA"' in alpha_run and "--verify-tag" in alpha_run
 
-    main_run = next(
+    stable_run = next(
         step["run"] for step in jobs["release-main"]["steps"] if step.get("name") == "Create discoverable main release"
     )
-    assert 'tag="v${VERSION}"' in main_run
-    assert 'gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs"' in main_run
-    assert '-f sha="$SOURCE_SHA"' in main_run
-    assert 'remote_tag_sha" != "$SOURCE_SHA"' in main_run
-    assert 'gh release view "$tag" --json isDraft,isPrerelease' in main_run
-    assert "Existing stable release is a draft or prerelease" in main_run and "remote_files" not in main_run
-    assert 'remote_guard_files=("$existing_dir"/hol_guard-*)' in main_run
-    assert '[[ "${#remote_guard_files[@]}" -gt 0 ]]' in main_run
-    assert 'gh attestation verify "$remote_file"' in main_run
-    assert '--bundle "$bundle" --source-digest "$SOURCE_SHA"' in main_run
-    assert "--verify-tag" in main_run
+    assert 'tag="v${VERSION}"' in stable_run
+    assert 'gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs"' in stable_run
+    assert '-f sha="$SOURCE_SHA"' in stable_run
+    assert 'remote_tag_sha" != "$SOURCE_SHA"' in stable_run
+    assert 'gh release view "$tag" --json isDraft,isPrerelease' in stable_run
+    assert "Existing stable release is a draft or prerelease" in stable_run
+    assert "remote_guard_files=" in stable_run and "verify_release_asset_inventory.py" in stable_run
+    assert '[[ "${#remote_guard_files[@]}" -gt 0 ]]' in stable_run
+    assert 'gh attestation verify "$remote_file"' in stable_run
+    assert '--bundle "$bundle" --source-digest "$SOURCE_SHA"' in stable_run
+    assert "--verify-tag" in stable_run and '"$existing_dir" dist "$VERSION"' in stable_run
 
 
 def test_release_3x_alpha_branches_remain_alpha_while_main_is_stable() -> None:

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -489,7 +489,7 @@ def test_release_tags_are_bound_to_the_exact_published_source() -> None:
     assert 'gh release view "$tag" --json isDraft,isPrerelease' in alpha_run
     assert 'gh release download "$tag"' in alpha_run and "verify_release_asset_inventory.py" in alpha_run
     assert 'cmp --silent "$local_file"' in alpha_run
-    assert '"$existing_dir" dist "$VERSION"' in alpha_run
+    assert '"$existing_dir" dist "$VERSION" alpha' in alpha_run
     assert "mapfile -d '' local_files" in alpha_run
     assert 'gh attestation verify "$remote_file"' in alpha_run and '--bundle "$bundle"' in alpha_run
     assert '--source-digest "$SOURCE_SHA"' in alpha_run and "--verify-tag" in alpha_run
@@ -507,7 +507,7 @@ def test_release_tags_are_bound_to_the_exact_published_source() -> None:
     assert '[[ "${#remote_guard_files[@]}" -gt 0 ]]' in stable_run
     assert 'gh attestation verify "$remote_file"' in stable_run
     assert '--bundle "$bundle" --source-digest "$SOURCE_SHA"' in stable_run
-    assert "--verify-tag" in stable_run and '"$existing_dir" dist "$VERSION"' in stable_run
+    assert "--verify-tag" in stable_run and '"$existing_dir" dist "$VERSION" stable' in stable_run
 
 
 def test_release_3x_alpha_branches_remain_alpha_while_main_is_stable() -> None:

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -490,6 +490,8 @@ def test_release_tags_are_bound_to_the_exact_published_source() -> None:
     assert 'gh release download "$tag"' in release_run
     assert 'cmp --silent "$local_file"' in release_run
     assert "mapfile -d '' local_files" in release_run
+    assert "remote_files" not in release_run
+    assert '[[ -f "$remote_file" ]]' in release_run
     assert 'gh attestation verify "$remote_file"' in release_run
     assert '--bundle "$bundle" --source-digest "$SOURCE_SHA"' in release_run
     assert "--verify-tag" in release_run
@@ -503,6 +505,8 @@ def test_release_tags_are_bound_to_the_exact_published_source() -> None:
     assert 'remote_tag_sha" != "$SOURCE_SHA"' in main_release_run
     assert 'gh release view "$tag" --json isDraft,isPrerelease' in main_release_run
     assert "Existing stable release is a draft or prerelease" in main_release_run
+    assert "remote_files" not in main_release_run
+    assert '[[ -f "$remote_file" ]]' in main_release_run
     assert 'remote_guard_files=("$existing_dir"/hol_guard-*)' in main_release_run
     assert '[[ "${#remote_guard_files[@]}" -gt 0 ]]' in main_release_run
     assert 'gh attestation verify "$remote_file"' in main_release_run

--- a/tests/test_verify_release_asset_inventory.py
+++ b/tests/test_verify_release_asset_inventory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import re
 from pathlib import Path
 
 import pytest
@@ -31,15 +32,28 @@ def test_accepts_owned_assets_and_matching_mcpb_pair(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    verify_release_assets(release_dir, dist_dir, VERSION)
+    verify_release_assets(release_dir, dist_dir, VERSION, "stable")
 
 
-def test_rejects_unowned_release_asset(tmp_path: Path) -> None:
+def test_accepts_complete_desktop_core_assets_for_alpha(tmp_path: Path) -> None:
     release_dir, dist_dir = _directories(tmp_path)
-    (release_dir / "unowned.bin").write_bytes(b"untrusted")
+    core_base = f"hol-guard-core-{VERSION}-aarch64-apple-darwin"
+    for suffix in ("", ".json", ".attested.json"):
+        (release_dir / f"{core_base}{suffix}").write_bytes(b"core asset")
 
-    with pytest.raises(ValueError, match=r"Unexpected release asset: unowned\.bin"):
-        verify_release_assets(release_dir, dist_dir, VERSION)
+    verify_release_assets(release_dir, dist_dir, VERSION, "alpha")
+
+
+@pytest.mark.parametrize(
+    "asset_name",
+    ["unowned.bin", f"hol-guard-core-{VERSION}-aarch64-apple-darwin"],
+)
+def test_rejects_unowned_stable_release_asset(tmp_path: Path, asset_name: str) -> None:
+    release_dir, dist_dir = _directories(tmp_path)
+    (release_dir / asset_name).write_bytes(b"untrusted")
+
+    with pytest.raises(ValueError, match=re.escape(f"Unexpected release asset: {asset_name}")):
+        verify_release_assets(release_dir, dist_dir, VERSION, "stable")
 
 
 @pytest.mark.parametrize("missing_suffix", ["", ".sha256"])
@@ -49,7 +63,16 @@ def test_rejects_incomplete_mcpb_pair(tmp_path: Path, missing_suffix: str) -> No
     (release_dir / f"hol-guard-{VERSION}.mcpb{other_suffix}").write_bytes(b"incomplete")
 
     with pytest.raises(ValueError, match="must both be present"):
-        verify_release_assets(release_dir, dist_dir, VERSION)
+        verify_release_assets(release_dir, dist_dir, VERSION, "stable")
+
+
+def test_rejects_incomplete_desktop_core_assets(tmp_path: Path) -> None:
+    release_dir, dist_dir = _directories(tmp_path)
+    core_base = f"hol-guard-core-{VERSION}-aarch64-apple-darwin"
+    (release_dir / core_base).write_bytes(b"incomplete core")
+
+    with pytest.raises(ValueError, match="must be a complete set"):
+        verify_release_assets(release_dir, dist_dir, VERSION, "alpha")
 
 
 def test_rejects_mcpb_checksum_mismatch(tmp_path: Path) -> None:
@@ -61,4 +84,4 @@ def test_rejects_mcpb_checksum_mismatch(tmp_path: Path) -> None:
     )
 
     with pytest.raises(ValueError, match="does not match its checksum"):
-        verify_release_assets(release_dir, dist_dir, VERSION)
+        verify_release_assets(release_dir, dist_dir, VERSION, "stable")

--- a/tests/test_verify_release_asset_inventory.py
+++ b/tests/test_verify_release_asset_inventory.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.verify_release_asset_inventory import verify_release_assets
+
+VERSION = "3.0.0a269"
+
+
+def _directories(tmp_path: Path) -> tuple[Path, Path]:
+    release_dir = tmp_path / "release"
+    dist_dir = tmp_path / "dist"
+    release_dir.mkdir()
+    dist_dir.mkdir()
+    owned_asset = b"owned wheel"
+    (release_dir / "hol_guard.whl").write_bytes(owned_asset)
+    (dist_dir / "hol_guard.whl").write_bytes(owned_asset)
+    return release_dir, dist_dir
+
+
+def test_accepts_owned_assets_and_matching_mcpb_pair(tmp_path: Path) -> None:
+    release_dir, dist_dir = _directories(tmp_path)
+    mcpb = release_dir / f"hol-guard-{VERSION}.mcpb"
+    mcpb.write_bytes(b"signed bundle")
+    digest = hashlib.sha256(mcpb.read_bytes()).hexdigest()
+    (release_dir / f"{mcpb.name}.sha256").write_text(
+        f"{digest}  /temporary/build/{mcpb.name}\n",
+        encoding="utf-8",
+    )
+
+    verify_release_assets(release_dir, dist_dir, VERSION)
+
+
+def test_rejects_unowned_release_asset(tmp_path: Path) -> None:
+    release_dir, dist_dir = _directories(tmp_path)
+    (release_dir / "unowned.bin").write_bytes(b"untrusted")
+
+    with pytest.raises(ValueError, match=r"Unexpected release asset: unowned\.bin"):
+        verify_release_assets(release_dir, dist_dir, VERSION)
+
+
+@pytest.mark.parametrize("missing_suffix", ["", ".sha256"])
+def test_rejects_incomplete_mcpb_pair(tmp_path: Path, missing_suffix: str) -> None:
+    release_dir, dist_dir = _directories(tmp_path)
+    other_suffix = ".sha256" if missing_suffix == "" else ""
+    (release_dir / f"hol-guard-{VERSION}.mcpb{other_suffix}").write_bytes(b"incomplete")
+
+    with pytest.raises(ValueError, match="must both be present"):
+        verify_release_assets(release_dir, dist_dir, VERSION)
+
+
+def test_rejects_mcpb_checksum_mismatch(tmp_path: Path) -> None:
+    release_dir, dist_dir = _directories(tmp_path)
+    (release_dir / f"hol-guard-{VERSION}.mcpb").write_bytes(b"bundle")
+    (release_dir / f"hol-guard-{VERSION}.mcpb.sha256").write_text(
+        f"{'0' * 64}  bundle.mcpb\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="does not match its checksum"):
+        verify_release_assets(release_dir, dist_dir, VERSION)


### PR DESCRIPTION
## Summary
- verify every release asset owned by the PyPI workflow without rejecting assets owned by MCPB distribution
- apply the same idempotency contract to alpha and stable releases
- ratchet the release workflow test against total remote-asset counting

## Verification
- `uv run --no-sync pytest -q tests/test_release_train_workflow.py`
- `uv run --no-sync ruff check tests/test_release_train_workflow.py`
- `uv run --no-sync ruff format --check tests/test_release_train_workflow.py`