### PR TITLE
fix(release): make Windows native wheel reproducible

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -442,6 +442,7 @@ jobs:
             runtime: rust/target/aarch64-apple-darwin/release/hol-guard-runtime
           - runner: windows-latest
             platform_tag: win_amd64
+            rustflags: -C link-arg=/Brepro
             target: x86_64-pc-windows-msvc
             runtime: rust/target/x86_64-pc-windows-msvc/release/hol-guard-runtime.exe
     steps:
@@ -479,6 +480,7 @@ jobs:
         env:
           HOL_GUARD_BUILD_SHA: ${{ needs.build.outputs.source_sha }}
           HOL_GUARD_PACKAGE_VERSION: ${{ needs.build.outputs.version }}
+          RUSTFLAGS: ${{ matrix.rustflags }}
           RUST_TARGET: ${{ matrix.target }}
           RUNTIME: ${{ matrix.runtime }}
         run: |

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 15815,
-  "maximum_test_source_lines": 341323,
+  "maximum_collected_cases": 15816,
+  "maximum_test_source_lines": 341331,
   "schema_version": 1
 }

--- a/tests/test_guard_daemon_manager.py
+++ b/tests/test_guard_daemon_manager.py
@@ -722,6 +722,7 @@ def test_authenticated_daemon_state_rejects_post_write_tampering(tmp_path):
 def test_daemon_token_and_state_use_atomic_replacement(tmp_path, monkeypatch):
     guard_home = tmp_path / "guard-home"
     replacements: list[tuple[Path, Path]] = []
+    monkeypatch.setattr(daemon_manager_module, "_current_guard_daemon_runtime_fingerprint", lambda: "f" * 64)
     real_replace = daemon_manager_module.os.replace
 
     def recording_replace(source, destination) -> None:
@@ -731,7 +732,6 @@ def test_daemon_token_and_state_use_atomic_replacement(tmp_path, monkeypatch):
     monkeypatch.setattr(daemon_manager_module.os, "replace", recording_replace)
 
     daemon_manager_module.write_guard_daemon_state(guard_home, 4781, "secret-token")
-
     destinations = {destination for _temporary_path, destination in replacements}
     assert destinations == {
         daemon_manager_module._auth_token_path(guard_home),

--- a/tests/test_unpublished_alpha_reservation.py
+++ b/tests/test_unpublished_alpha_reservation.py
@@ -29,3 +29,11 @@ def test_unpublished_alpha_reservation_is_released_when_publish_fails() -> None:
 def test_native_guard_wheel_timeout_covers_musl_builds() -> None:
     native = load_workflow(PUBLISH_WORKFLOW)["jobs"]["build-native-guard-wheels"]
     assert native["timeout-minutes"] == 45
+
+
+def test_windows_native_guard_wheel_uses_reproducible_linker_mode() -> None:
+    native = load_workflow(PUBLISH_WORKFLOW)["jobs"]["build-native-guard-wheels"]
+    windows = next(row for row in native["strategy"]["matrix"]["include"] if row["platform_tag"] == "win_amd64")
+    build = next(step for step in native["steps"] if step.get("name") == "Build version-matched runtime")
+    assert windows["rustflags"] == "-C link-arg=/Brepro"
+    assert build["env"]["RUSTFLAGS"] == "${{ matrix.rustflags }}"


### PR DESCRIPTION
## Summary
- pass MSVC reproducible-linker mode only to the Windows native runtime build
- lock the platform-specific release workflow contract with a focused test

## Verification
- 18 focused release-workflow tests
- Ruff check and format
- actionlint
- test-suite and code-quality ratchets