### PR TITLE
fix(guard): support Windows managed provider containment

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
-  "maximum_collected_cases": 16052,
-  "maximum_test_source_lines": 347312
+  "maximum_collected_cases": 16053,
+  "maximum_test_source_lines": 347334
 }

--- a/src/codex_plugin_scanner/guard/runtime/isolation_provider.py
+++ b/src/codex_plugin_scanner/guard/runtime/isolation_provider.py
@@ -15,12 +15,13 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import ntpath
 import os
 import platform
 import stat
 from collections.abc import Callable
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Final, Protocol, runtime_checkable
 
 from codex_plugin_scanner.guard.runtime.execution_assurance_contract import (
@@ -178,7 +179,7 @@ class ProviderRegistry:
         root = str(Path(self._provider_root).expanduser().resolve(strict=False))
         configured = Path(configured_path).expanduser()
         normalized = str(configured.resolve(strict=False))
-        if normalized != root and not normalized.startswith(root + "/"):
+        if not _path_is_within(normalized, root):
             raise ValueError("provider path is outside the Guard-owned provider root")
         if _path_has_symlink_below_root(configured, Path(root)):
             raise ValueError("provider artifact path must not contain symlinks")
@@ -302,6 +303,30 @@ def _provider_root_is_guard_owned(path: str) -> bool:
         or normalized.startswith("/library/application support/hol guard/")
         or normalized.startswith("c:/programdata/hol guard/")
     )
+
+
+def _path_is_within(path_value: str | Path, root_value: str | Path) -> bool:
+    """Return whether an already-normalized path is contained by its root.
+
+    Windows paths are compared with Windows flavor semantics even when tests run
+    on a non-Windows host, so drive letters, case folding, and backslash
+    separators cannot make a valid ProgramData provider appear out of scope.
+    """
+
+    path_text = os.fspath(path_value)
+    root_text = os.fspath(root_value)
+    root_drive, _ = ntpath.splitdrive(root_text)
+    if root_drive:
+        normalized_path = PureWindowsPath(ntpath.normcase(ntpath.normpath(path_text)))
+        normalized_root = PureWindowsPath(ntpath.normcase(ntpath.normpath(root_text)))
+    else:
+        normalized_path = Path(path_text)
+        normalized_root = Path(root_text)
+    try:
+        normalized_path.relative_to(normalized_root)
+    except ValueError:
+        return False
+    return True
 
 
 def _path_has_symlink_below_root(path: Path, root: Path) -> bool:

--- a/tests/test_guard_isolation_provider_path_containment.py
+++ b/tests/test_guard_isolation_provider_path_containment.py
@@ -1,0 +1,22 @@
+"""Regression coverage for provider registry path containment."""
+
+from codex_plugin_scanner.guard.runtime import isolation_provider as isolation_provider_module
+
+
+def test_provider_path_containment_uses_root_path_flavor() -> None:
+    windows_root = r"C:\ProgramData\HOL Guard\providers"
+    assert isolation_provider_module._path_is_within(
+        r"C:\ProgramData\HOL Guard\providers\oci-isolation.py", windows_root
+    )
+    assert isolation_provider_module._path_is_within(
+        r"c:\programdata\hol guard\PROVIDERS\oci-isolation.py", windows_root
+    )
+    assert not isolation_provider_module._path_is_within(
+        r"C:\ProgramData\HOL Guard\providers-evil\oci-isolation.py", windows_root
+    )
+    assert not isolation_provider_module._path_is_within(
+        r"D:\ProgramData\HOL Guard\providers\oci-isolation.py", windows_root
+    )
+    posix_root = "/usr/libexec/hol-guard/providers"
+    assert isolation_provider_module._path_is_within(f"{posix_root}/seatbelt", posix_root)
+    assert not isolation_provider_module._path_is_within(f"{posix_root}-evil/seatbelt", posix_root)


### PR DESCRIPTION
## Summary

- replace the hard-coded forward-slash prefix check in `ProviderRegistry.register()` with flavor-aware path containment
- normalize drive letters, case, and separators with Windows semantics for ProgramData provider roots
- preserve strict rejection of sibling-prefix and cross-drive paths
- add cross-platform regression coverage and ratchet the reviewed test inventory

## Validation

- Python compilation completed for the changed source and regression test
- regression cases cover native Windows separators, case folding, sibling-prefix escape, cross-drive escape, and POSIX containment

Resolves the remaining review finding on #2083.

Signed-off-by: Michael Kantor <6068672+kantorcodes@users.noreply.github.com>