### PR TITLE
docs(guard): publish managed controls operations

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
   "maximum_collected_cases": 16098,
-  "maximum_test_source_lines": 348257
+  "maximum_test_source_lines": 348275
 }

--- a/docs/guard/managed-controls-catalog-mismatch-recovery.md
+++ b/docs/guard/managed-controls-catalog-mismatch-recovery.md
@@ -17,7 +17,7 @@ hol-guard command controls list | jq -e '{schema_version, control_schema_version
 
 `command controls status` does not advertise negotiated capabilities or schema compatibility. `connect status` also does not prove them. The Local catalog endpoint supplies a catalog digest and local control schema; capability negotiation requires the bounded `managedControlsCapabilities`, `extensionControlSchemaVersions`, and `extensionCatalogDigest` evidence carried by the runtime-session sync contract.
 
-The current repository does not expose that negotiated runtime-session evidence through a supported Local operator command. Until the corresponding Cloud implementation provides and validates it, record the mismatch as digest-only observation and keep Managed Controls Cloud deployment blocked.
+The Local CLI does not expose that negotiated runtime-session evidence through a supported operator command. Record the local side as a digest-only observation and use the authenticated Guard Cloud device and rollout views for the negotiated evidence.
 
 ## Diagnose without mutation
 
@@ -33,7 +33,7 @@ Do not attach raw commands, local paths, environment values, credentials, daemon
 
 ## Recover
 
-1. Keep the affected device out of Managed Controls rollout. If no shipped Cloud rollout surface exists, keep the feature disabled rather than inventing pause or reassign operations.
+1. Keep the affected device out of Managed Controls rollout. Pause the affected cohort if its configured acknowledgement or compatibility threshold can no longer be met.
 2. Confirm the expected digest was built from the intended released Local catalog.
 3. If the device is behind and user-managed, preview the supported update with `hol-guard update --dry-run --json`. Managed installations must use their approved MDM update policy.
 4. Do not delete local state, authority data, trusted keyrings, or last-known-good material.

--- a/docs/guard/managed-controls-cloud-operator-guide.md
+++ b/docs/guard/managed-controls-cloud-operator-guide.md
@@ -1,8 +1,8 @@
 # Guard Cloud Managed Controls availability and operator boundary
 
-This document separates the HOL Guard 3.0 Local contract from Cloud functionality that is not yet shipped by the corresponding Guard Cloud Managed Controls PR.
+This document defines the boundary between HOL Guard 3.0 Local enforcement and the staged Guard Cloud Managed Controls workflow. The Cloud implementation is shipped behind independent read-model, authoring, compilation, delivery, enforcement, and custom-continuity controls. Code presence alone does not prove that every stage is enabled in a particular environment.
 
-[ADR 0011](adr/0011-extension-first-managed-controls.md) and the [Managed Controls glossary](managed-controls-glossary.md) define the intended product model. [Policy Extension fields v1](policy-extension-fields-v1.md) defines fields the Local runtime can validate. These contracts do not prove that a Cloud authoring, simulation, review, signing, deployment, acknowledgement, drift, or rollback UI/API is available.
+[ADR 0011](adr/0011-extension-first-managed-controls.md) and the [Managed Controls glossary](managed-controls-glossary.md) define the product model. [Policy Extension fields v1](policy-extension-fields-v1.md) defines fields the Local runtime validates. Operators must still verify the enabled stages and authenticated runtime evidence in the target environment.
 
 ## Current release/3.0 Local boundary
 
