### PR TITLE
fix(release): reserve stable tags before publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1172,8 +1172,8 @@ jobs:
           wheel="${wheels[0]}"
           [[ "$(uv tool run --from "$wheel" hol-guard --version)" == "hol-guard $VERSION" ]]
 
-  publish-main-pypi:
-    name: Publish main release to PyPI
+  reserve-main-tag:
+    name: Reserve stable tag
     if: >-
       always() &&
       vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
@@ -1184,6 +1184,51 @@ jobs:
       needs.assemble-native-guard-distributions.result == 'success' &&
       needs.build.outputs.channel == 'stable'
     needs: [build, assemble-native-guard-distributions]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.build.outputs.source_sha }}
+      - name: Bind stable tag to the exact main source
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          remote_main_sha=$(git ls-remote --exit-code origin refs/heads/main | awk '{print $1}')
+          if [[ "$remote_main_sha" != "$SOURCE_SHA" ]]; then
+            echo "Stable tag source is no longer the main branch head" >&2
+            exit 1
+          fi
+          tag="v${VERSION}"
+          remote_tag_sha=$(git ls-remote origin "refs/tags/${tag}" | awk '{print $1}')
+          if [[ -z "$remote_tag_sha" ]]; then
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref="refs/tags/${tag}" \
+              -f sha="$SOURCE_SHA" >/dev/null
+            remote_tag_sha=$(git ls-remote --exit-code origin "refs/tags/${tag}" | awk '{print $1}')
+          fi
+          if [[ "$remote_tag_sha" != "$SOURCE_SHA" ]]; then
+            echo "Stable tag does not target the exact main source" >&2
+            exit 1
+          fi
+
+  publish-main-pypi:
+    name: Publish main release to PyPI
+    if: >-
+      always() &&
+      vars.RELEASE_PUBLISHING_ENABLED == 'true' &&
+      github.event_name == 'push' &&
+      github.run_attempt == 1 &&
+      github.ref == 'refs/heads/main' &&
+      needs.build.result == 'success' &&
+      needs.assemble-native-guard-distributions.result == 'success' &&
+      needs.reserve-main-tag.result == 'success' &&
+      needs.build.outputs.channel == 'stable'
+    needs: [build, assemble-native-guard-distributions, reserve-main-tag]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1209,11 +1209,14 @@ jobs:
           tag="v${VERSION}"
           remote_tag_sha=$(git ls-remote origin "refs/tags/${tag}" | awk '{print $1}')
           if [[ -z "$remote_tag_sha" ]]; then
-            gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+            if ! gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
               -f ref="refs/tags/${tag}" \
-              -f sha="$SOURCE_SHA" >/dev/null
-            remote_tag_sha=$(git ls-remote --exit-code origin "refs/tags/${tag}" | awk '{print $1}')
+              -f sha="$SOURCE_SHA" >/dev/null; then
+              echo "Stable tag creation raced or failed; verifying the resulting remote ref" >&2
+            fi
           fi
+          git fetch --force --no-tags origin "+refs/tags/${tag}:refs/tags/${tag}"
+          remote_tag_sha=$(git rev-parse "${tag}^{commit}")
           if [[ "$remote_tag_sha" != "$SOURCE_SHA" ]]; then
             echo "Stable tag does not target the exact main source" >&2
             exit 1
@@ -1426,13 +1429,8 @@ jobs:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
           tag="v${VERSION}"
-          remote_tag_sha=$(git ls-remote origin "refs/tags/${tag}" | awk '{print $1}')
-          if [[ -z "$remote_tag_sha" ]]; then
-            gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
-              -f ref="refs/tags/${tag}" \
-              -f sha="$SOURCE_SHA" >/dev/null
-            remote_tag_sha=$(git ls-remote --exit-code origin "refs/tags/${tag}" | awk '{print $1}')
-          fi
+          git fetch --force --no-tags origin "+refs/tags/${tag}:refs/tags/${tag}"
+          remote_tag_sha=$(git rev-parse "${tag}^{commit}")
           if [[ "$remote_tag_sha" != "$SOURCE_SHA" ]]; then
             echo "Stable tag does not target the published source" >&2
             exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -267,10 +267,13 @@ jobs:
               list-versions --registry pypi)
             TESTPYPI_VERSIONS=$(uv run --no-sync python scripts/verify_release_registry.py \
               list-versions --registry testpypi)
