### PR TITLE
fix(guard): repair Core sidecar Mach-O headers after manifest rewrite

### DIFF
--- a/.github/workflows/desktop-core-alpha-feed.yml
+++ b/.github/workflows/desktop-core-alpha-feed.yml
@@ -11,6 +11,7 @@ on:
       - scripts/release/desktop_core_alpha_feed.py
       - scripts/release/stage_native_runtime_for_desktop_core.py
       - scripts/release/seal_pyinstaller_native_manifest.py
+      - scripts/release/fix_pyinstaller_macos_exe_headers.py
       - scripts/release/verify_pyinstaller_macos_signing.py
       - scripts/release/verify_pyinstaller_native_runtime.py
   push:
@@ -20,6 +21,7 @@ on:
       - scripts/release/desktop_core_alpha_feed.py
       - scripts/release/stage_native_runtime_for_desktop_core.py
       - scripts/release/seal_pyinstaller_native_manifest.py
+      - scripts/release/fix_pyinstaller_macos_exe_headers.py
       - scripts/release/verify_pyinstaller_macos_signing.py
       - scripts/release/verify_pyinstaller_native_runtime.py
   schedule:
@@ -361,6 +363,10 @@ jobs:
           ASSET="$DIST/hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}"
           chmod 0755 "$BUILT"
           python3 -I scripts/release/seal_pyinstaller_native_manifest.py \
+            --binary "$BUILT"
+          codesign --remove-signature "$BUILT"
+          uv run --directory "$SOURCE" --no-sync python \
+            "$GITHUB_WORKSPACE/scripts/release/fix_pyinstaller_macos_exe_headers.py" \
             --binary "$BUILT"
           codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" "$BUILT"
           python3 -I scripts/release/verify_pyinstaller_macos_signing.py \

--- a/.github/workflows/desktop-core-alpha-feed.yml
+++ b/.github/workflows/desktop-core-alpha-feed.yml
@@ -362,9 +362,9 @@ jobs:
           BUILT="$DIST/hol-guard"
           ASSET="$DIST/hol-guard-core-${CORE_VERSION}-${RELEASE_TARGET}"
           chmod 0755 "$BUILT"
+          codesign --remove-signature "$BUILT"
           python3 -I scripts/release/seal_pyinstaller_native_manifest.py \
             --binary "$BUILT"
-          codesign --remove-signature "$BUILT"
           uv run --directory "$SOURCE" --no-sync python \
             "$GITHUB_WORKSPACE/scripts/release/fix_pyinstaller_macos_exe_headers.py" \
             --binary "$BUILT"

--- a/ci/code-quality-baseline.json
+++ b/ci/code-quality-baseline.json
@@ -437,7 +437,7 @@
   },
   "oversized_files": {
     ".github/workflows/ci.yml": 554,
-    ".github/workflows/desktop-core-alpha-feed.yml": 533,
+    ".github/workflows/desktop-core-alpha-feed.yml": 539,
     ".github/workflows/publish.yml": 1710,
     "dashboard/src/app.tsx": 1106,
     "dashboard/src/approval-center-primitives.tsx": 1049,

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
   "maximum_collected_cases": 16275,
-  "maximum_test_source_lines": 351946
+  "maximum_test_source_lines": 351956
 }

