### PR TITLE
fix(release): publish native artifacts from main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -407,6 +407,11 @@ jobs:
             (github.event_name == 'push' && github.ref == 'refs/heads/release/3.0') ||
             (github.event_name == 'workflow_dispatch' && github.event.inputs.release_train == '3.0')
           )
+        ) ||
+        (
+          needs.build.outputs.channel == 'stable' &&
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/main'
         )
       )
     needs: build
@@ -1082,8 +1087,9 @@ jobs:
       github.run_attempt == 1 &&
       github.ref == 'refs/heads/main' &&
       needs.build.result == 'success' &&
+      needs.assemble-native-guard-distributions.result == 'success' &&
       needs.build.outputs.channel == 'stable'
-    needs: build
+    needs: [build, assemble-native-guard-distributions]
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:
@@ -1099,13 +1105,13 @@ jobs:
           version: "0.9.26"
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          name: distributions
+          name: distributions-native
           path: dist/
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          name: distribution-sha256
+          name: distribution-sha256-native
       - name: Verify immutable build artifact
-        run: sha256sum --check distribution-sha256.txt
+        run: sha256sum --check distribution-sha256-native.txt
       - name: Keep only the Guard release distribution
         run: rm -f dist/plugin_scanner-* dist/plugin-scanner-*
       - name: Revalidate main source before TestPyPI
@@ -1172,8 +1178,9 @@ jobs:
       github.run_attempt == 1 &&
       github.ref == 'refs/heads/main' &&
       needs.build.result == 'success' &&
+      needs.assemble-native-guard-distributions.result == 'success' &&
       needs.build.outputs.channel == 'stable'
-    needs: build
+    needs: [build, assemble-native-guard-distributions]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -1189,19 +1196,19 @@ jobs:
           version: "0.9.26"
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          name: distributions
+          name: distributions-native
           path: dist/
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          name: distribution-sha256
+          name: distribution-sha256-native
       - name: Verify immutable build artifact
-        run: sha256sum --check distribution-sha256.txt
+        run: sha256sum --check distribution-sha256-native.txt
       - name: Prepare project-specific distributions
         run: |
           shopt -s nullglob
           guard_files=(dist/hol_guard-* dist/hol-guard-*)
           scanner_files=(dist/plugin_scanner-* dist/plugin-scanner-*)
-          [[ "${#guard_files[@]}" == "2" && "${#scanner_files[@]}" == "2" ]]
+          [[ "${#guard_files[@]}" -ge "2" && "${#scanner_files[@]}" == "2" ]]
           mkdir dist-hol-guard dist-plugin-scanner
           cp "${guard_files[@]}" dist-hol-guard/
           cp "${scanner_files[@]}" dist-plugin-scanner/
@@ -1312,9 +1319,10 @@ jobs:
       github.run_attempt == 1 &&
       github.ref == 'refs/heads/main' &&
       needs.build.result == 'success' &&
+      needs.assemble-native-guard-distributions.result == 'success' &&
       needs.publish-main-pypi.result == 'success' &&
       needs.build.outputs.channel == 'stable'
-    needs: [build, publish-main-pypi]
+    needs: [build, assemble-native-guard-distributions, publish-main-pypi]
     runs-on: ubuntu-latest
     permissions:
       attestations: write
