### PR TITLE
Fix closed release-train validation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -410,11 +410,12 @@ jobs:
           needs.build.outputs.channel == 'canary'
         ) ||
         (
+          (needs.build.outputs.channel == 'alpha' || needs.build.outputs.channel == 'validation') &&
+          (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0')
+        ) ||
+        (
           needs.build.outputs.channel == 'alpha' &&
-          (
-            (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0') ||
             (github.event_name == 'workflow_dispatch' && github.event.inputs.release_train == '3.0')
-          )
         )
       )
     needs: build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -216,39 +216,47 @@ jobs:
               --argjson testpypi "$TESTPYPI_VERSIONS" \
               --argjson tags "$TAG_VERSIONS" \
               '$pypi + $testpypi + $tags | unique')
-            mapfile -t SOURCE_ALPHA_TAGS < <(
-              git tag --points-at "$SOURCE_SHA" --list "alpha/v${TRAIN}.0a*" | sed 's#^alpha/v##'
-            )
-            if [[ "${#SOURCE_ALPHA_TAGS[@]}" -gt 1 ]]; then
-              echo "Source commit has multiple reserved alpha versions" >&2
-              exit 1
-            fi
-            if [[ "${#SOURCE_ALPHA_TAGS[@]}" -eq 1 ]]; then
-              RELEASE_VERSION="${SOURCE_ALPHA_TAGS[0]}"
-              REUSING_RESERVED_ALPHA=true
-              uv run --no-sync python scripts/compute_alpha_release_version.py \
-                --release-train "$TRAIN" --validate-phase-only <<< "$EXISTING_VERSIONS"
+            PHASE_STATUS=$(uv run --no-sync python scripts/compute_alpha_release_version.py \
+              --release-train "$TRAIN" --phase-status <<< "$EXISTING_VERSIONS")
+            if [[ "$PHASE_STATUS" == "closed" ]]; then
+              CHANNEL="validation"
+              VERSION="$BASE_VERSION"
+              echo "Stable release closes train ${TRAIN}; validating without publishing"
             else
-              RELEASE_VERSION=$(uv run --no-sync python scripts/compute_alpha_release_version.py \
-                --release-train "$TRAIN" <<< "$EXISTING_VERSIONS")
-              REUSING_RESERVED_ALPHA=false
+              mapfile -t SOURCE_ALPHA_TAGS < <(
+                git tag --points-at "$SOURCE_SHA" --list "alpha/v${TRAIN}.0a*" | sed 's#^alpha/v##'
+              )
+              if [[ "${#SOURCE_ALPHA_TAGS[@]}" -gt 1 ]]; then
+                echo "Source commit has multiple reserved alpha versions" >&2
+                exit 1
+              fi
+              if [[ "${#SOURCE_ALPHA_TAGS[@]}" -eq 1 ]]; then
+                RELEASE_VERSION="${SOURCE_ALPHA_TAGS[0]}"
+                REUSING_RESERVED_ALPHA=true
+                uv run --no-sync python scripts/compute_alpha_release_version.py \
+                  --release-train "$TRAIN" --validate-phase-only <<< "$EXISTING_VERSIONS"
+              else
+                RELEASE_VERSION=$(uv run --no-sync python scripts/compute_alpha_release_version.py \
+                  --release-train "$TRAIN" <<< "$EXISTING_VERSIONS")
+                REUSING_RESERVED_ALPHA=false
+              fi
+              EXISTING_VERSIONS_ARRAY=()
+              if [[ "$REUSING_RESERVED_ALPHA" != "true" ]]; then
+                mapfile -t EXISTING_VERSIONS_ARRAY < <(jq -r '.[]' <<< "$EXISTING_VERSIONS")
+              fi
+              VALIDATOR_ARGS=(
+                --channel "$CHANNEL"
+                --version "$RELEASE_VERSION"
+                --git-ref "$TRAIN_REF"
+                --actual-ref "$ACTUAL_REF"
+                --github-sha "$SOURCE_SHA"
+                --expected-sha "$SOURCE_SHA"
+              )
+              for existing_version in "${EXISTING_VERSIONS_ARRAY[@]}"; do
+                VALIDATOR_ARGS+=(--existing-version "$existing_version")
+              done
+              VERSION=$(uv run --no-sync python scripts/validate_alpha_release.py "${VALIDATOR_ARGS[@]}")
             fi
