### PR TITLE
fix(storage): preserve state during recovery

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
-  "maximum_collected_cases": 16244,
-  "maximum_test_source_lines": 351052
+  "maximum_collected_cases": 16248,
+  "maximum_test_source_lines": 351150
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
   "maximum_collected_cases": 16248,
-  "maximum_test_source_lines": 351150
+  "maximum_test_source_lines": 351138
 }

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -24,6 +24,7 @@ else:  # pragma: no cover - runtime compatibility
 from .action_lattice import coerce_guard_action, normalize_guard_action
 from .approval_gate import ApprovalGateGrant, public_config, require_settings_write
 from .config_preset_support import apply_named_posture_harness_policy
+from .guard_home_state import database_has_custom_extension_state
 from .mdm.contracts import ManagedPolicy, ManagedPolicyState
 from .mdm.policy import apply_managed_policy, fail_closed_managed_policy, load_managed_policy
 from .models import GUARD_ACTION_VALUES, GuardAction, GuardMode
@@ -1338,23 +1339,19 @@ def _guard_home_has_state(path: Path) -> bool:
     entries = list(path.iterdir())
     if not entries:
         return False
-    state_entries = [
-        entry
-        for entry in entries
-        if entry.name
+    if any(
+        entry.name
         not in {
             "guard.db",
             "secrets",
             *GUARD_HOME_METADATA_FILES,
             *NON_MIGRATED_GUARD_RUNTIME_FILES,
         }
-    ]
-    if state_entries:
+        for entry in entries
+    ):
         return True
     secrets_dir = path / "secrets"
-    if secrets_dir.is_dir() and any(
-        entry.name not in {"key.bin", ".key-init.lock"} for entry in secrets_dir.iterdir()
-    ):
+    if secrets_dir.is_dir() and any(entry.name not in {"key.bin", ".key-init.lock"} for entry in secrets_dir.iterdir()):
         return True
     database_path = path / "guard.db"
     if not database_path.is_file():
@@ -1384,20 +1381,9 @@ def _guard_home_has_state(path: Path) -> bool:
                     continue
                 if connection.execute(f"select 1 from {table_name} limit 1").fetchone() is not None:
                     return True
-            if "extension_control_authority_snapshot" in tables:
-                snapshot = connection.execute(
-                    "select layers_json from extension_control_authority_snapshot where singleton = 1"
-                ).fetchone()
-                if snapshot is not None:
-                    try:
-                        layers = json.loads(str(snapshot[0]))
-                    except json.JSONDecodeError:
-                        return True
-                    if isinstance(layers, list) and layers:
-                        return True
+            return database_has_custom_extension_state(connection, tables)
     except sqlite3.Error:
         return True
-    return False
 
 
 def _guard_home_has_sync_credentials(path: Path) -> bool:

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -1352,7 +1352,9 @@ def _guard_home_has_state(path: Path) -> bool:
     if state_entries:
         return True
     secrets_dir = path / "secrets"
-    if secrets_dir.is_dir() and any(entry.name != "key.bin" for entry in secrets_dir.iterdir()):
+    if secrets_dir.is_dir() and any(
+        entry.name not in {"key.bin", ".key-init.lock"} for entry in secrets_dir.iterdir()
+    ):
         return True
     database_path = path / "guard.db"
     if not database_path.is_file():
@@ -1382,6 +1384,17 @@ def _guard_home_has_state(path: Path) -> bool:
                     continue
                 if connection.execute(f"select 1 from {table_name} limit 1").fetchone() is not None:
                     return True
+            if "extension_control_authority_snapshot" in tables:
+                snapshot = connection.execute(
+                    "select layers_json from extension_control_authority_snapshot where singleton = 1"
+                ).fetchone()
+                if snapshot is not None:
+                    try:
+                        layers = json.loads(str(snapshot[0]))
+                    except json.JSONDecodeError:
+                        return True
+                    if isinstance(layers, list) and layers:
+                        return True
     except sqlite3.Error:
         return True
     return False

