### PR TITLE
Normalize the 3.0.1 promotion version

### DIFF
--- a/.github/workflows/guard-network-remediation-proof.yml
+++ b/.github/workflows/guard-network-remediation-proof.yml
@@ -69,7 +69,9 @@ jobs:
         run: |
           uv venv --python 3.12 .proof-venv
           uv pip install --python .proof-venv/bin/python dist/*.whl
-          .proof-venv/bin/python -c 'from codex_plugin_scanner.version import __version__; assert __version__.startswith("3.0.0a")'
+          EXPECTED_VERSION=$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
+          INSTALLED_VERSION=$(.proof-venv/bin/python -c 'from importlib.metadata import version; print(version("hol-guard"))')
+          test "$INSTALLED_VERSION" = "$EXPECTED_VERSION"
           .proof-venv/bin/hol-guard --version
       - name: Upload formatted proof source
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

--- a/.github/workflows/guard-network-remediation-proof.yml
+++ b/.github/workflows/guard-network-remediation-proof.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           uv venv --python 3.12 .proof-venv
           uv pip install --python .proof-venv/bin/python dist/*.whl
-          EXPECTED_VERSION=$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
+          EXPECTED_VERSION=$(uv run --frozen python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
           INSTALLED_VERSION=$(.proof-venv/bin/python -c 'from importlib.metadata import version; print(version("hol-guard"))')
           test "$INSTALLED_VERSION" = "$EXPECTED_VERSION"
           .proof-venv/bin/hol-guard --version

--- a/ci/code-quality-baseline.json
+++ b/ci/code-quality-baseline.json
@@ -622,7 +622,7 @@
     "tests/test_guard_bulk_allow_once.py": 632,
     "tests/test_guard_cisco_runtime_cli.py": 745,
     "tests/test_guard_claude_adapter.py": 720,
-    "tests/test_guard_cli.py": 10103,
+    "tests/test_guard_cli.py": 10115,
     "tests/test_guard_cloud_local_sync.py": 1262,
     "tests/test_guard_cloud_review_sync.py": 742,
     "tests/test_guard_codex_browser_authority.py": 710,

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
-  "maximum_collected_cases": 16193,
-  "maximum_test_source_lines": 349961
+  "maximum_collected_cases": 16194,
+  "maximum_test_source_lines": 349969
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
   "maximum_collected_cases": 16194,
-  "maximum_test_source_lines": 349981
+  "maximum_test_source_lines": 349982
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
   "maximum_collected_cases": 16194,
-  "maximum_test_source_lines": 349969
+  "maximum_test_source_lines": 349981
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hol-guard"
-version = "3.0.0a0"
+version = "3.0.1"
 description = "Open-source antivirus and runtime protection for AI agents, tools, MCP servers, plugins, skills, and package installs."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/codex_plugin_scanner/version.py
+++ b/src/codex_plugin_scanner/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for tool version."""
 
-__version__ = "3.0.0a0"
+__version__ = "3.0.1"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -4194,6 +4194,12 @@ args = ["workspace-skill.js", "--changed"]
     def test_guard_update_dry_run_emits_planned_command(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"
         monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
+        monkeypatch.setattr(guard_update_commands_module, "_current_version", lambda: "3.0.1a1")
+        monkeypatch.setattr(
+            guard_update_commands_module,
+            "_latest_alpha_version_from_pypi",
+            lambda _current: "3.0.1a2",
+        )
 
         rc = main(["guard", "update", "--home", str(home_dir), "--alpha", "--dry-run", "--json"])
         output = json.loads(capsys.readouterr().out)
@@ -4206,6 +4212,12 @@ args = ["workspace-skill.js", "--changed"]
     def test_guard_update_dry_run_skips_guard_store_init(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"
         monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
+        monkeypatch.setattr(guard_update_commands_module, "_current_version", lambda: "3.0.1a1")
+        monkeypatch.setattr(
+            guard_update_commands_module,
+            "_latest_alpha_version_from_pypi",
+            lambda _current: "3.0.1a2",
+        )
         monkeypatch.setattr(
             guard_commands_module,
             "GuardStore",

--- a/tests/test_guard_network_remediation_proof.py
+++ b/tests/test_guard_network_remediation_proof.py
@@ -14,6 +14,14 @@ import pytest
 _REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 _SCRIPT_PATH = _REPOSITORY_ROOT / "scripts" / "guard_network_remediation_proof.py"
 _MANIFEST_PATH = _REPOSITORY_ROOT / "ci" / "guard-network-remediation-proof.v1.json"
+_WORKFLOW_PATH = _REPOSITORY_ROOT / ".github" / "workflows" / "guard-network-remediation-proof.yml"
+
+
+def test_network_remediation_proof_compares_the_exact_installed_version() -> None:
+    workflow = _WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert 'test "$INSTALLED_VERSION" = "$EXPECTED_VERSION"' in workflow
+    assert "3.0.0a" not in workflow
 
 
 def _load_module() -> ModuleType:

--- a/tests/test_guard_network_remediation_proof.py
+++ b/tests/test_guard_network_remediation_proof.py
@@ -21,6 +21,7 @@ def test_network_remediation_proof_compares_the_exact_installed_version() -> Non
     workflow = _WORKFLOW_PATH.read_text(encoding="utf-8")
 
     assert 'test "$INSTALLED_VERSION" = "$EXPECTED_VERSION"' in workflow
+    assert "EXPECTED_VERSION=$(uv run --frozen python" in workflow
     assert "3.0.0a" not in workflow
 
 

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -19,7 +19,7 @@ def test_source_distribution_and_package_versions_match():
     pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
     pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
     source_version = pyproject["project"]["version"]
-    assert source_version == package_version == "3.0.0a0"
+    assert source_version == package_version == "3.0.1"
     try:
         installed_version = distribution_version("hol-guard")
     except PackageNotFoundError:

--- a/uv.lock
+++ b/uv.lock
@@ -1174,7 +1174,7 @@ wheels = [
 
 [[package]]
 name = "hol-guard"
-version = "3.0.0a0"
+version = "3.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "cisco-ai-skill-scanner" },


### PR DESCRIPTION
## Summary

- normalize repository and runtime metadata to stable `3.0.1`
- keep source, lockfile, and installed distribution version checks aligned
- make the next main-branch publication compute the valid `3.0.1` successor

## Verification

- 125 focused release and version tests passed
- Managed Controls Local release gate passed
- documentation contract tests passed (9 tests)
- exact registry-derived main version computation returned `3.0.1`
- isolated wheel and source distribution built and passed `twine check`
- isolated wheel reported `hol-guard 3.0.1`
- test-suite and structural quality ratchets passed
- Ruff and `git diff --check` passed
