### PR TITLE
chore: reconcile main into release/3.0

### DIFF
--- a/ci/code-quality-baseline.json
+++ b/ci/code-quality-baseline.json
@@ -597,7 +597,7 @@
     "tests/test_action_runner.py": 707,
     "tests/test_bounded_cli_hook_bridge.py": 671,
     "tests/test_cli.py": 577,
-    "tests/test_codex_daemon_hook_bridge.py": 1003,
+    "tests/test_codex_daemon_hook_bridge.py": 1038,
     "tests/test_codex_hook_fallback_isolation.py": 583,
     "tests/test_command_keys_and_uri_schemes.py": 564,
     "tests/test_cursor_hooks.py": 2444,

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "maximum_collected_cases": 12862,
-  "maximum_test_source_lines": 293556,
+  "maximum_test_source_lines": 293572,
   "schema_version": 1
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
   "maximum_collected_cases": 16191,
-  "maximum_test_source_lines": 349942
+  "maximum_test_source_lines": 349944
 }

--- a/tests/test_codex_daemon_hook_bridge.py
+++ b/tests/test_codex_daemon_hook_bridge.py
@@ -20,6 +20,8 @@ from codex_plugin_scanner.guard.adapters import codex_daemon_hook_auth as hook_a
 from codex_plugin_scanner.guard.adapters import codex_daemon_hook_bridge as bridge
 from codex_plugin_scanner.guard.config import load_guard_config
 from codex_plugin_scanner.guard.daemon import manager as daemon_manager
+from codex_plugin_scanner.guard.daemon import runtime_hook_deadline as runtime_hook_deadline_module
+from codex_plugin_scanner.guard.daemon import server as daemon_server_module
 from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
 from codex_plugin_scanner.guard.runtime.local_temp_paths import trusted_temporary_root_for_path
 from codex_plugin_scanner.guard.store import GuardStore
@@ -31,7 +33,11 @@ from tests.codex_daemon_hook_bridge_fixtures import (
 )
 
 