@@ -1327,11 +1335,11 @@ jobs:
           ref: ${{ needs.build.outputs.source_sha }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          name: distributions
+          name: distributions-native
           path: dist/
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          name: distribution-sha256
+          name: distribution-sha256-native
       - name: Download release toolchain SBOM
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
@@ -1339,7 +1347,7 @@ jobs:
           path: dist/
       - name: Verify and select release assets
         run: |
-          sha256sum --check distribution-sha256.txt
+          sha256sum --check distribution-sha256-native.txt
           rm -f dist/plugin_scanner-* dist/plugin-scanner-*
       - name: Attest main release assets
         id: provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1165,8 +1165,11 @@ jobs:
             fi
             sleep 5
           done
-          wheel=$(jq -r '.install_paths[] | select(endswith(".whl"))' <<< "$result")
-          [[ -n "$wheel" ]]
+          mapfile -t wheels < <(
+            jq -r '.install_paths[] | select(endswith("-py3-none-any.whl"))' <<< "$result"
+          )
+          [[ "${#wheels[@]}" == "1" ]]
+          wheel="${wheels[0]}"
           [[ "$(uv tool run --from "$wheel" hol-guard --version)" == "hol-guard $VERSION" ]]
 
   publish-main-pypi:
@@ -1304,9 +1307,15 @@ jobs:
             fi
             sleep 5
           done
-          guard_wheel=$(jq -r '.install_paths[] | select(endswith(".whl"))' <<< "$guard_result")
-          scanner_wheel=$(jq -r '.install_paths[] | select(endswith(".whl"))' <<< "$scanner_result")
-          [[ -n "$guard_wheel" && -n "$scanner_wheel" ]]
+          mapfile -t guard_wheels < <(
+            jq -r '.install_paths[] | select(endswith("-py3-none-any.whl"))' <<< "$guard_result"
+          )
+          mapfile -t scanner_wheels < <(
+            jq -r '.install_paths[] | select(endswith(".whl"))' <<< "$scanner_result"
+          )
+          [[ "${#guard_wheels[@]}" == "1" && "${#scanner_wheels[@]}" == "1" ]]
+          guard_wheel="${guard_wheels[0]}"
+          scanner_wheel="${scanner_wheels[0]}"
           [[ "$(uv tool run --from "$guard_wheel" hol-guard --version)" == "hol-guard $VERSION" ]]
           [[ "$(uv tool run --from "$scanner_wheel" plugin-scanner --version)" == "plugin-scanner $VERSION" ]]
 

--- a/ci/code-quality-baseline.json
+++ b/ci/code-quality-baseline.json
@@ -437,7 +437,7 @@
   },
   "oversized_files": {
     ".github/workflows/ci.yml": 554,
-    ".github/workflows/publish.yml": 1629,
+    ".github/workflows/publish.yml": 1646,
     "dashboard/src/app.tsx": 1106,
     "dashboard/src/approval-center-primitives.tsx": 1049,
     "dashboard/src/approval-center-utils.ts": 901,
@@ -744,7 +744,7 @@
     "tests/test_policy_bundle_v2.py": 537,
     "tests/test_policy_decision_source_context.py": 570,
     "tests/test_policy_document_io.py": 679,
-    "tests/test_release_train_workflow.py": 559,
+    "tests/test_release_train_workflow.py": 587,
     "tests/test_update_desktop_core.py": 716,
     "tests/test_verify_release_registry.py": 567,
     "tests/test_zcode_adapter.py": 685

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
   "maximum_collected_cases": 16210,
-  "maximum_test_source_lines": 350451
+  "maximum_test_source_lines": 350479
 }

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -68,10 +68,14 @@ def test_release_branch_pushes_publish_alpha_while_main_pushes_publish_stable() 
         assert "github.run_attempt == 1" in condition
         assert "github.ref == 'refs/heads/main'" in condition
         assert "needs.build.outputs.channel == 'stable'" in condition
-    assert jobs["publish-main-pypi"]["needs"] == "build"
+    assert jobs["publish-main-pypi"]["needs"] == ["build", "assemble-native-guard-distributions"]
     assert "needs.publish-main-testpypi.result == 'success'" not in jobs["publish-main-pypi"]["if"]
     assert "vars.MAIN_TESTPYPI_ENABLED == 'true'" in jobs["publish-main-testpypi"]["if"]
-    assert jobs["release-main"]["needs"] == ["build", "publish-main-pypi"]
+    assert jobs["release-main"]["needs"] == [
+        "build",
+        "assemble-native-guard-distributions",
+        "publish-main-pypi",
+    ]
 
     workflow_text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
     assert "startsWith(github.ref, 'refs/tags/')" not in workflow_text
@@ -232,7 +236,8 @@ def test_release_publication_reuses_one_hashed_build_artifact() -> None:
     )
     for job_name in ("publish-main-testpypi",):
         steps = jobs[job_name]["steps"]