-            EXISTING_VERSIONS_ARRAY=()
-            if [[ "$REUSING_RESERVED_ALPHA" != "true" ]]; then
-              mapfile -t EXISTING_VERSIONS_ARRAY < <(jq -r '.[]' <<< "$EXISTING_VERSIONS")
-            fi
-            VALIDATOR_ARGS=(
-              --channel "$CHANNEL"
-              --version "$RELEASE_VERSION"
-              --git-ref "$TRAIN_REF"
-              --actual-ref "$ACTUAL_REF"
-              --github-sha "$SOURCE_SHA"
-              --expected-sha "$SOURCE_SHA"
-            )
-            for existing_version in "${EXISTING_VERSIONS_ARRAY[@]}"; do
-              VALIDATOR_ARGS+=(--existing-version "$existing_version")
-            done
-            VERSION=$(uv run --no-sync python scripts/validate_alpha_release.py "${VALIDATOR_ARGS[@]}")
           elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
             CHANNEL="canary"
             VERSION=$(BASE_VERSION="$BASE_VERSION" PR_NUMBER="$PR_NUMBER" GITHUB_RUN_NUMBER="$GITHUB_RUN_NUMBER" GITHUB_RUN_ATTEMPT="$GITHUB_RUN_ATTEMPT" python - <<'PY'

--- a/ci/code-quality-baseline.json
+++ b/ci/code-quality-baseline.json
@@ -425,7 +425,7 @@
   "oversized_files": {
     ".github/workflows/ci.yml": 554,
     ".github/workflows/desktop-core-alpha-feed.yml": 505,
-    ".github/workflows/publish.yml": 1629,
+    ".github/workflows/publish.yml": 1638,
     "dashboard/src/app.tsx": 1106,
     "dashboard/src/approval-center-primitives.tsx": 1049,
     "dashboard/src/approval-center-utils.ts": 901,
@@ -733,7 +733,7 @@
     "tests/test_policy_bundle_v2.py": 537,
     "tests/test_policy_decision_source_context.py": 570,
     "tests/test_policy_document_io.py": 679,
-    "tests/test_release_train_workflow.py": 559,
+    "tests/test_release_train_workflow.py": 568,
     "tests/test_update_desktop_core.py": 716,
     "tests/test_verify_release_registry.py": 567,
     "tests/test_zcode_adapter.py": 685

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
   "maximum_collected_cases": 16193,
-  "maximum_test_source_lines": 349963
+  "maximum_test_source_lines": 349970
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
-  "maximum_collected_cases": 16191,
-  "maximum_test_source_lines": 349944
+  "maximum_collected_cases": 16193,
+  "maximum_test_source_lines": 349963
 }

--- a/scripts/compute_alpha_release_version.py
+++ b/scripts/compute_alpha_release_version.py
@@ -7,11 +7,16 @@ import argparse
 import json
 import sys
 from collections.abc import Iterable
-from typing import cast
+from typing import Literal, cast
 
 from packaging.version import InvalidVersion, Version
 
 SUPPORTED_TRAINS = {"2.2": (2, 2, 0), "3.0": (3, 0, 0), "3.1": (3, 1, 0)}
+AlphaPhaseStatus = Literal["open", "closed"]
+
+
+class AlphaPhaseClosedError(ValueError):
+    """Raised when a release train has advanced beyond public alpha releases."""
 
 
 def _alpha_versions(release_train: str, existing_versions: Iterable[str]) -> list[int]:
@@ -30,11 +35,13 @@ def _alpha_versions(release_train: str, existing_versions: Iterable[str]) -> lis
         if version.release != release:
             continue
         if version.post is not None:
-            raise ValueError(f"Existing post release {version} closes the alpha phase for train {release_train}")
+            raise AlphaPhaseClosedError(
+                f"Existing post release {version} closes the alpha phase for train {release_train}"
+            )
         if version.pre is None and version.dev is None and version.post is None:
-            raise ValueError(f"Existing stable release {version} closes release train {release_train}")
+            raise AlphaPhaseClosedError(f"Existing stable release {version} closes release train {release_train}")
         if version.pre is not None and version.pre[0] != "a":
-            raise ValueError(
+            raise AlphaPhaseClosedError(
                 f"Existing non-alpha prerelease {version} closes the alpha phase for train {release_train}"
             )
         if version.pre is not None and version.pre[0] == "a" and version.dev is not None:
@@ -49,6 +56,14 @@ def validate_alpha_phase_open(release_train: str, existing_versions: Iterable[st
     _ = _alpha_versions(release_train, existing_versions)
 
 
+def alpha_phase_status(release_train: str, existing_versions: Iterable[str]) -> AlphaPhaseStatus:
+    try:
+        validate_alpha_phase_open(release_train, existing_versions)
+    except AlphaPhaseClosedError:
+        return "closed"
+    return "open"
+
+
 def compute_alpha_release_version(release_train: str, existing_versions: Iterable[str]) -> str:
     alpha_numbers = _alpha_versions(release_train, existing_versions)
     version_prefix = ".".join(str(part) for part in SUPPORTED_TRAINS[release_train])
@@ -61,6 +76,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     _ = parser.add_argument("--release-train", required=True)
     _ = parser.add_argument("--validate-phase-only", action="store_true")
+    _ = parser.add_argument("--phase-status", action="store_true")
     args = parser.parse_args()
 
     try:
@@ -73,7 +89,12 @@ def main() -> int:
         existing_versions = cast(list[str], items)
         release_train = cast(str, args.release_train)
         validate_phase_only = cast(bool, args.validate_phase_only)
-        if validate_phase_only:
+        phase_status = cast(bool, args.phase_status)
+        if validate_phase_only and phase_status:
+            raise ValueError("Choose only one phase inspection mode")
+        if phase_status:
+            print(alpha_phase_status(release_train, existing_versions))
+        elif validate_phase_only:
             validate_alpha_phase_open(release_train, existing_versions)
         else:
             print(compute_alpha_release_version(release_train, existing_versions))

--- a/scripts/compute_alpha_release_version.py
+++ b/scripts/compute_alpha_release_version.py
@@ -57,11 +57,14 @@ def validate_alpha_phase_open(release_train: str, existing_versions: Iterable[st
 
 
 def alpha_phase_status(release_train: str, existing_versions: Iterable[str]) -> AlphaPhaseStatus:
-    try:
-        validate_alpha_phase_open(release_train, existing_versions)
-    except AlphaPhaseClosedError:
-        return "closed"
-    return "open"
+    validate_alpha_phase_open(release_train, ())
+    closed = False
+    for version in existing_versions:
+        try:
+            validate_alpha_phase_open(release_train, (version,))
+        except AlphaPhaseClosedError:
+            closed = True
+    return "closed" if closed else "open"
 
 
 def compute_alpha_release_version(release_train: str, existing_versions: Iterable[str]) -> str:

--- a/tests/test_compute_alpha_release_version.py
+++ b/tests/test_compute_alpha_release_version.py
@@ -63,6 +63,8 @@ def test_phase_status_reports_a_closed_train_without_weakening_alpha_computation
 def test_phase_status_rejects_malformed_registry_versions() -> None:
     with pytest.raises(ValueError, match="invalid"):
         _ = alpha_phase_status("3.0", ["not-a-version"])
+    with pytest.raises(ValueError, match="invalid"):
+        _ = alpha_phase_status("3.0", ["3.0.0", "not-a-version"])
 
 
 @pytest.mark.parametrize("version", ["2.2.0b1", "2.2.0rc1"])

--- a/tests/test_compute_alpha_release_version.py
+++ b/tests/test_compute_alpha_release_version.py
@@ -6,7 +6,12 @@ import sys
 
 import pytest
 
-from scripts.compute_alpha_release_version import compute_alpha_release_version, main, validate_alpha_phase_open
+from scripts.compute_alpha_release_version import (
+    alpha_phase_status,
+    compute_alpha_release_version,
+    main,
+    validate_alpha_phase_open,
+)
 
 
 @pytest.mark.parametrize(
@@ -48,6 +53,16 @@ def test_rejects_noncanonical_or_malformed_existing_versions(existing: list[str]
 def test_same_train_stable_release_blocks_an_alpha() -> None:
     with pytest.raises(ValueError, match="stable release"):
         _ = compute_alpha_release_version("2.2", ["2.2.0"])
+
+
+def test_phase_status_reports_a_closed_train_without_weakening_alpha_computation() -> None:
+    assert alpha_phase_status("3.0", ["3.0.0a1"]) == "open"
+    assert alpha_phase_status("3.0", ["3.0.0a1", "3.0.0"]) == "closed"
+
+
+def test_phase_status_rejects_malformed_registry_versions() -> None:
+    with pytest.raises(ValueError, match="invalid"):
+        _ = alpha_phase_status("3.0", ["not-a-version"])
 
 
 @pytest.mark.parametrize("version", ["2.2.0b1", "2.2.0rc1"])

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -73,6 +73,11 @@ def test_release_branch_pushes_publish_alpha_while_main_pushes_publish_stable() 
     assert "vars.MAIN_TESTPYPI_ENABLED == 'true'" in jobs["publish-main-testpypi"]["if"]
     assert jobs["release-main"]["needs"] == ["build", "publish-main-pypi"]
 
+    native_condition = jobs["build-native-guard-wheels"]["if"]
+    assert "needs.build.outputs.channel == 'validation'" in native_condition
+    for job_name in ("reserve-alpha-tag", "publish-alpha-testpypi", "publish-alpha-pypi", "release-alpha"):
+        assert "validation" not in jobs[job_name]["if"]
+
     workflow_text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
     assert "startsWith(github.ref, 'refs/tags/')" not in workflow_text
     assert "github.ref == 'refs/heads/main'" in workflow_text

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -92,6 +92,10 @@ def test_main_push_build_computes_a_registry_derived_stable_version() -> None:
     assert 'SOURCE_SHA" != "$EXPECTED_SOURCE"' in compute_run
     assert 'TRAIN="3.0"' in compute_run
     assert "compute_alpha_release_version.py" in compute_run
+    assert "--phase-status" in compute_run
+    assert 'CHANNEL="validation"' in compute_run
+    assert 'VERSION="$BASE_VERSION"' in compute_run
+    assert "validating without publishing" in compute_run
     assert "validate_alpha_release.py" in compute_run
     assert 'elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]' in compute_run
     assert 'elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]' in compute_run


### PR DESCRIPTION
## Summary

- detect when a stable or later-phase release has closed the alpha train
- keep release-branch pushes build-and-verify capable through a validation-only channel
- prevent closed-train validation runs from reserving or publishing alpha artifacts

## Verification

- `uv run --no-sync pytest -q tests/test_compute_alpha_release_version.py tests/test_release_train_workflow.py`
- `uv run --no-sync ruff check scripts/compute_alpha_release_version.py tests/test_compute_alpha_release_version.py tests/test_release_train_workflow.py`
- `uv run --no-sync python scripts/ci/code_quality_audit.py`
- `git diff --check`
