### PR TITLE
fix(guard): restore readable sqlite stores after false-unusable recovery

### DIFF
--- a/ci/code-quality-baseline.json
+++ b/ci/code-quality-baseline.json
@@ -578,7 +578,7 @@
     "src/codex_plugin_scanner/guard/shims.py": 1595,
     "src/codex_plugin_scanner/guard/store_approvals.py": 1256,
     "src/codex_plugin_scanner/guard/store_base.py": 1680,
-    "src/codex_plugin_scanner/guard/store_connection_schema.py": 1358,
+    "src/codex_plugin_scanner/guard/store_connection_schema.py": 1376,
     "src/codex_plugin_scanner/guard/store_extension_control_authority.py": 1093,
     "src/codex_plugin_scanner/guard/store_oauth.py": 1173,
     "src/codex_plugin_scanner/guard/store_policy.py": 2463,

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
-  "maximum_collected_cases": 16019,
-  "maximum_test_source_lines": 346230
+  "maximum_collected_cases": 16024,
+  "maximum_test_source_lines": 346491
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
-  "maximum_collected_cases": 16024,
-  "maximum_test_source_lines": 346491
+  "maximum_collected_cases": 16027,
+  "maximum_test_source_lines": 346551
 }

--- a/src/codex_plugin_scanner/guard/daemon/local_cli_api.py
+++ b/src/codex_plugin_scanner/guard/daemon/local_cli_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -55,6 +56,7 @@ from ..runtime.package_json_script_memory import (
 )
 from ..runtime.package_json_scripts import looks_like_package_script_paste
 from .local_cli_continuity_api import decorate_local_cli_continuity
+from .local_cli_mcp_store import bound_mcp_observation, stored_mcp_has_tools, stored_mcp_recognition
 
 if TYPE_CHECKING:
     from ..store import GuardStore
@@ -98,8 +100,18 @@ class LocalCliApiService:
         home_dir = Path.home()
         live_command = None
         cli_id = payload.get("cli_id")
+        stored_id = cli_id if isinstance(cli_id, str) and is_local_cli_id(cli_id) else None
+        stored_mcp = stored_mcp_recognition(
+            self._store,
+            command,
+            cli_id=stored_id,
+            recognize_payload=self._recognize_payload,
+            recognize_summary=_recognize_mcp_summary,
+        )
+        if stored_mcp is not None and stored_mcp_has_tools(stored_mcp):
+            return stored_mcp
         tokens = mcp_launch_tokens(command, cwd=home_dir, home_dir=home_dir)
-        if isinstance(cli_id, str) and is_local_cli_id(cli_id):
+        if stored_id is not None:
             _ = self._observe_harness_mcp_servers()
             live_command = self._live_mcp_launch_command(payload)
         elif tokens is not None and is_package_mcp_launcher(tokens):
@@ -107,6 +119,8 @@ class LocalCliApiService:
         mcp_item = self._recognize_mcp(live_command or command, home_dir)
         if mcp_item is not None:
             return mcp_item
+        if stored_mcp is not None:
+            return stored_mcp
         operator_cwd = operator_working_directory(payload, home_dir=home_dir)
         package_scripts = recognize_operator_package_scripts(
             command,
@@ -154,8 +168,20 @@ class LocalCliApiService:
         tokens = mcp_launch_tokens(command, cwd=home_dir, home_dir=home_dir)
         if tokens is None or not looks_like_mcp_launch(tokens, command_text=command, cwd=home_dir, home_dir=home_dir):
             return None
-        probed = probe_stdio_mcp_server(command, cwd=home_dir, home_dir=home_dir)
+        try:
+            probed = probe_stdio_mcp_server(command, cwd=home_dir, home_dir=home_dir)
+        except (OSError, RuntimeError, TimeoutError):
+            probed = None
         if probed is None:
+            stored = stored_mcp_recognition(
+                self._store,
+                command,
+                cli_id=None,
+                recognize_payload=self._recognize_payload,
+                recognize_summary=_recognize_mcp_summary,
+            )
+            if stored is not None:
+                return stored
             if is_strict_package_mcp_launcher(tokens):
                 launcher = Path(tokens[0]).name
                 raise LocalCliApiError(
@@ -167,7 +193,7 @@ class LocalCliApiService:
                     ),
                 )
             return None
