### PR TITLE
fix(ci): classify synthetic benchmark fixture

### DIFF
--- a/scripts/bench_guard_hooks.py
+++ b/scripts/bench_guard_hooks.py
@@ -184,7 +184,7 @@ def _setup_cases(tmp: Path, workspace: Path) -> dict[str, HookReviewRequest]:
     # secret-early: secret at byte ~100
     secret_content = 'x = 1;\nconst credential = "BENCH_FIXTURE_CREDENTIAL_VALUE";\n' + "y = 2;\n" * 100
     secret_file = workspace / "src" / "secret.ts"
-    secret_file.write_text(secret_content)
+    secret_file.write_text(secret_content)  # codeql[py/clear-text-storage-sensitive-data] Synthetic test fixture.
     cases["secret-early"] = _make_request(
         harness="pi",
         event_name="PostToolUse",


### PR DESCRIPTION
## Summary

- classify the deliberately persisted benchmark fixture for the matching CodeQL query
- preserve the scanner input used to measure early sensitive-value detection

## Testing

- `uv run ruff check scripts/bench_guard_hooks.py`
- `uv run python -m py_compile scripts/bench_guard_hooks.py`
- `uv run python tests/guard_command_decision_diff.py --check`
- `uv run pytest tests/test_policy_bundle_delivery_runtime.py -q --tb=short`
- `git diff --check origin/release/3.0...HEAD`
