### PR TITLE
fix(dashboard): make the app detail breadcrumb navigable

### DIFF
--- a/ci/code-quality-baseline.json
+++ b/ci/code-quality-baseline.json
@@ -432,7 +432,7 @@
     "dashboard/src/app.tsx": 1106,
     "dashboard/src/approval-center-primitives.tsx": 1049,
     "dashboard/src/approval-center-utils.ts": 901,
-    "dashboard/src/apps/app-detail-workspace.tsx": 1975,
+    "dashboard/src/apps/app-detail-workspace.tsx": 1984,
     "dashboard/src/audit-workspace.tsx": 705,
     "dashboard/src/evidence/evidence-activity-heatmap.tsx": 527,
     "dashboard/src/fleet-workspace.tsx": 531,

--- a/dashboard/e2e/protection-health-ui.spec.ts
+++ b/dashboard/e2e/protection-health-ui.spec.ts
@@ -177,6 +177,11 @@ test("startup proving snapshot shows checking instead of degraded", async ({ pag
   await expect(page.getByRole("heading", { name: "Checking Codex protection" })).toBeVisible();
   await expect(page.getByText("Codex protection is degraded")).toHaveCount(0);
   await expect(page.getByText("Codex is protected")).toHaveCount(0);
+
+  await page.getByRole("navigation", { name: "Breadcrumb" }).getByRole("button", { name: "Apps" }).click();
+  await page.waitForURL(/\/protect/);
+  await expect(page.getByRole("heading", { name: "Checking app protection" })).toBeVisible();
+
   await page.screenshot({ path: testInfo.outputPath("protection-health-checking.png"), fullPage: true });
 });
 

--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -906,13 +906,14 @@ export function App() {
         inventory={inventory.kind === "ready" ? inventory.items : []}
         requests={requests.kind === "ready" ? requests.items : []}
         onGoHome={handleGoHome}
+        onOpenApps={handleOpenFleet}
         onOpenRequest={handleOpenRequest}
         onClearAppPolicies={handleClearAppPolicies}
         onClearPolicy={handleClearPolicy}
         onManagedInstallChanged={refreshStateWithoutResult}
       />
     );
-  }, [view, appDetailHarness, runtime, receipts, policies, inventory, requests, handleGoHome, handleOpenRequest, handleClearAppPolicies, handleClearPolicy, refreshStateWithoutResult]);
+  }, [view, appDetailHarness, runtime, receipts, policies, inventory, requests, handleGoHome, handleOpenFleet, handleOpenRequest, handleClearAppPolicies, handleClearPolicy, refreshStateWithoutResult]);
 
   const policyContent = useMemo(() => {
     if (runtime.kind !== "ready") {

--- a/dashboard/src/apps/app-detail-workspace.tsx
+++ b/dashboard/src/apps/app-detail-workspace.tsx
@@ -87,6 +87,7 @@ type AppDetailWorkspaceProps = {
   inventory: GuardInventoryItem[];
   requests: GuardApprovalRequest[];
   onGoHome: () => void;
+  onOpenApps?: () => void;
   onOpenRequest: (requestId: string) => void;
   onClearAppPolicies?: (harness: string) => Promise<void>;
   onClearPolicy?: (policy: GuardPolicyDecision) => Promise<void>;
@@ -375,7 +376,7 @@ export function AppDetailWorkspace(props: AppDetailWorkspaceProps) {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-2">
+      <nav className="flex items-center gap-2" aria-label="Breadcrumb">
         <button
           onClick={props.onGoHome}
           className="inline-flex items-center gap-1 rounded-full px-3 py-1.5 text-sm font-medium text-brand-dark transition-colors hover:bg-slate-100"
@@ -384,10 +385,19 @@ export function AppDetailWorkspace(props: AppDetailWorkspaceProps) {
           Home
         </button>
         <HiMiniChevronRight className="h-4 w-4 text-slate-300" aria-hidden="true" />
-        <span className="text-sm text-muted-foreground">Apps</span>
+        {props.onOpenApps ? (
+          <button
+            onClick={props.onOpenApps}
+            className="rounded-full px-3 py-1.5 text-sm font-medium text-brand-dark transition-colors hover:bg-slate-100"
+          >
+            Apps
+          </button>
+        ) : (
+          <span className="text-sm text-muted-foreground">Apps</span>
+        )}
         <HiMiniChevronRight className="h-4 w-4 text-slate-300" aria-hidden="true" />
-        <span className="text-sm font-medium text-brand-dark">{harnessDisplayName(harness)}</span>
-      </div>
+        <span className="text-sm font-medium text-brand-dark" aria-current="page">{harnessDisplayName(harness)}</span>
+      </nav>
 
       <GuardHero
         status={heroStatus}

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/app-detail-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/app-detail-workspace.js
@@ -256,7 +256,7 @@ function AppDetailWorkspace(props) {
     onGoSettings: handleGoSettings
   });
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-2", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("nav", { className: "flex items-center gap-2", "aria-label": "Breadcrumb", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs(
         "button",
         {
@@ -269,9 +269,16 @@ function AppDetailWorkspace(props) {
         }
       ),
       /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronRight, { className: "h-4 w-4 text-slate-300", "aria-hidden": "true" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm text-muted-foreground", children: "Apps" }),
+      props.onOpenApps ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "button",
+        {
+          onClick: props.onOpenApps,
+          className: "rounded-full px-3 py-1.5 text-sm font-medium text-brand-dark transition-colors hover:bg-slate-100",
+          children: "Apps"
+        }
+      ) : /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm text-muted-foreground", children: "Apps" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronRight, { className: "h-4 w-4 text-slate-300", "aria-hidden": "true" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark", children: harnessDisplayName(harness) })
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark", "aria-current": "page", children: harnessDisplayName(harness) })
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsx(
       GuardHero,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -31517,13 +31517,14 @@ function App() {
         inventory: inventory.kind === "ready" ? inventory.items : [],
         requests: requests.kind === "ready" ? requests.items : [],
         onGoHome: handleGoHome,
+        onOpenApps: handleOpenFleet,
         onOpenRequest: handleOpenRequest,
         onClearAppPolicies: handleClearAppPolicies,
         onClearPolicy: handleClearPolicy,
         onManagedInstallChanged: refreshStateWithoutResult
       }
     );
-  }, [view, appDetailHarness, runtime, receipts, policies, inventory, requests, handleGoHome, handleOpenRequest, handleClearAppPolicies, handleClearPolicy, refreshStateWithoutResult]);
+  }, [view, appDetailHarness, runtime, receipts, policies, inventory, requests, handleGoHome, handleOpenFleet, handleOpenRequest, handleClearAppPolicies, handleClearPolicy, refreshStateWithoutResult]);
   const policyContent = reactExports.useMemo(() => {
     if (runtime.kind !== "ready") {
       return null;


### PR DESCRIPTION
## Summary
- The "Apps" crumb on an app detail page was a plain, non-interactive label even though it sat between "Home" and the app name, so the only ways out of an app page were Home or the sidebar and there was no direct path back to the app list between apps.
- The crumb is now a button that opens the app catalog (the Protect route), matching the hover style of the adjacent Home button, and the current app name is marked as the current page. The trail is wrapped in a labelled navigation landmark.
- Covered by a fixture e2e assertion: clicking "Apps" in the breadcrumb lands on the Protect page.

## Testing
- `playwright test e2e/protection-health-ui.spec.ts` — 6 passed, including the new breadcrumb-navigation assertion.
- `npm test` in `dashboard/` — full chain green.