+            TAG_VERSIONS=$(git tag --list 'v*' | sed 's/^v//' | jq -R -s \
+              'split("\n") | map(select(length > 0))')
             VERSIONS=$(jq -n \
               --argjson pypi "$PYPI_VERSIONS" \
               --argjson testpypi "$TESTPYPI_VERSIONS" \
-              '$pypi + $testpypi | unique')
+              --argjson tags "$TAG_VERSIONS" \
+              '$pypi + $testpypi + $tags | unique')
             VERSION=$(uv run --no-sync python scripts/compute_main_release_version.py \
               --base-version "$BASE_VERSION" <<< "$VERSIONS")
           fi
@@ -1265,9 +1268,10 @@ jobs:
           SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
           VERSION: ${{ needs.build.outputs.version }}
         run: |
-          remote_main_sha=$(git ls-remote --exit-code origin refs/heads/main | awk '{print $1}')
-          if [[ "$remote_main_sha" != "$SOURCE_SHA" ]]; then
-            echo "Main publication source is no longer the branch head" >&2
+          git fetch --no-tags origin "+refs/tags/v${VERSION}:refs/tags/v${VERSION}"
+          reserved_source_sha=$(git rev-parse "v${VERSION}^{commit}")
+          if [[ "$reserved_source_sha" != "$SOURCE_SHA" ]]; then
+            echo "Stable tag does not target the exact publication source" >&2
             exit 1
           fi
           BASE_VERSION=$(uv run --with packaging==25.0 python scripts/sync_repo_version.py --check)
@@ -1275,11 +1279,14 @@ jobs:
             list-versions --registry pypi)
           TESTPYPI_VERSIONS=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
             list-versions --registry testpypi)
+          TAG_VERSIONS=$(git tag --list 'v*' | sed 's/^v//' | jq -R -s \
+            'split("\n") | map(select(length > 0))')
           RELEASE_VERSIONS=$(jq -n \
             --arg version "$VERSION" \
             --argjson pypi "$PYPI_VERSIONS" \
             --argjson testpypi "$TESTPYPI_VERSIONS" \
-            '$pypi + $testpypi + [$version] | unique')
+            --argjson tags "$TAG_VERSIONS" \
+            '$pypi + $testpypi + $tags + [$version] | unique')
           LATEST_RELEASE_VERSION=$(uv run --with packaging==25.0 python scripts/compute_main_release_version.py \
             --base-version "$BASE_VERSION" --latest-existing <<< "$RELEASE_VERSIONS")
           if [[ "$LATEST_RELEASE_VERSION" != "$VERSION" ]]; then

