### PR TITLE
fix(guard): explain native action consequences

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/benign_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_request_services/benign_requests.py
@@ -429,7 +429,7 @@ def build_tool_action_request_artifact(
             f"Requested `{request.tool_name}` action `{request.command_text}` via transparent wrappers "
             f"`{' -> '.join(wrapper_chain)}` ({request.action_class})."
         )
-    risk_summary = f"Requests a sensitive native tool action: {request.action_class}."
+    risk_summary = _tool_action_risk_summary(request)
     runtime_reason = request.reason
     if wrapper_chain:
         runtime_reason = (
@@ -513,6 +513,17 @@ def build_tool_action_request_artifact(
             ),
         },
     )
+
+
+def _tool_action_risk_summary(request: ToolActionRequestMatch) -> str:
+    """Describe the consequence that made a native tool action reviewable."""
+
+    if request.action_class.casefold() == "destructive shell command":
+        return (
+            "This command can delete or overwrite local files, discard work, or alter repository or system state. "
+            "Recovery may require version control or a backup."
+        )
+    return request.reason.rstrip(".") + "."
 
 
 def _path_is_within_roots(path: Path, roots: tuple[Path, ...]) -> bool:

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -4034,6 +4034,45 @@ def test_tool_action_request_classifier_detects_shell_wrapper_script_command():
     assert request.action_class == "destructive shell command"
 
 
+def test_destructive_tool_action_summary_explains_user_impact():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "rm -rf dangerous-marker.json"},
+    )
+
+    assert request is not None
+    artifact = build_tool_action_request_artifact(
+        "opencode",
+        request,
+        config_path="opencode.json",
+        source_scope="project",
+    )
+
+    assert artifact.metadata["runtime_request_summary"] == (
+        "This command can delete or overwrite local files, discard work, or alter repository or system state. "
+        "Recovery may require version control or a backup."
+    )
+
+
+def test_non_destructive_tool_action_summary_preserves_specific_classifier_reason():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "kubectl get secret app-credentials -o yaml"},
+    )
+
+    assert request is not None
+    artifact = build_tool_action_request_artifact(
+        "opencode",
+        request,
+        config_path="opencode.json",
+        source_scope="project",
+    )
+
+    summary = str(artifact.metadata["runtime_request_summary"])
+    assert "expose cluster credentials or application secrets" in summary
+    assert "sensitive native tool action" not in summary
+
+
 @pytest.mark.parametrize("shell_name", ["bash", "sh"])
 def test_tool_action_request_classifier_detects_clustered_shell_command_flag(shell_name: str):
     command = f"{shell_name} -cl 'rm -rf dangerous-marker.json'"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -14110,7 +14110,8 @@ def test_guard_hook_saved_artifact_approval_never_lowers_current_payload_block(t
     assert first_output["approval_requests"] == []
     assert first_output["terminal"] is True
     assert first_output["artifact_type"] == "tool_action_request"
-    assert "destructive shell command" in first_output["risk_summary"].lower()
+    assert "delete or overwrite local files" in first_output["risk_summary"].lower()
+    assert "recovery may require version control or a backup" in first_output["risk_summary"].lower()
     assert second_rc == 1
     assert second_output["policy_action"] == "block"
     assert second_output["approval_reuse"]["status"] == "rejected"
@@ -14857,7 +14858,8 @@ def test_guard_hook_codex_saved_artifact_approval_never_lowers_current_payload_b
     assert first_output["approval_requests"] == []
     assert first_output["terminal"] is True
     assert first_output["artifact_type"] == "tool_action_request"
-    assert "destructive shell command" in first_output["risk_summary"].lower()
+    assert "delete or overwrite local files" in first_output["risk_summary"].lower()
+    assert "recovery may require version control or a backup" in first_output["risk_summary"].lower()
     assert second_rc == 1
     assert second_output["policy_action"] == "block"
     assert second_output["approval_reuse"]["status"] == "rejected"


### PR DESCRIPTION
## Summary
- explain the concrete consequences of destructive native tool actions
- preserve classifier-specific risk explanations for other sensitive actions

## Testing
- `python -m ruff check src/codex_plugin_scanner/guard/runtime/secret_file_request_services/benign_requests.py tests/test_guard_risk.py`
- `python -m pytest tests/test_guard_risk.py tests/test_guard_manifest_install_firewall.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved risk summaries for tool actions involving destructive shell commands by clearly describing their potential impact.
  * Preserved specific explanatory reasons for other sensitive actions, such as retrieving Kubernetes secrets.

* **Tests**
  * Added coverage to verify accurate, user-impact-focused summaries for destructive and sensitive actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->