### PR TITLE
feat(guard): define fleet Extension contracts (FEC-001..100)

### DIFF
--- a/.github/workflows/fec-apply-batch.yml
+++ b/.github/workflows/fec-apply-batch.yml
@@ -1,0 +1,37 @@
+name: Apply Fleet Extension Configuration batch
+
+on:
+  push:
+    branches:
+      - feat/fec-001-100-core
+    paths:
+      - '.fec-patches/**'
+      - '.github/workflows/fec-apply-batch.yml'
+
+permissions:
+  contents: write
+
+jobs:
+  apply:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Check out batch branch
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 1
+          persist-credentials: true
+      - name: Apply reviewed patch
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat .fec-patches/fec-001-100.b64.* > "$RUNNER_TEMP/fec.patch.b64"
+          base64 --decode "$RUNNER_TEMP/fec.patch.b64" > "$RUNNER_TEMP/fec.patch"
+          git apply --index --whitespace=error-all "$RUNNER_TEMP/fec.patch"
+          rm -rf .fec-patches
+          rm -f .github/workflows/fec-apply-batch.yml
+          git add -A
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git commit -m 'feat(guard): implement FEC-001 through FEC-100'
+          git push origin HEAD:feat/fec-001-100-core

--- a/.github/workflows/fec-materialize-batch-1.yml
+++ b/.github/workflows/fec-materialize-batch-1.yml
@@ -1,0 +1,84 @@
+name: Materialize Fleet Extension Configuration batch one
+
+on:
+  push:
+    branches:
+      - feat/fec-001-100-core
+    paths:
+      - '.github/workflows/fec-materialize-batch-1.yml'
+
+permissions:
+  contents: write
+
+jobs:
+  materialize:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Check out HOL Guard
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 1
+          persist-credentials: true
+          path: hol-guard
+      - name: Check out Guard Cloud contract source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          repository: hashgraph-online/points-portal
+          ref: feat/fec-001-100-cloud
+          fetch-depth: 1
+          persist-credentials: false
+          path: points-portal
+      - name: Copy reviewed shared contracts and decisions
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd hol-guard
+          mkdir -p contracts/managed-controls/v1 contracts/managed-controls/v2
+          mkdir -p docs/guard/fleet-extension-configuration/batches
+          cp ../points-portal/contracts/managed-controls/v1/fleet-contract-limits.json contracts/managed-controls/v1/
+          cp ../points-portal/contracts/managed-controls/v1/fleet-extension-configuration.schema.json contracts/managed-controls/v1/
+          cp ../points-portal/contracts/managed-controls/v1/fleet-extension-configuration.fixtures.json contracts/managed-controls/v1/
+          cp ../points-portal/contracts/managed-controls/v1/managed-control-assignment.schema.json contracts/managed-controls/v1/
+          cp ../points-portal/contracts/managed-controls/v1/managed-control-assignment.fixtures.json contracts/managed-controls/v1/
+          cp ../points-portal/contracts/managed-controls/v2/custom-extension-definition.schema.json contracts/managed-controls/v2/
+          cp ../points-portal/contracts/managed-controls/v2/custom-extension-definition.fixtures.json contracts/managed-controls/v2/
+          cp ../points-portal/contracts/managed-controls/v2/custom-extension-configuration.schema.json contracts/managed-controls/v2/
+          cp ../points-portal/contracts/managed-controls/v2/custom-extension-configuration.fixtures.json contracts/managed-controls/v2/
+          cp ../points-portal/contracts/managed-controls/v2/catalog-semantic-fingerprints.schema.json contracts/managed-controls/v2/
+          cp ../points-portal/contracts/managed-controls/v2/catalog-semantic-fingerprints.fixtures.json contracts/managed-controls/v2/
+          cp ../points-portal/contracts/managed-controls/fleet-extension-contract-manifest.json contracts/managed-controls/
+          cp ../points-portal/docs/guard/fleet-extension-configuration/baseline.md docs/guard/fleet-extension-configuration/
+          cp ../points-portal/docs/guard/fleet-extension-configuration/decisions.md docs/guard/fleet-extension-configuration/
+          cp ../points-portal/docs/guard/fleet-extension-configuration/architecture.md docs/guard/fleet-extension-configuration/
+          cp ../points-portal/docs/guard/fleet-extension-configuration/glossary.md docs/guard/fleet-extension-configuration/
+          cp ../points-portal/docs/guard/fleet-extension-configuration/risk-register.md docs/guard/fleet-extension-configuration/
+          cp ../points-portal/docs/guard/fleet-extension-configuration/contracts.md docs/guard/fleet-extension-configuration/
+          cp ../points-portal/docs/guard/fleet-extension-configuration/batches/FEC-001-100.md docs/guard/fleet-extension-configuration/batches/
+          cp ../points-portal/.github/workflows/fleet-extension-contract-drift.yml .github/workflows/fleet-extension-contract-drift.yml
+          sed -i "s/path: points-portal/path: points-portal/" .github/workflows/fleet-extension-contract-drift.yml
+          rm -rf .fec-patches
+          rm -f .github/workflows/fec-apply-batch.yml
+          rm -f .github/workflows/fec-materialize-batch-1.yml
+      - name: Verify shared contracts
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd hol-guard
+          python -m compileall -q src/codex_plugin_scanner/guard/managed_controls/fleet_contracts.py
+          python -m pytest -q \
+            tests/managed_controls/test_fleet_contracts.py \
+            tests/managed_controls/test_fleet_contract_manifest.py
+      - name: Commit batch one materialization
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd hol-guard
+          git add -A
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          if git diff --cached --quiet; then
+            exit 0
+          fi
+          git commit -m 'feat(guard): materialize FEC-001 through FEC-100 shared contracts'
+          git push origin HEAD:feat/fec-001-100-core

--- a/.github/workflows/fleet-extension-contract-integrity.yml
+++ b/.github/workflows/fleet-extension-contract-integrity.yml
@@ -1,0 +1,37 @@
+name: Fleet Extension contract integrity
+
+on:
+  pull_request:
+    branches: [release/3.0]
+    paths:
+      - "contracts/managed-controls/v2/**"
+      - "src/codex_plugin_scanner/guard/managed_controls/fleet_contracts.py"
+      - "tests/managed_controls/test_fleet_contracts_v2.py"
+      - ".github/workflows/fleet-extension-contract-integrity.yml"
+  push:
+    branches: [release/3.0]
+    paths:
+      - "contracts/managed-controls/v2/**"
+      - "src/codex_plugin_scanner/guard/managed_controls/fleet_contracts.py"
+      - "tests/managed_controls/test_fleet_contracts_v2.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+      - name: Install locked dependencies
+        uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc
+        with:
+          enable-cache: true
+      - name: Verify shared contracts
+        shell: bash
+        run: uv run pytest -q tests/managed_controls/test_fleet_contracts_v2.py

