### PR TITLE
fix(guard): re-sign Core sidecar after native manifest rewrite

### DIFF
--- a/.github/workflows/desktop-core-alpha-feed.yml
+++ b/.github/workflows/desktop-core-alpha-feed.yml
@@ -362,6 +362,7 @@ jobs:
           chmod 0755 "$BUILT"
           python3 -I scripts/release/seal_pyinstaller_native_manifest.py \
             --binary "$BUILT"
+          codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" "$BUILT"
           python3 -I scripts/release/verify_pyinstaller_macos_signing.py \
             --binary "$BUILT" --team-id "$APPLE_TEAM_ID"
           python3 -I scripts/release/verify_pyinstaller_native_runtime.py \

--- a/ci/code-quality-baseline.json
+++ b/ci/code-quality-baseline.json
@@ -437,7 +437,7 @@
   },
   "oversized_files": {
     ".github/workflows/ci.yml": 554,
-    ".github/workflows/desktop-core-alpha-feed.yml": 532,
+    ".github/workflows/desktop-core-alpha-feed.yml": 533,
     ".github/workflows/publish.yml": 1710,
     "dashboard/src/app.tsx": 1106,
     "dashboard/src/approval-center-primitives.tsx": 1049,

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
   "maximum_collected_cases": 16275,
-  "maximum_test_source_lines": 351938
+  "maximum_test_source_lines": 351946
 }

--- a/tests/test_desktop_core_alpha_feed_macos_signing.py
+++ b/tests/test_desktop_core_alpha_feed_macos_signing.py
@@ -89,7 +89,12 @@ def test_signing_identity_is_imported_before_pyinstaller_build() -> None:
     assert run.index(
         'codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" "$NATIVE_RUNTIME"'
     ) < run.index("uv run --no-sync pyinstaller")
-    assert run.index("seal_pyinstaller_native_manifest.py") < run.index("verify_pyinstaller_macos_signing.py")
+    assert run.index("seal_pyinstaller_native_manifest.py") < run.index(
+        'codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" "$BUILT"'
+    )
+    assert run.index(
+        'codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" "$BUILT"'
+    ) < run.index("verify_pyinstaller_macos_signing.py")
     assert run.index("verify_pyinstaller_macos_signing.py") < run.index("verify_pyinstaller_native_runtime.py")
 
 

--- a/tests/test_desktop_core_alpha_feed_security.py
+++ b/tests/test_desktop_core_alpha_feed_security.py
@@ -186,7 +186,10 @@ def test_frozen_sidecar_stages_attested_native_runtime() -> None:
     native_verify = run.index("verify_pyinstaller_native_runtime.py")
     signing_verify = run.index("verify_pyinstaller_macos_signing.py")
     seal = run.index("seal_pyinstaller_native_manifest.py")
-    assert seal < signing_verify < native_verify
+    outer_sign = run.index(
+        'codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" "$BUILT"'
+    )
+    assert seal < outer_sign < signing_verify < native_verify
 
 
 def test_existing_asset_set_is_all_or_nothing(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- After rewriting the bundled native runtime manifest inside the Desktop Core sidecar, sign the sidecar again before version and bootstrap smoke checks.
- Keep native manifest rewrite and embedded Mach-O identity verification. The outer signature is invalidated when archive bytes change.

## Testing
- `python3 -m pytest -q tests/test_desktop_core_alpha_feed_macos_signing.py tests/test_desktop_core_alpha_feed_security.py --tb=short`
- `python3 scripts/ci/code_quality_audit.py --root . --baseline ci/code-quality-baseline.json`
