### PR TITLE
fix: normalize main release version

### DIFF
--- a/.github/workflows/guard-network-remediation-proof.yml
+++ b/.github/workflows/guard-network-remediation-proof.yml
@@ -69,7 +69,9 @@ jobs:
         run: |
           uv venv --python 3.12 .proof-venv
           uv pip install --python .proof-venv/bin/python dist/*.whl
-          .proof-venv/bin/python -c 'from codex_plugin_scanner.version import __version__; assert __version__.startswith("3.0.0a")'
+          EXPECTED_VERSION=$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
+          INSTALLED_VERSION=$(.proof-venv/bin/python -c 'from importlib.metadata import version; print(version("hol-guard"))')
+          test "$INSTALLED_VERSION" = "$EXPECTED_VERSION"
           .proof-venv/bin/hol-guard --version
       - name: Upload formatted proof source
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ hol-guard init
 
 `hol-guard init` discovers compatible AI agents, explains each setup change before applying it, and guides you through your first protected action.
 
-Guard 3.x alphas are opt-in and do not replace the stable 2.x release selected by normal installers. To evaluate a published alpha, pin its exact version from the [GitHub prereleases](https://github.com/hashgraph-online/hol-guard/releases):
+HOL Guard 3.0 is the current stable release selected by normal installers. To reproduce an exact stable installation, pin its version:
 
 ```bash
-pipx install --force "hol-guard==3.0.0a1"
+pipx install --force "hol-guard==3.0.0"
 ```
 
-Return to the stable 2.x channel with `pipx install --force "hol-guard<3"`.
+Legacy environments that must remain on the 2.x line can use `pipx install --force "hol-guard<3"`. Published prereleases remain available from [GitHub prereleases](https://github.com/hashgraph-online/hol-guard/releases) for explicit testing; normal installers do not select them.
 
 [Install guide](https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/get-started.md) · [GuardPolicy v1alpha1](https://github.com/hashgraph-online/hol-guard/blob/main/spec/guard-policy/v1alpha1/README.md) · [Supported agents](https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/harness-support.md) · [Local vs. cloud](https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/local-vs-cloud.md) · [Security policy](https://github.com/hashgraph-online/hol-guard/blob/main/SECURITY.md)
 

--- a/ci/code-quality-baseline.json
+++ b/ci/code-quality-baseline.json
@@ -622,7 +622,7 @@
     "tests/test_guard_bulk_allow_once.py": 632,
     "tests/test_guard_cisco_runtime_cli.py": 745,
     "tests/test_guard_claude_adapter.py": 720,
-    "tests/test_guard_cli.py": 10103,
+    "tests/test_guard_cli.py": 10115,
     "tests/test_guard_cloud_local_sync.py": 1262,
     "tests/test_guard_cloud_review_sync.py": 742,
     "tests/test_guard_codex_browser_authority.py": 710,

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
   "maximum_collected_cases": 16158,
-  "maximum_test_source_lines": 348941
+  "maximum_test_source_lines": 348953
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hol-guard"
-version = "3.0.0a0"
+version = "3.0.0"
 description = "Open-source antivirus and runtime protection for AI agents, tools, MCP servers, plugins, skills, and package installs."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/codex_plugin_scanner/version.py
+++ b/src/codex_plugin_scanner/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for tool version."""
 
-__version__ = "3.0.0a0"
+__version__ = "3.0.0"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -4194,6 +4194,12 @@ args = ["workspace-skill.js", "--changed"]
     def test_guard_update_dry_run_emits_planned_command(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"
         monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
+        monkeypatch.setattr(guard_update_commands_module, "_current_version", lambda: "3.0.0a289")
+        monkeypatch.setattr(
+            guard_update_commands_module,
+            "_latest_alpha_version_from_pypi",
+            lambda _current: "3.0.0a290",
+        )
 
         rc = main(["guard", "update", "--home", str(home_dir), "--alpha", "--dry-run", "--json"])
         output = json.loads(capsys.readouterr().out)
@@ -4206,6 +4212,12 @@ args = ["workspace-skill.js", "--changed"]
     def test_guard_update_dry_run_skips_guard_store_init(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"
         monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
+        monkeypatch.setattr(guard_update_commands_module, "_current_version", lambda: "3.0.0a289")
+        monkeypatch.setattr(
+            guard_update_commands_module,
+            "_latest_alpha_version_from_pypi",
+            lambda _current: "3.0.0a290",
+        )
         monkeypatch.setattr(
             guard_commands_module,
             "GuardStore",

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -19,7 +19,7 @@ def test_source_distribution_and_package_versions_match():
     pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
     pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
     source_version = pyproject["project"]["version"]
-    assert source_version == package_version == "3.0.0a0"
+    assert source_version == package_version == "3.0.0"
     try:
         installed_version = distribution_version("hol-guard")
     except PackageNotFoundError:

--- a/uv.lock
+++ b/uv.lock
@@ -1174,7 +1174,7 @@ wheels = [
 
 [[package]]
 name = "hol-guard"
-version = "3.0.0a0"
+version = "3.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "cisco-ai-skill-scanner" },


### PR DESCRIPTION
## Summary
- normalize promoted `main` metadata and runtime version to stable `3.0.0`
- align installed-wheel proof with the exact project version instead of an alpha prefix
- update install/channel guidance for stable 3.0 and legacy 2.x
- make alpha dry-run tests model an actual newer alpha candidate

## Root cause
The release branch intentionally carried an alpha source version, but promotion did not perform the stable normalization required by `compute_main_release_version.py`. Main publication therefore stopped at `Repository version must be a canonical X.Y.Z stable version`.

## Verification
- 56 focused release/version tests passed before review remediation
- 32 exact CLI/version/workflow/proof tests passed after remediation
- full basedpyright: 0 errors
- Ruff and actionlint passed
- test-suite and structural code-quality ratchets passed
- Managed Controls Local release gate passed
- isolated wheel/sdist build produced `hol_guard-3.0.0`
- isolated installed-wheel canary reported `hol-guard 3.0.0`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HOL Guard 3.0 is now the stable release selected by standard installers.
  * Prerelease builds remain available for testing, while 2.x usage is documented as legacy compatibility.

* **Documentation**
  * Added installation guidance for the exact `3.0.0` release.

* **Tests**
  * Updated version checks and alpha update dry-run coverage for the stable release transition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->