-        identity, server_hash, server_command, server_args_hash = _bound_mcp_observation(
+        identity, server_hash, server_command, server_args_hash = bound_mcp_observation(
             self._store,
             probed.identity,
             probed.server_identity,
@@ -197,7 +223,7 @@ class LocalCliApiService:
                 self._discovered_servers(),
                 seen_at=utc_now(),
             )
-        except (OSError, RuntimeError, TypeError, ValueError):
+        except (OSError, RuntimeError, TypeError, ValueError, sqlite3.Error):
             return {}
 
     def _discovered_servers(self) -> tuple[DiscoveredHarnessMcpServer, ...]:
@@ -369,49 +395,6 @@ class LocalCliApiService:
         if type(value) is not int:
             raise LocalCliApiError(400, f"missing_{key}")
         return value
-
-
-def _bound_mcp_observation(
-    store: object,
-    probed_identity: UnlistedCliIdentity,
-    server_identity: object,
-) -> tuple[UnlistedCliIdentity, str, str, str]:
-    identity_hash = getattr(server_identity, "identity_hash", "")
-    command = getattr(server_identity, "command", "")
-    args_hash = getattr(server_identity, "args_hash", "")
-    finder = getattr(store, "find_local_mcp_observation", None)
-    existing = (
-        finder(server_identity_hash=identity_hash, command=command, args_hash=args_hash) if callable(finder) else None
-    )
-    if not isinstance(existing, dict):
-        return probed_identity, str(identity_hash), str(command), str(args_hash)
-    cli_id = existing.get("cli_id")
-    stored_hash = existing.get("identity_hash")
-    if not isinstance(cli_id, str) or not isinstance(stored_hash, str):
-        return probed_identity, str(identity_hash), str(command), str(args_hash)
-    name = existing.get("name")
-    stored_label = existing.get("example_label")
-    identity = UnlistedCliIdentity(
-        cli_id=cli_id,
-        name=name if isinstance(name, str) and name.strip() else probed_identity.name,
-        kind="executable",
-        identity_hash=stored_hash,
-        example_label=stored_label
-        if isinstance(stored_label, str) and stored_label.strip()
-        else probed_identity.example_label,
-    )
-    return (
-        identity,
-        _string_field(existing.get("server_identity_hash"), identity_hash),
-        _string_field(existing.get("server_command"), command),
-        _string_field(existing.get("server_args_hash"), args_hash),
-    )
-
-
-def _string_field(value: object, fallback: object) -> str:
-    if isinstance(value, str) and value:
-        return value
-    return str(fallback)
 
 
 def _preview_summary(name: str, state: str) -> str:

--- a/src/codex_plugin_scanner/guard/daemon/local_cli_api.py
+++ b/src/codex_plugin_scanner/guard/daemon/local_cli_api.py
@@ -56,7 +56,7 @@ from ..runtime.package_json_script_memory import (
 )
 from ..runtime.package_json_scripts import looks_like_package_script_paste
 from .local_cli_continuity_api import decorate_local_cli_continuity
-from .local_cli_mcp_store import bound_mcp_observation, stored_mcp_has_tools, stored_mcp_recognition
+from .local_cli_mcp_store import bound_mcp_observation, stored_mcp_recognition
 
 if TYPE_CHECKING:
     from ..store import GuardStore
@@ -108,8 +108,6 @@ class LocalCliApiService:
             recognize_payload=self._recognize_payload,
             recognize_summary=_recognize_mcp_summary,
         )
-        if stored_mcp is not None and stored_mcp_has_tools(stored_mcp):
-            return stored_mcp
         tokens = mcp_launch_tokens(command, cwd=home_dir, home_dir=home_dir)
         if stored_id is not None:
             _ = self._observe_harness_mcp_servers()