-        assert any(step.get("run") == "sha256sum --check distribution-sha256.txt" for step in steps)
+        assert any(step.get("run") == "sha256sum --check distribution-sha256-native.txt" for step in steps)
+        assert any(step.get("with", {}).get("name") == "distributions-native" for step in steps)
         assert any(
             step.get("name") == "Keep only the Guard release distribution" and "plugin_scanner" in step.get("run", "")
             for step in steps
@@ -240,7 +245,7 @@ def test_release_publication_reuses_one_hashed_build_artifact() -> None:
 
     public_hashes = {
         "publish-alpha-pypi": "sha256sum --check distribution-sha256-native.txt",
-        "publish-main-pypi": "sha256sum --check distribution-sha256.txt",
+        "publish-main-pypi": "sha256sum --check distribution-sha256-native.txt",
     }
     for job_name in ("publish-alpha-pypi", "publish-main-pypi"):
         steps = jobs[job_name]["steps"]
@@ -256,6 +261,24 @@ def test_release_publication_reuses_one_hashed_build_artifact() -> None:
         if step.get("name") == "Prepare project-specific distributions"
     )
     assert '"${#guard_files[@]}" -ge "2"' in alpha_prepare["run"]
+    stable_prepare = next(
+        step
+        for step in jobs["publish-main-pypi"]["steps"]
+        if step.get("name") == "Prepare project-specific distributions"
+    )
+    assert '"${#guard_files[@]}" -ge "2"' in stable_prepare["run"]
+
+    stable_native = jobs["build-native-guard-wheels"]["if"]
+    assert "needs.build.outputs.channel == 'stable'" in stable_native
+    assert "github.ref == 'refs/heads/main'" in stable_native
+    for job_name in ("publish-main-testpypi", "publish-main-pypi", "release-main"):
+        job = jobs[job_name]
+        assert "assemble-native-guard-distributions" in job["needs"]
+        assert "needs.assemble-native-guard-distributions.result == 'success'" in job["if"]
+        assert any(
+            step.get("with", {}).get("name") == "distributions-native"
+            for step in job["steps"]
+        )
 
     workflow_text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
     assert "skip-existing" not in workflow_text and "pytest" not in workflow_text

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -371,6 +371,8 @@ def test_registry_state_is_revalidated_at_each_publication_boundary() -> None:
         < main_test_steps.index(main_test_verify)
     )
     assert "--download-dir verified-testpypi" in main_test_verify["run"]
+    assert 'select(endswith("-py3-none-any.whl"))' in main_test_verify["run"]
+    assert '"${#wheels[@]}" == "1"' in main_test_verify["run"]
 
     main_revalidation = next(
         step["run"] for step in jobs["publish-main-pypi"]["steps"] if step.get("name") == "Revalidate main publication"
@@ -443,6 +445,9 @@ def test_registry_state_is_revalidated_at_each_publication_boundary() -> None:
         assert 'attempt" == "60"' in verify_step["run"]
         assert '== "hol-guard $VERSION"' in verify_step["run"]
         assert '== "plugin-scanner $VERSION"' in verify_step["run"]
+        assert 'select(endswith("-py3-none-any.whl"))' in verify_step["run"]
+        assert '"${#guard_wheels[@]}" == "1"' in verify_step["run"]
+        assert '"${#scanner_wheels[@]}" == "1"' in verify_step["run"]
 
     alpha_steps = jobs["publish-alpha-pypi"]["steps"]
     alpha_inspect = next(step for step in alpha_steps if step.get("name") == "Inspect PyPI release state")


### PR DESCRIPTION
## Summary
- Build the complete native Guard wheel matrix for stable releases from `main`.
- Reuse one hashed native artifact set across TestPyPI, PyPI, and the stable GitHub release.
- Enforce stable native publication dependencies with release workflow contract tests.

## Testing
- `uv run --frozen --extra dev python -m pytest -q tests/test_release_train_workflow.py tests/test_unpublished_alpha_reservation.py tests/test_installed_canary_workflow.py tests/test_verify_release_asset_inventory.py tests/test_verify_release_registry.py tests/test_compute_main_release_version.py tests/test_release_toolchain_sbom.py`
- `uv run --frozen --extra dev ruff check tests/test_release_train_workflow.py`
- `actionlint .github/workflows/publish.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Process**
  * Stable releases now use native Guard distributions and matching checksums.
  * Native Guard wheels are built for stable pushes to the main branch.
  * Publishing and release steps wait for successful native distribution assembly.
  * Artifact validation confirms the expected pure-Python Guard and scanner wheels.
  * Projects with two or more Guard files are accepted during validation.

* **Tests**
  * Added coverage for stable artifact selection, build conditions, dependency checks, checksum validation, wheel filtering, and Guard-file requirements.
  * Updated the test baseline to reflect the latest source size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->