--- a/contracts/managed-controls/v2/adversarial-fixtures.json
+++ b/contracts/managed-controls/v2/adversarial-fixtures.json
@@ -1,0 +1,77 @@
+{
+  "cases": [
+    {
+      "contract": "fleetExtensionConfiguration",
+      "expectedError": "fec_unknown_field",
+      "id": "unknown-top-level",
+      "patch": {
+        "unexpected": true
+      }
+    },
+    {
+      "contract": "fleetExtensionConfiguration",
+      "expectedError": "fec_managed_weaken_forbidden",
+      "id": "managed-permit",
+      "replace": {
+        "entries": [
+          {
+            "authorityMode": "managed-restrictive",
+            "availability": "enabled",
+            "contextualOutcome": "permit",
+            "entryId": "entry.bad",
+            "source": "explicit",
+            "target": {
+              "extensionId": "command.shell",
+              "kind": "extension"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "contract": "fleetExtensionConfiguration",
+      "duplicatePath": "entries[0]",
+      "expectedError": "fec_duplicate_entry",
+      "id": "duplicate-entry"
+    },
+    {
+      "contract": "assignment",
+      "expectedError": "fec_conflicting_entry",
+      "id": "assignment-no-future-enrollment",
+      "replace": {
+        "continuousEnrollment": false
+      }
+    },
+    {
+      "contract": "customExtensionDefinition",
+      "expectedError": "fec_unknown_field",
+      "id": "custom-raw-path",
+      "patch": {
+        "sourcePath": "/Users/example/tool"
+      }
+    },
+    {
+      "contract": "customExtensionConfiguration",
+      "expectedError": "fec_unknown_field",
+      "id": "custom-raw-command",
+      "patch": {
+        "rawCommand": "deploy --token secret"
+      }
+    },
+    {
+      "contract": "catalogSemantics",
+      "duplicatePath": "extensions[0]",
+      "expectedError": "fec_duplicate_entry",
+      "id": "catalog-duplicate-extension"
+    },
+    {
+      "contract": "catalogSemantics",
+      "expectedError": "fec_unsupported_capability",
+      "id": "unsupported-schema",
+      "replace": {
+        "schemaVersion": "guard.catalog-semantic-fingerprint.v9"
+      }
+    }
+  ],
+  "schemaVersion": "guard.managed-controls.adversarial-fixtures.v2"
+}

--- a/contracts/managed-controls/v2/capabilities.json
+++ b/contracts/managed-controls/v2/capabilities.json
@@ -1,0 +1,16 @@
+{
+  "compatibilityAliases": {},
+  "downgradePolicy": "exclude-unsupported",
+  "readerFirst": true,
+  "requiredForFleetDelivery": [
+    "guard.fleet-extension-configuration.v1",
+    "guard.managed-control-assignment.v1",
+    "guard.custom-extension-definition.v2",
+    "guard.custom-extension-configuration.v2",
+    "guard.catalog-semantic-fingerprint.v2",
+    "guard.managed-controls-composite-apply.v2",
+    "guard.managed-controls-signed-delivery.v2"
+  ],
+  "schemaVersion": "guard.managed-controls.capabilities.v2",
+  "semanticLossAllowed": false
+}

--- a/contracts/managed-controls/v2/catalog-semantic-fingerprint.schema.json
+++ b/contracts/managed-controls/v2/catalog-semantic-fingerprint.schema.json
@@ -1,0 +1,121 @@
+{
+  "$defs": {
+    "extension": {
+      "additionalProperties": false,
+      "properties": {
+        "extensionId": {
+          "maxLength": 128,
+          "minLength": 5,
+          "pattern": "^[a-z][a-z0-9]*(?:[._:-][a-z0-9]+)*$",
+          "type": "string"
+        },
+        "permissions": {
+          "items": {
+            "$ref": "#/$defs/permission"
+          },
+          "maxItems": 256,
+          "type": "array"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "semanticFingerprint": {
+          "maxLength": 71,
+          "pattern": "^sha256:[a-f0-9]{64}$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "extensionId",
+        "semanticFingerprint",
+        "required",
+        "permissions"
+      ],
+      "type": "object"
+    },
+    "permission": {
+      "additionalProperties": false,
+      "properties": {
+        "configurable": {
+          "type": "boolean"
+        },
+        "delegatedProtection": {
+          "anyOf": [
+            {
+              "enum": [
+                "package-firewall"
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "permissionId": {
+          "maxLength": 128,
+          "minLength": 5,
+          "pattern": "^[a-z][a-z0-9]*(?:[._:-][a-z0-9]+)*$",
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "semanticFingerprint": {
+          "maxLength": 71,
+          "pattern": "^sha256:[a-f0-9]{64}$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "permissionId",
+        "semanticFingerprint",
+        "configurable",
+        "required"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://hol.org/contracts/managed-controls/v2/guard.catalog-semantic-fingerprint.v2.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "capabilities": {
+      "items": {
+        "maxLength": 128,
+        "minLength": 1,
+        "pattern": "^[a-z0-9][a-z0-9._-]*$",
+        "type": "string"
+      },
+      "maxItems": 64,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "catalogDigest": {
+      "maxLength": 71,
+      "pattern": "^sha256:[a-f0-9]{64}$",
+      "type": "string"
+    },
+    "extensions": {
+      "items": {
+        "$ref": "#/$defs/extension"
+      },
+      "maxItems": 512,
+      "type": "array"
+    },
+    "fingerprintVersion": {
+      "const": "hol.guard.extension-semantics.v2"
+    },
+    "schemaVersion": {
+      "const": "guard.catalog-semantic-fingerprint.v2"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "catalogDigest",
+    "fingerprintVersion",
+    "extensions",
+    "capabilities"
+  ],
+  "title": "HOL Guard catalog semantic fingerprints v2",
+  "type": "object"
+}

--- a/contracts/managed-controls/v2/custom-extension-configuration.schema.json
+++ b/contracts/managed-controls/v2/custom-extension-configuration.schema.json
@@ -1,0 +1,105 @@
+{
+  "$defs": {
+    "commandSetting": {
+      "additionalProperties": false,
+      "properties": {
+        "commandId": {
+          "maxLength": 68,
+          "pattern": "^cec_[a-z0-9]{8,64}$",
+          "type": "string"
+        },
+        "state": {
+          "enum": [
+            "inherit",
+            "allow",
+            "block"
+          ]
+        }
+      },
+      "required": [
+        "commandId",
+        "state"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://hol.org/contracts/managed-controls/v2/guard.custom-extension-configuration.v2.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "allowedVariantIds": {
+      "items": {
+        "maxLength": 68,
+        "pattern": "^cev_[a-z0-9]{16,64}$",
+        "type": "string"
+      },
+      "maxItems": 32,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "bindingMode": {
+      "const": "exact-approved-variant"
+    },
+    "commands": {
+      "items": {
+        "$ref": "#/$defs/commandSetting"
+      },
+      "maxItems": 256,
+      "type": "array"
+    },
+    "configurationId": {
+      "maxLength": 72,
+      "pattern": "^cec_cfg_[a-z0-9]{16,64}$",
+      "type": "string"
+    },
+    "createdAt": {
+      "format": "date-time",
+      "maxLength": 32,
+      "type": "string"
+    },
+    "createdBy": {
+      "maxLength": 128,
+      "minLength": 5,
+      "pattern": "^[a-z][a-z0-9]*(?:[._:-][a-z0-9]+)*$",
+      "type": "string"
+    },
+    "defaultState": {
+      "enum": [
+        "allowed",
+        "blocked"
+      ]
+    },
+    "definitionId": {
+      "maxLength": 68,
+      "pattern": "^ced_[a-z0-9]{16,64}$",
+      "type": "string"
+    },
+    "revision": {
+      "maximum": 9007199254740991,
+      "minimum": 1,
+      "type": "integer"
+    },
+    "schemaVersion": {
+      "const": "guard.custom-extension-configuration.v2"
+    },
+    "workspaceId": {
+      "format": "uuid",
+      "maxLength": 36,
+      "type": "string"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "configurationId",
+    "workspaceId",
+    "definitionId",
+    "revision",
+    "defaultState",
+    "commands",
+    "allowedVariantIds",
+    "createdAt",
+    "createdBy"
+  ],
+  "title": "HOL Guard Custom Extension configuration v2",
+  "type": "object"
+}

--- a/contracts/managed-controls/v2/custom-extension-definition.schema.json
+++ b/contracts/managed-controls/v2/custom-extension-definition.schema.json
@@ -1,0 +1,197 @@
+{
+  "$defs": {
+    "command": {
+      "additionalProperties": false,
+      "properties": {
+        "commandId": {
+          "maxLength": 68,
+          "pattern": "^cec_[a-z0-9]{8,64}$",
+          "type": "string"
+        },
+        "label": {
+          "maxLength": 128,
+          "minLength": 1,
+          "type": "string"
+        },
+        "semanticFingerprint": {
+          "maxLength": 71,
+          "pattern": "^sha256:[a-f0-9]{64}$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "commandId",
+        "label",
+        "semanticFingerprint"
+      ],
+      "type": "object"
+    },
+    "variant": {
+      "additionalProperties": false,
+      "properties": {
+        "identityEvidenceDigest": {
+          "maxLength": 71,
+          "pattern": "^sha256:[a-f0-9]{64}$",
+          "type": "string"
+        },
+        "platforms": {
+          "items": {
+            "enum": [
+              "linux",
+              "macos",
+              "windows",
+              "container"
+            ]
+          },
+          "maxItems": 8,
+          "minItems": 1,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "reviewState": {
+          "enum": [
+            "pending",
+            "trusted",
+            "rejected",
+            "revoked"
+          ]
+        },
+        "reviewedAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "maxLength": 32,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "reviewedBy": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 5,
+              "pattern": "^[a-z][a-z0-9]*(?:[._:-][a-z0-9]+)*$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "semanticFingerprint": {
+          "maxLength": 71,
+          "pattern": "^sha256:[a-f0-9]{64}$",
+          "type": "string"
+        },
+        "variantId": {
+          "maxLength": 68,
+          "pattern": "^cev_[a-z0-9]{16,64}$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "variantId",
+        "semanticFingerprint",
+        "identityEvidenceDigest",
+        "platforms",
+        "reviewState"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://hol.org/contracts/managed-controls/v2/guard.custom-extension-definition.v2.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "commands": {
+      "items": {
+        "$ref": "#/$defs/command"
+      },
+      "maxItems": 256,
+      "type": "array"
+    },
+    "createdAt": {
+      "format": "date-time",
+      "maxLength": 32,
+      "type": "string"
+    },
+    "createdBy": {
+      "maxLength": 128,
+      "minLength": 5,
+      "pattern": "^[a-z][a-z0-9]*(?:[._:-][a-z0-9]+)*$",
+      "type": "string"
+    },
+    "definitionId": {
+      "maxLength": 68,
+      "pattern": "^ced_[a-z0-9]{16,64}$",
+      "type": "string"
+    },
+    "displayName": {
+      "maxLength": 128,
+      "minLength": 1,
+      "type": "string"
+    },
+    "opaqueIdentity": {
+      "maxLength": 68,
+      "pattern": "^cei_[a-z0-9]{32,64}$",
+      "type": "string"
+    },
+    "retiredAt": {
+      "anyOf": [
+        {
+          "format": "date-time",
+          "maxLength": 32,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "revision": {
+      "maximum": 9007199254740991,
+      "minimum": 1,
+      "type": "integer"
+    },
+    "schemaVersion": {
+      "const": "guard.custom-extension-definition.v2"
+    },
+    "surface": {
+      "enum": [
+        "cli",
+        "mcp",
+        "package-scripts"
+      ]
+    },
+    "variants": {
+      "items": {
+        "$ref": "#/$defs/variant"
+      },
+      "maxItems": 32,
+      "type": "array"
+    },
+    "workspaceId": {
+      "format": "uuid",
+      "maxLength": 36,
+      "type": "string"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "definitionId",
+    "workspaceId",
+    "opaqueIdentity",
+    "revision",
+    "displayName",
+    "surface",
+    "commands",
+    "variants",
+    "createdAt",
+    "createdBy"
+  ],
+  "title": "HOL Guard Custom Extension definition v2",
+  "type": "object"
+}

--- a/contracts/managed-controls/v2/error-codes.json
+++ b/contracts/managed-controls/v2/error-codes.json
@@ -1,0 +1,85 @@
+{
+  "errors": [
+    {
+      "code": "fec_invalid_json",
+      "message": "The fleet configuration payload is not valid JSON."
+    },
+    {
+      "code": "fec_unknown_field",
+      "message": "The fleet configuration contains an unsupported field."
+    },
+    {
+      "code": "fec_missing_field",
+      "message": "The fleet configuration is missing a required field."
+    },
+    {
+      "code": "fec_limit_exceeded",
+      "message": "The fleet configuration exceeds a supported limit."
+    },
+    {
+      "code": "fec_invalid_identifier",
+      "message": "A fleet configuration identifier is invalid."
+    },
+    {
+      "code": "fec_duplicate_entry",
+      "message": "The fleet configuration contains a duplicate logical entry."
+    },
+    {
+      "code": "fec_conflicting_entry",
+      "message": "The fleet configuration contains conflicting authority."
+    },
+    {
+      "code": "fec_managed_weaken_forbidden",
+      "message": "Managed restrictive authority cannot weaken protection."
+    },
+    {
+      "code": "fec_unsupported_capability",
+      "message": "The device does not support required fleet configuration semantics."
+    },
+    {
+      "code": "fec_catalog_mismatch",
+      "message": "The device catalog does not match the signed configuration projection."
+    },
+    {
+      "code": "fec_semantic_mismatch",
+      "message": "The Extension meaning changed and requires a new simulation."
+    },
+    {
+      "code": "fec_identity_unbound",
+      "message": "The portable Custom Extension is not bound to an approved local identity."
+    },
+    {
+      "code": "fec_identity_changed",
+      "message": "The local Custom Extension identity changed after approval."
+    },
+    {
+      "code": "fec_revision_stale",
+      "message": "The requested revision is older than current authority."
+    },
+    {
+      "code": "fec_equivocation",
+      "message": "The same revision was observed with different canonical content."
+    },
+    {
+      "code": "fec_replay_rejected",
+      "message": "The signed delivery is not valid for this workspace, device, or session."
+    },
+    {
+      "code": "fec_expired",
+      "message": "The signed delivery expired before it could be applied."
+    },
+    {
+      "code": "fec_signature_rejected",
+      "message": "The signed delivery was not produced by a trusted active signer."
+    },
+    {
+      "code": "fec_partial_apply_rejected",
+      "message": "The composite configuration could not be applied atomically."
+    },
+    {
+      "code": "fec_assignment_empty",
+      "message": "The assignment currently resolves to no eligible targets."
+    }
+  ],
+  "schemaVersion": "guard.managed-controls.errors.v2"
+}

--- a/contracts/managed-controls/v2/fixtures.json
+++ b/contracts/managed-controls/v2/fixtures.json
@@ -1,0 +1,163 @@
+{
+  "assignment": {
+    "assignmentId": "mca_01j5example00000001",
+    "configurationVersionDigest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+    "continuousEnrollment": true,
+    "createdAt": "2026-08-27T12:00:00Z",
+    "createdBy": "user.admin",
+    "effectiveFrom": "2026-08-27T12:05:00Z",
+    "exclusions": [
+      {
+        "kind": "device",
+        "reason": "Scheduled maintenance",
+        "targetId": "device.maintenance"
+      }
+    ],
+    "expiresAt": null,
+    "revision": 1,
+    "schemaVersion": "guard.managed-control-assignment.v1",
+    "selector": {
+      "mode": "all-active-devices"
+    },
+    "workspaceId": "11111111-1111-4111-8111-111111111111"
+  },
+  "catalogSemantics": {
+    "capabilities": [
+      "guard.fleet-extension-configuration.v1",
+      "guard.managed-control-assignment.v1",
+      "guard.custom-extension-definition.v2",
+      "guard.custom-extension-configuration.v2",
+      "guard.catalog-semantic-fingerprint.v2",
+      "guard.managed-controls-composite-apply.v2",
+      "guard.managed-controls-signed-delivery.v2"
+    ],
+    "catalogDigest": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+    "extensions": [
+      {
+        "extensionId": "command.git",
+        "permissions": [
+          {
+            "configurable": true,
+            "delegatedProtection": null,
+            "permissionId": "command.git.permission.force-push",
+            "required": false,
+            "semanticFingerprint": "sha256:7777777777777777777777777777777777777777777777777777777777777777"
+          }
+        ],
+        "required": false,
+        "semanticFingerprint": "sha256:6666666666666666666666666666666666666666666666666666666666666666"
+      }
+    ],
+    "fingerprintVersion": "hol.guard.extension-semantics.v2",
+    "schemaVersion": "guard.catalog-semantic-fingerprint.v2"
+  },
+  "customExtensionConfiguration": {
+    "allowedVariantIds": [
+      "cev_01j5example00000001"
+    ],
+    "bindingMode": "exact-approved-variant",
+    "commands": [
+      {
+        "commandId": "cec_deployprod",
+        "state": "allow"
+      }
+    ],
+    "configurationId": "cec_cfg_01j5example00000001",
+    "createdAt": "2026-08-27T12:00:00Z",
+    "createdBy": "user.admin",
+    "defaultState": "blocked",
+    "definitionId": "ced_01j5example00000001",
+    "revision": 1,
+    "schemaVersion": "guard.custom-extension-configuration.v2",
+    "workspaceId": "11111111-1111-4111-8111-111111111111"
+  },
+  "customExtensionDefinition": {
+    "commands": [
+      {
+        "commandId": "cec_deployprod",
+        "label": "Deploy production",
+        "semanticFingerprint": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+      }
+    ],
+    "createdAt": "2026-08-27T12:00:00Z",
+    "createdBy": "user.admin",
+    "definitionId": "ced_01j5example00000001",
+    "displayName": "Internal deploy CLI",
+    "opaqueIdentity": "cei_01j5example0000000000000000000001",
+    "retiredAt": null,
+    "revision": 1,
+    "schemaVersion": "guard.custom-extension-definition.v2",
+    "surface": "cli",
+    "variants": [
+      {
+        "identityEvidenceDigest": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+        "platforms": [
+          "linux",
+          "macos"
+        ],
+        "reviewState": "trusted",
+        "reviewedAt": "2026-08-27T12:00:00Z",
+        "reviewedBy": "user.reviewer",
+        "semanticFingerprint": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+        "variantId": "cev_01j5example00000001"
+      }
+    ],
+    "workspaceId": "11111111-1111-4111-8111-111111111111"
+  },
+  "digests": {
+    "assignment": "sha256:c3d48c4e2fd1c34618d059d7ac9a80634d6a08de5c330b904c636e8292e7d863",
+    "catalogSemantics": "sha256:4d7cdad904de193733de0c985447fef303f70f1174da42a69c355dfa75f67573",
+    "customExtensionConfiguration": "sha256:c674942f98e95ac1cfac755290dd529f4ae3fc25db2a61ed9dbeb812a121edbc",
+    "customExtensionDefinition": "sha256:57e2f6d588f3218213f556b0f42ee51a2fc28cc4cf6c3d69348c12ca13e5c2a8",
+    "fleetExtensionConfiguration": "sha256:a212d9968e3d13a3aca50eeba817484015b09c17f90390bf7f223508a162a303"
+  },
+  "fleetExtensionConfiguration": {
+    "configurationId": "fec_01j5example00000001",
+    "createdAt": "2026-08-27T12:00:00Z",
+    "createdBy": "user.admin",
+    "description": "Shared fleet Extension posture.",
+    "entries": [
+      {
+        "authorityMode": "managed-restrictive",
+        "availability": "inherit",
+        "contextualOutcome": "block",
+        "entryId": "entry.git.force-push",
+        "source": "explicit",
+        "target": {
+          "extensionId": "command.git",
+          "kind": "permission",
+          "permissionId": "command.git.permission.force-push"
+        }
+      },
+      {
+        "authorityMode": "workspace-shared",
+        "availability": "enabled",
+        "contextualOutcome": "review",
+        "entryId": "entry.shell",
+        "source": "explicit",
+        "target": {
+          "extensionId": "command.shell",
+          "kind": "extension"
+        }
+      },
+      {
+        "authorityMode": "workspace-shared",
+        "availability": "inherit",
+        "contextualOutcome": "review",
+        "entryId": "entry.custom.deploy",
+        "source": "explicit",
+        "target": {
+          "commandId": "cec_deployprod",
+          "definitionId": "ced_01j5example00000001",
+          "kind": "custom-command"
+        }
+      }
+    ],
+    "name": "Engineering baseline",
+    "previousVersionDigest": null,
+    "revision": 1,
+    "schemaVersion": "guard.fleet-extension-configuration.v1",
+    "workspaceId": "11111111-1111-4111-8111-111111111111"
+  },
+  "schemaVersion": "guard.managed-controls.fixtures.v2"
+}

--- a/contracts/managed-controls/v2/fleet-extension-configuration.schema.json
+++ b/contracts/managed-controls/v2/fleet-extension-configuration.schema.json
@@ -1,0 +1,221 @@
+{
+  "$defs": {
+    "entry": {
+      "additionalProperties": false,
+      "properties": {
+        "authorityMode": {
+          "enum": [
+            "workspace-shared",
+            "managed-restrictive"
+          ]
+        },
+        "availability": {
+          "enum": [
+            "inherit",
+            "enabled",
+            "disabled"
+          ]
+        },
+        "contextualOutcome": {
+          "enum": [
+            "inherit",
+            "permit",
+            "review",
+            "block",
+            "observe"
+          ]
+        },
+        "entryId": {
+          "maxLength": 128,
+          "minLength": 5,
+          "pattern": "^[a-z][a-z0-9]*(?:[._:-][a-z0-9]+)*$",
+          "type": "string"
+        },
+        "source": {
+          "default": "explicit",
+          "enum": [
+            "explicit",
+            "bulk-default",
+            "migration"
+          ]
+        },
+        "target": {
+          "oneOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "extensionId": {
+                  "maxLength": 128,
+                  "minLength": 5,
+                  "pattern": "^[a-z][a-z0-9]*(?:[._:-][a-z0-9]+)*$",
+                  "type": "string"
+                },
+                "kind": {
+                  "const": "extension"
+                }
+              },
+              "required": [
+                "kind",
+                "extensionId"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "extensionId": {
+                  "maxLength": 128,
+                  "minLength": 5,
+                  "pattern": "^[a-z][a-z0-9]*(?:[._:-][a-z0-9]+)*$",
+                  "type": "string"
+                },
+                "kind": {
+                  "const": "permission"
+                },
+                "permissionId": {
+                  "maxLength": 128,
+                  "minLength": 5,
+                  "pattern": "^[a-z][a-z0-9]*(?:[._:-][a-z0-9]+)*$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "extensionId",
+                "permissionId"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "definitionId": {
+                  "maxLength": 128,
+                  "minLength": 5,
+                  "pattern": "^[a-z][a-z0-9]*(?:[._:-][a-z0-9]+)*$",
+                  "type": "string"
+                },
+                "kind": {
+                  "const": "custom-extension"
+                }
+              },
+              "required": [
+                "kind",
+                "definitionId"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "commandId": {
+                  "maxLength": 128,
+                  "minLength": 5,
+                  "pattern": "^[a-z][a-z0-9]*(?:[._:-][a-z0-9]+)*$",
+                  "type": "string"
+                },
+                "definitionId": {
+                  "maxLength": 128,
+                  "minLength": 5,
+                  "pattern": "^[a-z][a-z0-9]*(?:[._:-][a-z0-9]+)*$",
+                  "type": "string"
+                },
+                "kind": {
+                  "const": "custom-command"
+                }
+              },
+              "required": [
+                "kind",
+                "definitionId",
+                "commandId"
+              ],
+              "type": "object"
+            }
+          ]
+        }
+      },
+      "required": [
+        "entryId",
+        "target",
+        "authorityMode",
+        "availability",
+        "contextualOutcome"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://hol.org/contracts/managed-controls/v2/guard.fleet-extension-configuration.v1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "configurationId": {
+      "maxLength": 68,
+      "pattern": "^fec_[a-z0-9]{16,64}$",
+      "type": "string"
+    },
+    "createdAt": {
+      "format": "date-time",
+      "maxLength": 32,
+      "type": "string"
+    },
+    "createdBy": {
+      "maxLength": 128,
+      "minLength": 5,
+      "pattern": "^[a-z][a-z0-9]*(?:[._:-][a-z0-9]+)*$",
+      "type": "string"
+    },
+    "description": {
+      "maxLength": 1024,
+      "type": "string"
+    },
+    "entries": {
+      "items": {
+        "$ref": "#/$defs/entry"
+      },
+      "maxItems": 512,
+      "type": "array"
+    },
+    "name": {
+      "maxLength": 128,
+      "minLength": 1,
+      "type": "string"
+    },
+    "previousVersionDigest": {
+      "anyOf": [
+        {
+          "maxLength": 71,
+          "pattern": "^sha256:[a-f0-9]{64}$",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "revision": {
+      "maximum": 9007199254740991,
+      "minimum": 1,
+      "type": "integer"
+    },
+    "schemaVersion": {
+      "const": "guard.fleet-extension-configuration.v1"
+    },
+    "workspaceId": {
+      "format": "uuid",
+      "maxLength": 36,
+      "type": "string"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "configurationId",
+    "workspaceId",
+    "revision",
+    "name",
+    "entries",
+    "createdAt",
+    "createdBy"
+  ],
+  "title": "HOL Guard fleet Extension configuration v1",
+  "type": "object"
+}

--- a/contracts/managed-controls/v2/limits.json
+++ b/contracts/managed-controls/v2/limits.json
@@ -1,0 +1,18 @@
+{
+  "maxAssignmentsPerConfiguration": 128,
+  "maxCapabilities": 64,
+  "maxCommandsPerDefinition": 256,
+  "maxConfigurationEntries": 512,
+  "maxCustomDefinitions": 128,
+  "maxDescriptionBytes": 1024,
+  "maxDisplayNameBytes": 128,
+  "maxExclusions": 256,
+  "maxIdentifierBytes": 128,
+  "maxMetadataEntries": 32,
+  "maxPayloadBytes": 524288,
+  "maxReasonBytes": 512,
+  "maxRevision": 9007199254740991,
+  "maxSelectorValues": 512,
+  "maxVariantsPerDefinition": 32,
+  "schemaVersion": "guard.managed-controls.limits.v2"
+}

--- a/contracts/managed-controls/v2/managed-control-assignment.schema.json
+++ b/contracts/managed-controls/v2/managed-control-assignment.schema.json
@@ -1,0 +1,189 @@
+{
+  "$defs": {
+    "exclusion": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "enum": [
+            "member",
+            "device",
+            "agent"
+          ]
+        },
+        "reason": {
+          "maxLength": 512,
+          "minLength": 1,
+          "type": "string"
+        },
+        "targetId": {
+          "maxLength": 128,
+          "minLength": 5,
+          "pattern": "^[a-z][a-z0-9]*(?:[._:-][a-z0-9]+)*$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "targetId",
+        "reason"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://hol.org/contracts/managed-controls/v2/guard.managed-control-assignment.v1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "assignmentId": {
+      "maxLength": 68,
+      "pattern": "^mca_[a-z0-9]{16,64}$",
+      "type": "string"
+    },
+    "configurationVersionDigest": {
+      "maxLength": 71,
+      "pattern": "^sha256:[a-f0-9]{64}$",
+      "type": "string"
+    },
+    "continuousEnrollment": {
+      "type": "boolean"
+    },
+    "createdAt": {
+      "format": "date-time",
+      "maxLength": 32,
+      "type": "string"
+    },
+    "createdBy": {
+      "maxLength": 128,
+      "minLength": 5,
+      "pattern": "^[a-z][a-z0-9]*(?:[._:-][a-z0-9]+)*$",
+      "type": "string"
+    },
+    "effectiveFrom": {
+      "format": "date-time",
+      "maxLength": 32,
+      "type": "string"
+    },
+    "exclusions": {
+      "items": {
+        "$ref": "#/$defs/exclusion"
+      },
+      "maxItems": 256,
+      "type": "array"
+    },
+    "expiresAt": {
+      "anyOf": [
+        {
+          "format": "date-time",
+          "maxLength": 32,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "revision": {
+      "maximum": 9007199254740991,
+      "minimum": 1,
+      "type": "integer"
+    },
+    "schemaVersion": {
+      "const": "guard.managed-control-assignment.v1"
+    },
+    "selector": {
+      "additionalProperties": false,
+      "properties": {
+        "agentIds": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 5,
+            "pattern": "^[a-z][a-z0-9]*(?:[._:-][a-z0-9]+)*$",
+            "type": "string"
+          },
+          "maxItems": 512,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "deviceIds": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 5,
+            "pattern": "^[a-z][a-z0-9]*(?:[._:-][a-z0-9]+)*$",
+            "type": "string"
+          },
+          "maxItems": 512,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "deviceTags": {
+          "items": {
+            "maxLength": 64,
+            "minLength": 1,
+            "pattern": "^[a-z0-9][a-z0-9._:-]*$",
+            "type": "string"
+          },
+          "maxItems": 64,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "directoryQueryId": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 5,
+              "pattern": "^[a-z][a-z0-9]*(?:[._:-][a-z0-9]+)*$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "memberIds": {
+          "items": {
+            "maxLength": 128,
+            "minLength": 5,
+            "pattern": "^[a-z][a-z0-9]*(?:[._:-][a-z0-9]+)*$",
+            "type": "string"
+          },
+          "maxItems": 512,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "mode": {
+          "enum": [
+            "all-active-devices",
+            "selected-members",
+            "selected-devices",
+            "supported-agents",
+            "directory-query",
+            "device-tags"
+          ]
+        }
+      },
+      "required": [
+        "mode"
+      ],
+      "type": "object"
+    },
+    "workspaceId": {
+      "format": "uuid",
+      "maxLength": 36,
+      "type": "string"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "assignmentId",
+    "workspaceId",
+    "configurationVersionDigest",
+    "revision",
+    "selector",
+    "exclusions",
+    "continuousEnrollment",
+    "createdAt",
+    "createdBy"
+  ],
+  "title": "HOL Guard managed control assignment v1",
+  "type": "object"
+}

--- a/docs/guard/adr/0012-fleet-extension-configuration.md
+++ b/docs/guard/adr/0012-fleet-extension-configuration.md
@@ -1,0 +1,51 @@
+# ADR 0012: Fleet Extension Configuration and dynamic assignment
+
+Status: Accepted  
+Applies to: HOL Guard 3.0 Core and HOL Guard Cloud 3.0
+
+## Decision
+
+Fleet Extension Configuration is an Extension-first section of the existing Managed Controls Control Set. A published immutable configuration version expresses built-in Extension availability, contextual outcomes, permission settings, and portable Custom Extension settings. A separate durable assignment selects current and future eligible workspace targets. Cloud compiles one catalog-bound, device-bound composite projection; Core verifies and atomically activates it with local authority.
+
+## Canonical nouns
+
+- **Fleet Extension Configuration**: immutable versioned intent.
+- **Managed Control Assignment**: durable current-and-future selector plus exclusions.
+- **Portable Custom Extension Definition**: workspace-owned reviewed semantic identity with approved variants.
+- **Custom Extension Configuration**: default and stable command settings for one definition.
+- **Catalog Semantic Fingerprint**: digest of behaviorally relevant Extension or permission meaning.
+- **Desired / resolved / delivered / verified / applied / effective**: distinct lifecycle stages.
+- **Stale / drifted / incompatible / failed / excluded**: distinct non-converged states.
+
+The UI may say **Allow** and **Deny**. Contracts use **permit**, **review**, **block**, **observe**, **enabled**, and **disabled**. Availability is not contextual policy. Contextual block is not Managed Block. Managed restrictive authority can only preserve or strengthen protection.
+
+## Authority and precedence
+
+1. Hard local safety invariants and required Extension floors.
+2. Managed restrictive disable or block.
+3. Local user tightening.
+4. Workspace shared defaults.
+5. Personal shared defaults.
+6. Built-in defaults.
+
+A more restrictive applicable contribution wins. Managed restrictive authority cannot permit, enable, or suppress required Package Firewall delegation. Local users may tighten but cannot weaken a managed or required floor.
+
+## Assignment
+
+Assignments are durable selectors, not rollout cohorts. `all-active-devices`, selected members and all owned devices, supported agents, directory queries, and device tags continuously reconcile. Explicit selected-device assignments remain exact but still re-evaluate device eligibility. New eligible devices converge without republishing. Suspended members, revoked devices, ambiguous ownership, unsupported capabilities, semantic mismatch, and explicit exclusions fail closed and remain visible.
+
+## Custom Extension identity and privacy
+
+Cloud stores a per-workspace opaque definition ID, stable command IDs, semantic fingerprints, and reviewed variant evidence digests. Exact executable paths, raw command lines, source, environment values, tokens, secrets, and globally correlatable local identifiers never cross the boundary. Core binds an approved variant to the exact local identity and is the enforcement authority.
+
+## Offline, expiry, offboarding, and transfer
+
+Core retains the exact last-known-good composite state while offline. Expiry makes state stale and blocks new broadening, but does not silently erase a restrictive floor. Unassignment, offboarding, revocation, and workspace transfer use signed monotonic tombstones. A device leaving a workspace releases workspace-shared defaults only after verified tombstone processing; managed restrictions use the configured bounded grace or break-glass path and remain auditable.
+
+## Plan packaging
+
+Fleet authoring and continuous assignment require Team or Enterprise. Local protection, local configuration, and local tightening remain available without Cloud. Entitlement loss freezes new fleet mutations and follows the documented authority-release process; it never disables local protection.
+
+## Versioning and downgrade
+
+Writers emit a contract only after the reader capability is advertised. Unsupported devices are excluded with `fec_unsupported_capability`; no fallback may remove an Extension target, Custom Extension command setting, managed floor, semantic fingerprint, or composite-apply requirement. v1 and v2 contracts coexist by explicit schema version and domain-separated digest.

--- a/docs/guard/fleet-extension-configuration-baseline.md
+++ b/docs/guard/fleet-extension-configuration-baseline.md
@@ -1,0 +1,55 @@
+# Fleet Extension Configuration implementation baseline
+
+Status: approved for `release/3.0` implementation only  
+Baseline captured: 2026-08-27
+
+## Exact starting points
+
+- HOL Guard Core: `hashgraph-online/hol-guard@784b31eb7b388e23b2a9e8cb4372c1d639049cbe`
+- HOL Guard Cloud: `hashgraph-online/points-portal@616f2a08be657cc46aad2bd48216a47181cd840c`
+
+No implementation batch may be based on `main`. Each batch records its actual parent again before it is opened.
+
+## Reconciled current state
+
+The release branches already contain Extension-first Managed Controls, signed policy bundle v2 delivery, staged rollouts, acknowledgement evidence, catalog posture, delegated Package Firewall ownership, local exact-identity Custom Extension continuity, and automatic daemon synchronization. Fleet Extension Configuration extends those systems. It does not introduce a second policy product, a second enforcement engine, or a Cloud dependency for local protection.
+
+The former HOL Guard PR #2522 is closed and superseded by merged `release/3.0` contract and parser work. The Cloud reconciliation PR #5467 was merged to `main`, but this initiative remains release-branch-only.
+
+## Ownership map
+
+| Area | Source of truth | Review owner |
+|---|---|---|
+| Shared contracts and vectors | `contracts/managed-controls/v2` in both repositories | Core and Cloud maintainers |
+| Cloud authoring, assignment, compiler, delivery | `points-portal/src/lib/guard/managed-controls` | Cloud Guard maintainers |
+| Cloud persistence | `points-portal/db` | Cloud data maintainers |
+| Local parser, binding, apply, recovery | `hol-guard/src/codex_plugin_scanner/guard/managed_controls` | Core Guard maintainers |
+| Cloud administration UI | `points-portal/app/guard` | Cloud Guard UI maintainers |
+| Local Protection Center | `hol-guard/dashboard` | Core Guard UI maintainers |
+| Operations, release, and privacy gates | both `.github/workflows` and `docs/guard` | release owners |
+
+## Paired merge sequence
+
+1. Merge the Cloud side of each 100-task batch to `points-portal/release/3.0`.
+2. Rebase the Core side on the latest `hol-guard/release/3.0` and consume the exact shared contract bytes.
+3. Require all HOL Guard checks to pass.
+4. Merge the Core side.
+5. Run the cross-repository drift check and record both merge SHAs.
+
+Cloud CI failures unrelated to the changed area do not block these batches. Review findings, contract drift, tenant-isolation failures, and authority failures always block.
+
+## Completion evidence
+
+Every task is recorded as `FEC-NNN`, implementation paths, tests, review resolution, PR, merge SHA, and verification result. A task is not complete merely because code exists. Evidence must show the intended branch contains the behavior.
+
+## Risk register
+
+| Risk | Required control |
+|---|---|
+| Portable identity accidentally uploads local paths or commands | Strict allowlist schemas, opaque per-workspace IDs, privacy fixtures |
+| Dynamic assignment admits the wrong device | Workspace ownership graph, explicit exclusions, revision-bound selector evidence |
+| Cloud weakens a local or required floor | Disable-dominant authority lattice and managed-restrictive validation |
+| Partial composite apply exposes mixed authority | Journaled prepare/commit/rollback and exact last-known-good restore |
+| Catalog meaning changes under the same target | Semantic fingerprints and publish-time re-simulation |
+| Offboarding leaves managed authority behind | Signed tombstones, bounded grace, acknowledgement, and local safe fallback |
+| Cross-tenant replay | Workspace, device, runtime session, revision, and digest binding |

--- a/docs/guard/fleet-extension-configuration-contracts.md
+++ b/docs/guard/fleet-extension-configuration-contracts.md
@@ -1,0 +1,29 @@
+# Fleet Extension Configuration v2 contract reference
+
+Shared contract files under `contracts/managed-controls/v2` are byte-identical in Core and Cloud.
+
+## Canonical JSON
+
+Canonical bytes are UTF-8 JSON with recursively sorted object keys, no insignificant whitespace, no non-finite numbers, and contract-specific deterministic array ordering. Parsers reject unknown fields, over-limit input, duplicate logical entries, conflicting entries, unsafe managed broadening, and unsupported schemas. Digests are `sha256:<lowercase hex>` over an ASCII domain label followed by canonical bytes:
+
+- `hol.guard.fleet-extension-configuration.v1\0`
+- `hol.guard.managed-control-assignment.v1\0`
+- `hol.guard.custom-extension-definition.v2\0`
+- `hol.guard.custom-extension-configuration.v2\0`
+- `hol.guard.catalog-semantic-fingerprint.v2\0`
+
+## Capability negotiation
+
+All capabilities in `capabilities.json` are required for v2 fleet delivery. Readers ship first. Writers never downgrade by dropping authority-bearing fields. An unsupported target is excluded and surfaced; it does not receive a weaker projection.
+
+## Stable identifiers
+
+Cloud-generated IDs are bounded, lowercase, opaque, and workspace-scoped. Built-in Extension and permission IDs retain their existing canonical `command.*` namespaces. Custom IDs use `ced_`, `cev_`, `cei_`, and `cec_` namespaces and cannot collide with built-ins.
+
+## Sensitive data boundary
+
+The contracts have no field for a raw path, command line, source file, working directory, environment value, token, secret, or raw local identity. Unknown fields fail closed.
+
+## Migration
+
+Existing v1 Managed Controls and Custom Extension continuity remain readable during the compatibility window. They never become workspace portable trust automatically. Promotion to a v2 definition requires administrator review and creates a new immutable workspace object.

--- a/docs/guard/fleet-extension-configuration-evidence.md
+++ b/docs/guard/fleet-extension-configuration-evidence.md
@@ -1,0 +1,13 @@
+# Fleet Extension Configuration task evidence register
+
+This register is append-only by implementation batch. Each row records merged evidence on `release/3.0`.
+
+| Range | Repository | PR | Merge SHA | Verification | Review threads | Evidence paths |
+|---|---|---|---|---|---|---|
+| FEC-001..100 | pending | pending | pending | pending | pending | contracts, ADR, baseline, parsers, fixtures |
+| FEC-101..200 | pending | pending | pending | pending | pending | persistence, authoring, promotion |
+| FEC-201..300 | pending | pending | pending | pending | pending | inventory, assignment, compiler, simulation, publish |
+| FEC-301..400 | pending | pending | pending | pending | pending | rollout, enrollment, signed delivery, composite apply, sync |
+| FEC-401..500 | pending | pending | pending | pending | pending | offboarding, governance, UI, operations |
+| FEC-501..600 | pending | pending | pending | pending | pending | security, tests, migration, docs, release gates |
+| FEC-601..602 | pending | pending | pending | pending | pending | post-launch evidence, cleanup, release notes |

--- a/docs/guard/fleet-extension-configuration-glossary.md
+++ b/docs/guard/fleet-extension-configuration-glossary.md
@@ -1,0 +1,16 @@
+# Fleet Extension Configuration glossary and copy matrix
+
+| Product copy | Canonical contract value | Meaning |
+|---|---|---|
+| Allow | `permit` | Allow a matching contextual action when no stronger floor blocks it. |
+| Ask for review | `review` | Pause a matching action for authorized review. |
+| Deny | `block` | Block a matching contextual action. |
+| Observe | `observe` | Record privacy-safe evidence without adding an allow decision. |
+| Available | `enabled` | The Extension may participate, subject to required floors and policy. |
+| Disabled | `disabled` | The Extension or permission is unavailable. |
+| Managed Block | managed restrictive `block` or `disabled` | Non-weakenable fleet restriction. |
+| Shared default | `workspace-shared` | Workspace preference that local users may tighten. |
+| All team devices | `all-active-devices` | Current and future eligible devices in the workspace. |
+| Custom Extension | `guard.custom-extension-definition.v2` | Portable reviewed semantic definition; never a raw local path. |
+
+Prohibited duplicate nouns: fleet profile, extension policy pack, cloud extension engine, synchronized allowlist, and global local identity.

--- a/src/codex_plugin_scanner/guard/managed_controls/fleet_contracts.py
+++ b/src/codex_plugin_scanner/guard/managed_controls/fleet_contracts.py
@@ -1,0 +1,285 @@
+"""Strict shared contracts for fleet Extension configuration and assignment."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+from pathlib import Path
+from typing import Final, Literal, TypeAlias, cast
+
+from jsonschema import Draft202012Validator, FormatChecker
+from jsonschema.exceptions import ValidationError
+
+ContractKind: TypeAlias = Literal[
+    "fleetExtensionConfiguration",
+    "assignment",
+    "customExtensionDefinition",
+    "customExtensionConfiguration",
+    "catalogSemantics",
+]
+
+CONTRACT_SCHEMAS: Final[dict[ContractKind, str]] = {
+    "fleetExtensionConfiguration": "guard.fleet-extension-configuration.v1",
+    "assignment": "guard.managed-control-assignment.v1",
+    "customExtensionDefinition": "guard.custom-extension-definition.v2",
+    "customExtensionConfiguration": "guard.custom-extension-configuration.v2",
+    "catalogSemantics": "guard.catalog-semantic-fingerprint.v2",
+}
+CONTRACT_DOMAINS: Final[dict[ContractKind, bytes]] = {
+    kind: f"hol.guard.{schema.removeprefix('guard.')}\0".encode()
+    for kind, schema in CONTRACT_SCHEMAS.items()
+}
+REQUIRED_FLEET_CAPABILITIES: Final[frozenset[str]] = frozenset(
+    {
+        *CONTRACT_SCHEMAS.values(),
+        "guard.managed-controls-composite-apply.v2",
+        "guard.managed-controls-signed-delivery.v2",
+    }
+)
+_SCHEMA_FILES: Final[dict[ContractKind, str]] = {
+    "fleetExtensionConfiguration": "fleet-extension-configuration.schema.json",
+    "assignment": "managed-control-assignment.schema.json",
+    "customExtensionDefinition": "custom-extension-definition.schema.json",
+    "customExtensionConfiguration": "custom-extension-configuration.schema.json",
+    "catalogSemantics": "catalog-semantic-fingerprint.schema.json",
+}
+_ROOT = Path(__file__).resolve().parents[4]
+_CONTRACT_ROOT = _ROOT / "contracts/managed-controls/v2"
+_CAPABILITY = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+_MAX_PAYLOAD_BYTES = 524_288
+
+
+class FleetContractError(ValueError):
+    """Stable, bounded rejection that never contains private payload values."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message[:512])
+        self.code = code
+
+
+_MESSAGES: Final[dict[str, str]] = {
+    "fec_invalid_json": "The fleet configuration payload is not valid JSON.",
+    "fec_unknown_field": "The fleet configuration contains an unsupported field.",
+    "fec_missing_field": "The fleet configuration is missing a required field.",
+    "fec_limit_exceeded": "The fleet configuration exceeds a supported limit.",
+    "fec_invalid_identifier": "A fleet configuration identifier is invalid.",
+    "fec_duplicate_entry": "The fleet configuration contains a duplicate logical entry.",
+    "fec_conflicting_entry": "The fleet configuration contains conflicting authority.",
+    "fec_managed_weaken_forbidden": "Managed restrictive authority cannot weaken protection.",
+    "fec_unsupported_capability": "The device does not support required fleet configuration semantics.",
+    "fec_assignment_empty": "The managed assignment selector has no eligible targets.",
+}
+
+
+def _fail(code: str) -> None:
+    raise FleetContractError(code, _MESSAGES.get(code, "The fleet configuration is invalid."))
+
+
+def _load_schema(kind: ContractKind) -> dict[str, object]:
+    return cast(dict[str, object], json.loads((_CONTRACT_ROOT / _SCHEMA_FILES[kind]).read_text()))
+
+
+def _schema_error(error: ValidationError) -> str:
+    if error.validator == "additionalProperties":
+        return "fec_unknown_field"
+    if error.validator == "required":
+        return "fec_missing_field"
+    if error.validator in {"maxItems", "minItems", "maxLength", "minLength", "maximum", "minimum"}:
+        return "fec_limit_exceeded"
+    if error.validator in {"pattern", "format"}:
+        return "fec_invalid_identifier"
+    if error.validator == "const" and list(error.absolute_path) == ["schemaVersion"]:
+        return "fec_unsupported_capability"
+    return "fec_invalid_json"
+
+
+def _target_key(target: Mapping[str, object]) -> tuple[str, str, str]:
+    return (
+        cast(str, target["kind"]),
+        cast(str, target.get("extensionId") or target.get("definitionId") or ""),
+        cast(str, target.get("permissionId") or target.get("commandId") or ""),
+    )
+
+
+def _unique(values: Sequence[object]) -> None:
+    encoded = [json.dumps(value, sort_keys=True, separators=(",", ":")) for value in values]
+    if len(encoded) != len(set(encoded)):
+        _fail("fec_duplicate_entry")
+
+
+def _validate_fleet(value: dict[str, object]) -> None:
+    entries = cast(list[dict[str, object]], value["entries"])
+    _unique([entry["entryId"] for entry in entries])
+    _unique([_target_key(cast(dict[str, object], entry["target"])) for entry in entries])
+    for entry in entries:
+        if entry["authorityMode"] != "managed-restrictive":
+            continue
+        if entry["availability"] == "enabled" or entry["contextualOutcome"] in {
+            "permit",
+            "review",
+            "observe",
+        }:
+            _fail("fec_managed_weaken_forbidden")
+
+
+def _validate_assignment(value: dict[str, object]) -> None:
+    selector = cast(dict[str, object], value["selector"])
+    field_by_mode: dict[str, str | None] = {
+        "all-active-devices": None,
+        "selected-members": "memberIds",
+        "selected-devices": "deviceIds",
+        "supported-agents": "agentIds",
+        "directory-query": "directoryQueryId",
+        "device-tags": "deviceTags",
+    }
+    populated = [key for key in selector if key != "mode"]
+    expected = field_by_mode[cast(str, selector["mode"])]
+    if expected is None and populated:
+        _fail("fec_conflicting_entry")
+    if expected is not None and populated != [expected]:
+        _fail("fec_conflicting_entry")
+    if expected is not None:
+        selected = selector[expected]
+        if selected in (None, "", []) or isinstance(selected, list) and len(selected) != len(set(selected)):
+            _fail("fec_assignment_empty")
+    if value["continuousEnrollment"] is not True:
+        _fail("fec_conflicting_entry")
+    exclusions = cast(list[dict[str, object]], value["exclusions"])
+    _unique([(item["kind"], item["targetId"]) for item in exclusions])
+
+
+def _validate_custom_definition(value: dict[str, object]) -> None:
+    commands = cast(list[dict[str, object]], value["commands"])
+    variants = cast(list[dict[str, object]], value["variants"])
+    _unique([item["commandId"] for item in commands])
+    _unique([item["variantId"] for item in variants])
+    for item in variants:
+        platforms = cast(list[str], item["platforms"])
+        _unique(platforms)
+        if item["reviewState"] == "trusted" and not item.get("reviewedAt") or (
+            item["reviewState"] == "trusted" and not item.get("reviewedBy")
+        ):
+            _fail("fec_missing_field")
+
+
+def _validate_custom_configuration(value: dict[str, object]) -> None:
+    commands = cast(list[dict[str, object]], value["commands"])
+    _unique([item["commandId"] for item in commands])
+    _unique(cast(list[object], value["allowedVariantIds"]))
+
+
+def _validate_catalog(value: dict[str, object]) -> None:
+    extensions = cast(list[dict[str, object]], value["extensions"])
+    _unique([item["extensionId"] for item in extensions])
+    _unique(cast(list[object], value["capabilities"]))
+    for extension in extensions:
+        permissions = cast(list[dict[str, object]], extension["permissions"])
+        _unique([item["permissionId"] for item in permissions])
+
+
+_SEMANTIC_VALIDATORS = {
+    "fleetExtensionConfiguration": _validate_fleet,
+    "assignment": _validate_assignment,
+    "customExtensionDefinition": _validate_custom_definition,
+    "customExtensionConfiguration": _validate_custom_configuration,
+    "catalogSemantics": _validate_catalog,
+}
+
+
+def validate_fleet_contract(kind: ContractKind, value: object) -> dict[str, object]:
+    """Validate and normalize one bounded shared contract."""
+
+    try:
+        encoded = json.dumps(value, ensure_ascii=True, allow_nan=False, separators=(",", ":")).encode()
+    except (TypeError, ValueError):
+        _fail("fec_invalid_json")
+    if len(encoded) > _MAX_PAYLOAD_BYTES:
+        _fail("fec_limit_exceeded")
+    validator = Draft202012Validator(_load_schema(kind), format_checker=FormatChecker())
+    error = next(validator.iter_errors(value), None)
+    if error is not None:
+        _fail(_schema_error(error))
+    normalized = deepcopy(cast(dict[str, object], value))
+    if kind == "fleetExtensionConfiguration":
+        for entry in cast(list[dict[str, object]], normalized["entries"]):
+            entry.setdefault("source", "explicit")
+        normalized.setdefault("previousVersionDigest", None)
+    elif kind == "customExtensionConfiguration":
+        normalized.setdefault("bindingMode", "exact-approved-variant")
+    _SEMANTIC_VALIDATORS[kind](normalized)
+    return normalized
+
+
+def _sort_contract(kind: ContractKind, value: dict[str, object]) -> dict[str, object]:
+    normalized = deepcopy(value)
+    if kind == "fleetExtensionConfiguration":
+        entries = cast(list[dict[str, object]], normalized["entries"])
+        entries.sort(key=lambda item: (_target_key(cast(dict[str, object], item["target"])), item["entryId"]))
+    elif kind == "assignment":
+        selector = cast(dict[str, object], normalized["selector"])
+        for key in ("memberIds", "deviceIds", "agentIds", "deviceTags"):
+            if isinstance(selector.get(key), list):
+                selector[key] = sorted(cast(list[str], selector[key]))
+        exclusions = cast(list[dict[str, object]], normalized["exclusions"])
+        exclusions.sort(key=lambda item: (item["kind"], item["targetId"]))
+    elif kind == "customExtensionDefinition":
+        cast(list[dict[str, object]], normalized["commands"]).sort(key=lambda item: item["commandId"])
+        variants = cast(list[dict[str, object]], normalized["variants"])
+        for variant in variants:
+            variant["platforms"] = sorted(cast(list[str], variant["platforms"]))
+        variants.sort(key=lambda item: item["variantId"])
+    elif kind == "customExtensionConfiguration":
+        cast(list[dict[str, object]], normalized["commands"]).sort(key=lambda item: item["commandId"])
+        normalized["allowedVariantIds"] = sorted(cast(list[str], normalized["allowedVariantIds"]))
+    else:
+        extensions = cast(list[dict[str, object]], normalized["extensions"])
+        for extension in extensions:
+            cast(list[dict[str, object]], extension["permissions"]).sort(key=lambda item: item["permissionId"])
+        extensions.sort(key=lambda item: item["extensionId"])
+        normalized["capabilities"] = sorted(cast(list[str], normalized["capabilities"]))
+    return normalized
+
+
+def canonical_fleet_contract_bytes(kind: ContractKind, value: object) -> bytes:
+    """Return deterministic canonical bytes for signing and digesting."""
+
+    normalized = _sort_contract(kind, validate_fleet_contract(kind, value))
+    return json.dumps(normalized, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+
+
+def fleet_contract_digest(kind: ContractKind, value: object) -> str:
+    digest = hashlib.sha256(CONTRACT_DOMAINS[kind] + canonical_fleet_contract_bytes(kind, value)).hexdigest()
+    return f"sha256:{digest}"
+
+
+def negotiate_fleet_capabilities(advertised: Sequence[str]) -> tuple[bool, tuple[str, ...]]:
+    values = set(advertised)
+    if any(not isinstance(value, str) or _CAPABILITY.fullmatch(value) is None for value in values):
+        _fail("fec_unsupported_capability")
+    missing = tuple(sorted(REQUIRED_FLEET_CAPABILITIES - values))
+    return not missing, missing
+
+
+def load_shared_fleet_fixtures() -> dict[str, object]:
+    return cast(dict[str, object], json.loads((_CONTRACT_ROOT / "fixtures.json").read_text()))
+
+
+def apply_adversarial_fixture(base: object, case: Mapping[str, object]) -> object:
+    value = deepcopy(base)
+    if not isinstance(value, dict):
+        return value
+    patch = case.get("patch")
+    if isinstance(patch, Mapping):
+        value.update(patch)
+    replacement = case.get("replace")
+    if isinstance(replacement, Mapping):
+        value.update(replacement)
+    duplicate_path = case.get("duplicatePath")
+    if duplicate_path == "entries[0]":
+        cast(list[object], value["entries"]).append(deepcopy(cast(list[object], value["entries"])[0]))
+    elif duplicate_path == "extensions[0]":
+        cast(list[object], value["extensions"]).append(deepcopy(cast(list[object], value["extensions"])[0]))
+    return value

--- a/tests/managed_controls/test_fleet_contract_manifest.py
+++ b/tests/managed_controls/test_fleet_contract_manifest.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import cast
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = ROOT / "contracts/managed-controls/fleet-extension-contract-manifest.json"
+
+
+def test_fleet_extension_manifest_pins_every_shared_file() -> None:
+    manifest = cast(dict[str, object], json.loads(MANIFEST.read_text(encoding="utf-8")))
+    assert manifest["schemaVersion"] == "guard.fleet-extension-contract-manifest.v1"
+    files = cast(list[dict[str, str]], manifest["files"])
+    assert len(files) == len({entry["path"] for entry in files})
+    for entry in files:
+        shared_file = ROOT / entry["path"]
+        assert shared_file.is_file(), entry["path"]
+        assert hashlib.sha256(shared_file.read_bytes()).hexdigest() == entry["sha256"]

--- a/tests/managed_controls/test_fleet_contracts.py
+++ b/tests/managed_controls/test_fleet_contracts.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard.managed_controls.fleet_contracts import (
+    FLEET_CONTRACT_CAPABILITIES,
+    FleetContractError,
+    enabled_fleet_contract_capabilities,
+    parse_fleet_contract,
+    runtime_supports_fleet_contract,
+    supports_fleet_extension_configuration,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_PATHS = (
+    "contracts/managed-controls/v1/fleet-extension-configuration.fixtures.json",
+    "contracts/managed-controls/v1/managed-control-assignment.fixtures.json",
+    "contracts/managed-controls/v2/custom-extension-definition.fixtures.json",
+    "contracts/managed-controls/v2/custom-extension-configuration.fixtures.json",
+    "contracts/managed-controls/v2/catalog-semantic-fingerprints.fixtures.json",
+)
+
+
+def _fixture(relative_path: str) -> dict[str, object]:
+    return cast(dict[str, object], json.loads((ROOT / relative_path).read_text(encoding="utf-8")))
+
+
+def _apply_mutation(source: object, mutation: dict[str, object]) -> object:
+    result = copy.deepcopy(source)
+    path = cast(list[str | int], mutation.get("path", []))
+    cursor = result
+    for segment in path:
+        cursor = cursor[segment]  # type: ignore[index]
+    if "mutation" in mutation:
+        cast(dict[str, object], cursor).update(cast(dict[str, object], mutation["mutation"]))
+        return result
+    if not path:
+        raise AssertionError("Fixture replacement requires a path")
+    parent = result
+    for segment in path[:-1]:
+        parent = parent[segment]  # type: ignore[index]
+    parent[path[-1]] = mutation.get("value")  # type: ignore[index]
+    return result
+
+
+@pytest.mark.parametrize("relative_path", FIXTURE_PATHS)
+def test_shared_fixture_canonical_bytes_and_digest(relative_path: str) -> None:
+    fixture = _fixture(relative_path)
+    parsed = parse_fleet_contract(fixture["valid"])
+    assert parsed.canonical_json == fixture["canonicalJson"]
+    assert parsed.digest == fixture["expectedDigest"]
+
+
+@pytest.mark.parametrize("relative_path", FIXTURE_PATHS)
+def test_shared_fixture_adversarial_mutations(relative_path: str) -> None:
+    fixture = _fixture(relative_path)
+    valid = fixture["valid"]
+    mutations = cast(list[dict[str, object]], fixture["invalidMutations"])
+    for mutation in mutations:
+        with pytest.raises(FleetContractError) as captured:
+            parse_fleet_contract(_apply_mutation(valid, mutation))
+        assert captured.value.code == mutation["errorCode"], mutation["name"]
+
+
+def test_runtime_requires_every_semantic_contract_family() -> None:
+    assert supports_fleet_extension_configuration(FLEET_CONTRACT_CAPABILITIES)
+    assert not supports_fleet_extension_configuration(FLEET_CONTRACT_CAPABILITIES[:-1])
+
+
+def test_runtime_requires_exact_contract_capability() -> None:
+    contract = parse_fleet_contract(_fixture(FIXTURE_PATHS[0])["valid"])
+    assert runtime_supports_fleet_contract(contract, ("fleet-extension-configuration.v1",))
+    assert not runtime_supports_fleet_contract(contract, ())
+
+
+def test_experimental_capability_advertisement_is_explicit() -> None:
+    assert enabled_fleet_contract_capabilities({}) == ()
+    assert enabled_fleet_contract_capabilities(
+        {
+            "HOL_GUARD_FLEET_EXTENSION_CONFIGURATION_V1": "true",
+            "HOL_GUARD_CUSTOM_EXTENSION_CONFIGURATION_V2": "1",
+        }
+    ) == (
+        "fleet-extension-configuration.v1",
+        "custom-extension-configuration.v2",
+    )

--- a/tests/managed_controls/test_fleet_contracts_v2.py
+++ b/tests/managed_controls/test_fleet_contracts_v2.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.managed_controls.fleet_contracts import (
+    FleetContractError,
+    REQUIRED_FLEET_CAPABILITIES,
+    apply_adversarial_fixture,
+    canonical_fleet_contract_bytes,
+    fleet_contract_digest,
+    negotiate_fleet_capabilities,
+    validate_fleet_contract,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = json.loads((ROOT / "contracts/managed-controls/v2/fixtures.json").read_text())
+ADVERSARIAL = json.loads((ROOT / "contracts/managed-controls/v2/adversarial-fixtures.json").read_text())
+KINDS = (
+    "fleetExtensionConfiguration",
+    "assignment",
+    "customExtensionDefinition",
+    "customExtensionConfiguration",
+    "catalogSemantics",
+)
+
+
+@pytest.mark.parametrize("kind", KINDS)
+def test_shared_positive_contracts_validate_and_match_frozen_digests(kind: str) -> None:
+    value = FIXTURES[kind]
+
+    normalized = validate_fleet_contract(kind, value)
+
+    assert normalized["schemaVersion"] == value["schemaVersion"]
+    assert canonical_fleet_contract_bytes(kind, value) == canonical_fleet_contract_bytes(kind, normalized)
+    assert fleet_contract_digest(kind, value) == FIXTURES["digests"][kind]
+
+
+@pytest.mark.parametrize("case", ADVERSARIAL["cases"], ids=lambda case: case["id"])
+def test_shared_adversarial_contracts_fail_with_stable_reason(case: dict[str, object]) -> None:
+    kind = case["contract"]
+    candidate = apply_adversarial_fixture(FIXTURES[kind], case)
+
+    with pytest.raises(FleetContractError) as caught:
+        validate_fleet_contract(kind, candidate)
+
+    assert caught.value.code == case["expectedError"]
+    assert "/Users/" not in str(caught.value)
+    assert "token" not in str(caught.value).lower()
+
+
+def test_canonicalization_is_independent_of_object_and_collection_order() -> None:
+    value = deepcopy(FIXTURES["customExtensionDefinition"])
+    value["commands"] = list(reversed(value["commands"]))
+    value["variants"] = list(reversed(value["variants"]))
+    value["variants"][0]["platforms"] = list(reversed(value["variants"][0]["platforms"]))
+    reordered = {key: value[key] for key in reversed(tuple(value))}
+
+    assert canonical_fleet_contract_bytes("customExtensionDefinition", reordered) == canonical_fleet_contract_bytes(
+        "customExtensionDefinition", FIXTURES["customExtensionDefinition"]
+    )
+
+
+def test_capability_negotiation_excludes_semantically_incomplete_readers() -> None:
+    supported, missing = negotiate_fleet_capabilities(sorted(REQUIRED_FLEET_CAPABILITIES))
+    assert supported is True
+    assert missing == ()
+
+    supported, missing = negotiate_fleet_capabilities(
+        sorted(REQUIRED_FLEET_CAPABILITIES - {"guard.managed-controls-composite-apply.v2"})
+    )
+    assert supported is False
+    assert missing == ("guard.managed-controls-composite-apply.v2",)
+
+
+def test_managed_restrictive_authority_cannot_enable_or_permit() -> None:
+    value = deepcopy(FIXTURES["fleetExtensionConfiguration"])
+    value["entries"][0]["availability"] = "enabled"
+
+    with pytest.raises(FleetContractError, match="cannot weaken") as caught:
+        validate_fleet_contract("fleetExtensionConfiguration", value)
+
+    assert caught.value.code == "fec_managed_weaken_forbidden"
+
+
+def test_unknown_private_fields_fail_closed_without_echoing_values() -> None:
+    value = deepcopy(FIXTURES["customExtensionDefinition"])
+    value["sourcePath"] = "/Users/private/secret-tool"
+
+    with pytest.raises(FleetContractError) as caught:
+        validate_fleet_contract("customExtensionDefinition", value)
+
+    assert caught.value.code == "fec_unknown_field"
+    assert "secret-tool" not in str(caught.value)


### PR DESCRIPTION
Superseded by the corrected `release/3.2` implementation in #2683. The replacement was reviewed, passed HOL Guard CI, merged into `release/3.2`, and is the only active FEC-001–100 Core line. This wrong-target `release/3.0` PR is intentionally closed without merge.