--- a/src/codex_plugin_scanner/guard/daemon/local_cli_mcp_store.py
+++ b/src/codex_plugin_scanner/guard/daemon/local_cli_mcp_store.py
@@ -1,0 +1,109 @@
+"""Read stored MCP observations when live probing is unavailable."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+from ..runtime.local_cli_identity import UnlistedCliIdentity
+from ..runtime.local_mcp_probe import mcp_launch_tokens
+from ..runtime.mcp_protection import build_mcp_server_identity
+
+RecognizePayload = Callable[[str, dict[str, object], str, str], dict[str, object]]
+RecognizeSummary = Callable[[str, str, int], str]
+
+
+def stored_mcp_has_tools(payload: dict[str, object]) -> bool:
+    item = payload.get("item")
+    if not isinstance(item, dict):
+        return False
+    commands = item.get("commands")
+    if not isinstance(commands, list) or not commands:
+        return False
+    return any(isinstance(entry, dict) and entry.get("command_id") for entry in commands)
+
+
+def stored_mcp_recognition(
+    store: object,
+    command: str,
+    *,
+    cli_id: str | None,
+    recognize_payload: RecognizePayload,
+    recognize_summary: RecognizeSummary,
+) -> dict[str, object] | None:
+    tokens = mcp_launch_tokens(command, cwd=Path.home(), home_dir=Path.home())
+    launch_command = None
+    args_hash = None
+    if tokens is not None:
+        identity = build_mcp_server_identity(
+            config_path="",
+            command=tokens[0],
+            args=tuple(tokens[1:]),
+            transport="stdio",
+        )
+        launch_command = identity.command
+        args_hash = identity.args_hash
+    finder = getattr(store, "find_local_mcp_observation", None)
+    found = finder(cli_id=cli_id, command=launch_command, args_hash=args_hash) if callable(finder) else None
+    if found is None:
+        return None
+    found_id = found.get("cli_id")
+    if not isinstance(found_id, str):
+        return None
+    lister = getattr(store, "list_local_cli_items", None)
+    listed = next(
+        (item for item in (lister() if callable(lister) else []) if item.get("cli_id") == found_id),
+        None,
+    )
+    if listed is None:
+        return None
+    help_status = listed.get("help_status")
+    status = help_status if help_status in {"ok", "empty", "failed"} else "failed"
+    raw_commands = listed.get("commands")
+    count = len(raw_commands) if isinstance(raw_commands, list) else 0
+    name = listed.get("name")
+    label = name if isinstance(name, str) and name.strip() else found_id
+    return recognize_payload(found_id, listed, status, recognize_summary(label, status, count))
+
+
+def bound_mcp_observation(
+    store: object,
+    probed_identity: UnlistedCliIdentity,
+    server_identity: object,
+) -> tuple[UnlistedCliIdentity, str, str, str]:
+    identity_hash = getattr(server_identity, "identity_hash", "")
+    command = getattr(server_identity, "command", "")
+    args_hash = getattr(server_identity, "args_hash", "")
+    finder = getattr(store, "find_local_mcp_observation", None)
+    existing = (
+        finder(server_identity_hash=identity_hash, command=command, args_hash=args_hash) if callable(finder) else None
+    )
+    if not isinstance(existing, dict):
+        return probed_identity, str(identity_hash), str(command), str(args_hash)
+    cli_id = existing.get("cli_id")
+    stored_hash = existing.get("identity_hash")
+    if not isinstance(cli_id, str) or not isinstance(stored_hash, str):
+        return probed_identity, str(identity_hash), str(command), str(args_hash)
+    name = existing.get("name")
+    stored_label = existing.get("example_label")
+    identity = UnlistedCliIdentity(
+        cli_id=cli_id,
+        name=name if isinstance(name, str) and name.strip() else probed_identity.name,
+        kind="executable",
+        identity_hash=stored_hash,
+        example_label=stored_label
+        if isinstance(stored_label, str) and stored_label.strip()
+        else probed_identity.example_label,
+    )
+    return (
+        identity,
+        _string_field(existing.get("server_identity_hash"), identity_hash),
+        _string_field(existing.get("server_command"), command),
+        _string_field(existing.get("server_args_hash"), args_hash),
+    )
+
+
+def _string_field(value: object, fallback: object) -> str:
+    if isinstance(value, str) and value:
+        return value
+    return str(fallback)

--- a/src/codex_plugin_scanner/guard/daemon/local_cli_mcp_store.py
+++ b/src/codex_plugin_scanner/guard/daemon/local_cli_mcp_store.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+import sqlite3
+from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 
 from ..runtime.local_cli_identity import UnlistedCliIdentity
@@ -31,39 +32,48 @@ def stored_mcp_recognition(
     recognize_payload: RecognizePayload,
     recognize_summary: RecognizeSummary,
 ) -> dict[str, object] | None:
-    tokens = mcp_launch_tokens(command, cwd=Path.home(), home_dir=Path.home())
-    launch_command = None
-    args_hash = None
-    if tokens is not None:
-        identity = build_mcp_server_identity(
-            config_path="",
-            command=tokens[0],
-            args=tuple(tokens[1:]),
-            transport="stdio",
+    try:
+        finder = getattr(store, "find_local_mcp_observation", None)
+        if not callable(finder):
+            return None
+        found: object
+        if cli_id is not None:
+            found = finder(cli_id=cli_id)
+        else:
+            tokens = mcp_launch_tokens(command, cwd=Path.home(), home_dir=Path.home())
+            if tokens is None:
+                return None
+            identity = build_mcp_server_identity(
+                config_path="",
+                command=tokens[0],
+                args=tuple(tokens[1:]),
+                transport="stdio",
+            )
+            found = finder(command=identity.command, args_hash=identity.args_hash)
+        if not isinstance(found, Mapping):
+            return None
+        found_id = found.get("cli_id")
+        if not isinstance(found_id, str):
+            return None
+        lister = getattr(store, "list_local_cli_items", None)
+        listed_raw = lister() if callable(lister) else ()
+        if not isinstance(listed_raw, Sequence) or isinstance(listed_raw, (str, bytes)):
+            return None
+        listed = next(
+            (item for item in listed_raw if isinstance(item, dict) and item.get("cli_id") == found_id),
+            None,
         )
-        launch_command = identity.command
-        args_hash = identity.args_hash
-    finder = getattr(store, "find_local_mcp_observation", None)
-    found = finder(cli_id=cli_id, command=launch_command, args_hash=args_hash) if callable(finder) else None
-    if found is None:
+        if listed is None:
+            return None
+        help_status = listed.get("help_status")
+        status = help_status if help_status in {"ok", "empty", "failed"} else "failed"
+        raw_commands = listed.get("commands")
+        count = len(raw_commands) if isinstance(raw_commands, list) else 0
+        name = listed.get("name")
+        label = name if isinstance(name, str) and name.strip() else found_id
+        return recognize_payload(found_id, listed, status, recognize_summary(label, status, count))
+    except sqlite3.Error:
         return None
-    found_id = found.get("cli_id")
-    if not isinstance(found_id, str):
-        return None
-    lister = getattr(store, "list_local_cli_items", None)
-    listed = next(
-        (item for item in (lister() if callable(lister) else []) if item.get("cli_id") == found_id),
-        None,
-    )
-    if listed is None:
-        return None
-    help_status = listed.get("help_status")
-    status = help_status if help_status in {"ok", "empty", "failed"} else "failed"
-    raw_commands = listed.get("commands")
-    count = len(raw_commands) if isinstance(raw_commands, list) else 0
-    name = listed.get("name")
-    label = name if isinstance(name, str) and name.strip() else found_id
-    return recognize_payload(found_id, listed, status, recognize_summary(label, status, count))
 
 
 def bound_mcp_observation(

--- a/src/codex_plugin_scanner/guard/sqlite_recovery.py
+++ b/src/codex_plugin_scanner/guard/sqlite_recovery.py
@@ -17,9 +17,13 @@ SQLITE_IO_ERROR_MARKER = "disk i/o error"
 SQLiteStoreProbe = Literal["fatal", "healthy", "io", "unknown"]
 
 
+def _sqlite_readonly_uri(path: Path) -> str:
+    return f"{path.resolve().as_uri()}?mode=ro"
+
+
 def _probe_sqlite_store(path: Path) -> SQLiteStoreProbe:
     try:
-        with sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=1.0) as connection:
+        with sqlite3.connect(_sqlite_readonly_uri(path), uri=True, timeout=1.0) as connection:
             result = connection.execute("pragma quick_check").fetchone()
     except sqlite3.DatabaseError as error:
         message = str(error).lower()
@@ -74,12 +78,25 @@ def restore_readable_sqlite_store(*, destination: Path, quarantined: Path) -> bo
         return False
     if _probe_sqlite_store(quarantined) != "healthy":
         return False
+    extras = [
+        (Path(f"{quarantined}{suffix}"), Path(f"{destination}{suffix}"))
+        for suffix in ("-wal", "-shm")
+        if Path(f"{quarantined}{suffix}").exists() and not Path(f"{quarantined}{suffix}").is_symlink()
+    ]
     try:
         quarantined.replace(destination)
-        for suffix in ("-wal", "-shm"):
-            extra = Path(f"{quarantined}{suffix}")
-            if extra.exists() and not extra.is_symlink():
-                extra.replace(Path(f"{destination}{suffix}"))
+    except OSError:
+        return False
+    moved: list[tuple[Path, Path]] = []
+    try:
+        for source, target in extras:
+            source.replace(target)
+            moved.append((source, target))
         return True
     except OSError:
+        for source, target in reversed(moved):
+            with suppress(OSError):
+                target.replace(source)
+        with suppress(OSError):
+            destination.replace(quarantined)
         return False

--- a/src/codex_plugin_scanner/guard/sqlite_recovery.py
+++ b/src/codex_plugin_scanner/guard/sqlite_recovery.py
@@ -19,7 +19,7 @@ SQLiteStoreProbe = Literal["fatal", "healthy", "io", "unknown"]
 
 def _probe_sqlite_store(path: Path) -> SQLiteStoreProbe:
     try:
-        with sqlite3.connect(path, timeout=0.1) as connection:
+        with sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=1.0) as connection:
             result = connection.execute("pragma quick_check").fetchone()
     except sqlite3.DatabaseError as error:
         message = str(error).lower()
@@ -65,3 +65,21 @@ def sqlite_store_is_proven_unusable(
     if state != "io" or not _guard_home_accepts_sqlite_write(guard_home):
         return False
     return _probe_sqlite_store(path) in {"fatal", "io"}
+
+
+def restore_readable_sqlite_store(*, destination: Path, quarantined: Path) -> bool:
+    """Move a quarantined store back when it still opens and passes integrity."""
+
+    if destination.exists() or destination.is_symlink():
+        return False
+    if _probe_sqlite_store(quarantined) != "healthy":
+        return False
+    try:
+        quarantined.replace(destination)
+        for suffix in ("-wal", "-shm"):
+            extra = Path(f"{quarantined}{suffix}")
+            if extra.exists() and not extra.is_symlink():
+                extra.replace(Path(f"{destination}{suffix}"))
+        return True
+    except OSError:
+        return False

--- a/src/codex_plugin_scanner/guard/store_connection_schema.py
+++ b/src/codex_plugin_scanner/guard/store_connection_schema.py
@@ -185,6 +185,7 @@ class StoreConnectionSchemaMixin:
     _startup_prefetched_policy_integrity_repair_failed = False
     _storage_recovery_local: ClassVar[threading.local] = threading.local()
     _storage_gate_local: ClassVar[threading.local] = threading.local()
+    _last_sqlite_recovery = "skipped"
 
     def _current_thread_owns_storage_recovery(self) -> bool:
         return getattr(self._storage_recovery_local, "owner", None) == id(self)
@@ -364,9 +365,8 @@ class StoreConnectionSchemaMixin:
                     raise
         if fatal_error is None:
             return
-        self._recover_fatal_sqlite_store(fatal_error, failed_identity=failed_identity)
-        retry = sqlite_error_is_busy_locked(fatal_error) or getattr(self, "_last_sqlite_recovery", None) == "restored"
-        if not retry:
+        recovered = self._recover_fatal_sqlite_store(fatal_error, failed_identity=failed_identity)
+        if not recovered and not sqlite_error_is_busy_locked(fatal_error):
             raise fatal_error
         with self._hold_storage_gate(exclusive=False), self._connect_once() as connection:
             yield connection

--- a/src/codex_plugin_scanner/guard/store_connection_schema.py
+++ b/src/codex_plugin_scanner/guard/store_connection_schema.py
@@ -22,6 +22,7 @@ from .sqlite_profile import (
 from .sqlite_recovery import (
     FATAL_SQLITE_ERROR_MARKERS,
     SQLITE_IO_ERROR_MARKER,
+    restore_readable_sqlite_store,
     sqlite_store_is_proven_unusable,
 )
 
@@ -264,6 +265,7 @@ class StoreConnectionSchemaMixin:
         *,
         failed_identity: tuple[int, int] | None = None,
     ) -> bool:
+        self._last_sqlite_recovery = "skipped"
         is_io_error = SQLITE_IO_ERROR_MARKER in str(error).lower()
         if (
             not isinstance(error, sqlite3.DatabaseError)
@@ -286,6 +288,7 @@ class StoreConnectionSchemaMixin:
             except OSError:
                 current_identity = None
             if current_identity != failed_identity:
+                self._last_sqlite_recovery = "replaced"
                 return True
 
             if not self._store_is_proven_unusable(error):
@@ -293,19 +296,24 @@ class StoreConnectionSchemaMixin:
 
             stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
             quarantine_id = f"{stamp}-{uuid4().hex[:8]}"
+            quarantined = self.guard_home / f"guard.db.corrupt-{quarantine_id}"
             for suffix in ("", "-wal", "-shm"):
                 source = Path(f"{self.path}{suffix}")
                 if not source.exists() or source.is_symlink():
                     continue
-                destination = self.guard_home / f"guard.db.corrupt-{quarantine_id}{suffix}"
-                source.replace(destination)
+                source.replace(self.guard_home / f"{quarantined.name}{suffix}")
             _store_logger.error(
                 "Guard quarantined an unusable SQLite store after a fatal storage error: %s",
                 type(error).__name__,
             )
             self._storage_recovery_local.owner = id(self)
             try:
-                self._initialize_schema()
+                if restore_readable_sqlite_store(destination=self.path, quarantined=quarantined):
+                    self._last_sqlite_recovery = "restored"
+                    _store_logger.error("Guard restored the quarantined SQLite store after it still opened cleanly.")
+                else:
+                    self._initialize_schema()
+                    self._last_sqlite_recovery = "reinitialized"
             finally:
                 self._storage_recovery_local.owner = None
             return True
@@ -336,12 +344,15 @@ class StoreConnectionSchemaMixin:
             with self._connect_once() as connection:
                 yield connection
             return
+        yielded = False
         fatal_error: sqlite3.DatabaseError | None = None
         failed_identity: tuple[int, int] | None = None
         with self._hold_storage_gate(exclusive=False):
             try:
                 with self._connect_once() as connection:
+                    yielded = True
                     yield connection
+                return
             except sqlite3.DatabaseError as error:
                 fatal_error = error
                 try:
@@ -349,9 +360,16 @@ class StoreConnectionSchemaMixin:
                     failed_identity = failed_stat.st_dev, failed_stat.st_ino
                 except OSError:
                     failed_identity = None
-        if fatal_error is not None:
-            self._recover_fatal_sqlite_store(fatal_error, failed_identity=failed_identity)
+                if yielded:
+                    raise
+        if fatal_error is None:
+            return
+        self._recover_fatal_sqlite_store(fatal_error, failed_identity=failed_identity)
+        retry = sqlite_error_is_busy_locked(fatal_error) or getattr(self, "_last_sqlite_recovery", None) == "restored"
+        if not retry:
             raise fatal_error
+        with self._hold_storage_gate(exclusive=False), self._connect_once() as connection:
+            yield connection
 
     @contextmanager
     def _connect_once(self) -> Iterator[sqlite3.Connection]:

--- a/tests/test_guard_local_cli_mcp_recognize.py
+++ b/tests/test_guard_local_cli_mcp_recognize.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from codex_plugin_scanner.guard.adapters.harness_mcp_discovery import (
+    discover_harness_mcp_servers,
+    persist_discovered_harness_mcp_servers,
+)
+from codex_plugin_scanner.guard.daemon.local_cli_api import LocalCliApiService
+from codex_plugin_scanner.guard.local_cli_trust import utc_now
+from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _artifact(
+    *,
+    harness: str,
+    name: str,
+    command: str,
+    args: tuple[str, ...],
+) -> GuardArtifact:
+    return GuardArtifact(
+        artifact_id=f"{harness}:mcp:{name}",
+        name=name,
+        harness=harness,
+        artifact_type="mcp_server",
+        source_scope="user",
+        config_path=f"{harness}/mcp.json",
+        command=command,
+        args=args,
+        transport="stdio",
+        metadata={},
+    )
+
+
+def _detection(harness: str, *artifacts: GuardArtifact) -> HarnessDetection:
+    return HarnessDetection(
+        harness=harness,
+        installed=True,
+        command_available=True,
+        config_paths=(f"{harness}/mcp.json",),
+        artifacts=artifacts,
+    )
+
+
+def test_recognize_keeps_stored_mcp_when_live_probe_fails(tmp_path: Path, monkeypatch) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.local_cli_api.Path.home",
+        staticmethod(lambda: home),
+    )
+    detection = _detection(
+        "cursor",
+        _artifact(
+            harness="cursor",
+            name="filesystem",
+            command="npx",
+            args=("-y", "@modelcontextprotocol/server-filesystem"),
+        ),
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.local_cli_api.discover_harness_mcp_servers",
+        lambda **_kwargs: discover_harness_mcp_servers(
+            home_dir=home,
+            guard_home=home,
+            detections=(detection,),
+        ),
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.local_cli_api.probe_stdio_mcp_server",
+        lambda *_args, **_kwargs: None,
+    )
+    service = LocalCliApiService(store=GuardStore(home))
+    _ = service._observe_harness_mcp_servers()
+    listed = service.list_items()["items"][0]
+    assert isinstance(listed, dict)
+    recognized = service.recognize(
+        {
+            "command": str(listed["example_label"]),
+            "cli_id": str(listed["cli_id"]),
+        }
+    )
+    item = recognized["item"]
+    assert isinstance(item, dict)
+    assert item["cli_id"] == listed["cli_id"]
+    assert item["name"] == "filesystem"
+    assert item["surface"] == "mcp"
+
+
+def test_recognize_survives_discovery_store_lock(tmp_path: Path, monkeypatch) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.local_cli_api.Path.home",
+        staticmethod(lambda: home),
+    )
+    detection = _detection(
+        "cursor",
+        _artifact(
+            harness="cursor",
+            name="filesystem",
+            command="npx",
+            args=("-y", "@modelcontextprotocol/server-filesystem"),
+        ),
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.local_cli_api.discover_harness_mcp_servers",
+        lambda **_kwargs: discover_harness_mcp_servers(
+            home_dir=home,
+            guard_home=home,
+            detections=(detection,),
+        ),
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.local_cli_api.probe_stdio_mcp_server",
+        lambda *_args, **_kwargs: None,
+    )
+
+    def boom(*_args, **_kwargs):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.local_cli_api.persist_discovered_harness_mcp_servers",
+        boom,
+    )
+    service = LocalCliApiService(store=GuardStore(home))
+    _ = persist_discovered_harness_mcp_servers(
+        service._store,
+        discover_harness_mcp_servers(home_dir=home, guard_home=home, detections=(detection,)),
+        seen_at=utc_now(),
+    )
+    listed = service.list_items()["items"][0]
+    assert isinstance(listed, dict)
+    recognized = service.recognize(
+        {
+            "command": str(listed["example_label"]),
+            "cli_id": str(listed["cli_id"]),
+        }
+    )
+    item = recognized["item"]
+    assert isinstance(item, dict)
+    assert item["cli_id"] == listed["cli_id"]
+    assert item["surface"] == "mcp"

--- a/tests/test_guard_local_cli_mcp_recognize.py
+++ b/tests/test_guard_local_cli_mcp_recognize.py
@@ -8,6 +8,7 @@ from codex_plugin_scanner.guard.adapters.harness_mcp_discovery import (
     persist_discovered_harness_mcp_servers,
 )
 from codex_plugin_scanner.guard.daemon.local_cli_api import LocalCliApiService
+from codex_plugin_scanner.guard.daemon.local_cli_mcp_store import stored_mcp_recognition
 from codex_plugin_scanner.guard.local_cli_trust import utc_now
 from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
 from codex_plugin_scanner.guard.store import GuardStore
@@ -143,3 +144,18 @@ def test_recognize_survives_discovery_store_lock(tmp_path: Path, monkeypatch) ->
     assert isinstance(item, dict)
     assert item["cli_id"] == listed["cli_id"]
     assert item["surface"] == "mcp"
+
+
+def test_stored_mcp_recognition_returns_none_on_sqlite_error() -> None:
+    class LockedStore:
+        def find_local_mcp_observation(self, **_kwargs: object) -> dict[str, object]:
+            raise sqlite3.OperationalError("database is locked")
+
+    recognized = stored_mcp_recognition(
+        LockedStore(),
+        "npx -y chrome-devtools-mcp@latest",
+        cli_id="local-cli.mcp-12345678",
+        recognize_payload=lambda *_args, **_kwargs: {"item": {}},
+        recognize_summary=lambda *_args, **_kwargs: "",
+    )
+    assert recognized is None

--- a/tests/test_guard_sqlite_failure_containment.py
+++ b/tests/test_guard_sqlite_failure_containment.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 import sqlite3
 import threading
 import time
+from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
 
 from codex_plugin_scanner.guard import store_connection_schema
+from codex_plugin_scanner.guard.local_cli_trust import utc_now
+from codex_plugin_scanner.guard.runtime.local_cli_identity import UnlistedCliIdentity
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -20,6 +24,21 @@ def _corrupt_store(path: Path) -> bytes:
 
 def _quarantined_databases(guard_home: Path) -> list[Path]:
     return sorted(guard_home.glob("guard.db.corrupt-*"))
+
+
+def _connects_store(database: str | Path, path: Path) -> bool:
+    raw = str(database)
+    if raw.startswith("file:"):
+        raw = raw.removeprefix("file:").split("?", 1)[0]
+    return Path(raw) == path
+
+
+def _main_quarantined_databases(guard_home: Path) -> list[Path]:
+    return [
+        path
+        for path in _quarantined_databases(guard_home)
+        if not path.name.endswith("-wal") and not path.name.endswith("-shm")
+    ]
 
 
 def test_store_startup_quarantines_corruption_and_recovers(tmp_path: Path) -> None:
@@ -118,12 +137,12 @@ def test_transient_io_error_does_not_quarantine_healthy_store(
     real_connect = store_connection_schema.sqlite3.connect
     attempts = 0
 
-    def fail_once(database: str | Path, timeout: float = 5.0) -> sqlite3.Connection:
+    def fail_once(database: str | Path, timeout: float = 5.0, **kwargs: object) -> sqlite3.Connection:
         nonlocal attempts
         attempts += 1
         if attempts == 1:
             raise sqlite3.OperationalError("disk I/O error")
-        return real_connect(database, timeout=timeout)
+        return real_connect(database, timeout=timeout, **kwargs)
 
     monkeypatch.setattr(store_connection_schema.sqlite3, "connect", fail_once)
 
@@ -142,13 +161,13 @@ def test_io_error_that_clears_after_directory_probe_does_not_quarantine(
     real_connect = store_connection_schema.sqlite3.connect
     active_attempts = 0
 
-    def fail_first_active_probe(database: str | Path, timeout: float = 5.0) -> sqlite3.Connection:
+    def fail_first_active_probe(database: str | Path, timeout: float = 5.0, **kwargs: object) -> sqlite3.Connection:
         nonlocal active_attempts
-        if Path(database) == store.path:
+        if _connects_store(database, store.path):
             active_attempts += 1
             if active_attempts == 1:
                 raise sqlite3.OperationalError("disk I/O error")
-        return real_connect(database, timeout=timeout)
+        return real_connect(database, timeout=timeout, **kwargs)
 
     monkeypatch.setattr("codex_plugin_scanner.guard.sqlite_recovery.sqlite3.connect", fail_first_active_probe)
 
@@ -170,12 +189,12 @@ def test_fatal_error_recovers_when_rechecks_report_persistent_io(
     real_connect = store_connection_schema.sqlite3.connect
     active_attempts = 0
 
-    def fail_active_probes(database: str | Path, timeout: float = 5.0) -> sqlite3.Connection:
+    def fail_active_probes(database: str | Path, timeout: float = 5.0, **kwargs: object) -> sqlite3.Connection:
         nonlocal active_attempts
-        if Path(database) == store.path:
+        if _connects_store(database, store.path):
             active_attempts += 1
             raise sqlite3.OperationalError("disk I/O error")
-        return real_connect(database, timeout=timeout)
+        return real_connect(database, timeout=timeout, **kwargs)
 
     monkeypatch.setattr("codex_plugin_scanner.guard.sqlite_recovery.sqlite3.connect", fail_active_probes)
 
@@ -186,6 +205,103 @@ def test_fatal_error_recovers_when_rechecks_report_persistent_io(
         is True
     )
     assert active_attempts == 2
+
+
+def test_recovery_restores_readable_quarantined_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard", prime_policy_integrity=False)
+    identity = UnlistedCliIdentity(
+        cli_id="local-cli.ship-12345678",
+        name="ship",
+        kind="executable",
+        identity_hash="a" * 64,
+        example_label="ship",
+    )
+    store.record_local_cli_observation(identity, seen_at=utc_now())
+    store.upsert_local_cli_grant(
+        identity=identity,
+        state="allowed",
+        expected_revision=0,
+        updated_at=utc_now(),
+    )
+    monkeypatch.setattr(store, "_store_is_proven_unusable", lambda _error: True)
+
+    recovered = store._recover_fatal_sqlite_store(  # pyright: ignore[reportPrivateUsage]
+        sqlite3.DatabaseError("database disk image is malformed")
+    )
+
+    assert recovered is True
+    assert getattr(store, "_last_sqlite_recovery", None) == "restored"
+    assert _main_quarantined_databases(store.guard_home) == []
+    granted = store.read_local_cli_grant(identity.cli_id)
+    assert granted is not None
+    assert granted["state"] == "allowed"
+
+
+def test_connect_retries_after_restored_readable_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard", prime_policy_integrity=False)
+    identity = UnlistedCliIdentity(
+        cli_id="local-cli.ship-12345678",
+        name="ship",
+        kind="executable",
+        identity_hash="a" * 64,
+        example_label="ship",
+    )
+    store.record_local_cli_observation(identity, seen_at=utc_now())
+    store.upsert_local_cli_grant(
+        identity=identity,
+        state="allowed",
+        expected_revision=0,
+        updated_at=utc_now(),
+    )
+    original_connect_once = store._connect_once  # pyright: ignore[reportPrivateUsage]
+    calls = {"count": 0}
+
+    @contextmanager
+    def fail_first_open() -> Iterator[sqlite3.Connection]:
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise sqlite3.DatabaseError("database disk image is malformed")
+        with original_connect_once() as connection:
+            yield connection
+
+    monkeypatch.setattr(store, "_connect_once", fail_first_open)
+    monkeypatch.setattr(store, "_store_is_proven_unusable", lambda _error: True)
+
+    assert store.get_runtime_state() is None
+    granted = store.read_local_cli_grant(identity.cli_id)
+    assert granted is not None
+    assert granted["state"] == "allowed"
+    assert calls["count"] >= 2
+    assert _main_quarantined_databases(store.guard_home) == []
+
+
+def test_connect_retries_busy_lock_without_quarantine(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard", prime_policy_integrity=False)
+    original_connect_once = store._connect_once  # pyright: ignore[reportPrivateUsage]
+    calls = {"count": 0}
+
+    @contextmanager
+    def fail_first_busy() -> Iterator[sqlite3.Connection]:
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise sqlite3.OperationalError("database is locked")
+        with original_connect_once() as connection:
+            yield connection
+
+    monkeypatch.setattr(store, "_connect_once", fail_first_busy)
+
+    assert store.get_runtime_state() is None
+    assert _quarantined_databases(store.guard_home) == []
+    assert calls["count"] >= 2
 
 
 def test_stale_fatal_error_does_not_quarantine_healthy_store(tmp_path: Path) -> None:

--- a/tests/test_guard_sqlite_failure_containment.py
+++ b/tests/test_guard_sqlite_failure_containment.py
@@ -29,8 +29,11 @@ def _quarantined_databases(guard_home: Path) -> list[Path]:
 def _connects_store(database: str | Path, path: Path) -> bool:
     raw = str(database)
     if raw.startswith("file:"):
-        raw = raw.removeprefix("file:").split("?", 1)[0]
-    return Path(raw) == path
+        from urllib.parse import unquote, urlparse
+
+        parsed = urlparse(raw)
+        raw = unquote(parsed.path)
+    return Path(raw) == path or Path(raw) == path.resolve()
 
 
 def _main_quarantined_databases(guard_home: Path) -> list[Path]:
@@ -76,8 +79,7 @@ def test_live_store_recovers_after_fatal_sqlite_error(tmp_path: Path) -> None:
     store = GuardStore(guard_home, prime_policy_integrity=False)
     corrupt_bytes = _corrupt_store(store.path)
 
-    with pytest.raises(sqlite3.DatabaseError, match="file is not a database"):
-        store.get_runtime_state()
+    assert store.get_runtime_state() is None
 
     with sqlite3.connect(store.path) as connection:
         assert connection.execute("pragma quick_check").fetchone() == ("ok",)
@@ -304,6 +306,48 @@ def test_connect_retries_busy_lock_without_quarantine(
     assert calls["count"] >= 2
 
 
+def test_probe_encodes_reserved_path_characters(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.sqlite_recovery import _probe_sqlite_store, _sqlite_readonly_uri
+
+    home = tmp_path / "guard?home"
+    home.mkdir()
+    path = home / "guard.db"
+    with sqlite3.connect(path) as connection:
+        connection.execute("create table keep (value integer)")
+        connection.commit()
+    uri = _sqlite_readonly_uri(path)
+    assert "%3F" in uri.upper()
+    assert _probe_sqlite_store(path) == "healthy"
+
+
+def test_restore_rolls_back_when_sidecar_move_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codex_plugin_scanner.guard.sqlite_recovery import restore_readable_sqlite_store
+
+    destination = tmp_path / "guard.db"
+    quarantined = tmp_path / "guard.db.corrupt-1"
+    with sqlite3.connect(quarantined) as connection:
+        connection.execute("create table keep (value integer)")
+        connection.execute("insert into keep values (7)")
+        connection.commit()
+    wal = Path(f"{quarantined}-wal")
+    wal.write_bytes(b"wal")
+    original_replace = Path.replace
+
+    def fail_wal(self: Path, target: Path, /, **_kwargs: object) -> Path:
+        if self == wal:
+            raise OSError("sidecar busy")
+        return original_replace(self, target)
+
+    monkeypatch.setattr(Path, "replace", fail_wal)
+    assert restore_readable_sqlite_store(destination=destination, quarantined=quarantined) is False
+    assert destination.exists() is False
+    assert quarantined.exists() is True
+    assert wal.exists() is True
+
+
 def test_stale_fatal_error_does_not_quarantine_healthy_store(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard", prime_policy_integrity=False)
 
@@ -344,7 +388,7 @@ def test_connect_does_not_quarantine_replacement_inode(
 
     monkeypatch.setattr(store, "_recover_fatal_sqlite_store", replace_before_recovery)
 
-    with pytest.raises(sqlite3.DatabaseError, match="file is not a database"):
+    with pytest.raises(sqlite3.DatabaseError):
         store.get_runtime_state()
 
     assert observed_identity == failed_identity


### PR DESCRIPTION
## Summary
- Restore a quarantined SQLite store in place when it still opens and passes integrity, instead of initializing an empty database.
- Retry the in-flight store request after that restore, or after a busy/locked error, so a false-unusable recovery does not fail the original API call.
- Keep stored MCP recognition when a live stdio probe fails, and continue recognition when harness discovery cannot write because the store is locked.

## Testing
- `ruff check` and `ruff format` on the changed Python files
- `pytest tests/test_guard_sqlite_failure_containment.py tests/test_guard_harness_mcp_discovery.py tests/test_guard_local_cli_mcp_recognize.py -q`