--- a/scripts/release/fix_pyinstaller_macos_exe_headers.py
+++ b/scripts/release/fix_pyinstaller_macos_exe_headers.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Expand onefile Mach-O LINKEDIT so codesign can cover a rewritten CArchive."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--binary", type=Path, required=True)
+    args = parser.parse_args()
+    if not args.binary.is_file():
+        raise SystemExit(f"Binary does not exist: {args.binary}")
+    try:
+        from PyInstaller.utils.osx import fix_exe_for_code_signing
+    except ImportError as error:
+        raise SystemExit("PyInstaller is required to repair onefile Mach-O headers") from error
+    try:
+        fix_exe_for_code_signing(str(args.binary.resolve()))
+    except (AssertionError, OSError, ValueError) as error:
+        raise SystemExit(str(error)) from error
+    print(f"repaired onefile Mach-O headers for {args.binary.name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_desktop_core_alpha_feed_macos_signing.py
+++ b/tests/test_desktop_core_alpha_feed_macos_signing.py
@@ -89,7 +89,11 @@ def test_signing_identity_is_imported_before_pyinstaller_build() -> None:
     assert run.index(
         'codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" "$NATIVE_RUNTIME"'
     ) < run.index("uv run --no-sync pyinstaller")
-    assert run.index("seal_pyinstaller_native_manifest.py") < run.index(
+    assert run.index("seal_pyinstaller_native_manifest.py") < run.index('codesign --remove-signature "$BUILT"')
+    assert run.index('codesign --remove-signature "$BUILT"') < run.index(
+        "fix_pyinstaller_macos_exe_headers.py"
+    )
+    assert run.index("fix_pyinstaller_macos_exe_headers.py") < run.index(
         'codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" "$BUILT"'
     )
     assert run.index(

--- a/tests/test_desktop_core_alpha_feed_macos_signing.py
+++ b/tests/test_desktop_core_alpha_feed_macos_signing.py
@@ -89,10 +89,8 @@ def test_signing_identity_is_imported_before_pyinstaller_build() -> None:
     assert run.index(
         'codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" "$NATIVE_RUNTIME"'
     ) < run.index("uv run --no-sync pyinstaller")
-    assert run.index("seal_pyinstaller_native_manifest.py") < run.index('codesign --remove-signature "$BUILT"')
-    assert run.index('codesign --remove-signature "$BUILT"') < run.index(
-        "fix_pyinstaller_macos_exe_headers.py"
-    )
+    assert run.index('codesign --remove-signature "$BUILT"') < run.index("seal_pyinstaller_native_manifest.py")
+    assert run.index("seal_pyinstaller_native_manifest.py") < run.index("fix_pyinstaller_macos_exe_headers.py")
     assert run.index("fix_pyinstaller_macos_exe_headers.py") < run.index(
         'codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" "$BUILT"'
     )

--- a/tests/test_desktop_core_alpha_feed_security.py
+++ b/tests/test_desktop_core_alpha_feed_security.py
@@ -183,13 +183,17 @@ def test_frozen_sidecar_stages_attested_native_runtime() -> None:
     assert "--add-binary" not in run
     assert "python3 -I scripts/release/seal_pyinstaller_native_manifest.py" in run
     assert "python3 -I scripts/release/verify_pyinstaller_native_runtime.py" in run
+    assert 'codesign --remove-signature "$BUILT"' in run
+    assert "fix_pyinstaller_macos_exe_headers.py" in run
     native_verify = run.index("verify_pyinstaller_native_runtime.py")
     signing_verify = run.index("verify_pyinstaller_macos_signing.py")
     seal = run.index("seal_pyinstaller_native_manifest.py")
+    strip_sign = run.index('codesign --remove-signature "$BUILT"')
+    repair_headers = run.index("fix_pyinstaller_macos_exe_headers.py")
     outer_sign = run.index(
         'codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" "$BUILT"'
     )
-    assert seal < outer_sign < signing_verify < native_verify
+    assert seal < strip_sign < repair_headers < outer_sign < signing_verify < native_verify
 
 
 def test_existing_asset_set_is_all_or_nothing(tmp_path: Path, capsys) -> None:

--- a/tests/test_desktop_core_alpha_feed_security.py
+++ b/tests/test_desktop_core_alpha_feed_security.py
@@ -193,7 +193,7 @@ def test_frozen_sidecar_stages_attested_native_runtime() -> None:
     outer_sign = run.index(
         'codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" "$BUILT"'
     )
-    assert seal < strip_sign < repair_headers < outer_sign < signing_verify < native_verify
+    assert strip_sign < seal < repair_headers < outer_sign < signing_verify < native_verify
 
 
 def test_existing_asset_set_is_all_or_nothing(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- After rewriting the bundled native runtime manifest, strip the stale outer signature, expand Mach-O LINKEDIT to cover the new file length, and sign the Desktop Core sidecar again.
- Keep native manifest rewrite and embedded Mach-O identity verification. Smoke version and bootstrap checks run only after that outer signature is valid.

## Testing
- `python3 -m pytest -q tests/test_desktop_core_alpha_feed_macos_signing.py tests/test_desktop_core_alpha_feed_security.py --tb=short`
- `python3 scripts/ci/code_quality_audit.py --root . --baseline ci/code-quality-baseline.json`