--- a/ci/code-quality-baseline.json
+++ b/ci/code-quality-baseline.json
@@ -437,7 +437,7 @@
   },
   "oversized_files": {
     ".github/workflows/ci.yml": 554,
-    ".github/workflows/publish.yml": 1646,
+    ".github/workflows/publish.yml": 1691,
     "dashboard/src/app.tsx": 1106,
     "dashboard/src/approval-center-primitives.tsx": 1049,
     "dashboard/src/approval-center-utils.ts": 901,
@@ -744,7 +744,7 @@
     "tests/test_policy_bundle_v2.py": 537,
     "tests/test_policy_decision_source_context.py": 570,
     "tests/test_policy_document_io.py": 679,
-    "tests/test_release_train_workflow.py": 587,
+    "tests/test_release_train_workflow.py": 602,
     "tests/test_update_desktop_core.py": 716,
     "tests/test_verify_release_registry.py": 567,
     "tests/test_zcode_adapter.py": 685

--- a/ci/code-quality-baseline.json
+++ b/ci/code-quality-baseline.json
@@ -744,7 +744,7 @@
     "tests/test_policy_bundle_v2.py": 537,
     "tests/test_policy_decision_source_context.py": 570,
     "tests/test_policy_document_io.py": 679,
-    "tests/test_release_train_workflow.py": 608,
+    "tests/test_release_train_workflow.py": 611,
     "tests/test_update_desktop_core.py": 716,
     "tests/test_verify_release_registry.py": 567,
     "tests/test_zcode_adapter.py": 685

--- a/ci/code-quality-baseline.json
+++ b/ci/code-quality-baseline.json
@@ -437,7 +437,7 @@
   },
   "oversized_files": {
     ".github/workflows/ci.yml": 554,
-    ".github/workflows/publish.yml": 1691,
+    ".github/workflows/publish.yml": 1698,
     "dashboard/src/app.tsx": 1106,
     "dashboard/src/approval-center-primitives.tsx": 1049,
     "dashboard/src/approval-center-utils.ts": 901,
@@ -744,7 +744,7 @@
     "tests/test_policy_bundle_v2.py": 537,
     "tests/test_policy_decision_source_context.py": 570,
     "tests/test_policy_document_io.py": 679,
-    "tests/test_release_train_workflow.py": 602,
+    "tests/test_release_train_workflow.py": 608,
     "tests/test_update_desktop_core.py": 716,
     "tests/test_verify_release_registry.py": 567,
     "tests/test_zcode_adapter.py": 685

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
   "maximum_collected_cases": 16210,
-  "maximum_test_source_lines": 350494
+  "maximum_test_source_lines": 350500
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
   "maximum_collected_cases": 16210,
-  "maximum_test_source_lines": 350500
+  "maximum_test_source_lines": 350503
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
   "maximum_collected_cases": 16210,
-  "maximum_test_source_lines": 350479
+  "maximum_test_source_lines": 350494
 }

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -118,7 +118,8 @@ def test_main_push_build_computes_a_registry_derived_stable_version() -> None:
     assert "verify_release_registry.py" in compute_run
     assert "list-versions --registry pypi" in compute_run
     assert "list-versions --registry testpypi" in compute_run
-    assert "'$pypi + $testpypi | unique'" in compute_run
+    assert "git tag --list 'v*'" in compute_run
+    assert "'$pypi + $testpypi + $tags | unique'" in compute_run
     assert "compute_main_release_version.py" in compute_run
     assert "if" not in stamp_step
     assert "sync_repo_version.py --check" in stamp_run
@@ -397,17 +398,22 @@ def test_registry_state_is_revalidated_at_each_publication_boundary() -> None:
         for step in jobs["publish-main-testpypi"]["steps"]
         if step.get("name") == "Revalidate main source before TestPyPI"
     )
-    for main_source_revalidation in (main_testpypi_revalidation, main_revalidation):
-        assert "git ls-remote --exit-code origin refs/heads/main" in main_source_revalidation
-        assert '[[ "$remote_main_sha" != "$SOURCE_SHA" ]]' in main_source_revalidation
-        assert "Main publication source is no longer the branch head" in main_source_revalidation
-        assert 'git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main' not in main_source_revalidation
+    assert "git ls-remote --exit-code origin refs/heads/main" in main_testpypi_revalidation
+    assert '[[ "$remote_main_sha" != "$SOURCE_SHA" ]]' in main_testpypi_revalidation
+    assert "Main publication source is no longer the branch head" in main_testpypi_revalidation
+    assert 'git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main' not in main_testpypi_revalidation
+    assert 'git fetch --no-tags origin "+refs/tags/v${VERSION}:refs/tags/v${VERSION}"' in main_revalidation
+    assert 'git rev-parse "v${VERSION}^{commit}"' in main_revalidation
+    assert '[[ "$reserved_source_sha" != "$SOURCE_SHA" ]]' in main_revalidation
+    assert "Stable tag does not target the exact publication source" in main_revalidation
+    assert "refs/heads/main" not in main_revalidation
     assert "compute_main_release_version.py" in main_revalidation
     assert main_revalidation.count("uv run --with packaging==25.0") == 5
     assert "uv run --no-sync" not in main_revalidation
     assert "list-versions --registry pypi" in main_revalidation
     assert "list-versions --registry testpypi" in main_revalidation
-    assert "'$pypi + $testpypi + [$version] | unique'" in main_revalidation
+    assert "git tag --list 'v*'" in main_revalidation
+    assert "'$pypi + $testpypi + $tags + [$version] | unique'" in main_revalidation
     assert '<<< "$RELEASE_VERSIONS"' in main_revalidation
     assert '[[ "$LATEST_RELEASE_VERSION" != "$VERSION" ]]' in main_revalidation
     assert "--latest-existing" in main_revalidation

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -62,13 +62,28 @@ def test_release_branch_pushes_publish_alpha_while_main_pushes_publish_stable() 
         assert "github.event_name == 'push'" in condition
         assert "github.ref == 'refs/heads/release/3.0'" in condition
         assert "github.event.action == 'closed'" not in condition
