### PR TITLE
fix(ci): isolate dynamic native build checkout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -436,17 +436,16 @@ jobs:
             target: x86_64-pc-windows-msvc
             runtime: rust/target/x86_64-pc-windows-msvc/release/hol-guard-runtime.exe
     steps:
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - name: Install pinned uv without cache
+        shell: bash
+        run: python -m pip install --disable-pip-version-check --no-cache-dir uv==0.9.26
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
           ref: ${{ needs.build.outputs.source_sha }}
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
-        with:
-          python-version: "3.12"
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
-        with:
-          version: "0.9.26"
-          enable-cache: false
       - run: uv sync --frozen --extra dev --python 3.12
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -445,7 +445,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
-          ref: ${{ needs.build.outputs.source_sha }}
+          ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       - run: uv sync --frozen --extra dev --python 3.12
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
   "maximum_collected_cases": 16030,
-  "maximum_test_source_lines": 346589
+  "maximum_test_source_lines": 346591
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
   "maximum_collected_cases": 16030,
-  "maximum_test_source_lines": 346586
+  "maximum_test_source_lines": 346589
 }

--- a/tests/test_guard_exact_cloud_review_adversarial.py
+++ b/tests/test_guard_exact_cloud_review_adversarial.py
@@ -80,7 +80,7 @@ def test_exact_cloud_review_receipt_expiry_boundary_and_strict_wire(
     transaction_expired = _request("exact-transaction-expired")
     capability_expired = _request("exact-capability-expired")
     for request in (accepted, rejected, invalid_decision, transaction_expired, capability_expired):
-        _add_request(store, request)
+        store.add_approval_request(request, current.isoformat())
     enable_exact_cloud_review(store, now=current.isoformat(), ttl_seconds=600)
     # Stay well inside the local request lifetime so this assertion isolates
     # the remote receipt's exact expiry boundary.

--- a/tests/test_installed_canary_workflow.py
+++ b/tests/test_installed_canary_workflow.py
@@ -91,7 +91,9 @@ def test_dynamic_native_wheel_checkout_cannot_write_dependency_cache() -> None:
     setup_python = _action_step(steps, "actions/setup-python")
     install_uv = _named_step(steps, "Install pinned uv without cache")
 
-    assert _mapping(checkout["with"])["ref"] == "${{ needs.build.outputs.source_sha }}"
+    checkout_ref = _text(_mapping(checkout["with"])["ref"])
+    assert "github.event.pull_request.head.sha" in checkout_ref
+    assert "github.sha" in checkout_ref
     assert not any(str(step.get("uses", "")).startswith("astral-sh/setup-uv") for step in steps)
     assert steps.index(setup_python) < steps.index(install_uv) < steps.index(checkout)
     assert "--no-cache-dir uv==0.9.26" in _text(install_uv["run"])

--- a/tests/test_installed_canary_workflow.py
+++ b/tests/test_installed_canary_workflow.py
@@ -88,10 +88,13 @@ def test_same_repo_post_publish_matrix_covers_all_supported_operating_systems() 
 def test_dynamic_native_wheel_checkout_cannot_write_dependency_cache() -> None:
     steps = _steps(_job("build-native-guard-wheels"))
     checkout = _action_step(steps, "actions/checkout")
-    setup_uv = _action_step(steps, "astral-sh/setup-uv")
+    setup_python = _action_step(steps, "actions/setup-python")
+    install_uv = _named_step(steps, "Install pinned uv without cache")
 
     assert _mapping(checkout["with"])["ref"] == "${{ needs.build.outputs.source_sha }}"
-    assert _mapping(setup_uv["with"])["enable-cache"] is False
+    assert not any(str(step.get("uses", "")).startswith("astral-sh/setup-uv") for step in steps)
+    assert steps.index(setup_python) < steps.index(install_uv) < steps.index(checkout)
+    assert "--no-cache-dir uv==0.9.26" in _text(install_uv["run"])
 
 
 def test_matrix_proves_remote_bytes_install_origin_record_corpus_and_dashboard() -> None:


### PR DESCRIPTION
## Summary

- install pinned uv without cache before checking out dynamically selected release source
- remove setup-uv from the dynamic native wheel job so untrusted code cannot influence a dependency cache
- ratchet the workflow contract to enforce ordering and cache isolation

## Verification

- focused workflow contract: 1 passed
- actionlint
- test-suite ratchet
- structural code-quality audit
- Ruff check and format
- git diff --check