### PR TITLE
fix(guard): reseal Core native manifest after PyInstaller signing

### DIFF
--- a/.github/workflows/desktop-core-alpha-feed.yml
+++ b/.github/workflows/desktop-core-alpha-feed.yml
@@ -7,8 +7,10 @@ on:
       - tests/test_desktop_core_alpha_feed_macos_signing.py
       - tests/test_stage_native_runtime_for_desktop_core.py
       - tests/test_verify_pyinstaller_native_runtime.py
+      - tests/test_seal_pyinstaller_native_manifest.py
       - scripts/release/desktop_core_alpha_feed.py
       - scripts/release/stage_native_runtime_for_desktop_core.py
+      - scripts/release/seal_pyinstaller_native_manifest.py
       - scripts/release/verify_pyinstaller_macos_signing.py
       - scripts/release/verify_pyinstaller_native_runtime.py
   push:
@@ -17,6 +19,7 @@ on:
       - .github/workflows/desktop-core-alpha-feed.yml
       - scripts/release/desktop_core_alpha_feed.py
       - scripts/release/stage_native_runtime_for_desktop_core.py
+      - scripts/release/seal_pyinstaller_native_manifest.py
       - scripts/release/verify_pyinstaller_macos_signing.py
       - scripts/release/verify_pyinstaller_native_runtime.py
   schedule:
@@ -357,6 +360,8 @@ jobs:
           BUILT="$DIST/hol-guard"
           ASSET="$DIST/hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}"
           chmod 0755 "$BUILT"
+          python3 -I scripts/release/seal_pyinstaller_native_manifest.py \
+            --binary "$BUILT"
           python3 -I scripts/release/verify_pyinstaller_macos_signing.py \
             --binary "$BUILT" --team-id "$APPLE_TEAM_ID"
           python3 -I scripts/release/verify_pyinstaller_native_runtime.py \

--- a/ci/code-quality-baseline.json
+++ b/ci/code-quality-baseline.json
@@ -437,7 +437,7 @@
   },
   "oversized_files": {
     ".github/workflows/ci.yml": 554,
-    ".github/workflows/desktop-core-alpha-feed.yml": 527,
+    ".github/workflows/desktop-core-alpha-feed.yml": 532,
     ".github/workflows/publish.yml": 1710,
     "dashboard/src/app.tsx": 1106,
     "dashboard/src/approval-center-primitives.tsx": 1049,

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
-  "maximum_collected_cases": 16273,
-  "maximum_test_source_lines": 351885
+  "maximum_collected_cases": 16275,
+  "maximum_test_source_lines": 351938
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
-  "maximum_collected_cases": 16269,
-  "maximum_test_source_lines": 351704
+  "maximum_collected_cases": 16271,
+  "maximum_test_source_lines": 351835
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
-  "maximum_collected_cases": 16271,
-  "maximum_test_source_lines": 351835
+  "maximum_collected_cases": 16273,
+  "maximum_test_source_lines": 351885
 }