-    for job_name in ("publish-main-testpypi", "publish-main-pypi", "release-main"):
+    for job_name in ("publish-main-testpypi", "reserve-main-tag", "publish-main-pypi", "release-main"):
         condition = jobs[job_name]["if"]
         assert "github.event_name == 'push'" in condition
         assert "github.run_attempt == 1" in condition
         assert "github.ref == 'refs/heads/main'" in condition
         assert "needs.build.outputs.channel == 'stable'" in condition
-    assert jobs["publish-main-pypi"]["needs"] == ["build", "assemble-native-guard-distributions"]
+    assert jobs["reserve-main-tag"]["needs"] == ["build", "assemble-native-guard-distributions"]
+    assert jobs["reserve-main-tag"]["permissions"] == {"contents": "write"}
+    reserve_run = next(
+        step["run"]
+        for step in jobs["reserve-main-tag"]["steps"]
+        if step.get("name") == "Bind stable tag to the exact main source"
+    )
+    assert "git ls-remote --exit-code origin refs/heads/main" in reserve_run
+    assert '-f ref="refs/tags/${tag}"' in reserve_run
+    assert '-f sha="$SOURCE_SHA"' in reserve_run
+    assert jobs["publish-main-pypi"]["needs"] == [
+        "build",
+        "assemble-native-guard-distributions",
+        "reserve-main-tag",
+    ]
+    assert "needs.reserve-main-tag.result == 'success'" in jobs["publish-main-pypi"]["if"]
     assert "needs.publish-main-testpypi.result == 'success'" not in jobs["publish-main-pypi"]["if"]
     assert "vars.MAIN_TESTPYPI_ENABLED == 'true'" in jobs["publish-main-testpypi"]["if"]
     assert jobs["release-main"]["needs"] == [

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -78,6 +78,9 @@ def test_release_branch_pushes_publish_alpha_while_main_pushes_publish_stable() 
     assert "git ls-remote --exit-code origin refs/heads/main" in reserve_run
     assert '-f ref="refs/tags/${tag}"' in reserve_run
     assert '-f sha="$SOURCE_SHA"' in reserve_run
+    assert 'git fetch --force --no-tags origin "+refs/tags/${tag}:refs/tags/${tag}"' in reserve_run
+    assert 'git rev-parse "${tag}^{commit}"' in reserve_run
+    assert "verifying the resulting remote ref" in reserve_run
     assert jobs["publish-main-pypi"]["needs"] == [
         "build",
         "assemble-native-guard-distributions",
@@ -542,8 +545,8 @@ def test_release_tags_are_bound_to_the_exact_published_source() -> None:
         step["run"] for step in jobs["release-main"]["steps"] if step.get("name") == "Create discoverable main release"
     )
     assert 'tag="v${VERSION}"' in stable_run
-    assert 'gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs"' in stable_run
-    assert '-f sha="$SOURCE_SHA"' in stable_run
+    assert 'git fetch --force --no-tags origin "+refs/tags/${tag}:refs/tags/${tag}"' in stable_run
+    assert 'git rev-parse "${tag}^{commit}"' in stable_run
     assert 'remote_tag_sha" != "$SOURCE_SHA"' in stable_run
     assert 'gh release view "$tag" --json isDraft,isPrerelease' in stable_run
     assert "Existing stable release is a draft or prerelease" in stable_run


### PR DESCRIPTION
## Summary
- reserve each stable version tag after native artifacts pass and before PyPI publication
- bind the tag to the exact current `main` source in a least-privilege job
- require successful tag reservation before the PyPI publishing environment runs

## Verification
- 98 focused release workflow tests
- Ruff
- Actionlint
- test-suite and structural quality ratchets
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Stable releases from the main branch now reserve and verify the matching version tag before publishing.
  * Publishing is blocked unless the tag points to the exact source commit.

* **Tests**
  * Added coverage to verify tag reservation, source validation, permissions, and publishing dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->