### PR TITLE
fix(release): copy Cloud Review artifacts into Desktop Core freeze

### DIFF
--- a/.github/workflows/desktop-core-alpha-feed.yml
+++ b/.github/workflows/desktop-core-alpha-feed.yml
@@ -318,6 +318,14 @@ jobs:
               *) echo "Version stamping changed an unexpected Core file: $changed_path" >&2; exit 1 ;;
             esac
           done < <(git -C "$SOURCE" diff --name-only)
+          # Editable uv installs do not apply hatch force-include, so copy the
+          # Cloud Review artifacts into package data before PyInstaller freeze.
+          DATA_ROOT="$SOURCE/src/codex_plugin_scanner/guard/contracts/data/guard-cloud-review"
+          mkdir -p "$DATA_ROOT/v2"
+          cp "$SOURCE/contracts/guard-cloud-review/v2/contract.json" "$DATA_ROOT/v2/contract.json"
+          cp "$SOURCE/contracts/guard-cloud-review/v2/command-result.json" "$DATA_ROOT/v2/command-result.json"
+          cp "$SOURCE/contracts/guard-cloud-review/v2/fixtures.json" "$DATA_ROOT/v2/fixtures.json"
+          cp "$SOURCE/docs/guard/contracts/guard-cloud-review.md" "$DATA_ROOT/guard-cloud-review.md"
           (
             cd "$SOURCE"
             uv run --no-sync pyinstaller --codesign-identity "$APPLE_SIGNING_IDENTITY" \

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
-  "maximum_collected_cases": 12861,
-  "maximum_test_source_lines": 293542,
+  "maximum_collected_cases": 12862,
+  "maximum_test_source_lines": 293556,
   "schema_version": 1
 }

--- a/tests/test_desktop_core_alpha_feed_security.py
+++ b/tests/test_desktop_core_alpha_feed_security.py
@@ -131,9 +131,16 @@ def test_macos_feed_avoids_bash4_only_builtins_and_binds_mode() -> None:
 
 def test_frozen_sidecar_copies_cloud_review_package_data() -> None:
     text = workflow_text()
-    assert "codex_plugin_scanner/guard/contracts/data/guard-cloud-review" in text
-    assert "contracts/guard-cloud-review/v2/contract.json" in text
-    assert "docs/guard/contracts/guard-cloud-review.md" in text
+    copies = (
+        'cp "$SOURCE/contracts/guard-cloud-review/v2/contract.json" "$DATA_ROOT/v2/contract.json"',
+        'cp "$SOURCE/contracts/guard-cloud-review/v2/command-result.json" "$DATA_ROOT/v2/command-result.json"',
+        'cp "$SOURCE/contracts/guard-cloud-review/v2/fixtures.json" "$DATA_ROOT/v2/fixtures.json"',
+        'cp "$SOURCE/docs/guard/contracts/guard-cloud-review.md" "$DATA_ROOT/guard-cloud-review.md"',
+    )
+    assert 'DATA_ROOT="$SOURCE/src/codex_plugin_scanner/guard/contracts/data/guard-cloud-review"' in text
+    assert 'mkdir -p "$DATA_ROOT/v2"' in text
+    for command in copies:
+        assert command in text
 
 
 def test_existing_asset_set_is_all_or_nothing(tmp_path: Path, capsys) -> None:

--- a/tests/test_desktop_core_alpha_feed_security.py
+++ b/tests/test_desktop_core_alpha_feed_security.py
@@ -129,6 +129,13 @@ def test_macos_feed_avoids_bash4_only_builtins_and_binds_mode() -> None:
     assert '-name "hol_guard-${CORE_VERSION}-*.whl"' not in text
 
 
+def test_frozen_sidecar_copies_cloud_review_package_data() -> None:
+    text = workflow_text()
+    assert "codex_plugin_scanner/guard/contracts/data/guard-cloud-review" in text
+    assert "contracts/guard-cloud-review/v2/contract.json" in text
+    assert "docs/guard/contracts/guard-cloud-review.md" in text
+
+
 def test_existing_asset_set_is_all_or_nothing(tmp_path: Path, capsys) -> None:
     namespace = runpy.run_path(str(TOOL))
     assets = tmp_path / "assets.txt"


### PR DESCRIPTION
## Summary
- Copy Guard Cloud Review contract artifacts into package data before the Desktop Core PyInstaller freeze so the signed sidecar can start.
- Cover that packaging step in the feed workflow contract test.

## Testing
- `pytest tests/test_desktop_core_alpha_feed_security.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * macOS standalone builds now include Cloud Review contract files, scanner data, and documentation.
  * Cloud Review features in packaged applications can access the required supporting artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->