### PR TITLE
fix(guard): stop warn-action artifacts from forcing a review prompt

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/prompt.py
+++ b/src/codex_plugin_scanner/guard/cli/prompt.py
@@ -62,7 +62,7 @@ def resolve_interactive_decisions(
     review_items = [
         artifact
         for artifact in prompt_artifacts
-        if artifact.policy_action in {"warn", "review", "require-reapproval", "block"}
+        if artifact.policy_action in {"review", "require-reapproval", "block"}
     ]
     if not review_items:
         evaluation["blocked"] = False

--- a/tests/test_guard_approval_gate.py
+++ b/tests/test_guard_approval_gate.py
@@ -1941,6 +1941,91 @@ def test_approval_gate_allow_once_requires_password_prompt(tmp_path: Path, monke
     assert store.list_receipts(limit=5) == []
 
 
+def test_warn_artifact_is_not_prompted_alongside_a_review_artifact(tmp_path: Path) -> None:
+    """A ``warn`` artifact must never open its own review prompt.
+
+    ``warn`` is not a blocking action (see ``_BLOCKING_ACTIONS`` in
+    ``runtime/decisions.py`` and the accepted-vs-not-applicable branches of
+    ``evaluate_approval_reuse``), so a saved allow rule correctly leaves it as
+    ``not-applicable`` -- there is nothing for the rule to unblock. Before this
+    fix, ``resolve_interactive_decisions`` still swept every ``warn`` artifact
+    into its review-prompt list whenever *any other* artifact in the same run
+    was genuinely blocking, forcing a prompt that no saved rule could ever
+    satisfy.
+    """
+    store = _store(tmp_path)
+
+    review_artifact = guard_prompt_module.PromptArtifact(
+        harness="hermes",
+        artifact_id="hermes:skill:apple:reminders",
+        artifact_name="reminders",
+        artifact_hash="hash-review",
+        policy_action="review",
+        changed_fields=("runtime_tool_call",),
+        provenance_summary="global artifact",
+        recommendation="review",
+        publisher=None,
+        config_path="/root/.hermes/skills/apple/reminders/SKILL.md",
+        source_scope="global",
+        artifact_type="tool_action_request",
+        command=None,
+        transport=None,
+        metadata={},
+        current_snapshot=None,
+        removed=False,
+    )
+    warn_artifact = guard_prompt_module.PromptArtifact(
+        harness="hermes",
+        artifact_id="hermes:skill:apple:apple-notes",
+        artifact_name="apple-notes",
+        artifact_hash="hash-warn",
+        policy_action="warn",
+        changed_fields=("first_seen",),
+        provenance_summary="global artifact defined at /root/.hermes/skills/apple/apple-notes/SKILL.md",
+        recommendation="warn",
+        publisher=None,
+        config_path="/root/.hermes/skills/apple/apple-notes/SKILL.md",
+        source_scope="global",
+        artifact_type="skill",
+        command=None,
+        transport=None,
+        metadata={},
+        current_snapshot=None,
+        removed=False,
+    )
+    evaluation = {
+        "blocked": True,
+        "artifacts": [
+            {"artifact_id": review_artifact.artifact_id, "policy_action": "review"},
+            {"artifact_id": warn_artifact.artifact_id, "policy_action": "warn"},
+        ],
+    }
+
+    prompt_calls = 0
+
+    def _input(_prompt: str) -> str:
+        nonlocal prompt_calls
+        prompt_calls += 1
+        assert prompt_calls == 1, "the warn artifact must not open a second review prompt"
+        return "1"
+
+    resolved = guard_prompt_module.resolve_interactive_decisions(
+        store,
+        evaluation,
+        [review_artifact, warn_artifact],
+        workspace=None,
+        now="2026-08-30T00:00:00+00:00",
+        console=Console(file=io.StringIO(), force_terminal=False),
+        input_func=_input,
+    )
+
+    assert prompt_calls == 1
+    payloads = {item["artifact_id"]: item for item in resolved["artifacts"]}
+    assert payloads[review_artifact.artifact_id]["policy_action"] == "allow"
+    assert payloads[warn_artifact.artifact_id]["policy_action"] == "warn"
+    assert "user_override" not in payloads[warn_artifact.artifact_id]
+
+
 def test_approval_gate_background_remote_policy_sync_fails_closed_without_crashing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
`resolve_interactive_decisions` swept every artifact whose `policy_action` was `warn` into the interactive review list, alongside the genuinely blocking actions (`review`, `require-reapproval`, `block`). This contradicted the rest of the codebase, where `warn` is explicitly non-blocking:

- `_BLOCKING_ACTIONS` in `runtime/decisions.py` excludes `warn`, so `enforcement.blocking` is already `False` for it.
- `evaluate_approval_reuse` only lets a saved `allow` clear a current `review` (or `require-reapproval` with a fresh/durable grant); a `warn` current action always returns `not-applicable`, by design (there is a dedicated regression test for exactly this, `tests/test_guard_approval_reuse.py::test_saved_allow_is_not_consumed_when_current_action_needs_no_review`).

The effect: once *any* artifact in a harness run was genuinely blocking (e.g. a `require-reapproval` artifact among hundreds), the interactive resolver re-prompted for *every* `warn` artifact too. No saved `allow` rule -- harness-scoped, global, or interactive "always allow" -- could ever satisfy that prompt, because `evaluate_approval_reuse` treats a saved allow against `warn` as not-applicable on purpose. Guard policy integrity correctly reported the rules as valid; they were simply never consulted for `warn` artifacts riding along with a blocked run.

Remove `warn` from the review-trigger set so it matches `_BLOCKING_ACTIONS` and the approval-reuse semantics used everywhere else. A `warn` artifact no longer opens its own prompt; it was never treated as blocking anywhere but this one filter.

Adds a regression test pairing a `review` artifact (which still prompts) with a `warn` artifact (which must not), reproducing the reported hermes/apple-notes case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Warning-only findings are no longer included in interactive approval prompts.
  * Interactive reviews now focus on findings that require a decision, while warnings retain their warning status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->