--- a/src/codex_plugin_scanner/guard/guard_home_state.py
+++ b/src/codex_plugin_scanner/guard/guard_home_state.py
@@ -1,0 +1,24 @@
+"""Durable state detection for guard-home migration."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+
+def database_has_custom_extension_state(
+    connection: sqlite3.Connection,
+    tables: set[str],
+) -> bool:
+    if "extension_control_authority_snapshot" not in tables:
+        return False
+    snapshot = connection.execute(
+        "select layers_json from extension_control_authority_snapshot where singleton = 1"
+    ).fetchone()
+    if snapshot is None:
+        return False
+    try:
+        layers = json.loads(str(snapshot[0]))
+    except json.JSONDecodeError:
+        return True
+    return isinstance(layers, list) and bool(layers)

--- a/src/codex_plugin_scanner/guard/sqlite_recovery.py
+++ b/src/codex_plugin_scanner/guard/sqlite_recovery.py
@@ -15,6 +15,8 @@ FATAL_SQLITE_ERROR_MARKERS = (
 )
 SQLITE_IO_ERROR_MARKER = "disk i/o error"
 SQLiteStoreProbe = Literal["fatal", "healthy", "io", "unknown"]
+SQLiteFileIdentity = tuple[int, int, int, int]
+SQLiteStoreIdentity = tuple[SQLiteFileIdentity | None, SQLiteFileIdentity | None, SQLiteFileIdentity | None]
 
 
 def _sqlite_readonly_uri(path: Path) -> str:
@@ -49,6 +51,18 @@ def _guard_home_accepts_sqlite_write(guard_home: Path) -> bool:
             probe_path.unlink()
 
 
+def _sqlite_store_identity(path: Path) -> SQLiteStoreIdentity:
+    identities: list[SQLiteFileIdentity | None] = []
+    for candidate in (path, Path(f"{path}-wal"), Path(f"{path}-shm")):
+        try:
+            metadata = candidate.stat()
+        except OSError:
+            identities.append(None)
+            continue
+        identities.append((metadata.st_dev, metadata.st_ino, metadata.st_size, metadata.st_mtime_ns))
+    return identities[0], identities[1], identities[2]
+
+
 def sqlite_store_is_proven_unusable(
     *,
     path: Path,
@@ -61,14 +75,16 @@ def sqlite_store_is_proven_unusable(
     io_error = SQLITE_IO_ERROR_MARKER in str(error).lower()
     if not fatal_error and not io_error:
         return False
-    state = _probe_sqlite_store(path)
-    if state == "healthy":
+    initial_identity = _sqlite_store_identity(path)
+    first_state = _probe_sqlite_store(path)
+    confirmed_identity = _sqlite_store_identity(path)
+    if initial_identity != confirmed_identity or first_state == "healthy":
         return False
-    if state == "fatal":
-        return True
-    if state != "io" or not _guard_home_accepts_sqlite_write(guard_home):
+    if first_state != "fatal" or not _guard_home_accepts_sqlite_write(guard_home):
         return False
-    return _probe_sqlite_store(path) in {"fatal", "io"}
+    second_state = _probe_sqlite_store(path)
+    final_identity = _sqlite_store_identity(path)
+    return second_state == "fatal" and confirmed_identity == final_identity
 
 
 def restore_readable_sqlite_store(*, destination: Path, quarantined: Path) -> bool:

--- a/src/codex_plugin_scanner/guard/sqlite_recovery.py
+++ b/src/codex_plugin_scanner/guard/sqlite_recovery.py
@@ -15,7 +15,7 @@ FATAL_SQLITE_ERROR_MARKERS = (
 )
 SQLITE_IO_ERROR_MARKER = "disk i/o error"
 SQLiteStoreProbe = Literal["fatal", "healthy", "io", "unknown"]
-SQLiteFileIdentity = tuple[int, int, int, int]
+SQLiteFileIdentity = tuple[int, int, int, int, int]
 SQLiteStoreIdentity = tuple[SQLiteFileIdentity | None, SQLiteFileIdentity | None, SQLiteFileIdentity | None]
 
 
@@ -59,7 +59,9 @@ def _sqlite_store_identity(path: Path) -> SQLiteStoreIdentity:
         except OSError:
             identities.append(None)
             continue
-        identities.append((metadata.st_dev, metadata.st_ino, metadata.st_size, metadata.st_mtime_ns))
+        identities.append(
+            (metadata.st_dev, metadata.st_ino, metadata.st_size, metadata.st_mtime_ns, metadata.st_ctime_ns)
+        )
     return identities[0], identities[1], identities[2]
 
 

--- a/tests/test_guard_config_paths.py
+++ b/tests/test_guard_config_paths.py
@@ -434,28 +434,6 @@ def test_migrate_guard_home_state_replaces_retired_credentials_only_destination(
     assert migrated_store.get_sync_payload("credentials") is None
 
 
-def test_migrate_guard_home_state_preserves_custom_extension_authority(tmp_path):
-    canonical_home = tmp_path / ".hol-guard"
-    legacy_home = tmp_path / ".config" / ".ai-plugin-scanner-guard"
-    _create_sqlite_guard_db(legacy_home / "guard.db")
-    canonical_home.mkdir(parents=True)
-    with sqlite3.connect(canonical_home / "guard.db") as connection:
-        connection.execute(
-            "create table extension_control_authority_snapshot (singleton integer, layers_json text)"
-        )
-        connection.execute("insert into extension_control_authority_snapshot values (1, '[{\"kind\":\"local\"}]')")
-
-    _migrate_guard_home_state(source=legacy_home, destination=canonical_home)
-
-    with sqlite3.connect(canonical_home / "guard.db") as connection:
-        row = connection.execute("select singleton from extension_control_authority_snapshot").fetchone()
-        legacy_table = connection.execute(
-            "select 1 from sqlite_master where type = 'table' and name = 'migration_probe'"
-        ).fetchone()
-    assert row == (1,)
-    assert legacy_table is None
-
-
 def test_resolve_guard_home_does_not_migrate_retired_legacy_credentials(tmp_path, monkeypatch):
     home_dir = tmp_path / "home"
     canonical_home = home_dir / ".hol-guard"

--- a/tests/test_guard_config_paths.py
+++ b/tests/test_guard_config_paths.py
@@ -434,6 +434,28 @@ def test_migrate_guard_home_state_replaces_retired_credentials_only_destination(
     assert migrated_store.get_sync_payload("credentials") is None
 
 
+def test_migrate_guard_home_state_preserves_custom_extension_authority(tmp_path):
+    canonical_home = tmp_path / ".hol-guard"
+    legacy_home = tmp_path / ".config" / ".ai-plugin-scanner-guard"
+    _create_sqlite_guard_db(legacy_home / "guard.db")
+    canonical_home.mkdir(parents=True)
+    with sqlite3.connect(canonical_home / "guard.db") as connection:
+        connection.execute(
+            "create table extension_control_authority_snapshot (singleton integer, layers_json text)"
+        )
+        connection.execute("insert into extension_control_authority_snapshot values (1, '[{\"kind\":\"local\"}]')")
+
+    _migrate_guard_home_state(source=legacy_home, destination=canonical_home)
+
+    with sqlite3.connect(canonical_home / "guard.db") as connection:
+        row = connection.execute("select singleton from extension_control_authority_snapshot").fetchone()
+        legacy_table = connection.execute(
+            "select 1 from sqlite_master where type = 'table' and name = 'migration_probe'"
+        ).fetchone()
+    assert row == (1,)
+    assert legacy_table is None
+
+
 def test_resolve_guard_home_does_not_migrate_retired_legacy_credentials(tmp_path, monkeypatch):
     home_dir = tmp_path / "home"
     canonical_home = home_dir / ".hol-guard"

--- a/tests/test_guard_sqlite_failure_containment.py
+++ b/tests/test_guard_sqlite_failure_containment.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import sqlite3
 import threading
 import time
@@ -208,81 +207,6 @@ def test_fatal_error_does_not_recover_when_rechecks_report_persistent_io(
         is False
     )
     assert active_attempts == 1
-
-
-def test_fatal_error_requires_two_stable_fatal_probes(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    store = GuardStore(tmp_path / "guard", prime_policy_integrity=False)
-    probes = iter(["fatal", "healthy"])
-    monkeypatch.setattr(
-        "codex_plugin_scanner.guard.sqlite_recovery._probe_sqlite_store",
-        lambda _path: next(probes),
-    )
-
-    assert (
-        store._store_is_proven_unusable(  # pyright: ignore[reportPrivateUsage]
-            sqlite3.DatabaseError("database disk image is malformed")
-        )
-        is False
-    )
-
-
-def test_fatal_error_recovery_rejects_changing_sqlite_sidecars(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    store = GuardStore(tmp_path / "guard", prime_policy_integrity=False)
-    wal = Path(f"{store.path}-wal")
-    wal.write_bytes(b"first")
-    probe_count = 0
-
-    def fatal_probe(_path: Path) -> str:
-        nonlocal probe_count
-        probe_count += 1
-        if probe_count == 1:
-            wal.write_bytes(b"changed")
-        return "fatal"
-
-    monkeypatch.setattr("codex_plugin_scanner.guard.sqlite_recovery._probe_sqlite_store", fatal_probe)
-
-    assert (
-        store._store_is_proven_unusable(  # pyright: ignore[reportPrivateUsage]
-            sqlite3.DatabaseError("database disk image is malformed")
-        )
-        is False
-    )
-    assert probe_count == 1
-
-
-def test_fatal_error_recovery_rejects_same_size_sidecar_rewrite_with_restored_mtime(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    store = GuardStore(tmp_path / "guard", prime_policy_integrity=False)
-    wal = Path(f"{store.path}-wal")
-    wal.write_bytes(b"first")
-    original_stat = wal.stat()
-    probe_count = 0
-
-    def fatal_probe(_path: Path) -> str:
-        nonlocal probe_count
-        probe_count += 1
-        if probe_count == 1:
-            wal.write_bytes(b"other")
-            os.utime(wal, ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns))
-        return "fatal"
-
-    monkeypatch.setattr("codex_plugin_scanner.guard.sqlite_recovery._probe_sqlite_store", fatal_probe)
-
-    assert (
-        store._store_is_proven_unusable(  # pyright: ignore[reportPrivateUsage]
-            sqlite3.DatabaseError("database disk image is malformed")
-        )
-        is False
-    )
-    assert probe_count == 1
 
 
 def test_recovery_restores_readable_quarantined_store(

--- a/tests/test_guard_sqlite_failure_containment.py
+++ b/tests/test_guard_sqlite_failure_containment.py
@@ -179,11 +179,11 @@ def test_io_error_that_clears_after_directory_probe_does_not_quarantine(
         )
         is False
     )
-    assert active_attempts == 2
+    assert active_attempts == 1
     assert _quarantined_databases(store.guard_home) == []
 
 
-def test_fatal_error_recovers_when_rechecks_report_persistent_io(
+def test_fatal_error_does_not_recover_when_rechecks_report_persistent_io(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -204,9 +204,55 @@ def test_fatal_error_recovers_when_rechecks_report_persistent_io(
         store._store_is_proven_unusable(  # pyright: ignore[reportPrivateUsage]
             sqlite3.DatabaseError("database disk image is malformed")
         )
-        is True
+        is False
     )
-    assert active_attempts == 2
+    assert active_attempts == 1
+
+
+def test_fatal_error_requires_two_stable_fatal_probes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard", prime_policy_integrity=False)
+    probes = iter(["fatal", "healthy"])
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.sqlite_recovery._probe_sqlite_store",
+        lambda _path: next(probes),
+    )
+
+    assert (
+        store._store_is_proven_unusable(  # pyright: ignore[reportPrivateUsage]
+            sqlite3.DatabaseError("database disk image is malformed")
+        )
+        is False
+    )
+
+
+def test_fatal_error_recovery_rejects_changing_sqlite_sidecars(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard", prime_policy_integrity=False)
+    wal = Path(f"{store.path}-wal")
+    wal.write_bytes(b"first")
+    probe_count = 0
+
+    def fatal_probe(_path: Path) -> str:
+        nonlocal probe_count
+        probe_count += 1
+        if probe_count == 1:
+            wal.write_bytes(b"changed")
+        return "fatal"
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.sqlite_recovery._probe_sqlite_store", fatal_probe)
+
+    assert (
+        store._store_is_proven_unusable(  # pyright: ignore[reportPrivateUsage]
+            sqlite3.DatabaseError("database disk image is malformed")
+        )
+        is False
+    )
+    assert probe_count == 1
 
 
 def test_recovery_restores_readable_quarantined_store(

--- a/tests/test_guard_sqlite_failure_containment.py
+++ b/tests/test_guard_sqlite_failure_containment.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sqlite3
 import threading
 import time
@@ -242,6 +243,35 @@ def test_fatal_error_recovery_rejects_changing_sqlite_sidecars(
         probe_count += 1
         if probe_count == 1:
             wal.write_bytes(b"changed")
+        return "fatal"
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.sqlite_recovery._probe_sqlite_store", fatal_probe)
+
+    assert (
+        store._store_is_proven_unusable(  # pyright: ignore[reportPrivateUsage]
+            sqlite3.DatabaseError("database disk image is malformed")
+        )
+        is False
+    )
+    assert probe_count == 1
+
+
+def test_fatal_error_recovery_rejects_same_size_sidecar_rewrite_with_restored_mtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard", prime_policy_integrity=False)
+    wal = Path(f"{store.path}-wal")
+    wal.write_bytes(b"first")
+    original_stat = wal.stat()
+    probe_count = 0
+
+    def fatal_probe(_path: Path) -> str:
+        nonlocal probe_count
+        probe_count += 1
+        if probe_count == 1:
+            wal.write_bytes(b"other")
+            os.utime(wal, ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns))
         return "fatal"
 
     monkeypatch.setattr("codex_plugin_scanner.guard.sqlite_recovery._probe_sqlite_store", fatal_probe)

--- a/tests/test_guard_state_persistence.py
+++ b/tests/test_guard_state_persistence.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.config import _migrate_guard_home_state
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def test_migrate_guard_home_state_preserves_custom_extension_authority(tmp_path: Path) -> None:
+    canonical_home = tmp_path / ".hol-guard"
+    legacy_home = tmp_path / ".config" / ".ai-plugin-scanner-guard"
+    legacy_home.mkdir(parents=True)
+    with sqlite3.connect(legacy_home / "guard.db") as connection:
+        connection.execute("create table migration_probe (value text)")
+    canonical_home.mkdir(parents=True)
+    with sqlite3.connect(canonical_home / "guard.db") as connection:
+        connection.execute(
+            "create table extension_control_authority_snapshot (singleton integer, layers_json text)"
+        )
+        connection.execute("insert into extension_control_authority_snapshot values (1, '[{\"kind\":\"local\"}]')")
+
+    _migrate_guard_home_state(source=legacy_home, destination=canonical_home)
+
+    with sqlite3.connect(canonical_home / "guard.db") as connection:
+        row = connection.execute("select singleton from extension_control_authority_snapshot").fetchone()
+        legacy_table = connection.execute(
+            "select 1 from sqlite_master where type = 'table' and name = 'migration_probe'"
+        ).fetchone()
+    assert row == (1,)
+    assert legacy_table is None
+
+
+def test_fatal_error_requires_two_stable_fatal_probes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard", prime_policy_integrity=False)
+    probes = iter(["fatal", "healthy"])
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.sqlite_recovery._probe_sqlite_store",
+        lambda _path: next(probes),
+    )
+
+    assert (
+        store._store_is_proven_unusable(  # pyright: ignore[reportPrivateUsage]
+            sqlite3.DatabaseError("database disk image is malformed")
+        )
+        is False
+    )
+
+
+@pytest.mark.parametrize("restore_mtime", [False, True])
+def test_fatal_error_recovery_rejects_sidecar_rewrite(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    restore_mtime: bool,
+) -> None:
+    store = GuardStore(tmp_path / "guard", prime_policy_integrity=False)
+    wal = Path(f"{store.path}-wal")
+    wal.write_bytes(b"first")
+    original_stat = wal.stat()
+    probe_count = 0
+
+    def fatal_probe(_path: Path) -> str:
+        nonlocal probe_count
+        probe_count += 1
+        if probe_count == 1:
+            wal.write_bytes(b"other")
+            if restore_mtime:
+                os.utime(wal, ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns))
+        return "fatal"
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.sqlite_recovery._probe_sqlite_store", fatal_probe)
+
+    assert (
+        store._store_is_proven_unusable(  # pyright: ignore[reportPrivateUsage]
+            sqlite3.DatabaseError("database disk image is malformed")
+        )
+        is False
+    )
+    assert probe_count == 1


### PR DESCRIPTION
## Summary
- require repeated corruption proof against an unchanged SQLite database and sidecars before recovery can replace durable state
- preserve custom extension authority during guard-home migration
- ignore the authority key initialization lock when deciding whether a destination already contains user state

## Testing
- `uv run --no-sync pytest tests/test_guard_sqlite_failure_containment.py tests/test_guard_daemon_storage_liveness.py tests/test_guard_extension_control_authority.py tests/test_guard_sqlite_profile.py tests/test_guard_config_paths.py --tb=short`
- `uv run --no-sync basedpyright --level error`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/sqlite_recovery.py src/codex_plugin_scanner/guard/config.py tests/test_guard_sqlite_failure_containment.py tests/test_guard_config_paths.py`
- `uv build`
- `uv tool run --from dist/hol_guard-3.0.1-py3-none-any.whl hol-guard --version`

## Notes
- The full local suite was stopped after 481 passing tests because it is designed to run in CI shards; the complete focused persistence and extension-control suite passed locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Guard state migrations now preserve custom extension authorization settings.
  - Improved detection of existing guard state, including custom extension data and temporary initialization files.
  - Enhanced database recovery checks to avoid treating changing or intermittently inaccessible storage as permanently unusable.
  - Recovery now requires consistent confirmation before declaring a database irrecoverable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->