### PR TITLE
fix(daemon): contain worker shutdown during upgrades

### DIFF
--- a/ci/code-quality-baseline.json
+++ b/ci/code-quality-baseline.json
@@ -524,7 +524,7 @@
     "src/codex_plugin_scanner/guard/daemon/hook_process_runner.py": 749,
     "src/codex_plugin_scanner/guard/daemon/manager.py": 3178,
     "src/codex_plugin_scanner/guard/daemon/runtime_hook_scheduler.py": 535,
-    "src/codex_plugin_scanner/guard/daemon/server.py": 8776,
+    "src/codex_plugin_scanner/guard/daemon/server.py": 8782,
     "src/codex_plugin_scanner/guard/inventory_contract.py": 1818,
     "src/codex_plugin_scanner/guard/local_supply_chain.py": 4513,
     "src/codex_plugin_scanner/guard/mcp_tool_calls.py": 1576,

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
-  "maximum_collected_cases": 16097,
-  "maximum_test_source_lines": 348216
+  "maximum_collected_cases": 16098,
+  "maximum_test_source_lines": 348257
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
   "maximum_collected_cases": 16097,
-  "maximum_test_source_lines": 348214
+  "maximum_test_source_lines": 348216
 }

--- a/dashboard/e2e/installed-extension-control-center.spec.ts
+++ b/dashboard/e2e/installed-extension-control-center.spec.ts
@@ -13,7 +13,7 @@ const approvalPassword = process.env.GUARD_INSTALLED_APPROVAL_PASSWORD ?? "";
 const extensionId = "command.api-gateway";
 const permissionId = "command.api-gateway.permission.delete";
 const governedRuleId = "command.api-gateway.delete";
