### PR TITLE
fix(release): publish from authoritative branch events

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,16 +28,16 @@ on:
     branches: [main, release/3.0]
   pull_request:
     branches: [main, release/3.0]
-    types: [opened, synchronize, reopened, labeled, closed]
+    types: [opened, synchronize, reopened, labeled]
 
 permissions:
   contents: read
   pull-requests: read
 
 concurrency:
-  # Serialize publish-capable events for one release branch while keeping
-  # ordinary pull-request validation isolated by its merge ref.
-  group: hol-guard-publish-${{ github.event.pull_request.merged && format('refs/heads/{0}', github.event.pull_request.base.ref) || github.ref }}
+  # Serialize publish-capable branch events while keeping pull-request
+  # validation isolated by its merge ref.
+  group: hol-guard-publish-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -81,7 +81,6 @@ jobs:
   build:
     name: Build + Verify
     if: >-
-      (github.event.action != 'closed' || github.event.pull_request.merged) &&
       (github.event_name != 'workflow_dispatch' || github.run_attempt == 1) &&
       (github.event_name != 'push' || github.run_attempt == 1) &&
       (github.event_name != 'push' || !contains(github.event.head_commit.message || '', '[skip release publish]')) &&
@@ -97,7 +96,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
-          ref: ${{ (github.event.pull_request.merged && github.event.pull_request.merge_commit_sha) || (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
+          ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.12"
@@ -126,10 +125,6 @@ jobs:
           GITHUB_EVENT_ACTION: ${{ github.event.action }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_MERGED: ${{ github.event.pull_request.merged }}
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          PR_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
-          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
           GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
           GITHUB_ACTOR_ID: ${{ github.actor_id }}
@@ -197,7 +192,7 @@ jobs:
               VALIDATOR_ARGS+=(--existing-version "$existing_version")
             done
             VERSION=$(uv run --no-sync python scripts/validate_alpha_release.py "${VALIDATOR_ARGS[@]}")
-          elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/release/3.0" ]] || [[ "$GITHUB_EVENT_NAME" == "pull_request" && "$GITHUB_EVENT_ACTION" == "closed" && "$PR_MERGED" == "true" && "$PR_BASE_REF" == "release/3.0" && "$PR_HEAD_REPO" == "$GITHUB_REPOSITORY" && -n "$PR_MERGE_SHA" ]]; then
+          elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/release/3.0" ]]; then
             if [[ "$RELEASE_PUBLISHING_ENABLED" != "true" ]]; then
               echo "Release publishing is disabled until protected environments are verified" >&2
               exit 1
@@ -206,11 +201,6 @@ jobs:
             TRAIN_REF="refs/heads/release/${TRAIN}"
             ACTUAL_REF="$GITHUB_REF"
             EXPECTED_SOURCE="$GITHUB_SHA"
-            if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
-              SOURCE_SHA="$PR_MERGE_SHA"
-              EXPECTED_SOURCE="$PR_MERGE_SHA"
-              ACTUAL_REF="$TRAIN_REF"
-            fi
             if [[ "$SOURCE_SHA" != "$EXPECTED_SOURCE" ]]; then
               echo "Checked-out source does not match the immutable release source" >&2
               exit 1
@@ -414,7 +404,7 @@ jobs:
         (
           needs.build.outputs.channel == 'alpha' &&
           (
-            (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0') || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged && github.event.pull_request.base.ref == 'release/3.0' && github.event.pull_request.head.repo.full_name == github.repository) ||
+            (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0') ||
             (github.event_name == 'workflow_dispatch' && github.event.inputs.release_train == '3.0')
           )
         )
@@ -782,7 +772,7 @@ jobs:
       needs.build.outputs.channel == 'alpha' &&
       (
         (github.event_name == 'workflow_dispatch' && github.run_attempt == 1) ||
-        (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0') || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged && github.event.pull_request.base.ref == 'release/3.0' && github.event.pull_request.head.repo.full_name == github.repository)
+        (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0')
       )
     needs: [build, assemble-native-guard-distributions]
     runs-on: ubuntu-latest
@@ -812,7 +802,7 @@ jobs:
       needs.build.outputs.channel == 'alpha' &&
       (
         (github.event_name == 'workflow_dispatch' && github.run_attempt == 1) ||
-        (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0') || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged && github.event.pull_request.base.ref == 'release/3.0' && github.event.pull_request.head.repo.full_name == github.repository)
+        (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0')
       )
     needs: [build, reserve-alpha-tag, assemble-native-guard-distributions]
     runs-on: ubuntu-latest
@@ -917,7 +907,7 @@ jobs:
       needs.build.outputs.channel == 'alpha' &&
       (
         (github.event_name == 'workflow_dispatch' && github.run_attempt == 1) ||
-        (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0') || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged && github.event.pull_request.base.ref == 'release/3.0' && github.event.pull_request.head.repo.full_name == github.repository)
+        (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0')
       )
     needs: [build, reserve-alpha-tag, assemble-native-guard-distributions]
     runs-on: ubuntu-latest
@@ -1433,7 +1423,7 @@ jobs:
       needs.build.outputs.channel == 'alpha' &&
       (
         (github.event_name == 'workflow_dispatch' && github.run_attempt == 1) ||
-        (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0') || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged && github.event.pull_request.base.ref == 'release/3.0' && github.event.pull_request.head.repo.full_name == github.repository)
+        (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0')
       )
     needs: [build, publish-alpha-pypi]
     runs-on: ubuntu-latest
@@ -1541,7 +1531,7 @@ jobs:
         (
           (
             (github.event_name == 'workflow_dispatch' && github.run_attempt == 1) ||
-            (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0') || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged && github.event.pull_request.base.ref == 'release/3.0' && github.event.pull_request.head.repo.full_name == github.repository)
+            (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0')
           ) &&
           needs.build.outputs.channel == 'alpha' &&
           needs.publish-alpha-pypi.result == 'success' &&

--- a/tests/test_pr_testpypi_canary_workflow.py
+++ b/tests/test_pr_testpypi_canary_workflow.py
@@ -13,7 +13,7 @@ def test_pr_canary_requires_maintainer_opt_in_for_same_repository_prs() -> None:
 
     assert workflow[True]["pull_request"] == {
         "branches": ["main", "release/3.0"],
-        "types": ["opened", "synchronize", "reopened", "labeled", "closed"],
+        "types": ["opened", "synchronize", "reopened", "labeled"],
     }
     assert workflow["permissions"] == {"contents": "read", "pull-requests": "read"}
     job = workflow["jobs"]["publish-testpypi"]

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -43,7 +43,6 @@ def test_release_branches_run_ci_and_pr_canaries() -> None:
         "synchronize",
         "reopened",
         "labeled",
-        "closed",
     ]
     assert "tags" not in publish[True]["push"]
 
@@ -62,9 +61,7 @@ def test_release_branch_pushes_publish_alpha_while_main_pushes_publish_stable() 
         assert "github.event_name == 'workflow_dispatch'" in condition
         assert "github.event_name == 'push'" in condition
         assert "github.ref == 'refs/heads/release/3.0'" in condition
-        assert "github.event.action == 'closed'" in condition
-        assert "github.event.pull_request.merged" in condition
-        assert "github.event.pull_request.base.ref == 'release/3.0'" in condition
+        assert "github.event.action == 'closed'" not in condition
     for job_name in ("publish-main-testpypi", "publish-main-pypi", "release-main"):
         condition = jobs[job_name]["if"]
         assert "github.event_name == 'push'" in condition
@@ -91,9 +88,7 @@ def test_main_push_build_computes_a_registry_derived_stable_version() -> None:
     assert 'VERSION="$BASE_VERSION"' in compute_run
     assert 'elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/release/3.0" ]]' in compute_run
     assert "pull_request" in compute_run
-    assert compute_run.index("PR_MERGE_SHA") < compute_run.index('elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]')
-    assert 'SOURCE_SHA="$PR_MERGE_SHA"' in compute_run
-    assert 'ACTUAL_REF="$TRAIN_REF"' in compute_run
+    assert "PR_MERGE_SHA" not in compute_run
     assert 'SOURCE_SHA" != "$EXPECTED_SOURCE"' in compute_run
     assert 'TRAIN="3.0"' in compute_run
     assert "compute_alpha_release_version.py" in compute_run
@@ -542,21 +537,17 @@ def test_release_push_can_be_explicitly_suppressed_by_merge_marker() -> None:
     assert "github.event_name != 'push'" in condition
     assert "github.event.head_commit.message || ''" in condition
     assert "[skip release publish]" in condition
-    assert "github.event.action != 'closed'" in workflow["jobs"]["build"]["if"]
-    assert "github.event.pull_request.merged" in workflow["jobs"]["build"]["if"]
+    assert "github.event.action != 'closed'" not in workflow["jobs"]["build"]["if"]
 
 
-def test_release_merged_same_repo_pr_publishes_alpha_when_push_is_missing() -> None:
+def test_release_branch_push_is_the_single_automatic_alpha_publisher() -> None:
     workflow = _workflow(PUBLISH_WORKFLOW)
     jobs = workflow["jobs"]
     workflow_text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
 
-    assert "closed" in workflow[True]["pull_request"]["types"]
-    assert "github.event.pull_request.merge_commit_sha" in workflow_text
-    assert (
-        "hol-guard-publish-${{ github.event.pull_request.merged && "
-        "format('refs/heads/{0}', github.event.pull_request.base.ref) || github.ref }}" in workflow_text
-    )
+    assert "closed" not in workflow[True]["pull_request"]["types"]
+    assert "github.event.pull_request.merge_commit_sha" not in workflow_text
+    assert "group: hol-guard-publish-${{ github.ref }}" in workflow_text
     for job_name in (
         "reserve-alpha-tag",
         "publish-alpha-testpypi",
@@ -564,5 +555,5 @@ def test_release_merged_same_repo_pr_publishes_alpha_when_push_is_missing() -> N
         "release-alpha",
     ):
         condition = jobs[job_name]["if"]
-        assert "github.event.action == 'closed'" in condition
-        assert "github.event.pull_request.head.repo.full_name == github.repository" in condition
+        assert "github.event.action == 'closed'" not in condition
+        assert "github.event.pull_request.merged" not in condition


### PR DESCRIPTION
## Summary
- make release-branch pushes and authorized dispatches the only publish-capable events
- keep pull requests limited to validation and opt-in canaries
- ratchet workflow tests against PR-closed publication

## Verification
- `uv run --no-sync pytest -q tests/test_release_train_workflow.py tests/test_pr_testpypi_canary_workflow.py tests/test_privileged_workflow_policy.py`
- `uv run --no-sync ruff check tests/test_release_train_workflow.py tests/test_pr_testpypi_canary_workflow.py`
- `actionlint .github/workflows/publish.yml`
- `git diff --check`