-def _start_daemon(daemon: GuardDaemonServer) -> None:
+def _start_daemon(daemon: GuardDaemonServer, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(daemon_server_module, "_RUNTIME_HOOK_ADMISSION_TIMEOUT_SECONDS", 10.0)
+    monkeypatch.setattr(daemon_server_module, "_RUNTIME_HOOK_PROCESS_TIMEOUT_SECONDS", 10.0)
+    monkeypatch.setattr(runtime_hook_deadline_module, "_MAX_BUDGET_SECONDS", 12.0)
+    monkeypatch.setattr(daemon._server.hook_process_runner, "_timeout_seconds", 8.0)
     try:
         daemon.start()
         deadline = time.monotonic() + 5
@@ -40,7 +46,7 @@ def _start_daemon(daemon: GuardDaemonServer) -> None:
             try:
                 with opener.open(f"http://127.0.0.1:{daemon.port}/healthz", timeout=0.25) as response:
                     if response.status == 200:
-                        return
+                        break
                     if time.monotonic() >= deadline:
                         raise TimeoutError("Guard daemon health check did not return HTTP 200")
                     time.sleep(0.01)
@@ -48,6 +54,11 @@ def _start_daemon(daemon: GuardDaemonServer) -> None:
                 if time.monotonic() >= deadline:
                     raise
                 time.sleep(0.01)
+        if not daemon._server.hook_process_runner.wait_for_capacity(  # pyright: ignore[reportPrivateUsage]
+            minimum_workers=1,
+            timeout_seconds=15,
+        ):
+            raise TimeoutError("Guard daemon hook workers did not become ready")
     except BaseException:
         daemon.stop()
         raise
@@ -367,7 +378,7 @@ def test_bridge_authenticates_real_daemon_before_hook_delivery(
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     daemon = GuardDaemonServer(GuardStore(guard_home), host="127.0.0.1", port=0)
-    _start_daemon(daemon)
+    _start_daemon(daemon, monkeypatch)
     config = _bridge_config(guard_home, daemon.port)
     config["query"] = urlencode(
         {
@@ -409,7 +420,7 @@ def test_bridge_real_daemon_uses_payload_cwd_for_bounded_compound_read(
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     daemon = GuardDaemonServer(GuardStore(guard_home), host="127.0.0.1", port=0)
-    _start_daemon(daemon)
+    _start_daemon(daemon, monkeypatch)
     config = _bridge_config(guard_home, daemon.port)
     config["query"] = urlencode({"guard-home": str(guard_home), "home": str(tmp_path)})
     config["fallback_command"] = [sys.executable, "-c", "raise SystemExit(1)"]
@@ -445,7 +456,7 @@ def test_bridge_real_daemon_emits_schema_exact_post_tool_response(
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     daemon = GuardDaemonServer(GuardStore(guard_home), host="127.0.0.1", port=0)
-    _start_daemon(daemon)
+    _start_daemon(daemon, monkeypatch)
     config = _bridge_config(guard_home, daemon.port)
     config["query"] = urlencode({"guard-home": str(guard_home), "home": str(tmp_path)})
     config["fallback_command"] = [sys.executable, "-c", "raise SystemExit(1)"]
@@ -497,7 +508,7 @@ def test_bridge_real_daemon_prefers_payload_cwd_for_verified_git_fetch(
     )
     store = GuardStore(guard_home)
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
-    _start_daemon(daemon)
+    _start_daemon(daemon, monkeypatch)
     config = _bridge_config(guard_home, daemon.port)
     config["query"] = urlencode(
         {
@@ -567,7 +578,7 @@ def test_bridge_real_daemon_reviews_git_fetch_without_repository_bound_cwd(
     )
     store = GuardStore(guard_home)
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
-    _start_daemon(daemon)
+    _start_daemon(daemon, monkeypatch)
     config = _bridge_config(guard_home, daemon.port)
     config["query"] = urlencode(
         {"guard-home": str(guard_home), "home": str(tmp_path), "workspace": str(session_workspace)}
@@ -632,8 +643,9 @@ def test_bridge_real_daemon_allows_static_github_content_read_with_safe_jq_filte
     session_workspace.mkdir()
     store = GuardStore(guard_home)
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
-    _start_daemon(daemon)
+    _start_daemon(daemon, monkeypatch)
     config = _bridge_config(guard_home, daemon.port)
+    config["hook_timeouts"] = {"PreToolUse": 30}
     config["query"] = urlencode({"guard-home": str(guard_home), "home": str(tmp_path)})
     config["fallback_command"] = [sys.executable, "-c", "raise SystemExit(1)"]
     monkeypatch.setattr(
@@ -760,7 +772,7 @@ def test_bridge_real_daemon_keeps_unsafe_github_pipeline_companions_reviewed(
     session_workspace.mkdir()
     store = GuardStore(guard_home)
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
-    _start_daemon(daemon)
+    _start_daemon(daemon, monkeypatch)
     config = _bridge_config(guard_home, daemon.port)
     config["query"] = urlencode({"guard-home": str(guard_home), "home": str(tmp_path)})
     config["fallback_command"] = [sys.executable, "-c", "raise SystemExit(1)"]
@@ -805,7 +817,7 @@ def test_bridge_real_daemon_uses_exec_command_workdir_for_verified_git_fetch(
     assert guard_config.mode == "prompt"
     assert guard_config.security_level == "balanced"
     daemon = GuardDaemonServer(GuardStore(guard_home), host="127.0.0.1", port=0)
-    _start_daemon(daemon)
+    _start_daemon(daemon, monkeypatch)
     config = _bridge_config(guard_home, daemon.port)
     config["query"] = urlencode({"guard-home": str(guard_home), "home": str(tmp_path)})
     config["fallback_command"] = [sys.executable, "-c", "raise SystemExit(1)"]
@@ -843,7 +855,7 @@ def test_bridge_real_daemon_rejects_untrusted_exec_command_workdir(
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     daemon = GuardDaemonServer(GuardStore(guard_home), host="127.0.0.1", port=0)
-    _start_daemon(daemon)
+    _start_daemon(daemon, monkeypatch)
     config = _bridge_config(guard_home, daemon.port)
     config["query"] = urlencode({"guard-home": str(guard_home), "home": str(tmp_path)})
     config["fallback_command"] = [sys.executable, "-c", "raise SystemExit(1)"]
@@ -886,7 +898,7 @@ def test_bridge_real_daemon_rejects_temp_root_workdir_without_falling_back_to_re
     temporary_root = trusted_temporary_root_for_path(tmp_path)
     assert temporary_root is not None
     daemon = GuardDaemonServer(GuardStore(guard_home), host="127.0.0.1", port=0)
-    _start_daemon(daemon)
+    _start_daemon(daemon, monkeypatch)
     config = _bridge_config(guard_home, daemon.port)
     config["query"] = urlencode({"guard-home": str(guard_home), "home": str(tmp_path)})
     config["fallback_command"] = [sys.executable, "-c", "raise SystemExit(1)"]
@@ -922,7 +934,7 @@ def test_bridge_real_daemon_ignores_workdir_for_opaque_tool(
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     daemon = GuardDaemonServer(GuardStore(guard_home), host="127.0.0.1", port=0)
-    _start_daemon(daemon)
+    _start_daemon(daemon, monkeypatch)
     config = _bridge_config(guard_home, daemon.port)
     config["query"] = urlencode({"guard-home": str(guard_home), "home": str(tmp_path)})
     config["fallback_command"] = [sys.executable, "-c", "raise SystemExit(1)"]

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -27,6 +27,7 @@ from codex_plugin_scanner.guard.cli import commands as guard_commands_module
 from codex_plugin_scanner.guard.config import GuardConfig
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.daemon import manager as daemon_manager_module
+from codex_plugin_scanner.guard.daemon import runtime_hook_deadline as runtime_hook_deadline_module
 from codex_plugin_scanner.guard.daemon import server as daemon_server_module
 from codex_plugin_scanner.guard.daemon.discovery import load_authenticated_daemon_state
 from codex_plugin_scanner.guard.desktop_notifications import DesktopNotificationSetupResult
@@ -989,8 +990,11 @@ class TestGuardSurfaceServer:
         workspace_dir = tmp_path / "workspace"
         workspace_dir.mkdir(parents=True, exist_ok=True)
         store = GuardStore(home_dir)
+        monkeypatch.setattr(daemon_server_module, "_RUNTIME_HOOK_ADMISSION_TIMEOUT_SECONDS", 10.0)
         monkeypatch.setattr(daemon_server_module, "_RUNTIME_HOOK_PROCESS_TIMEOUT_SECONDS", 8.0)
+        monkeypatch.setattr(runtime_hook_deadline_module, "_MAX_BUDGET_SECONDS", 12.0)
         daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        monkeypatch.setattr(daemon._server.hook_process_runner, "_timeout_seconds", 8.0)
         daemon.start()
 
         try:


### PR DESCRIPTION
## Summary

- reconcile the current main hook-load test stabilization into release/3.0
- preserve release-side bridge flow coverage while using bounded daemon readiness waits
- refresh the exact combined test-suite ratchet

## Verification

- 126 real-daemon bridge tests passed; 23 unrelated cases deselected
- focused surface hook test passed
- test-suite ratchet passed
- Ruff check and format check passed
- git diff --check passed