--- a/scripts/release/seal_pyinstaller_native_manifest.py
+++ b/scripts/release/seal_pyinstaller_native_manifest.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Rewrite the bundled native manifest to match PyInstaller-packaged runtime bytes."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import zlib
+from pathlib import Path
+
+_SIGNING_PATH = Path(__file__).with_name("verify_pyinstaller_macos_signing.py")
+_RUNTIME_NAMES = {"hol-guard-runtime", "hol-guard-runtime.exe"}
+_MANIFEST_NAME = "runtime-manifest.json"
+_NATIVE_PARENT = "_native"
+_MANIFEST_SCHEMA = "hol-guard-native-runtime.v1"
+
+
+class NativeManifestSealError(ValueError):
+    """Raised when the packaged native manifest cannot be resealed in place."""
+
+
+def _load_signing_module():
+    spec = importlib.util.spec_from_file_location("verify_pyinstaller_macos_signing", _SIGNING_PATH)
+    if spec is None or spec.loader is None:
+        raise SystemExit("PyInstaller signing verifier is missing")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _posix_name(name: str) -> str:
+    return name.replace("\\", "/")
+
+
+def _is_native_runtime_entry(name: str) -> bool:
+    parts = Path(_posix_name(name)).parts
+    return len(parts) >= 2 and parts[-1] in _RUNTIME_NAMES and parts[-2] == _NATIVE_PARENT
+
+
+def _is_native_manifest_entry(name: str) -> bool:
+    parts = Path(_posix_name(name)).parts
+    return len(parts) >= 2 and parts[-1] == _MANIFEST_NAME and parts[-2] == _NATIVE_PARENT
+
+
+def _encode_manifest(payload: dict[str, object], *, compressed: bool, stored_length: int) -> bytes:
+    encoded = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    packed = zlib.compress(encoded) if compressed else encoded
+    if len(packed) > stored_length:
+        raise NativeManifestSealError("resealed native manifest does not fit the packaged entry")
+    if compressed and len(packed) != stored_length:
+        raise NativeManifestSealError("compressed native manifest cannot be padded in place")
+    if not compressed:
+        packed = packed + (b" " * (stored_length - len(packed)))
+    return packed
+
+
+def seal(binary: Path) -> None:
+    signing = _load_signing_module()
+    archive_start, _declared_runtime, entries = signing._archive_layout(binary)
+    runtime_entries = [entry for entry in entries if _is_native_runtime_entry(entry[0])]
+    manifest_entries = [entry for entry in entries if _is_native_manifest_entry(entry[0])]
+    if len(runtime_entries) != 1:
+        raise NativeManifestSealError(
+            f"Core archive must contain exactly one native runtime; found {len(runtime_entries)}"
+        )
+    if len(manifest_entries) != 1:
+        raise NativeManifestSealError(
+            f"Core archive must contain exactly one native manifest; found {len(manifest_entries)}"
+        )
+    runtime_name, runtime_offset, runtime_length, runtime_compressed, _typecode = runtime_entries[0]
+    manifest_name, manifest_offset, manifest_length, manifest_compressed, _manifest_type = manifest_entries[0]
+    with binary.open("r+b") as handle:
+        runtime = signing._entry_bytes(
+            handle,
+            archive_start,
+            runtime_name,
+            runtime_offset,
+            runtime_length,
+            runtime_compressed,
+        )
+        manifest_bytes = signing._entry_bytes(
+            handle,
+            archive_start,
+            manifest_name,
+            manifest_offset,
+            manifest_length,
+            manifest_compressed,
+        )
+        try:
+            payload = json.loads(manifest_bytes.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise NativeManifestSealError("Bundled native manifest is not valid JSON") from error
+        if not isinstance(payload, dict) or payload.get("schema") != _MANIFEST_SCHEMA:
+            raise NativeManifestSealError("Bundled native manifest failed identity checks")
+        digest = hashlib.sha256(runtime).hexdigest()
+        if payload.get("runtime_sha256") == digest and payload.get("runtime_size") == len(runtime):
+            print(f"native manifest already matches packaged runtime {runtime_name!r}")
+            return
+        payload["runtime_sha256"] = digest
+        payload["runtime_size"] = len(runtime)
+        packed = _encode_manifest(payload, compressed=manifest_compressed, stored_length=manifest_length)
+        handle.seek(archive_start + manifest_offset)
+        written = handle.write(packed)
+        if written != manifest_length:
+            raise NativeManifestSealError("failed to overwrite the packaged native manifest")
+    print(f"resealed native manifest for {runtime_name!r} ({len(runtime)} bytes)")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--binary", type=Path, required=True)
+    args = parser.parse_args()
+    if not args.binary.is_file():
+        raise SystemExit(f"Binary does not exist: {args.binary}")
+    try:
+        seal(args.binary)
+    except (OSError, ValueError) as error:
+        raise SystemExit(str(error)) from error
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release/seal_pyinstaller_native_manifest.py
+++ b/scripts/release/seal_pyinstaller_native_manifest.py
@@ -103,12 +103,16 @@ def seal(binary: Path) -> None:
                     runtime = signing._entry_bytes(handle, archive_start, name, offset, stored_length, compressed)
                 except (OSError, ValueError, zlib.error) as error:
                     raise NativeManifestSealError(f"Bundled native runtime is not readable: {name}") from error
+                if len(runtime) != uncompressed:
+                    raise NativeManifestSealError("Bundled native runtime size does not match its TOC entry")
             if native._is_native_manifest_entry(name):
                 try:
                     decoded = signing._entry_bytes(handle, archive_start, name, offset, stored_length, compressed)
                     parsed = json.loads(decoded.decode("utf-8"))
                 except (UnicodeDecodeError, json.JSONDecodeError, ValueError, OSError, zlib.error) as error:
                     raise NativeManifestSealError("Bundled native manifest is not valid JSON") from error
+                if len(decoded) != uncompressed:
+                    raise NativeManifestSealError("Bundled native manifest size does not match its TOC entry")
                 if not isinstance(parsed, dict) or parsed.get("schema") != _MANIFEST_SCHEMA:
                     raise NativeManifestSealError("Bundled native manifest failed identity checks")
                 payload = parsed

--- a/scripts/release/seal_pyinstaller_native_manifest.py
+++ b/scripts/release/seal_pyinstaller_native_manifest.py
@@ -7,60 +7,79 @@ import argparse
 import hashlib
 import importlib.util
 import json
+import struct
 import zlib
 from pathlib import Path
 
-_SIGNING_PATH = Path(__file__).with_name("verify_pyinstaller_macos_signing.py")
-_RUNTIME_NAMES = {"hol-guard-runtime", "hol-guard-runtime.exe"}
-_MANIFEST_NAME = "runtime-manifest.json"
-_NATIVE_PARENT = "_native"
+_NATIVE_VERIFIER_PATH = Path(__file__).with_name("verify_pyinstaller_native_runtime.py")
 _MANIFEST_SCHEMA = "hol-guard-native-runtime.v1"
 
 
 class NativeManifestSealError(ValueError):
-    """Raised when the packaged native manifest cannot be resealed in place."""
+    """Raised when the packaged native manifest cannot be resealed."""
 
 
-def _load_signing_module():
-    spec = importlib.util.spec_from_file_location("verify_pyinstaller_macos_signing", _SIGNING_PATH)
+def _load_native_verifier():
+    spec = importlib.util.spec_from_file_location("verify_pyinstaller_native_runtime", _NATIVE_VERIFIER_PATH)
     if spec is None or spec.loader is None:
-        raise SystemExit("PyInstaller signing verifier is missing")
+        raise SystemExit("PyInstaller native runtime verifier is missing")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
 
 
-def _posix_name(name: str) -> str:
-    return name.replace("\\", "/")
+def _encode_manifest(payload: dict[str, object]) -> bytes:
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
 
 
-def _is_native_runtime_entry(name: str) -> bool:
-    parts = Path(_posix_name(name)).parts
-    return len(parts) >= 2 and parts[-1] in _RUNTIME_NAMES and parts[-2] == _NATIVE_PARENT
-
-
-def _is_native_manifest_entry(name: str) -> bool:
-    parts = Path(_posix_name(name)).parts
-    return len(parts) >= 2 and parts[-1] == _MANIFEST_NAME and parts[-2] == _NATIVE_PARENT
-
-
-def _encode_manifest(payload: dict[str, object], *, compressed: bool, stored_length: int) -> bytes:
-    encoded = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
-    packed = zlib.compress(encoded) if compressed else encoded
-    if len(packed) > stored_length:
-        raise NativeManifestSealError("resealed native manifest does not fit the packaged entry")
-    if compressed and len(packed) != stored_length:
-        raise NativeManifestSealError("compressed native manifest cannot be padded in place")
-    if not compressed:
-        packed = packed + (b" " * (stored_length - len(packed)))
-    return packed
+def _rebuild_carchive(
+    signing,
+    *,
+    prefix: bytes,
+    suffix: bytes,
+    pyvers: int,
+    pylib_name: str,
+    entries: list[tuple[str, bytes, int, bool, str]],
+) -> bytes:
+    raw_runtime = pylib_name.encode("utf-8")
+    if not raw_runtime or len(raw_runtime) >= 64:
+        raise NativeManifestSealError("PyInstaller CArchive Python runtime name cannot be resealed")
+    payload = bytearray()
+    toc = bytearray()
+    for name, stored, uncompressed, compressed, typecode in entries:
+        offset = len(payload)
+        payload.extend(stored)
+        raw_name = name.encode("utf-8") + b"\0"
+        toc.extend(
+            struct.pack(
+                signing.TOC_FORMAT,
+                signing.TOC_HEADER_LENGTH + len(raw_name),
+                offset,
+                len(stored),
+                uncompressed,
+                1 if compressed else 0,
+                typecode.encode("ascii"),
+            )
+        )
+        toc.extend(raw_name)
+    cookie = struct.pack(
+        signing.COOKIE_FORMAT,
+        signing.COOKIE_MAGIC,
+        len(payload) + len(toc) + signing.COOKIE_LENGTH,
+        len(payload),
+        len(toc),
+        pyvers,
+        raw_runtime + (b"\0" * (64 - len(raw_runtime))),
+    )
+    return prefix + bytes(payload) + bytes(toc) + cookie + suffix
 
 
 def seal(binary: Path) -> None:
-    signing = _load_signing_module()
-    archive_start, _declared_runtime, entries = signing._archive_layout(binary)
-    runtime_entries = [entry for entry in entries if _is_native_runtime_entry(entry[0])]
-    manifest_entries = [entry for entry in entries if _is_native_manifest_entry(entry[0])]
+    native = _load_native_verifier()
+    signing = native._load_signing_module()
+    archive_start, cookie_offset, pyvers, pylib_name, entries = signing._archive_toc(binary)
+    runtime_entries = [entry for entry in entries if native._is_native_runtime_entry(entry[0])]
+    manifest_entries = [entry for entry in entries if native._is_native_manifest_entry(entry[0])]
     if len(runtime_entries) != 1:
         raise NativeManifestSealError(
             f"Core archive must contain exactly one native runtime; found {len(runtime_entries)}"
@@ -69,43 +88,56 @@ def seal(binary: Path) -> None:
         raise NativeManifestSealError(
             f"Core archive must contain exactly one native manifest; found {len(manifest_entries)}"
         )
-    runtime_name, runtime_offset, runtime_length, runtime_compressed, _typecode = runtime_entries[0]
-    manifest_name, manifest_offset, manifest_length, manifest_compressed, _manifest_type = manifest_entries[0]
-    with binary.open("r+b") as handle:
-        runtime = signing._entry_bytes(
-            handle,
-            archive_start,
-            runtime_name,
-            runtime_offset,
-            runtime_length,
-            runtime_compressed,
+    data = binary.read_bytes()
+    rebuilt: list[tuple[str, bytes, int, bool, str]] = []
+    runtime: bytes | None = None
+    payload: dict[str, object] | None = None
+    with binary.open("rb") as handle:
+        for name, offset, stored_length, uncompressed, compressed, typecode in entries:
+            stored = data[archive_start + offset : archive_start + offset + stored_length]
+            if len(stored) != stored_length:
+                raise NativeManifestSealError(f"Truncated PyInstaller archive entry: {name}")
+            rebuilt.append((name, stored, uncompressed, compressed, typecode))
+            if native._is_native_runtime_entry(name):
+                try:
+                    runtime = signing._entry_bytes(handle, archive_start, name, offset, stored_length, compressed)
+                except (OSError, ValueError, zlib.error) as error:
+                    raise NativeManifestSealError(f"Bundled native runtime is not readable: {name}") from error
+            if native._is_native_manifest_entry(name):
+                try:
+                    decoded = signing._entry_bytes(handle, archive_start, name, offset, stored_length, compressed)
+                    parsed = json.loads(decoded.decode("utf-8"))
+                except (UnicodeDecodeError, json.JSONDecodeError, ValueError, OSError, zlib.error) as error:
+                    raise NativeManifestSealError("Bundled native manifest is not valid JSON") from error
+                if not isinstance(parsed, dict) or parsed.get("schema") != _MANIFEST_SCHEMA:
+                    raise NativeManifestSealError("Bundled native manifest failed identity checks")
+                payload = parsed
+    if runtime is None or payload is None:
+        raise NativeManifestSealError("Core archive native runtime or manifest could not be read")
+    digest = hashlib.sha256(runtime).hexdigest()
+    if payload.get("runtime_sha256") == digest and payload.get("runtime_size") == len(runtime):
+        print(f"native manifest already matches packaged runtime {runtime_entries[0][0]!r}")
+        return
+    payload["runtime_sha256"] = digest
+    payload["runtime_size"] = len(runtime)
+    encoded = _encode_manifest(payload)
+    sealed: list[tuple[str, bytes, int, bool, str]] = []
+    for name, stored, uncompressed, compressed, typecode in rebuilt:
+        if native._is_native_manifest_entry(name):
+            sealed.append((name, encoded, len(encoded), False, typecode))
+            continue
+        sealed.append((name, stored, uncompressed, compressed, typecode))
+    binary.write_bytes(
+        _rebuild_carchive(
+            signing,
+            prefix=data[:archive_start],
+            suffix=data[cookie_offset + signing.COOKIE_LENGTH :],
+            pyvers=pyvers,
+            pylib_name=pylib_name,
+            entries=sealed,
         )
-        manifest_bytes = signing._entry_bytes(
-            handle,
-            archive_start,
-            manifest_name,
-            manifest_offset,
-            manifest_length,
-            manifest_compressed,
-        )
-        try:
-            payload = json.loads(manifest_bytes.decode("utf-8"))
-        except (UnicodeDecodeError, json.JSONDecodeError) as error:
-            raise NativeManifestSealError("Bundled native manifest is not valid JSON") from error
-        if not isinstance(payload, dict) or payload.get("schema") != _MANIFEST_SCHEMA:
-            raise NativeManifestSealError("Bundled native manifest failed identity checks")
-        digest = hashlib.sha256(runtime).hexdigest()
-        if payload.get("runtime_sha256") == digest and payload.get("runtime_size") == len(runtime):
-            print(f"native manifest already matches packaged runtime {runtime_name!r}")
-            return
-        payload["runtime_sha256"] = digest
-        payload["runtime_size"] = len(runtime)
-        packed = _encode_manifest(payload, compressed=manifest_compressed, stored_length=manifest_length)
-        handle.seek(archive_start + manifest_offset)
-        written = handle.write(packed)
-        if written != manifest_length:
-            raise NativeManifestSealError("failed to overwrite the packaged native manifest")
-    print(f"resealed native manifest for {runtime_name!r} ({len(runtime)} bytes)")
+    )
+    print(f"resealed native manifest for {runtime_entries[0][0]!r} ({len(runtime)} bytes)")
 
 
 def main() -> None:
@@ -116,7 +148,7 @@ def main() -> None:
         raise SystemExit(f"Binary does not exist: {args.binary}")
     try:
         seal(args.binary)
-    except (OSError, ValueError) as error:
+    except (OSError, ValueError, zlib.error) as error:
         raise SystemExit(str(error)) from error
 
 

--- a/scripts/release/verify_pyinstaller_macos_signing.py
+++ b/scripts/release/verify_pyinstaller_macos_signing.py
@@ -54,9 +54,7 @@ def _archive_toc(
         cookie = handle.read(COOKIE_LENGTH)
         if len(cookie) != COOKIE_LENGTH:
             raise ValueError("Truncated PyInstaller CArchive cookie")
-        magic, archive_length, toc_offset, toc_length, pyvers, raw_pylib_name = struct.unpack(
-            COOKIE_FORMAT, cookie
-        )
+        magic, archive_length, toc_offset, toc_length, pyvers, raw_pylib_name = struct.unpack(COOKIE_FORMAT, cookie)
         try:
             pylib_name = raw_pylib_name.rstrip(b"\0").decode("utf-8")
         except UnicodeDecodeError as exc:
@@ -79,15 +77,11 @@ def _archive_toc(
         header = toc[cursor : cursor + TOC_HEADER_LENGTH]
         if len(header) != TOC_HEADER_LENGTH:
             raise ValueError("Truncated PyInstaller TOC header")
-        entry_length, offset, length, uncompressed, compressed, raw_typecode = struct.unpack(
-            TOC_FORMAT, header
-        )
+        entry_length, offset, length, uncompressed, compressed, raw_typecode = struct.unpack(TOC_FORMAT, header)
         name_length = entry_length - TOC_HEADER_LENGTH
         if name_length <= 0 or cursor + entry_length > len(toc):
             raise ValueError("Invalid PyInstaller TOC entry length")
-        raw_name = toc[
-            cursor + TOC_HEADER_LENGTH : cursor + TOC_HEADER_LENGTH + name_length
-        ]
+        raw_name = toc[cursor + TOC_HEADER_LENGTH : cursor + TOC_HEADER_LENGTH + name_length]
         try:
             name = raw_name.rstrip(b"\0").decode("utf-8")
             typecode = raw_typecode.decode("ascii")
@@ -95,6 +89,10 @@ def _archive_toc(
             raise ValueError("Invalid PyInstaller TOC text encoding") from exc
         if not name:
             raise ValueError("PyInstaller TOC entry has an empty name")
+        if offset < 0 or length < 0 or uncompressed < 0:
+            raise ValueError(f"PyInstaller TOC entry {name!r} has an invalid range")
+        if offset > toc_offset or length > toc_offset - offset:
+            raise ValueError(f"PyInstaller TOC entry {name!r} overlaps the archive TOC")
         entries.append((name, offset, length, uncompressed, bool(compressed), typecode))
         cursor += entry_length
     return archive_start, cookie_offset, pyvers, pylib_name, entries
@@ -102,10 +100,14 @@ def _archive_toc(
 
 def _archive_layout(binary: Path) -> tuple[int, str, list[tuple[str, int, int, bool, str]]]:
     archive_start, _cookie_offset, _pyvers, pylib_name, entries = _archive_toc(binary)
-    return archive_start, pylib_name, [
-        (name, offset, length, compressed, typecode)
-        for name, offset, length, _uncompressed, compressed, typecode in entries
-    ]
+    return (
+        archive_start,
+        pylib_name,
+        [
+            (name, offset, length, compressed, typecode)
+            for name, offset, length, _uncompressed, compressed, typecode in entries
+        ],
+    )
 
 
 def _entry_bytes(
@@ -227,9 +229,7 @@ def verify(binary: Path, expected_team_id: str) -> None:
 
     macho_count = 0
     declared_runtime_verified = False
-    with binary.open("rb") as handle, tempfile.TemporaryDirectory(
-        prefix="hol-guard-pyi-signing-"
-    ) as tmp:
+    with binary.open("rb") as handle, tempfile.TemporaryDirectory(prefix="hol-guard-pyi-signing-") as tmp:
         runtime_entry = _resolve_declared_runtime(handle, archive_start, declared_runtime, entries)
         runtime_name = runtime_entry[0]
         root = Path(tmp)
@@ -251,8 +251,7 @@ def verify(binary: Path, expected_team_id: str) -> None:
             actual_team_id = _team_id(extracted)
             if actual_team_id != expected_team_id:
                 raise ValueError(
-                    f"Embedded Mach-O {name!r} has TeamIdentifier={actual_team_id!r}; "
-                    f"expected {expected_team_id!r}"
+                    f"Embedded Mach-O {name!r} has TeamIdentifier={actual_team_id!r}; expected {expected_team_id!r}"
                 )
             if name == runtime_name:
                 declared_runtime_verified = True
@@ -260,9 +259,7 @@ def verify(binary: Path, expected_team_id: str) -> None:
     if macho_count == 0:
         raise ValueError("PyInstaller archive contained no Mach-O binary entries")
     if not declared_runtime_verified:
-        raise ValueError(
-            f"Cookie-declared Python runtime {declared_runtime!r} was not signature-verified"
-        )
+        raise ValueError(f"Cookie-declared Python runtime {declared_runtime!r} was not signature-verified")
     print(
         f"verified {macho_count} embedded Mach-O binaries, including declared Python runtime "
         f"{declared_runtime!r}, with TeamIdentifier={expected_team_id}"

--- a/scripts/release/verify_pyinstaller_macos_signing.py
+++ b/scripts/release/verify_pyinstaller_macos_signing.py
@@ -45,14 +45,16 @@ def _find_cookie(handle) -> int:
     raise ValueError("PyInstaller CArchive cookie was not found")
 
 
-def _archive_layout(binary: Path) -> tuple[int, str, list[tuple[str, int, int, bool, str]]]:
+def _archive_toc(
+    binary: Path,
+) -> tuple[int, int, int, str, list[tuple[str, int, int, int, bool, str]]]:
     with binary.open("rb") as handle:
         cookie_offset = _find_cookie(handle)
         handle.seek(cookie_offset)
         cookie = handle.read(COOKIE_LENGTH)
         if len(cookie) != COOKIE_LENGTH:
             raise ValueError("Truncated PyInstaller CArchive cookie")
-        magic, archive_length, toc_offset, toc_length, _pyvers, raw_pylib_name = struct.unpack(
+        magic, archive_length, toc_offset, toc_length, pyvers, raw_pylib_name = struct.unpack(
             COOKIE_FORMAT, cookie
         )
         try:
@@ -71,13 +73,13 @@ def _archive_layout(binary: Path) -> tuple[int, str, list[tuple[str, int, int, b
         if len(toc) != toc_length:
             raise ValueError("Truncated PyInstaller CArchive TOC")
 
-    entries: list[tuple[str, int, int, bool, str]] = []
+    entries: list[tuple[str, int, int, int, bool, str]] = []
     cursor = 0
     while cursor < len(toc):
         header = toc[cursor : cursor + TOC_HEADER_LENGTH]
         if len(header) != TOC_HEADER_LENGTH:
             raise ValueError("Truncated PyInstaller TOC header")
-        entry_length, offset, length, _uncompressed, compressed, raw_typecode = struct.unpack(
+        entry_length, offset, length, uncompressed, compressed, raw_typecode = struct.unpack(
             TOC_FORMAT, header
         )
         name_length = entry_length - TOC_HEADER_LENGTH
@@ -93,9 +95,17 @@ def _archive_layout(binary: Path) -> tuple[int, str, list[tuple[str, int, int, b
             raise ValueError("Invalid PyInstaller TOC text encoding") from exc
         if not name:
             raise ValueError("PyInstaller TOC entry has an empty name")
-        entries.append((name, offset, length, bool(compressed), typecode))
+        entries.append((name, offset, length, uncompressed, bool(compressed), typecode))
         cursor += entry_length
-    return archive_start, pylib_name, entries
+    return archive_start, cookie_offset, pyvers, pylib_name, entries
+
+
+def _archive_layout(binary: Path) -> tuple[int, str, list[tuple[str, int, int, bool, str]]]:
+    archive_start, _cookie_offset, _pyvers, pylib_name, entries = _archive_toc(binary)
+    return archive_start, pylib_name, [
+        (name, offset, length, compressed, typecode)
+        for name, offset, length, _uncompressed, compressed, typecode in entries
+    ]
 
 
 def _entry_bytes(

--- a/tests/test_desktop_core_alpha_feed_macos_signing.py
+++ b/tests/test_desktop_core_alpha_feed_macos_signing.py
@@ -83,11 +83,13 @@ def test_signing_identity_is_imported_before_pyinstaller_build() -> None:
     assert isinstance(run, str)
     assert '--codesign-identity "$APPLE_SIGNING_IDENTITY"' in run
     assert "verify_pyinstaller_macos_signing.py" in run
+    assert "seal_pyinstaller_native_manifest.py" in run
     assert "verify_pyinstaller_native_runtime.py" in run
     assert '--team-id "$APPLE_TEAM_ID"' in run
     assert run.index(
         'codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" "$NATIVE_RUNTIME"'
     ) < run.index("uv run --no-sync pyinstaller")
+    assert run.index("seal_pyinstaller_native_manifest.py") < run.index("verify_pyinstaller_macos_signing.py")
     assert run.index("verify_pyinstaller_macos_signing.py") < run.index("verify_pyinstaller_native_runtime.py")
 
 

--- a/tests/test_desktop_core_alpha_feed_security.py
+++ b/tests/test_desktop_core_alpha_feed_security.py
@@ -181,10 +181,12 @@ def test_frozen_sidecar_stages_attested_native_runtime() -> None:
     assert '--add-data "$NATIVE_RUNTIME:codex_plugin_scanner/_native"' in run
     assert '--add-data "$NATIVE_MANIFEST:codex_plugin_scanner/_native"' in run
     assert "--add-binary" not in run
+    assert "python3 -I scripts/release/seal_pyinstaller_native_manifest.py" in run
     assert "python3 -I scripts/release/verify_pyinstaller_native_runtime.py" in run
     native_verify = run.index("verify_pyinstaller_native_runtime.py")
     signing_verify = run.index("verify_pyinstaller_macos_signing.py")
-    assert signing_verify < native_verify
+    seal = run.index("seal_pyinstaller_native_manifest.py")
+    assert seal < signing_verify < native_verify
 
 
 def test_existing_asset_set_is_all_or_nothing(tmp_path: Path, capsys) -> None:

--- a/tests/test_seal_pyinstaller_native_manifest.py
+++ b/tests/test_seal_pyinstaller_native_manifest.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import struct
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SEALER = ROOT / "scripts" / "release" / "seal_pyinstaller_native_manifest.py"
+VERIFIER = ROOT / "scripts" / "release" / "verify_pyinstaller_native_runtime.py"
+SIGNING = ROOT / "scripts" / "release" / "verify_pyinstaller_macos_signing.py"
+
+
+def _load(path: Path, name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fake_archive(
+    path: Path,
+    *,
+    declared_runtime: str,
+    entries: list[tuple[str, bytes, str]],
+) -> None:
+    signing = _load(SIGNING, "verify_pyinstaller_macos_signing")
+    payload = bytearray()
+    toc = bytearray()
+    for name, data, typecode in entries:
+        offset = len(payload)
+        payload.extend(data)
+        raw_name = name.encode("utf-8") + b"\0"
+        entry_length = signing.TOC_HEADER_LENGTH + len(raw_name)
+        toc.extend(
+            struct.pack(
+                signing.TOC_FORMAT,
+                entry_length,
+                offset,
+                len(data),
+                len(data),
+                0,
+                typecode.encode("ascii"),
+            )
+        )
+        toc.extend(raw_name)
+
+    raw_runtime = declared_runtime.encode("utf-8")
+    assert len(raw_runtime) < 64
+    cookie = struct.pack(
+        signing.COOKIE_FORMAT,
+        signing.COOKIE_MAGIC,
+        len(payload) + len(toc) + signing.COOKIE_LENGTH,
+        len(payload),
+        len(toc),
+        312,
+        raw_runtime + (b"\0" * (64 - len(raw_runtime))),
+    )
+    path.write_bytes(bytes(payload) + bytes(toc) + cookie)
+
+
+def _manifest(*, runtime: bytes, digest: str | None = None) -> dict[str, object]:
+    return {
+        "schema": "hol-guard-native-runtime.v1",
+        "protocol_version": 1,
+        "package_version": "3.0.14",
+        "target": "aarch64-apple-darwin",
+        "platform_tag": "macosx_11_0_arm64",
+        "source_sha": "a" * 40,
+        "rule_digest": "b" * 64,
+        "runtime_sha256": digest if digest is not None else hashlib.sha256(runtime).hexdigest(),
+        "runtime_size": len(runtime),
+    }
+
+
+def test_sealer_rewrites_stale_manifest_after_packaged_runtime_changes(tmp_path: Path) -> None:
+    sealer = _load(SEALER, "seal_pyinstaller_native_manifest")
+    verifier = _load(VERIFIER, "verify_pyinstaller_native_runtime")
+    runtime = b"re-signed-native-runtime"
+    archive = tmp_path / "hol-guard"
+    _fake_archive(
+        archive,
+        declared_runtime="Python",
+        entries=[
+            ("Python", b"\xcf\xfa\xed\xfe-runtime", "b"),
+            ("codex_plugin_scanner/_native/hol-guard-runtime", runtime, "x"),
+            (
+                "codex_plugin_scanner/_native/runtime-manifest.json",
+                json.dumps(_manifest(runtime=runtime, digest="c" * 64)).encode("utf-8"),
+                "x",
+            ),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="digest"):
+        verifier.verify(archive)
+
+    sealer.seal(archive)
+    verifier.verify(archive)
+
+
+def test_sealer_is_idempotent_when_manifest_already_matches(tmp_path: Path) -> None:
+    sealer = _load(SEALER, "seal_pyinstaller_native_manifest")
+    verifier = _load(VERIFIER, "verify_pyinstaller_native_runtime")
+    runtime = b"signed-native-runtime"
+    archive = tmp_path / "hol-guard"
+    _fake_archive(
+        archive,
+        declared_runtime="Python",
+        entries=[
+            ("Python", b"\xcf\xfa\xed\xfe-runtime", "b"),
+            ("codex_plugin_scanner/_native/hol-guard-runtime", runtime, "x"),
+            (
+                "codex_plugin_scanner/_native/runtime-manifest.json",
+                json.dumps(_manifest(runtime=runtime)).encode("utf-8"),
+                "x",
+            ),
+        ],
+    )
+
+    sealer.seal(archive)
+    verifier.verify(archive)

--- a/tests/test_seal_pyinstaller_native_manifest.py
+++ b/tests/test_seal_pyinstaller_native_manifest.py
@@ -30,6 +30,7 @@ def _fake_archive(
     declared_runtime: str,
     entries: list[tuple[str, bytes, str] | tuple[str, bytes, str, bool]],
     prefix: bytes = b"",
+    uncompressed_by_name: dict[str, int] | None = None,
 ) -> None:
     signing = _load(SIGNING, "verify_pyinstaller_macos_signing")
     payload = bytearray()
@@ -44,13 +45,18 @@ def _fake_archive(
         offset = len(payload)
         payload.extend(stored)
         raw_name = name.encode("utf-8") + b"\0"
+        toc_uncompressed = (
+            uncompressed_by_name[name]
+            if uncompressed_by_name is not None and name in uncompressed_by_name
+            else len(data)
+        )
         toc.extend(
             struct.pack(
                 signing.TOC_FORMAT,
                 signing.TOC_HEADER_LENGTH + len(raw_name),
                 offset,
                 len(stored),
-                len(data),
+                toc_uncompressed,
                 1 if compressed else 0,
                 typecode.encode("ascii"),
             )
@@ -175,3 +181,50 @@ def test_sealer_accepts_matching_compressed_manifest_without_rewrite(tmp_path: P
     _archive_start, _pylib, entries = signing._archive_layout(archive)
     manifest = next(entry for entry in entries if entry[0].endswith("runtime-manifest.json"))
     assert manifest[3] is True
+
+
+def test_archive_toc_rejects_entry_that_overlaps_toc(tmp_path: Path) -> None:
+    signing = _load(SIGNING, "verify_pyinstaller_macos_signing")
+    payload = b"data"
+    name = "codex_plugin_scanner/_native/hol-guard-runtime"
+    raw_name = name.encode("utf-8") + b"\0"
+    toc = struct.pack(
+        signing.TOC_FORMAT,
+        signing.TOC_HEADER_LENGTH + len(raw_name),
+        len(payload),
+        4,
+        4,
+        0,
+        b"x",
+    )
+    toc += raw_name
+    raw_runtime = b"Python"
+    cookie = struct.pack(
+        signing.COOKIE_FORMAT,
+        signing.COOKIE_MAGIC,
+        len(payload) + len(toc) + signing.COOKIE_LENGTH,
+        len(payload),
+        len(toc),
+        312,
+        raw_runtime + (b"\0" * (64 - len(raw_runtime))),
+    )
+    archive = tmp_path / "hol-guard"
+    archive.write_bytes(payload + toc + cookie)
+
+    with pytest.raises(ValueError, match="overlaps the archive TOC"):
+        signing._archive_toc(archive)
+
+
+def test_sealer_rejects_runtime_uncompressed_size_mismatch(tmp_path: Path) -> None:
+    sealer = _load(SEALER, "seal_pyinstaller_native_manifest")
+    runtime = b"size-mismatch-runtime"
+    archive = tmp_path / "hol-guard"
+    _fake_archive(
+        archive,
+        declared_runtime="Python",
+        entries=_native_entries(runtime, digest=None, compressed=False),
+        uncompressed_by_name={"codex_plugin_scanner/_native/hol-guard-runtime": 999},
+    )
+
+    with pytest.raises(ValueError, match="size does not match"):
+        sealer.seal(archive)

--- a/tests/test_seal_pyinstaller_native_manifest.py
+++ b/tests/test_seal_pyinstaller_native_manifest.py
@@ -4,6 +4,7 @@ import hashlib
 import importlib.util
 import json
 import struct
+import zlib
 from pathlib import Path
 from types import ModuleType
 
@@ -27,24 +28,30 @@ def _fake_archive(
     path: Path,
     *,
     declared_runtime: str,
-    entries: list[tuple[str, bytes, str]],
+    entries: list[tuple[str, bytes, str] | tuple[str, bytes, str, bool]],
+    prefix: bytes = b"",
 ) -> None:
     signing = _load(SIGNING, "verify_pyinstaller_macos_signing")
     payload = bytearray()
     toc = bytearray()
-    for name, data, typecode in entries:
+    for item in entries:
+        compressed = False
+        if len(item) == 4:
+            name, data, typecode, compressed = item
+        else:
+            name, data, typecode = item
+        stored = zlib.compress(data) if compressed else data
         offset = len(payload)
-        payload.extend(data)
+        payload.extend(stored)
         raw_name = name.encode("utf-8") + b"\0"
-        entry_length = signing.TOC_HEADER_LENGTH + len(raw_name)
         toc.extend(
             struct.pack(
                 signing.TOC_FORMAT,
-                entry_length,
+                signing.TOC_HEADER_LENGTH + len(raw_name),
                 offset,
+                len(stored),
                 len(data),
-                len(data),
-                0,
+                1 if compressed else 0,
                 typecode.encode("ascii"),
             )
         )
@@ -61,7 +68,7 @@ def _fake_archive(
         312,
         raw_runtime + (b"\0" * (64 - len(raw_runtime))),
     )
-    path.write_bytes(bytes(payload) + bytes(toc) + cookie)
+    path.write_bytes(prefix + bytes(payload) + bytes(toc) + cookie)
 
 
 def _manifest(*, runtime: bytes, digest: str | None = None) -> dict[str, object]:
@@ -78,6 +85,16 @@ def _manifest(*, runtime: bytes, digest: str | None = None) -> dict[str, object]
     }
 
 
+def _native_entries(runtime: bytes, *, digest: str | None, compressed: bool) -> list[tuple[str, bytes, str, bool]]:
+    manifest = json.dumps(_manifest(runtime=runtime, digest=digest), indent=2).encode("utf-8")
+    return [
+        ("Python", b"\xcf\xfa\xed\xfe-runtime", "b", False),
+        ("codex_plugin_scanner/_native/hol-guard-runtime", runtime, "x", compressed),
+        ("codex_plugin_scanner/_native/runtime-manifest.json", manifest, "x", compressed),
+        ("trailing.dat", b"keep-me", "x", compressed),
+    ]
+
+
 def test_sealer_rewrites_stale_manifest_after_packaged_runtime_changes(tmp_path: Path) -> None:
     sealer = _load(SEALER, "seal_pyinstaller_native_manifest")
     verifier = _load(VERIFIER, "verify_pyinstaller_native_runtime")
@@ -86,15 +103,7 @@ def test_sealer_rewrites_stale_manifest_after_packaged_runtime_changes(tmp_path:
     _fake_archive(
         archive,
         declared_runtime="Python",
-        entries=[
-            ("Python", b"\xcf\xfa\xed\xfe-runtime", "b"),
-            ("codex_plugin_scanner/_native/hol-guard-runtime", runtime, "x"),
-            (
-                "codex_plugin_scanner/_native/runtime-manifest.json",
-                json.dumps(_manifest(runtime=runtime, digest="c" * 64)).encode("utf-8"),
-                "x",
-            ),
-        ],
+        entries=_native_entries(runtime, digest="c" * 64, compressed=False),
     )
 
     with pytest.raises(ValueError, match="digest"):
@@ -112,16 +121,57 @@ def test_sealer_is_idempotent_when_manifest_already_matches(tmp_path: Path) -> N
     _fake_archive(
         archive,
         declared_runtime="Python",
-        entries=[
-            ("Python", b"\xcf\xfa\xed\xfe-runtime", "b"),
-            ("codex_plugin_scanner/_native/hol-guard-runtime", runtime, "x"),
-            (
-                "codex_plugin_scanner/_native/runtime-manifest.json",
-                json.dumps(_manifest(runtime=runtime)).encode("utf-8"),
-                "x",
-            ),
-        ],
+        entries=_native_entries(runtime, digest=None, compressed=False),
     )
 
     sealer.seal(archive)
     verifier.verify(archive)
+
+
+def test_sealer_rewrites_compressed_stale_manifest_and_preserves_neighbors(tmp_path: Path) -> None:
+    sealer = _load(SEALER, "seal_pyinstaller_native_manifest")
+    verifier = _load(VERIFIER, "verify_pyinstaller_native_runtime")
+    signing = _load(SIGNING, "verify_pyinstaller_macos_signing")
+    runtime = b"re-signed-compressed-runtime"
+    archive = tmp_path / "hol-guard"
+    prefix = b"BOOTLOADER"
+    _fake_archive(
+        archive,
+        declared_runtime="Python",
+        entries=_native_entries(runtime, digest="d" * 64, compressed=True),
+        prefix=prefix,
+    )
+
+    with pytest.raises(ValueError, match="digest"):
+        verifier.verify(archive)
+
+    sealer.seal(archive)
+    verifier.verify(archive)
+    assert archive.read_bytes().startswith(prefix)
+    archive_start, _pylib, entries = signing._archive_layout(archive)
+    trailing = next(entry for entry in entries if entry[0] == "trailing.dat")
+    with archive.open("rb") as handle:
+        assert signing._entry_bytes(handle, archive_start, *trailing[:4]) == b"keep-me"
+    manifest = next(entry for entry in entries if entry[0].endswith("runtime-manifest.json"))
+    assert manifest[3] is False
+
+
+def test_sealer_accepts_matching_compressed_manifest_without_rewrite(tmp_path: Path) -> None:
+    sealer = _load(SEALER, "seal_pyinstaller_native_manifest")
+    verifier = _load(VERIFIER, "verify_pyinstaller_native_runtime")
+    signing = _load(SIGNING, "verify_pyinstaller_macos_signing")
+    runtime = b"matching-compressed-runtime"
+    archive = tmp_path / "hol-guard"
+    _fake_archive(
+        archive,
+        declared_runtime="Python",
+        entries=_native_entries(runtime, digest=None, compressed=True),
+    )
+    before = archive.read_bytes()
+
+    sealer.seal(archive)
+    verifier.verify(archive)
+    assert archive.read_bytes() == before
+    _archive_start, _pylib, entries = signing._archive_layout(archive)
+    manifest = next(entry for entry in entries if entry[0].endswith("runtime-manifest.json"))
+    assert manifest[3] is True


### PR DESCRIPTION
## Summary
- After PyInstaller packages the attested native runtime into the Desktop Core sidecar, rewrite the CArchive native manifest so `runtime_sha256` and `runtime_size` match the packaged bytes.
- Keep `--add-data` packaging. PyInstaller compresses DATA entries and can re-sign Mach-O payloads, which changes digest after the pre-package identity refresh.
- Preserve neighboring archive entries and the bootloader prefix. Write the updated manifest uncompressed. Reject TOC entries that overlap the archive payload, and fail closed if extracted native bytes do not match the TOC size.

## Testing
- `python3 -m pytest -q tests/test_seal_pyinstaller_native_manifest.py tests/test_verify_pyinstaller_native_runtime.py tests/test_desktop_core_alpha_feed_macos_signing.py tests/test_desktop_core_alpha_feed_security.py --tb=short`
- `python3 scripts/ci/code_quality_audit.py --root . --baseline ci/code-quality-baseline.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native manifest sealing for standalone Core builds.
  * Improved support for compressed and uncompressed application archives while preserving bundled components.

* **Bug Fixes**
  * Ensured manifest sealing occurs before macOS signing and runtime verification.
  * Improved handling of incomplete, unreadable, or structurally invalid archive and runtime data.

* **Tests**
  * Added coverage for manifest updates, compression handling, archive preservation, validation, and build-step ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->