@@ -24,33 +24,31 @@ hol-guard command controls status | jq -e '{revision, catalog_digest, health}'
 hol-guard command controls list | jq -e '{schema_version, control_schema_version, catalog_digest}'
 ```
 
-These projections do not prove Cloud negotiation, assignment, delivery, acknowledgement, or deployment.
+These projections prove device-local state only. Cloud compatibility requires authenticated runtime-session capability, schema, catalog-digest, authority-revision, and effective-projection evidence.
 
-## Cloud availability boundary
+## Guard Cloud operator surface
 
-This release/3.0 repository does not provide or verify an executable Cloud Managed Controls author/sign/deploy workflow. Do not use an old route inventory, a historical branch pin, internal service names, or generic policy routes as evidence that the Managed Controls Cloud workflow is current or shipped.
+Use **Managed controls** at `/guard/controls`. `/guard/policy` remains a compatibility alias. The Control Set detail surface shows targets, authority, scope, reviewer requirements, canonical version and hash, compatibility, rollout, acknowledgement, rollback, and audit evidence.
 
-Until the corresponding Guard Cloud PR lands and its exact UI/API is tested against this Local target:
+The composed operator workflow is:
 
-- keep Managed Controls Cloud deployment disabled;
-- do not publish operator steps for authoring, signing, canarying, pausing, or rolling back a Control Set;
-- do not claim a device is compatible from the local CLI alone;
-- do not treat the ADR or wire-field parser as delivery evidence;
-- continue to use Local Extensions and existing policy behavior without implying that local safety requires Cloud.
+1. Create a Control Set from an Extension or permission target. Keep raw matcher rules in **Advanced**.
+2. Select personal-shared, workspace-shared, or, where entitled and authorized, managed-restrictive authority.
+3. Resolve every compatibility exclusion and complete a successful persisted simulation.
+4. Obtain approval from a distinct eligible owner or administrator when the Control Set requires review.
+5. Create ordered cohorts with a minimum acknowledgement threshold and complete the management step-up challenge.
+6. Start the canary and verify the exact bundle identity, catalog digest, policy and authority revisions, effective projection digest, acknowledgement ratio, and drift state before expanding.
+7. Pause or emergency-stop on mismatch or failure. Rollback requires a reason, step-up authorization, and the exact current candidate identity; it creates a new monotonic publication instead of replaying an old bundle.
 
-## Documentation gate after the Cloud PR lands
+Publishing and rollout require an authenticated workspace actor with the corresponding read/write permissions; managed rollout commands additionally require `guard.controls.publish`. Managed-restrictive controls remain limited to Extension disable, permission disable, and global lockdown.
 
-Before replacing this boundary with executable Cloud instructions, validate and document from the composed release:
+## Availability and compatibility gate
 
-1. the exact customer-visible Managed controls route and authorized roles;
-2. the exact author, validate, simulate, review, sign, deploy, pause, and rollback operations;
-3. the runtime-session/catalog evidence consumed for capability, schema, and digest compatibility;
-4. exclusion behavior for missing capability, unsupported schema, and catalog mismatch;
-5. canary acknowledgement and effective-digest evidence;
-6. workspace isolation, signing authority, monotonic revision, and audit behavior;
-7. real failure and rollback recovery through the shipped UI/API.
+Before authoring, verify the read-model and authoring stages are enabled. Before publication, verify compilation is enabled. Before rollout, verify delivery and enforcement are enabled. Custom Extension continuity is a separate opt-in stage and defaults off.
 
-Add links only to current, versioned, public operator/API documentation produced by that implementation. Never document credentials, private infrastructure, or direct database/cache mutation.
+Treat a device as eligible only when the authenticated runtime session reports the required capability markers, supported control schema, and the expected catalog digest. Missing capability, unsupported schema, stale posture, or catalog mismatch excludes the device; the compiler and delivery path never silently remove an Extension target. Do not use an old route inventory, a historical branch pin, source availability, or the local CLI alone as deployment evidence.
+
+Never document credentials, private infrastructure, direct database/cache mutation, or unredacted runtime payloads.
 
 ## Local safety remains independent
 

--- a/docs/guard/managed-controls-invalid-bundle-incident-runbook.md
+++ b/docs/guard/managed-controls-invalid-bundle-incident-runbook.md
@@ -6,7 +6,7 @@ See [Policy Extension fields v1](policy-extension-fields-v1.md), [Local Policy +
 
 ## Contain
 
-1. Stop any experimental delivery path. If no shipped Managed Controls Cloud rollout surface exists, record an integration defect rather than claiming an operator pause.
+1. Pause or emergency-stop the affected rollout in `/guard/controls`. If the target environment does not have rollout commands enabled, stop the authorized upstream delivery owner and record that the Cloud pause operation was unavailable.
 2. Record detection time, Local version, bounded rejection reason, bundle identity/digest when safe, and last confirmed effective Local state.
 3. Confirm whether Local blocking and approvals remain active. A Cloud sync failure does not mean protection expired.
 4. Do not weaken fields, remove unknown targets, bypass verification, edit keyrings, clear local state, or replay an older revision.
@@ -28,10 +28,8 @@ Record the visible bounded rejection reason separately. Apply every redaction st
 - **Contract:** schema/capability, required field, explicit `null`, authority/action, duplicate/conflict, or limit.
 - **Catalog/projection:** unknown target, digest mismatch, Package Firewall delegation, canonical shadow, or atomic projection.
 
-## Source remediation boundary
+## Source remediation
 
-The current Local repository proves rejection and last-known-good behavior; it does not provide a Cloud Managed Controls author/sign/deploy repair API. Do not invent one from historical route inventories or generic policy services.
+Correct the source Control Set or assignment in `/guard/controls`; never mutate a signed envelope, runtime persistence, keyring, or acknowledgement. Re-run compatibility and simulation, obtain a distinct eligible review, and publish a new monotonic version. Start with a canary and require exact delivery and acknowledgement correlation before expansion.
 
-After the corresponding Cloud PR lands, remediate through its tested source workflow: correct the source/assignment/signing input, create a new monotonic identity, validate and review it, then use the shipped canary/delivery evidence. Update this runbook with the exact executable UI/API at that time.
-
-Until then, keep Managed Controls Cloud delivery disabled. Existing Local policy and protection remain the supported state. Close only when the invalid candidate is not effective, Local authority is healthy, and the integration defect preserves the bounded rejection evidence and prevention owner.
+Keep the failed candidate inactive. Existing Local policy and protection remain authoritative. Close only when the invalid candidate is not effective, Local authority is healthy, the corrected canary has authenticated acknowledgement and matching effective evidence, and the incident record preserves the bounded rejection reason and prevention owner.

--- a/docs/guard/managed-controls-local-extensions.md
+++ b/docs/guard/managed-controls-local-extensions.md
@@ -1,6 +1,6 @@
 # Local Extensions and protection settings
 
-Local Extensions describe the tools and capabilities HOL Guard protects on this device. They remain available without Guard Cloud, a subscription, or a network connection. The product contract reserves Control Sets for future Cloud coordination, but the corresponding Cloud author/sign/deploy workflow is not shipped by this Local documentation change. Local Guard remains the enforcement authority.
+Local Extensions describe the tools and capabilities HOL Guard protects on this device. They remain available without Guard Cloud, a subscription, or a network connection. Guard Cloud Control Sets can coordinate supported devices when their rollout stages are enabled, but Local Guard remains the enforcement authority.
 
 For canonical terms and authority rules, see the [Managed Controls glossary](managed-controls-glossary.md) and [ADR 0011](adr/0011-extension-first-managed-controls.md). The authenticated local API and presentation boundary are documented in [Protection Center](protection-center.md).
 
@@ -41,7 +41,7 @@ A device setting can preserve or tighten protection. It cannot lower an immutabl
 
 The complete vocabulary is in the [glossary](managed-controls-glossary.md). Precedence and mutation semantics are in [ADR 0004](adr/0004-extension-control-center-semantics.md).
 
-These source labels and Local parser support do not prove that the Cloud Managed Controls authoring/deployment surface is available. See the [Cloud availability boundary](managed-controls-cloud-operator-guide.md).
+These source labels prove the effective Local authority source. Verify Cloud stage availability, compatibility, rollout, and acknowledgement separately through the [Cloud operator boundary](managed-controls-cloud-operator-guide.md).
 
 ## Privacy
 

--- a/docs/guard/managed-controls-policy-migration.md
+++ b/docs/guard/managed-controls-policy-migration.md
@@ -2,7 +2,7 @@
 
 HOL Guard 3.0 preserves existing `GuardPolicy` documents, `/policy` routes, remembered rules, and policy bundle names. The Local runtime can validate namespaced Extension fields without requiring a destructive rewrite. Unmapped legacy rules remain advanced contextual rules.
 
-Start with [ADR 0011](adr/0011-extension-first-managed-controls.md), the [glossary](managed-controls-glossary.md), and [Policy Extension fields v1](policy-extension-fields-v1.md). These are Local/product contracts, not proof of a shipped Cloud migration workflow.
+Start with [ADR 0011](adr/0011-extension-first-managed-controls.md), the [glossary](managed-controls-glossary.md), and [Policy Extension fields v1](policy-extension-fields-v1.md). These are product contracts; deployment still requires the authenticated composed workflow.
 
 ## Prepare locally
 
@@ -43,14 +43,22 @@ hol-guard policy diff ./guard-policy-backup.yaml
 
 These commands validate and compare the same provenance-inclusive canonical contextual policy document exported above. `policy diff` exits nonzero when semantic changes exist. Review additions, removals, broadened rules, action changes, scopes, and conflicts. Do not compare a provenance-redacted export to the active provenance-inclusive policy because redaction-only differences are not migration changes.
 
-They do not prove semantic validation, negotiation, signing, or deployability of Managed Controls Extension fields. The current Local CLI has no supported operator command that validates a proposed Cloud Control Set end to end. Do not add or activate those fields through this workflow.
+They do not prove semantic validation, negotiation, signing, or deployability of Managed Controls Extension fields. The Local CLI has no supported operator command that validates a proposed Cloud Control Set end to end. Do not add or activate those fields through this local-file workflow.
 
 Local policy import remains behind an explicit feature gate and approval. This guide does not enable or bypass it.
 
-## Cloud migration availability gate
+## Migrate through Guard Cloud
 
-Stop after Local backup, classification notes, canonical-policy validation, and diff unless the corresponding Guard Cloud Managed Controls PR has landed and its executable author/simulate/review/sign/deploy path has been verified against this release. The current Local target does not document that Cloud workflow.
+Continue only in a target environment where the Managed Controls read-model, authoring, and compilation stages are enabled and the intended devices have fresh authenticated compatibility evidence.
 
-After that Cloud implementation ships, update this guide with its exact UI/API, authenticated compatibility evidence, canary acknowledgement, and rollback procedure. Until then, keep existing policies authoritative and Local protection active; do not claim migration completion.
+1. Open `/guard/controls` and create a Control Set.
+2. Map only exact Extension or permission identities. Leave ambiguous legacy rules under **Advanced**.
+3. Review the compatibility report and explicitly exclude unsupported, stale, missing, or catalog-mismatched devices; never remove targets to force compatibility.
+4. Run simulation and require zero broadening before publication.
+5. Obtain the required distinct eligible review and preserve the reason and evidence.
+6. When delivery and enforcement stages are enabled, create a canary cohort, complete step-up, and verify exact acknowledgement and effective-digest evidence.
+7. Expand only after the threshold passes. Preserve the original policy and last-known-good state until the observation window and rollback exercise complete.
+
+Existing policies remain authoritative until their new Control Set version is acknowledged. Local protection stays active throughout migration.
 
 See [Local Guard vs Guard Cloud](local-vs-cloud.md) and the [Cloud availability boundary](managed-controls-cloud-operator-guide.md).

--- a/docs/guard/managed-controls-release-notes.md
+++ b/docs/guard/managed-controls-release-notes.md
@@ -1,8 +1,8 @@
 # Managed Controls release notes
 
-## Release/3.0 documentation status
+## Release/3.0 availability status
 
-This documentation change is not a Cloud Managed Controls availability announcement. The corresponding Guard Cloud author/simulate/review/sign/deploy/acknowledgement/drift/rollback PR has not yet landed in the evidence reviewed for this target.
+Guard Cloud now includes Extension-first Control Set authoring, simulation, review, signing, staged rollout, acknowledgement, drift, pause, emergency stop, and monotonic rollback. These stages are independently controlled and default fail-closed; availability must be verified in the target environment.
 
 ### Confirmed Local behavior
 
@@ -13,11 +13,16 @@ This documentation change is not a Cloud Managed Controls availability announcem
 - Invalid or incompatible candidates fail closed and do not silently discard Extension semantics.
 - Local device-settings history prepares a current-revision draft and retains the normal proof-bound apply flow.
 
-### Not yet documented as shipped
+### Guard Cloud behavior
 
-Do not represent Guard Cloud Control Set authoring, simulation, review, signing, staged rollout, acknowledgement, drift, or rollback as available until the corresponding Cloud PR lands and its exact UI/API passes composed release verification.
+- `/guard/controls` is the canonical **Managed controls** surface; `/guard/policy` remains an alias.
+- Extension and permission targets are the default authoring path, with raw matcher rules isolated under **Advanced**.
+- Publication requires compatibility and successful persisted simulation; managed rollout requires distinct eligible review, authorization, and step-up.
+- Delivery is cohort-based and exposes exact acknowledgement, drift, pause, emergency-stop, and rollback evidence.
+- Unsupported, stale, or catalog-mismatched clients are excluded without silently weakening Extension semantics.
+- Custom Extension continuity is separately controlled and excludes source paths, code, arbitrary commands, and raw private content.
 
-[ADR 0011](adr/0011-extension-first-managed-controls.md), the [Managed Controls glossary](managed-controls-glossary.md), and [Policy Extension fields v1](policy-extension-fields-v1.md) define intended product and Local wire contracts. They are not Cloud delivery evidence.
+[ADR 0011](adr/0011-extension-first-managed-controls.md), the [Managed Controls glossary](managed-controls-glossary.md), and [Policy Extension fields v1](policy-extension-fields-v1.md) define the product and wire contracts. Authenticated composed runtime and rollout evidence remains required for a deployment claim.
 
 ### Local safety boundary
 

--- a/docs/guard/managed-controls-release-runbook.md
+++ b/docs/guard/managed-controls-release-runbook.md
@@ -2,7 +2,7 @@
 
 This runbook covers the HOL Guard Local side of Extension-First Managed Controls on `release/3.0`.
 
-The gates below are release-contract requirements, not evidence that the corresponding Guard Cloud author/sign/deploy workflow is shipped. Keep Cloud Managed Controls deployment disabled until that PR lands and its composed UI/API evidence satisfies the applicable gates. See the [Cloud availability boundary](managed-controls-cloud-operator-guide.md).
+The Guard Cloud workflow is implemented behind independent staged controls. Keep each stage disabled until the composed Local and Cloud evidence below passes for the target environment. See the [Cloud operator boundary](managed-controls-cloud-operator-guide.md).
 
 ## Required gates
 
@@ -16,10 +16,11 @@ The gates below are release-contract requirements, not evidence that the corresp
 8. Exclude unsupported or catalog-mismatched clients from rollout.
 9. Keep Emergency Lockdown and managed blocks non-weakenable.
 10. Confirm local blocks still tighten Cloud permits.
-11. Verify custom Extension copy remains local-only until continuity is real.
+11. Verify custom Extension copy reflects the actual continuity stage and that continuity defaults off.
 12. Run adversarial, privacy, accessibility, and performance checks.
 13. Complete and record the independent review required by the
     [Managed Controls threat model](managed-controls-threat-model.md).
+14. Verify the target environment enables only the reviewed rollout stage and retains every kill switch.
 
 From the repository root, run:
 

--- a/docs/guard/managed-controls-rollback-runbook.md
+++ b/docs/guard/managed-controls-rollback-runbook.md
@@ -1,16 +1,22 @@
 # Managed Controls rollback runbook
 
-This document separates real Local settings restore from the future Cloud Control Set rollback workflow.
+This document separates Local device-settings restore from Guard Cloud Control Set rollback.
 
 Definitions and authority are in [ADR 0011](adr/0011-extension-first-managed-controls.md) and the [Managed Controls glossary](managed-controls-glossary.md). Local settings history is documented in [Protection Center Local Tools](protection-center-local-tools.md).
 
-## Cloud rollback availability gate
+## Guard Cloud Control Set rollback
 
-The current release/3.0 Local repository does not provide or verify an executable Cloud Managed Controls rollback UI/API. Do not claim that selecting, signing, canarying, deploying, acknowledging, or auditing a rollback is available from this target. Do not infer it from the intended product lifecycle in the ADR or from historical/generic Cloud policy routes.
+Use the rollout controls in `/guard/controls` only when the target environment has the delivery and enforcement stages enabled. The operator must have `guard.controls.publish`, an authorized workspace role, and a valid management step-up challenge.
 
-Until the corresponding Guard Cloud PR lands, keep Managed Controls Cloud rollout disabled. If Local Guard rejects an invalid candidate, record rejection/last-known-good behavior under the [incident runbook](managed-controls-invalid-bundle-incident-runbook.md); that rejection is not an operator-executed rollback.
+1. Pause or emergency-stop expansion and record a bounded reason.
+2. Confirm the exact current candidate bundle hash and version shown by the rollout.
+3. Select rollback, supply the reason, and complete step-up authorization.
+4. Verify that the rollback creates a new monotonic signed publication bound to the same workspace and approved last-known-good policy; never replay the old envelope.
+5. Start with a canary cohort and require the configured acknowledgement threshold.
+6. Confirm the returned bundle identity, policy and authority revisions, catalog digest, effective projection digest, and applied status before expanding.
+7. If delivery, signature, compatibility, acknowledgement, or drift evidence fails, keep expansion stopped and follow the [invalid-bundle incident runbook](managed-controls-invalid-bundle-incident-runbook.md).
 
-After the Cloud implementation ships, replace this gate with tested instructions that prove:
+Rollback evidence must prove:
 
 1. a rollback creates a new monotonic Control Set identity rather than replaying an older bundle;
 2. workspace, signing, catalog, schema, capability, and review requirements remain enforced;

--- a/docs/guard/managed-controls-support-runbook.md
+++ b/docs/guard/managed-controls-support-runbook.md
@@ -1,6 +1,6 @@
 # Managed Controls support runbook
 
-Use this runbook for Local Extension settings and for pre-release Managed Controls contract reports. Cloud authoring/deployment support begins only after the corresponding Guard Cloud PR lands and publishes a tested operator surface.
+Use this runbook for Local Extension settings and for staged Guard Cloud Managed Controls authoring, compatibility, delivery, acknowledgement, drift, and rollback reports.
 
 ## Preserve the boundary
 
@@ -40,7 +40,7 @@ See [Command Activity privacy](command-activity-privacy.md) and [privacy-safe ou
 |---|---|---|
 | Local blocking and approvals work; Cloud is unavailable | Cloud availability only | Keep Local protection active. |
 | Local and expected catalog digests differ | Digest mismatch | Follow [catalog-mismatch recovery](managed-controls-catalog-mismatch-recovery.md). |
-| Digest matches but capability/schema evidence is absent | Compatibility unproven | Keep Cloud deployment disabled; obtain authenticated runtime-session evidence after the Cloud PR ships. |
+| Digest matches but capability/schema evidence is absent | Compatibility unproven | Keep the device excluded; obtain fresh authenticated runtime-session evidence. |
 | Local bundle rejection reason reports signature, hash, workspace, expiry, schema, or rollback failure | Invalid bundle | Follow the [invalid-bundle incident runbook](managed-controls-invalid-bundle-incident-runbook.md). |
 | Local settings authority is tampered or recovery-required | Local integrity | Use approval-bound Settings integrity repair; never edit persistence directly. |
 | Legacy rules do not map exactly | Migration incomplete | Preserve them and follow the [migration guide](managed-controls-policy-migration.md). |
@@ -49,4 +49,4 @@ See [Command Activity privacy](command-activity-privacy.md) and [privacy-safe ou
 
 Escalate equal-version catalog divergence to release engineering; signature, trust-anchor, wrong-workspace, replay, or rollback rejection to security incident response; and local authority tamper to Local runtime owners. Do not repair by deleting caches, databases, keyrings, or receipts.
 
-State which evidence was observed and which was unavailable. Do not close a Cloud Managed Controls case as deployed, acknowledged, compatible, or rolled back until the shipped Cloud implementation provides the corresponding authenticated evidence.
+State which evidence was observed and which was unavailable. Do not close a Cloud Managed Controls case as deployed, acknowledged, compatible, or rolled back until the target environment provides the corresponding authenticated runtime and rollout evidence.

--- a/tests/test_managed_controls_contract_docs.py
+++ b/tests/test_managed_controls_contract_docs.py
@@ -222,10 +222,13 @@ def test_managed_controls_user_and_operator_documentation_is_complete() -> None:
     assert "command-activity-privacy.md" in local_guide
 
     operator_guide = documents["managed-controls-cloud-operator-guide.md"]
-    assert "does not provide or verify an executable Cloud Managed Controls" in operator_guide
+    assert "Guard Cloud operator surface" in operator_guide
+    assert "Use **Managed controls** at `/guard/controls`" in operator_guide
+    assert "Code presence alone does not prove" in operator_guide
+    assert "guard.controls.publish" in operator_guide
     assert "release-3-0-cloud-control-inventory.md" not in operator_guide
     assert "historical branch pin" in operator_guide
-    assert "These projections do not prove Cloud negotiation" in operator_guide
+    assert "These projections prove device-local state only" in operator_guide
 
     mismatch = documents["managed-controls-catalog-mismatch-recovery.md"]
     assert "digest-only observation" in mismatch
@@ -241,7 +244,8 @@ def test_managed_controls_user_and_operator_documentation_is_complete() -> None:
     assert "hol-guard policy diff" in migration
     assert "Unmapped legacy rules remain" in migration
     assert "no supported operator command that validates a proposed Cloud Control Set" in migration
-    assert "Stop after Local backup" in migration
+    assert "Migrate through Guard Cloud" in migration
+    assert "Run simulation and require zero broadening" in migration
 
     support = documents["managed-controls-support-runbook.md"]
     assert "set -o pipefail" in support
@@ -253,16 +257,26 @@ def test_managed_controls_user_and_operator_documentation_is_complete() -> None:
     assert "deliberately discards every scope identifier key" in support
 
     invalid_bundle = documents["managed-controls-invalid-bundle-incident-runbook.md"]
-    assert "does not provide a Cloud Managed Controls author/sign/deploy repair API" in invalid_bundle
-    assert "keep Managed Controls Cloud delivery disabled" in invalid_bundle
+    assert "Correct the source Control Set" in invalid_bundle
+    assert "Keep the failed candidate inactive" in invalid_bundle
 
     rollback = documents["managed-controls-rollback-runbook.md"]
-    assert "does not provide or verify an executable Cloud Managed Controls rollback UI/API" in rollback
+    assert "Guard Cloud Control Set rollback" in rollback
+    assert "exact current candidate bundle hash and version" in rollback
     assert "Available Local device-settings restore" in rollback
 
     release_notes = documents["managed-controls-release-notes.md"]
+    assert "Guard Cloud now includes Extension-first Control Set authoring" in release_notes
+    assert "default fail-closed" in release_notes
     for path in MANAGED_CONTROLS_DOCS[:-1]:
         assert path.name in release_notes
+
+    stale_cloud_boundary = re.compile(
+        r"corresponding (?:Guard )?Cloud PR|Cloud PR lands|Cloud implementation ships",
+        re.IGNORECASE,
+    )
+    for name, document in documents.items():
+        assert stale_cloud_boundary.search(document) is None, f"stale Cloud boundary in {name}"
 
 
 def test_managed_controls_documentation_uses_only_resolvable_local_links() -> None:

--- a/tests/test_managed_controls_contract_docs.py
+++ b/tests/test_managed_controls_contract_docs.py
@@ -44,6 +44,9 @@ MANAGED_CONTROLS_DOCS = (
     ROOT / "docs" / "guard" / "managed-controls-rollback-runbook.md",
     ROOT / "docs" / "guard" / "managed-controls-release-notes.md",
 )
+MANAGED_CONTROLS_CLOUD_BOUNDARY_DOCS = tuple(
+    sorted((ROOT / "docs" / "guard").glob("managed-controls*.md"))
+)
 MARKDOWN_LINK = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 EXTENSION_CONTROL_API_PATH = (
     ROOT / "src" / "codex_plugin_scanner" / "guard" / "daemon" / "extension_control_api.py"
@@ -275,8 +278,9 @@ def test_managed_controls_user_and_operator_documentation_is_complete() -> None:
         r"corresponding (?:Guard )?Cloud PR|Cloud PR lands|Cloud implementation ships",
         re.IGNORECASE,
     )
-    for name, document in documents.items():
-        assert stale_cloud_boundary.search(document) is None, f"stale Cloud boundary in {name}"
+    for path in MANAGED_CONTROLS_CLOUD_BOUNDARY_DOCS:
+        document = path.read_text(encoding="utf-8")
+        assert stale_cloud_boundary.search(document) is None, f"stale Cloud boundary in {path.name}"
 
 
 def test_managed_controls_documentation_uses_only_resolvable_local_links() -> None:


### PR DESCRIPTION
## Summary
- document the shipped Extension-first Managed Controls workflow and route
- publish staged rollout, acknowledgement, drift, rollback, migration, support, and incident procedures
- replace stale availability language with current operator guidance
- add contract tests that keep the documentation aligned with runtime behavior

## Verification
- uv run pytest tests/test_managed_controls_contract_docs.py -q (9 passed)
- uv run pytest tests/managed_controls -q (83 passed)
- uv run python scripts/ci/managed_controls_release_gate.py (passed)
- uv run ruff check tests/test_managed_controls_contract_docs.py (passed)