-const expectedExtensionCount = 59;
+const expectedExtensionCount = 60;
 
 async function installSession(page: import("@playwright/test").Page) {
   await page.addInitScript(({ daemon, token }) => {

--- a/src/codex_plugin_scanner/guard/daemon/hook_process_runner.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_process_runner.py
@@ -414,7 +414,7 @@ class HookProcessRunner(HookProcessRunnerLifecycleMixin):
                 attempted_slot_ids.add(slot_id)
                 if not slot.isolation_ready and not slot.pre_isolation_contained:
                     remaining = max(0.0, deadline - time.monotonic())
-                    _ = hook_worker_became_isolated(slot, remaining)
+                    _ = hook_worker_became_isolated(slot, min(_HOOK_PROCESS_READY_TIMEOUT_SECONDS, remaining))
                 _ = self._retire_slot(slot, graceful=True)
 
             remaining = deadline - time.monotonic()

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -371,6 +371,7 @@ _RUNTIME_HOOK_ADMISSION_TIMEOUT_SECONDS = 3.0
 _RUNTIME_HOOK_PROCESS_TIMEOUT_SECONDS = 1.45
 _RUNTIME_POST_HOOK_PROCESS_TIMEOUT_SECONDS = 2.75
 _DAEMON_REQUEST_READ_TIMEOUT_SECONDS = 0.4
+_DAEMON_SERVE_THREAD_START_TIMEOUT_SECONDS = 5.0
 _DAEMON_CONNECTION_ADMISSION_WAIT_SECONDS = 0.05
 _DAEMON_CONTROL_ADMISSION_WAIT_SECONDS = 1.0
 _DAEMON_UNCLASSIFIED_WATCHDOG_POLL_SECONDS = 0.025
@@ -7967,6 +7968,7 @@ class GuardDaemonServer:
         self._extension_control_refresh_interval_seconds = extension_control_refresh_interval_seconds
         self._cloud_review_sync_worker: CloudReviewSyncWorker | None = None
         self._thread: threading.Thread | None = None
+        self._serve_loop_started = threading.Event()
         self._watchdog_thread: threading.Thread | None = None
 
     def start(self) -> None:
@@ -7980,9 +7982,12 @@ class GuardDaemonServer:
         self._begin_service()
         serve_thread_started = False
         try:
+            self._serve_loop_started.clear()
             self._thread = threading.Thread(target=self._serve_forever, daemon=True)
             self._thread.start()
             serve_thread_started = True
+            if not self._serve_loop_started.wait(timeout=_DAEMON_SERVE_THREAD_START_TIMEOUT_SECONDS):
+                raise RuntimeError("Guard daemon serve thread did not become ready")
             self._server.hook_process_runner.enable_full_capacity()
         except BaseException as error:
             self._diagnostics.record_exception("daemon_start_thread_failed")
@@ -8208,6 +8213,7 @@ class GuardDaemonServer:
     def _serve_forever(self) -> None:
         stop_reason = "serve_loop_returned"
         try:
+            self._serve_loop_started.set()
             self._server.serve_forever()
             if self._shutdown_started.is_set():
                 stop_reason = "requested_shutdown"

--- a/tests/test_guard_daemon_startup_rollback.py
+++ b/tests/test_guard_daemon_startup_rollback.py
@@ -39,6 +39,47 @@ def test_daemon_start_preserves_deferred_hook_worker_backfill(
         daemon.stop()
 
 
+def test_daemon_start_waits_for_serve_loop_entry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    daemon = GuardDaemonServer(
+        GuardStore(tmp_path / "guard-home"),
+        host="127.0.0.1",
+        port=0,
+        idle_timeout_seconds=0,
+    )
+    original_serve_forever = daemon._serve_forever
+    serve_thread_entered = threading.Event()
+    release_serve_thread = threading.Event()
+    start_errors: list[BaseException] = []
+
+    def delayed_serve_forever() -> None:
+        serve_thread_entered.set()
+        assert release_serve_thread.wait(timeout=5)
+        original_serve_forever()
+
+    def start_daemon() -> None:
+        try:
+            daemon.start()
+        except BaseException as error:
+            start_errors.append(error)
+
+    monkeypatch.setattr(daemon, "_serve_forever", delayed_serve_forever)
+    starter = threading.Thread(target=start_daemon)
+    try:
+        starter.start()
+        assert serve_thread_entered.wait(timeout=10)
+        assert starter.is_alive()
+        release_serve_thread.set()
+        starter.join(timeout=10)
+        assert not starter.is_alive()
+        assert start_errors == []
+    finally:
+        release_serve_thread.set()
+        daemon.stop()
+
+
 def test_occupied_port_preserves_bind_error_during_partial_server_cleanup(tmp_path: Path) -> None:
     diagnostics_threads_before = {
         thread.ident

--- a/tests/test_guard_daemon_worker_isolation.py
+++ b/tests/test_guard_daemon_worker_isolation.py
@@ -11,6 +11,12 @@ from codex_plugin_scanner.guard.daemon import server as guard_daemon_module
 from codex_plugin_scanner.guard.store import GuardStore
 
 
+@pytest.fixture(autouse=True)
+def _skip_unrelated_hook_worker_startup(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(guard_daemon_module.HookProcessRunner, "start", lambda _self, **_: None)
+    monkeypatch.setattr(guard_daemon_module.HookProcessRunner, "require_initial_capacity", lambda _self: None)
+
+
 @pytest.mark.daemon_headless_refresh
 def test_daemon_headless_refresh_stops_cleanly(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     store = GuardStore(tmp_path / "guard-home")

--- a/tests/test_guard_hook_process_containment.py
+++ b/tests/test_guard_hook_process_containment.py
@@ -168,11 +168,7 @@ def test_close_waits_for_inflight_worker_isolation_before_retirement(
 
     assert runner.close_contained()
     assert len(isolation_waits) == 1
-    containment_timeout = hook_runner_module._HOOK_PROCESS_READY_TIMEOUT_SECONDS + min(
-        hook_runner_module._HOOK_PROCESS_CLOSE_CONTAINMENT_GRACE_SECONDS,
-        hook_runner_module._HOOK_PROCESS_READY_TIMEOUT_SECONDS,
-    )
-    assert 0 < isolation_waits[0] <= containment_timeout
+    assert 0 < isolation_waits[0] <= hook_runner_module._HOOK_PROCESS_READY_TIMEOUT_SECONDS
     assert runner.stats()["workers"] == 0
 
 


### PR DESCRIPTION
## Summary
- cap worker isolation waits at the documented readiness timeout during daemon shutdown
- preserve the broader containment grace period for remaining background cleanup
- align the installed dashboard contract with the current extension catalog
- isolate background-worker composition tests from unrelated hook-worker startup
- wait for the HTTP serve loop before reporting daemon startup success

## Testing
- `uv run pytest -q tests/test_guard_daemon_worker_isolation.py tests/test_guard_hook_process_containment.py::test_close_waits_for_inflight_worker_isolation_before_retirement tests/test_guard_hook_process_runner.py::test_queued_work_releases_deferred_backfill tests/test_guard_daemon_startup_rollback.py`
- `for run in 1 2 3 4 5; do uv run pytest -q "tests/test_codex_daemon_hook_bridge.py::test_bridge_real_daemon_allows_static_github_content_read_with_safe_jq_filter[gh pr list -q'.[] | select(.state == \"REVIEW_REQUIRED\")']" || exit 1; done`
- `uv run python -c "from codex_plugin_scanner.guard.runtime import runner; assert len(runner.build_builtin_extension_catalog_wire(guard_version='test', generated_at='2026-08-25T12:00:00Z')['extensions']) == 60"`
- `uv run --no-sync python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory test-inventory.json`
- `uv run --no-sync python scripts/ci/code_quality_audit.py --root . --baseline ci/code-quality-baseline.json --json-output code-quality-audit.json`
- `uv run ruff check src/codex_plugin_scanner/guard/daemon/hook_process_runner.py tests/test_guard_hook_process_containment.py tests/test_policy_bundle_delivery_runtime.py`
- `uv run ruff format --check src/codex_plugin_scanner/guard/daemon/hook_process_runner.py tests/test_guard_hook_process_containment.py tests/test_policy_bundle_delivery_runtime.py`
