### PR TITLE
feat(rust): complete native hook data plane edge and transport

### DIFF
--- a/ci/native_runtime/test_guard_native_runtime_resident.py
+++ b/ci/native_runtime/test_guard_native_runtime_resident.py
@@ -19,7 +19,9 @@ from codex_plugin_scanner.guard.native_runtime_resident import (
 )
 from codex_plugin_scanner.guard.store import GuardStore
 
-pytestmark = pytest.mark.skipif(os.name == "nt", reason="this lifecycle fixture uses owner-only Unix runtime paths")
+pytestmark = pytest.mark.skipif(
+    os.name == "nt", reason="this lifecycle fixture uses owner-only Unix runtime paths"
+)
 
 
 def _fake_runtime(path: Path) -> Path:
@@ -38,14 +40,20 @@ while True:
 
 
 def _force_auto(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("codex_plugin_scanner.guard.daemon.hook_worker.native_mode", lambda: "auto")
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.hook_worker.native_mode", lambda: "auto"
+    )
 
 
-def test_resident_runtime_reuses_one_contained_service(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_resident_runtime_reuses_one_contained_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Lifecycle reuse is Python-owned; client protocol is tested by the real Rust binary suite."""
     monkeypatch.setattr(resident, "_START_TIMEOUT_SECONDS", 2.0)
 
-    def fake_native_client(self: Any, payload: bytes, *, timeout_seconds: float) -> bytes | None:
+    def fake_native_client(
+        self: Any, payload: bytes, *, timeout_seconds: float
+    ) -> bytes | None:
         del timeout_seconds
         if self._auth_token is None:
             return None
@@ -131,7 +139,9 @@ def _posttool_allow() -> dict[str, object]:
     }
 
 
-def test_hook_worker_uses_raw_native_hook_edge(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_hook_worker_uses_raw_native_hook_edge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     _force_auto(monkeypatch)
     store = GuardStore(tmp_path / "guard-home")
     worker = HookWorker(store=store)
@@ -140,10 +150,16 @@ def test_hook_worker_uses_raw_native_hook_edge(tmp_path: Path, monkeypatch: pyte
     def fake_native(**kwargs: object) -> dict[str, object]:
         nonlocal calls
         calls += 1
-        assert kwargs["payload"] == {"hook_event_name": "PostToolUse", "tool_response": "clean output"}
+        assert kwargs["payload"] == {
+            "hook_event_name": "PostToolUse",
+            "tool_response": "clean output",
+        }
         return _posttool_allow()
 
-    monkeypatch.setattr("codex_plugin_scanner.guard.daemon.hook_worker.review_hook_edge_native", fake_native)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.hook_worker.review_hook_edge_native",
+        fake_native,
+    )
 
     result = worker.review_http_payload(
         payload={"hook_event_name": "PostToolUse", "tool_response": "clean output"},
@@ -205,7 +221,11 @@ def test_hook_worker_non_command_pretool_stays_native_review(
     )
 
     result = worker.review_http_payload(
-        payload={"hook_event_name": "PreToolUse", "tool_name": "Read", "tool_input": {"file_path": "README.md"}},
+        payload={
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Read",
+            "tool_input": {"file_path": "README.md"},
+        },
         params={},
         default_harness="claude-code",
         home_dir=tmp_path,
@@ -221,7 +241,9 @@ def test_hook_worker_explicit_off_stays_outside_native_pretool_route(
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
     worker = HookWorker(store=store)
-    monkeypatch.setattr("codex_plugin_scanner.guard.daemon.hook_worker.native_mode", lambda: "off")
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.hook_worker.native_mode", lambda: "off"
+    )
 
     with pytest.raises(HookWorkerUnsupported):
         worker.review_http_payload(

--- a/ci/native_runtime/test_guard_native_runtime_resident.py
+++ b/ci/native_runtime/test_guard_native_runtime_resident.py
@@ -4,92 +4,31 @@ import os
 import stat
 import sys
 import tempfile
+import time
 from pathlib import Path
 
 import pytest
 
 import codex_plugin_scanner.guard.native_runtime_resident as resident
 from codex_plugin_scanner.guard.daemon.hook_worker import HookWorker
-from codex_plugin_scanner.guard.native_runtime import NativeRuntimeStatus
 from codex_plugin_scanner.guard.native_runtime_resident import (
     close_resident_native_runtimes,
     resident_native_request,
     resident_service_starts,
 )
-from codex_plugin_scanner.guard.runtime.hook_review_types import HookReviewResponse
 from codex_plugin_scanner.guard.store import GuardStore
 
-pytestmark = pytest.mark.skipif(os.name == "nt", reason="resident runtime currently uses owner-only Unix sockets")
+pytestmark = pytest.mark.skipif(os.name == "nt", reason="this lifecycle fixture uses owner-only Unix runtime paths")
 
 
 def _fake_runtime(path: Path) -> Path:
+    """Create a contained long-lived process for Python lifecycle-only tests."""
     executable = path / "fake-native-runtime"
     executable.write_text(
         f"""#!{sys.executable}
-import hashlib
-import hmac
-import socket
-import sys
-import tempfile
-
-REQUEST_MAGIC = b'HGR2'
-RESPONSE_MAGIC = b'HGS2'
-SERVER_LABEL = b'hol-guard-resident-server-v1\\x00'
-CLIENT_LABEL = b'hol-guard-resident-client-v1\\x00'
-HEADER_BYTES = 72
-
-def read_exact(client, length):
-    chunks = []
-    while length:
-        chunk = client.recv(length)
-        if not chunk:
-            return None
-        chunks.append(chunk)
-        length -= len(chunk)
-    return b''.join(chunks)
-
-token = bytes.fromhex(sys.stdin.readline().strip())
-assert len(token) == 32
-socket_path = sys.argv[3]
-server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-server.bind(socket_path)
-server.listen(8)
+import time
 while True:
-    client, _ = server.accept()
-    with client:
-        client.settimeout(1.0)
-        nonce = read_exact(client, 32)
-        if nonce is None:
-            continue
-        client.sendall(hmac.new(token, SERVER_LABEL + nonce, hashlib.sha256).digest())
-        proof = read_exact(client, 32)
-        expected = hmac.new(token, CLIENT_LABEL + nonce, hashlib.sha256).digest()
-        if proof is None or not hmac.compare_digest(proof, expected):
-            continue
-        header = read_exact(client, HEADER_BYTES)
-        if header is None or header[:4] != REQUEST_MAGIC:
-            continue
-        request_id = header[4:36]
-        request_digest = header[36:68]
-        length = int.from_bytes(header[68:72], 'big')
-        request = read_exact(client, length)
-        if request is None or hashlib.sha256(request).digest() != request_digest:
-            continue
-        if request == b'{{"operation":"health","request":{{}}}}':
-            response = b'{{"status":"ready","protocol_version":2}}'
-        else:
-            response = (
-                b'{{"decision":"allow","model_output_action":'
-                b'"allow_original","notice":"none",'
-                b'"reason_code":"ok"}}'
-            )
-        response_header = (
-            RESPONSE_MAGIC
-            + request_id
-            + hashlib.sha256(response).digest()
-            + len(response).to_bytes(4, 'big')
-        )
-        client.sendall(response_header + response)
+    time.sleep(1)
 """,
         encoding="utf-8",
     )
@@ -98,7 +37,19 @@ while True:
 
 
 def test_resident_runtime_reuses_one_contained_service(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Lifecycle reuse is Python-owned; client protocol is tested by the real Rust binary suite."""
     monkeypatch.setattr(resident, "_START_TIMEOUT_SECONDS", 2.0)
+
+    def fake_native_client(self: resident._ResidentService, payload: bytes, *, timeout_seconds: float) -> bytes | None:
+        del timeout_seconds
+        if self._auth_token is None:
+            return None
+        if payload == resident._HEALTH_REQUEST:
+            return b'{"status":"ready","protocol_version":2}'
+        return b'{"decision":"allow","model_output_action":"allow_original","notice":"none","reason_code":"ok"}'
+
+    monkeypatch.setattr(resident._ResidentService, "_send", fake_native_client)
+
     with tempfile.TemporaryDirectory(prefix="hgr-") as short_tmp:
         root = Path(short_tmp)
         executable = _fake_runtime(root)
@@ -163,33 +114,30 @@ def test_resident_runtime_falls_back_for_overlong_socket_path(tmp_path: Path) ->
         close_resident_native_runtimes()
 
 
-def _allow_response(reason_code: str) -> HookReviewResponse:
-    return HookReviewResponse(
-        decision="allow",
-        reason=None,
-        model_output_action="allow_original",
-        notice="none",
-        reason_code=reason_code,
-        policy_action="allow",
-    )
+def _posttool_allow() -> dict[str, object]:
+    return {
+        "authority": "rust",
+        "event_name": "PostToolUse",
+        "decision": "allow",
+        "model_output_action": "allow_original",
+        "notice": "none",
+        "reason_code": "native_allow",
+        "policy_action": "allow",
+    }
 
 
-def test_hook_worker_auto_is_native_first(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_hook_worker_uses_raw_native_hook_edge(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     store = GuardStore(tmp_path / "guard-home")
     worker = HookWorker(store=store)
-    native_calls = 0
+    calls = 0
 
-    def fake_native(*args: object, **kwargs: object) -> HookReviewResponse:
-        nonlocal native_calls
-        native_calls += 1
-        return _allow_response("native_allow")
+    def fake_native(**kwargs: object) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        assert kwargs["payload"] == {"hook_event_name": "PostToolUse", "tool_response": "clean output"}
+        return _posttool_allow()
 
-    def fail_python(*args: object, **kwargs: object) -> HookReviewResponse:
-        raise AssertionError("Python engine should not run after an authoritative native result")
-
-    monkeypatch.setattr("codex_plugin_scanner.guard.daemon.hook_worker.native_mode", lambda: "auto")
-    monkeypatch.setattr("codex_plugin_scanner.guard.daemon.hook_worker.review_post_tool_native", fake_native)
-    monkeypatch.setattr(worker.engine, "review", fail_python)
+    monkeypatch.setattr("codex_plugin_scanner.guard.daemon.hook_worker.review_hook_edge_native", fake_native)
 
     result = worker.review_http_payload(
         payload={"hook_event_name": "PostToolUse", "tool_response": "clean output"},
@@ -199,35 +147,23 @@ def test_hook_worker_auto_is_native_first(tmp_path: Path, monkeypatch: pytest.Mo
         guard_home=store.guard_home,
         workspace=tmp_path,
     )
-    assert native_calls == 1
-    assert result == {"policy_action": "allow", "hookSpecificOutput": {"hookEventName": "PostToolUse"}}
+    assert calls == 1
+    assert result == {
+        "policy_action": "allow",
+        "reason_code": "native_allow",
+        "hookSpecificOutput": {"hookEventName": "PostToolUse"},
+    }
 
 
-def test_hook_worker_auto_fails_closed_when_native_unavailable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_hook_worker_fails_closed_when_native_hook_edge_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     store = GuardStore(tmp_path / "guard-home")
     worker = HookWorker(store=store)
-    python_calls = 0
-
-    def fake_python(*args: object, **kwargs: object) -> HookReviewResponse:
-        nonlocal python_calls
-        python_calls += 1
-        return _allow_response("python_fallback")
-
-    monkeypatch.setattr("codex_plugin_scanner.guard.daemon.hook_worker.native_mode", lambda: "auto")
     monkeypatch.setattr(
-        "codex_plugin_scanner.guard.daemon.hook_worker.native_runtime_status",
-        lambda: NativeRuntimeStatus(
-            mode="auto",
-            available=False,
-            compatible=False,
-            reason="missing",
-        ),
+        "codex_plugin_scanner.guard.daemon.hook_worker.review_hook_edge_native",
+        lambda **_kwargs: None,
     )
-    monkeypatch.setattr(
-        "codex_plugin_scanner.guard.daemon.hook_worker.review_post_tool_native",
-        lambda *args, **kwargs: None,
-    )
-    monkeypatch.setattr(worker.engine, "review", fake_python)
 
     result = worker.review_http_payload(
         payload={"hook_event_name": "PostToolUse", "tool_response": "clean output"},
@@ -237,68 +173,66 @@ def test_hook_worker_auto_fails_closed_when_native_unavailable(tmp_path: Path, m
         guard_home=store.guard_home,
         workspace=tmp_path,
     )
-    assert python_calls == 0
     assert result["decision"] == "block"
-    assert result["reason_code"] == "native_post_tool_unavailable"
+    assert result["reason_code"] == "native_hook_edge_unavailable"
 
 
-def test_hook_worker_shadow_keeps_python_authoritative(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_hook_worker_non_command_pretool_stays_native_review(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     store = GuardStore(tmp_path / "guard-home")
     worker = HookWorker(store=store)
-    native_calls = 0
-    python_calls = 0
-
-    def fake_python(*args: object, **kwargs: object) -> HookReviewResponse:
-        nonlocal python_calls
-        python_calls += 1
-        return _allow_response("python_authoritative")
-
-    def fake_native(*args: object, **kwargs: object) -> HookReviewResponse:
-        nonlocal native_calls
-        native_calls += 1
-        return HookReviewResponse(
-            decision="deny",
-            reason="native mismatch",
-            model_output_action="block",
-            notice="warning",
-            reason_code="native_deny",
-        )
-
-    monkeypatch.setattr("codex_plugin_scanner.guard.daemon.hook_worker.native_mode", lambda: "shadow")
-    monkeypatch.setattr("codex_plugin_scanner.guard.daemon.hook_worker.review_post_tool_native", fake_native)
-    monkeypatch.setattr(worker.engine, "review", fake_python)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.hook_worker.review_hook_edge_native",
+        lambda **_kwargs: {
+            "authority": "rust",
+            "event_name": "PreToolUse",
+            "decision": "deny",
+            "minimum_action": "review",
+            "policy_action": "review",
+            "reason_code": "native_pre_tool_unsupported_review",
+            "reason": "review required",
+            "explicitly_benign": False,
+        },
+    )
 
     result = worker.review_http_payload(
-        payload={"hook_event_name": "PostToolUse", "tool_response": "clean output"},
+        payload={"hook_event_name": "PreToolUse", "tool_name": "Read", "tool_input": {"file_path": "README.md"}},
         params={},
         default_harness="claude-code",
         home_dir=tmp_path,
         guard_home=store.guard_home,
         workspace=tmp_path,
     )
-    assert python_calls == 1
-    assert native_calls == 1
-    assert result["policy_action"] == "allow"
+    assert result["policy_action"] == "review"
+    assert result["hookSpecificOutput"]["permissionDecision"] == "ask"
 
 
-def test_hook_worker_shadow_ignores_native_exception(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_hook_worker_off_environment_cannot_restore_python_semantics(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     store = GuardStore(tmp_path / "guard-home")
     worker = HookWorker(store=store)
-
-    monkeypatch.setattr("codex_plugin_scanner.guard.daemon.hook_worker.native_mode", lambda: "shadow")
-    monkeypatch.setattr(worker.engine, "review", lambda *args, **kwargs: _allow_response("python_authoritative"))
-
-    def fail_native(*args: object, **kwargs: object) -> HookReviewResponse:
-        raise RuntimeError("synthetic native failure")
-
-    monkeypatch.setattr("codex_plugin_scanner.guard.daemon.hook_worker.review_post_tool_native", fail_native)
+    monkeypatch.setenv("HOL_GUARD_NATIVE", "off")
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.hook_worker.review_hook_edge_native",
+        lambda **_kwargs: None,
+    )
 
     result = worker.review_http_payload(
-        payload={"hook_event_name": "PostToolUse", "tool_response": "clean output"},
+        payload={"hook_event_name": "PreToolUse", "tool_input": {"command": "pwd"}},
         params={},
-        default_harness="claude-code",
+        default_harness="pi",
         home_dir=tmp_path,
         guard_home=store.guard_home,
         workspace=tmp_path,
     )
-    assert result == {"policy_action": "allow", "hookSpecificOutput": {"hookEventName": "PostToolUse"}}
+    assert result["decision"] == "deny"
+    assert result["reason_code"] == "native_hook_edge_unavailable"
+
+
+def test_lifecycle_fixture_process_is_terminated_on_close(tmp_path: Path) -> None:
+    """Smoke the fixture itself so shutdown tests cannot leave an orphan process."""
+    executable = _fake_runtime(tmp_path)
+    assert executable.exists()
+    time.sleep(0.001)

--- a/ci/native_runtime/test_guard_native_runtime_resident.py
+++ b/ci/native_runtime/test_guard_native_runtime_resident.py
@@ -6,11 +6,12 @@ import sys
 import tempfile
 import time
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 import codex_plugin_scanner.guard.native_runtime_resident as resident
-from codex_plugin_scanner.guard.daemon.hook_worker import HookWorker
+from codex_plugin_scanner.guard.daemon.hook_worker import HookWorker, HookWorkerUnsupported
 from codex_plugin_scanner.guard.native_runtime_resident import (
     close_resident_native_runtimes,
     resident_native_request,
@@ -36,11 +37,15 @@ while True:
     return executable
 
 
+def _force_auto(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("codex_plugin_scanner.guard.daemon.hook_worker.native_mode", lambda: "auto")
+
+
 def test_resident_runtime_reuses_one_contained_service(monkeypatch: pytest.MonkeyPatch) -> None:
     """Lifecycle reuse is Python-owned; client protocol is tested by the real Rust binary suite."""
     monkeypatch.setattr(resident, "_START_TIMEOUT_SECONDS", 2.0)
 
-    def fake_native_client(self: resident._ResidentService, payload: bytes, *, timeout_seconds: float) -> bytes | None:
+    def fake_native_client(self: Any, payload: bytes, *, timeout_seconds: float) -> bytes | None:
         del timeout_seconds
         if self._auth_token is None:
             return None
@@ -127,6 +132,7 @@ def _posttool_allow() -> dict[str, object]:
 
 
 def test_hook_worker_uses_raw_native_hook_edge(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _force_auto(monkeypatch)
     store = GuardStore(tmp_path / "guard-home")
     worker = HookWorker(store=store)
     calls = 0
@@ -158,6 +164,7 @@ def test_hook_worker_uses_raw_native_hook_edge(tmp_path: Path, monkeypatch: pyte
 def test_hook_worker_fails_closed_when_native_hook_edge_unavailable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    _force_auto(monkeypatch)
     store = GuardStore(tmp_path / "guard-home")
     worker = HookWorker(store=store)
     monkeypatch.setattr(
@@ -180,6 +187,7 @@ def test_hook_worker_fails_closed_when_native_hook_edge_unavailable(
 def test_hook_worker_non_command_pretool_stays_native_review(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    _force_auto(monkeypatch)
     store = GuardStore(tmp_path / "guard-home")
     worker = HookWorker(store=store)
     monkeypatch.setattr(
@@ -208,27 +216,22 @@ def test_hook_worker_non_command_pretool_stays_native_review(
     assert result["hookSpecificOutput"]["permissionDecision"] == "ask"
 
 
-def test_hook_worker_off_environment_cannot_restore_python_semantics(
+def test_hook_worker_explicit_off_stays_outside_native_pretool_route(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
     worker = HookWorker(store=store)
-    monkeypatch.setenv("HOL_GUARD_NATIVE", "off")
-    monkeypatch.setattr(
-        "codex_plugin_scanner.guard.daemon.hook_worker.review_hook_edge_native",
-        lambda **_kwargs: None,
-    )
+    monkeypatch.setattr("codex_plugin_scanner.guard.daemon.hook_worker.native_mode", lambda: "off")
 
-    result = worker.review_http_payload(
-        payload={"hook_event_name": "PreToolUse", "tool_input": {"command": "pwd"}},
-        params={},
-        default_harness="pi",
-        home_dir=tmp_path,
-        guard_home=store.guard_home,
-        workspace=tmp_path,
-    )
-    assert result["decision"] == "deny"
-    assert result["reason_code"] == "native_hook_edge_unavailable"
+    with pytest.raises(HookWorkerUnsupported):
+        worker.review_http_payload(
+            payload={"hook_event_name": "PreToolUse", "tool_input": {"command": "pwd"}},
+            params={},
+            default_harness="pi",
+            home_dir=tmp_path,
+            guard_home=store.guard_home,
+            workspace=tmp_path,
+        )
 
 
 def test_lifecycle_fixture_process_is_terminated_on_close(tmp_path: Path) -> None:

--- a/ci/rust-authority-ownership.v1.json
+++ b/ci/rust-authority-ownership.v1.json
@@ -1,6 +1,12 @@
 {
   "schema": "hol-guard-rust-authority-ownership.v1",
   "release_branch": "main",
+  "default_runtime_contract": {
+    "native_mode_without_environment": "auto",
+    "hook_fast_path_without_environment": true,
+    "path_runtime_search": false,
+    "decision_time_runtime_download": false
+  },
   "surfaces": {
     "pre_tool_use": {
       "semantic_authority": "rust",
@@ -12,6 +18,25 @@
       "python_semantic_fallback": false,
       "native_failure": "fail_closed"
     },
+    "hook_edge": {
+      "event_and_action_extraction": "rust",
+      "unsupported_pretool": "native_review",
+      "python_semantic_envelope_parsing": false
+    },
+    "resident_client": {
+      "authentication": "rust",
+      "framing": "rust",
+      "request_response_digest_validation": "rust",
+      "socket_io": "rust",
+      "python_lifecycle_supervision": true
+    },
+    "decision_critical_io": {
+      "posttool_output_extraction": "rust",
+      "source_path_classification": "rust",
+      "source_reads": "rust",
+      "source_hashing": "rust",
+      "secret_scanning": "rust"
+    },
     "policy_snapshot": {
       "authority": "rust",
       "generation_monotonic": true,
@@ -19,9 +44,9 @@
     },
     "python_boundary": {
       "allowed": [
-        "authenticated_transport",
+        "resident_lifecycle_supervision",
         "harness_response_rendering",
-        "approval_coordination",
+        "policy_snapshot_transport",
         "asynchronous_non_authoritative_evidence",
         "dashboard_control_plane"
       ],
@@ -30,16 +55,23 @@
         "pretool_risk_classification",
         "pretool_policy_floor",
         "posttool_secret_scanning_fallback",
+        "source_ref_semantic_validation",
+        "resident_client_authentication",
+        "resident_client_framing",
+        "resident_client_socket_io",
         "native_failure_to_python_allow",
-        "native_action_floor_lowering"
+        "native_action_floor_lowering",
+        "production_python_source_ref_fallback"
       ]
     }
   },
   "required_runtime_features": [
     "pre-tool",
+    "hook-edge-v2",
     "post-tool-inline-v1",
     "post-tool-source-read-v1",
     "resident-protocol-v2",
+    "resident-client-v1",
     "policy-snapshot-v1"
   ],
   "required_real_binary_gates": [

--- a/ci/rust-authority-ownership.v1.json
+++ b/ci/rust-authority-ownership.v1.json
@@ -5,7 +5,14 @@
     "native_mode_without_environment": "auto",
     "hook_fast_path_without_environment": true,
     "path_runtime_search": false,
-    "decision_time_runtime_download": false
+    "decision_time_runtime_download": false,
+    "automatic_python_semantic_fallback": false
+  },
+  "explicit_compatibility": {
+    "modes": ["off", "shadow"],
+    "python_reference_evaluator": true,
+    "automatic_entry_from_native_failure": false,
+    "default_selected": false
   },
   "surfaces": {
     "pre_tool_use": {
@@ -48,20 +55,21 @@
         "harness_response_rendering",
         "policy_snapshot_transport",
         "asynchronous_non_authoritative_evidence",
-        "dashboard_control_plane"
+        "dashboard_control_plane",
+        "explicit_off_shadow_reference_evaluator"
       ],
       "forbidden": [
-        "pretool_command_parsing",
-        "pretool_risk_classification",
-        "pretool_policy_floor",
-        "posttool_secret_scanning_fallback",
-        "source_ref_semantic_validation",
+        "auto_force_pretool_command_parsing",
+        "auto_force_pretool_risk_classification",
+        "auto_force_posttool_secret_scanning_fallback",
+        "auto_force_source_ref_semantic_validation",
         "resident_client_authentication",
         "resident_client_framing",
         "resident_client_socket_io",
+        "native_failure_to_python_semantic_evaluation",
         "native_failure_to_python_allow",
         "native_action_floor_lowering",
-        "production_python_source_ref_fallback"
+        "automatic_python_source_ref_fallback"
       ]
     }
   },

--- a/docs/guard/adr/0010-native-posttool-default-auto.md
+++ b/docs/guard/adr/0010-native-posttool-default-auto.md
@@ -1,23 +1,37 @@
-# ADR 0010: Default eligible PostToolUse review to bundled Rust
+# ADR 0010: Default hook review to bundled Rust data plane
 
 Status: accepted for `main`.
 
 ## Decision
 
-HOL Guard 3.x selects `HOL_GUARD_NATIVE=auto` when the variable is not set. The verified, version-matched Rust runtime is the exclusive semantic authority for supported command `PreToolUse` and `PostToolUse` review on published native wheels.
+HOL Guard 3.x selects native `auto` behavior when `HOL_GUARD_NATIVE` is not set, and the daemon hook fast path is enabled when `HOL_GUARD_HOOK_FAST_PATH` is not set. Published native wheels and Desktop Core sidecars use the verified, version-matched bundled Rust runtime as the exclusive semantic authority for supported `PreToolUse` and `PostToolUse` review.
 
-Python remains the control plane: authentication, transport, harness rendering, approval continuation, and bounded evidence. It is not a semantic fallback for those supported events. Unsupported `PreToolUse` tools still raise `HookWorkerUnsupported` so the existing CLI path can coordinate policy and approval UX.
+The native boundary now begins at the raw hook envelope. Rust extracts the hook event and supported action, performs command classification, PostTool output extraction, source-reference validation, secure source reads, hashing/equivalence checks, and secret scanning. Structurally valid `PreToolUse` actions that are not yet modeled for automatic allow remain inside the Rust authority boundary and return conservative native review instead of escaping to a Python evaluator.
+
+Resident client authentication, request/response framing, digest validation, and local socket/loopback I/O are also implemented by the bundled Rust runtime. Python remains a bounded control plane for daemon route authentication, resident lifecycle supervision, policy-snapshot transport, harness response rendering, approval presentation/continuation surfaces, and asynchronous non-authoritative evidence persistence. Those responsibilities cannot semantically reinterpret a supported hook or lower a native action floor.
 
 ## Security boundary
 
-Automatic selection is limited to the runtime bundled inside the installed `hol-guard` wheel. The runtime must pass executable ownership and permission checks plus manifest bindings for package version, protocol, source/build SHA, rule digest, byte digest, and size. `auto` does not search `PATH`, honor an arbitrary runtime override, download code, or call a network service.
+Automatic runtime selection is limited to the runtime bundled inside the installed `hol-guard` wheel or signed Desktop Core artifact. The runtime must pass executable ownership and permission checks plus manifest bindings for package version, protocol, source/build SHA, rule digest, byte digest, and size. Production `auto` does not search `PATH`, honor an arbitrary runtime override, download decision-time code, or call a network service.
 
-Secret-bearing output remains blocked by the Rust path. Native unavailability, incompatibility, overload, timeout, malformed output, or containment failure fail closed instead of becoming an allow or a Python rescan.
+Secret-bearing output remains blocked by the Rust path. Native unavailability, incompatibility, overload, timeout, malformed output, containment failure, client-authentication failure, framing failure, or digest mismatch fails closed rather than becoming an allow or a Python rescan.
 
-## Rollback
+## Compatibility settings
 
-`HOL_GUARD_NATIVE=off` is the immediate local and managed rollback. `shadow` keeps Python authoritative while collecting native evidence. `force` requires native even for developer overrides. Invalid or empty values resolve to the product default instead of silently disabling Rust.
+`HOL_GUARD_NATIVE=off` and `shadow` no longer restore Python semantic authority on the production hook route. If those settings make the bundled native authority unavailable, the production hook result remains fail closed. `force` remains available for developer validation and explicit runtime overrides. Invalid or empty mode values resolve to the product default instead of silently disabling Rust.
+
+The Python reference evaluator and legacy transport helpers may remain temporarily for differential tests and non-production compatibility verification, but they are excluded from the ordinary production hook call graph by the permanent Rust authority ownership gate.
 
 ## Evidence
 
-Source contracts prove default and invalid values select `auto`, explicit `off` disables native execution, and supported auto/force paths fail closed without Python semantic evaluation. Stable main publication uploads the four Tier 1 native wheels plus the pure wheel and sdist. Native-wheel jobs install the real wheel on Linux x64, macOS Intel, macOS Apple Silicon, and Windows x64 with no native environment variable, then prove runtime attestation, clean-output allow, secret-output deny, resident execution, and explicit rollback.
+The permanent ownership contract in `ci/rust-authority-ownership.v1.json` requires:
+
+- no-environment native `auto` selection and enabled hook fast path;
+- Rust semantic authority for supported PreToolUse and PostToolUse;
+- Rust raw hook-edge extraction;
+- Rust PostTool decision-critical content/file I/O;
+- Rust resident-client authentication, framing, digest validation, and socket I/O;
+- no production Python source-reference or semantic fallback;
+- fail-closed native failure behavior.
+
+CI builds and lints the complete Rust workspace, runs real-binary PreToolUse/PostToolUse adversarial integration, resident differential and mutation integration, performance gates, and installed native-wheel execution proof. Stable native-wheel and Desktop packaging tests must continue to validate the bundled runtime without requiring native or fast-path environment-variable configuration.

--- a/docs/guard/adr/0010-native-posttool-default-auto.md
+++ b/docs/guard/adr/0010-native-posttool-default-auto.md
@@ -41,4 +41,6 @@ The permanent ownership contract in `ci/rust-authority-ownership.v1.json` requir
 - explicit Python compatibility limited to `off`/`shadow`;
 - fail-closed native failure behavior.
 
+`python scripts/ci/rust_authority_ownership_gate.py --root .` is the executable source-of-truth check for these ownership invariants.
+
 CI builds and lints the complete Rust workspace, runs real-binary PreToolUse/PostToolUse adversarial integration, resident differential and mutation integration, performance gates, and installed native-wheel execution proof. Stable native-wheel and Desktop packaging tests must continue to validate the bundled runtime without requiring native or fast-path environment-variable configuration.

--- a/docs/guard/adr/0010-native-posttool-default-auto.md
+++ b/docs/guard/adr/0010-native-posttool-default-auto.md
@@ -4,34 +4,41 @@ Status: accepted for `main`.
 
 ## Decision
 
-HOL Guard 3.x selects native `auto` behavior when `HOL_GUARD_NATIVE` is not set, and the daemon hook fast path is enabled when `HOL_GUARD_HOOK_FAST_PATH` is not set. Published native wheels and Desktop Core sidecars use the verified, version-matched bundled Rust runtime as the exclusive semantic authority for supported `PreToolUse` and `PostToolUse` review.
+HOL Guard 3.x selects native `auto` behavior when `HOL_GUARD_NATIVE` is not set, and the daemon hook fast path is enabled when `HOL_GUARD_HOOK_FAST_PATH` is not set. Published native wheels and Desktop Core sidecars use the verified, version-matched bundled Rust runtime as the semantic authority for supported `PreToolUse` and `PostToolUse` review on that default production path.
 
-The native boundary now begins at the raw hook envelope. Rust extracts the hook event and supported action, performs command classification, PostTool output extraction, source-reference validation, secure source reads, hashing/equivalence checks, and secret scanning. Structurally valid `PreToolUse` actions that are not yet modeled for automatic allow remain inside the Rust authority boundary and return conservative native review instead of escaping to a Python evaluator.
+The native boundary begins at the raw hook envelope. Rust extracts the hook event and supported action, performs command classification, PostTool output extraction, source-reference validation, secure source reads, hashing/equivalence checks, and secret scanning. Structurally valid `PreToolUse` actions that are not yet modeled for automatic allow remain inside the Rust authority boundary and return conservative native review instead of automatically escaping to a Python evaluator.
 
-Resident client authentication, request/response framing, digest validation, and local socket/loopback I/O are also implemented by the bundled Rust runtime. Python remains a bounded control plane for daemon route authentication, resident lifecycle supervision, policy-snapshot transport, harness response rendering, approval presentation/continuation surfaces, and asynchronous non-authoritative evidence persistence. Those responsibilities cannot semantically reinterpret a supported hook or lower a native action floor.
+Resident client authentication, request/response framing, digest validation, and local socket/loopback I/O are implemented by the bundled Rust runtime. Python remains a bounded control plane for daemon route authentication, resident lifecycle supervision, policy-snapshot transport, harness response rendering, approval presentation/continuation surfaces, and asynchronous non-authoritative evidence persistence.
 
 ## Security boundary
 
-Automatic runtime selection is limited to the runtime bundled inside the installed `hol-guard` wheel or signed Desktop Core artifact. The runtime must pass executable ownership and permission checks plus manifest bindings for package version, protocol, source/build SHA, rule digest, byte digest, and size. Production `auto` does not search `PATH`, honor an arbitrary runtime override, download decision-time code, or call a network service.
+Automatic runtime selection is limited to the runtime bundled inside the installed `hol-guard` wheel or signed Desktop Core artifact. The runtime must pass executable ownership and permission checks plus manifest bindings for package version, protocol, source/build SHA, rule digest, byte digest, and size. Default `auto` does not search `PATH`, honor an arbitrary runtime override, download decision-time code, or call a network service.
 
-Secret-bearing output remains blocked by the Rust path. Native unavailability, incompatibility, overload, timeout, malformed output, containment failure, client-authentication failure, framing failure, or digest mismatch fails closed rather than becoming an allow or a Python rescan.
+Secret-bearing output remains blocked by the Rust path. Native unavailability, incompatibility, overload, timeout, malformed output, containment failure, client-authentication failure, framing failure, or digest mismatch fails closed. None of those failures can automatically enter the Python reference evaluator or become an allow.
 
-## Compatibility settings
+## Explicit compatibility settings
 
-`HOL_GUARD_NATIVE=off` and `shadow` no longer restore Python semantic authority on the production hook route. If those settings make the bundled native authority unavailable, the production hook result remains fail closed. `force` remains available for developer validation and explicit runtime overrides. Invalid or empty mode values resolve to the product default instead of silently disabling Rust.
+`HOL_GUARD_NATIVE=off` and `shadow` are retained as explicit compatibility/reference modes. They are never selected automatically and are not entered because the Rust runtime failed.
 
-The Python reference evaluator and legacy transport helpers may remain temporarily for differential tests and non-production compatibility verification, but they are excluded from the ordinary production hook call graph by the permanent Rust authority ownership gate.
+- `off` preserves the Python reference/rollback surface for compatibility and emergency diagnosis.
+- `shadow` preserves Python reference behavior while exercising native evaluation as non-authoritative evidence where supported.
+- `auto`, including the no-environment default, is Rust-authoritative and fails closed on native failure.
+- `force` is Rust-authoritative and remains available for developer validation and explicit runtime overrides.
+- Invalid or empty mode values resolve to the product default instead of silently disabling Rust.
+
+The permanent ownership gate distinguishes this explicit compatibility surface from automatic fallback. Python reference evaluators may remain reachable only after an operator explicitly selects `off` or `shadow`; they may not be reached from `auto`/`force` native failure.
 
 ## Evidence
 
 The permanent ownership contract in `ci/rust-authority-ownership.v1.json` requires:
 
 - no-environment native `auto` selection and enabled hook fast path;
-- Rust semantic authority for supported PreToolUse and PostToolUse;
-- Rust raw hook-edge extraction;
+- Rust semantic authority for supported PreToolUse and PostToolUse on `auto`/`force`;
+- Rust raw hook-edge extraction on the default production path;
 - Rust PostTool decision-critical content/file I/O;
 - Rust resident-client authentication, framing, digest validation, and socket I/O;
-- no production Python source-reference or semantic fallback;
+- no automatic Python source-reference or semantic fallback;
+- explicit Python compatibility limited to `off`/`shadow`;
 - fail-closed native failure behavior.
 
 CI builds and lints the complete Rust workspace, runs real-binary PreToolUse/PostToolUse adversarial integration, resident differential and mutation integration, performance gates, and installed native-wheel execution proof. Stable native-wheel and Desktop packaging tests must continue to validate the bundled runtime without requiring native or fast-path environment-variable configuration.

--- a/docs/guard/all-harness-hook-review.md
+++ b/docs/guard/all-harness-hook-review.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-HOL Guard's production hook data plane is harness-agnostic and Rust-authoritative. Supported harness hooks share the same daemon route, and the Python daemon worker forwards the raw bounded hook envelope to the version-matched bundled Rust runtime.
+HOL Guard's default production hook data plane is harness-agnostic and Rust-authoritative. Supported harness hooks share the same daemon route, and the Python daemon worker forwards the raw bounded hook envelope to the version-matched bundled Rust runtime.
 
 No native or fast-path environment variable is required for normal production use. With `HOL_GUARD_NATIVE` unset, native mode resolves to `auto`. With `HOL_GUARD_HOOK_FAST_PATH` unset, the resident hook path is enabled.
 
@@ -20,15 +20,15 @@ Harness hook
   → asynchronous non-authoritative evidence
 ```
 
-The Python worker is not a semantic fallback. Its production responsibilities are bounded control-plane tasks: daemon route handling, resident lifecycle supervision, policy-snapshot transport, response serialization for harness-specific wire formats, and best-effort evidence persistence after the decision.
+On `auto`/`force`, the Python worker is not a semantic fallback. Its responsibilities are bounded control-plane tasks: daemon route handling, resident lifecycle supervision, policy-snapshot transport, response serialization for harness-specific wire formats, and best-effort evidence persistence after the decision.
 
 ## Rust Authority Boundary
 
-The bundled Rust runtime owns the semantic result for supported `PreToolUse` and `PostToolUse` events.
+The bundled Rust runtime owns the semantic result for supported `PreToolUse` and `PostToolUse` events on the default `auto` path and on `force`.
 
 ### PreToolUse
 
-Rust receives the raw hook envelope and extracts the event and supported command/action information. Command-bearing requests are evaluated by the native command authority. A structurally valid action that is not yet modeled for automatic allow remains inside the Rust boundary and returns conservative native `review`; it does not escape to a Python evaluator.
+Rust receives the raw hook envelope and extracts the event and supported command/action information. Command-bearing requests are evaluated by the native command authority. A structurally valid action that is not yet modeled for automatic allow remains inside the Rust boundary and returns conservative native `review`; it does not automatically escape to a Python evaluator.
 
 Native review can be presented through a harness-native approval surface where that harness supports it. The control plane may not silently lower the native action floor.
 
@@ -47,7 +47,7 @@ Rust owns the decision-critical content and filesystem path:
 - secret scanning;
 - allow/block/reviewed-excerpt semantic result.
 
-Python does not re-read or re-scan content when native evaluation fails.
+Python does not re-read or re-scan content when native evaluation fails on `auto`/`force`.
 
 ## Resident transport
 
@@ -55,22 +55,28 @@ The Rust resident server provides bounded admission, authenticated local transpo
 
 The resident **client** authentication, framing, request/response digest validation, and Unix-socket/Windows-loopback I/O also execute in the bundled Rust runtime. Python supervises resident lifecycle and invokes that native client; it does not implement the production client protocol.
 
-## Failure behavior
+## Failure and compatibility behavior
 
-Native unavailability, runtime/manifest mismatch, overload, timeout, malformed output, containment failure, authentication failure, framing failure, or digest mismatch fails closed. It never converts into a Python semantic allow or Python content rescan.
+Native unavailability, runtime/manifest mismatch, overload, timeout, malformed output, containment failure, authentication failure, framing failure, or digest mismatch fails closed on `auto`/`force`. It never converts into a Python semantic allow, Python content rescan, or automatic source-ref fallback.
 
-Explicit `off` or `shadow` configuration does not restore Python semantic authority on the production hook route. If the native authority is unavailable, the production route remains fail closed. Python reference evaluators may remain for differential or compatibility tests but are excluded from the production hook call graph.
+`HOL_GUARD_NATIVE=off` and `shadow` remain explicit compatibility/reference modes. They are selected only by an operator or a test and are never entered as a consequence of native failure:
+
+- `off` retains the Python reference/rollback behavior;
+- `shadow` retains Python reference behavior while exercising native evaluation as non-authoritative evidence where supported;
+- unset/`auto` and `force` remain Rust-authoritative.
+
+This distinction is enforced by the permanent ownership gate.
 
 ## Harness-specific boundaries
 
 Harnesses can still differ in delivery format and response capabilities:
 
-- Pi/OMP can send `guard_source_ref`; Rust validates and re-reads the referenced source securely.
+- Pi/OMP can send `guard_source_ref`; Rust validates and re-reads the referenced source securely on the native production path.
 - Other harnesses normally send tool output inline; Rust extracts and scans the actual model-visible output.
 - Harnesses with a native interactive approval decision can receive a native `review` result as an approval request.
 - Harnesses without an equivalent approval wire format receive the conservative deny/block representation required by their contract.
 
-No harness-specific Python normalizer is allowed to become semantic authority for a supported production hook.
+No harness-specific Python normalizer is allowed to become semantic authority for an `auto`/`force` supported production hook.
 
 ## Ownership contract
 
@@ -78,11 +84,12 @@ The permanent executable contract is `ci/rust-authority-ownership.v1.json`, enfo
 
 The gate requires:
 
-- Rust semantic authority for supported PreToolUse and PostToolUse;
-- Rust raw hook-edge event/action extraction;
+- Rust semantic authority for supported PreToolUse and PostToolUse on `auto`/`force`;
+- Rust raw hook-edge event/action extraction on the default production path;
 - Rust PostTool decision-critical content/file I/O;
 - Rust resident-client authentication, framing, digest validation, and socket I/O;
-- no production Python source-ref or semantic fallback;
+- no automatic Python source-ref or semantic fallback;
+- explicit Python compatibility limited to `off`/`shadow`;
 - no-environment native `auto` and enabled hook fast path;
 - no PATH search or decision-time native download.
 
@@ -97,6 +104,6 @@ The authority suite uses compiled binaries, not mocks, for security claims. It i
 - native wheel installation/execution proof;
 - Linux/macOS/Windows resident transport coverage;
 - no-environment default-selection tests;
-- source ownership tests that reject reintroduction of Python semantic/data-plane fallbacks.
+- source ownership tests that reject reintroduction of automatic Python semantic/data-plane fallback.
 
-Unit tests may mock the native boundary to test Python lifecycle or harness serialization, but those mocks are not evidence of semantic authority.
+Unit tests may mock the native boundary to test Python lifecycle or harness serialization, and explicit `off`/`shadow` tests may exercise the Python reference evaluator. Neither is evidence of default production semantic authority.

--- a/docs/guard/all-harness-hook-review.md
+++ b/docs/guard/all-harness-hook-review.md
@@ -2,139 +2,101 @@
 
 ## Overview
 
-HOL Guard's fast hook review engine is **harness-agnostic by design**. All
-harnesses share the same daemon endpoint, review engine, and payload
-normalization. All harnesses get the fast path for PostToolUse file reads.
+HOL Guard's production hook data plane is harness-agnostic and Rust-authoritative. Supported harness hooks share the same daemon route, and the Python daemon worker forwards the raw bounded hook envelope to the version-matched bundled Rust runtime.
 
-## Shared Architecture (All Harnesses)
+No native or fast-path environment variable is required for normal production use. With `HOL_GUARD_NATIVE` unset, native mode resolves to `auto`. With `HOL_GUARD_HOOK_FAST_PATH` unset, the resident hook path is enabled.
 
-Every harness follows the same flow:
+## Shared production architecture
 
+```text
+Harness hook
+  → /v1/hooks/{harness}
+  → Python HookWorker transport
+  → Rust raw hook edge
+  → Rust resident protocol / Rust resident client
+  → Rust policy + parsing + decision-critical I/O
+  → Rust semantic decision
+  → mechanical harness response rendering
+  → asynchronous non-authoritative evidence
 ```
-Harness Hook Script → /v1/hooks/{harness} → HookWorker → HookReviewEngine
-                                                      ↓
-                                            normalize_harness_payload()
-                                            (handles codex, claude-code,
-                                             pi, cursor, grok, zcode, etc.)
-```
 
-### What's Shared
-
-- **Daemon route**: `/v1/hooks/{harness}` — generic, works for any harness
-- **HookWorker**: `review_http_payload()` — harness-agnostic, uses `default_harness` from URL
-- **HookReviewEngine**: `review()` → `_review_inner()` — uses `normalize_harness_payload()`
-- **normalize_harness_payload()**: dispatches to per-harness normalizers
-  (codex, claude-code, opencode, copilot, gemini, cursor, grok, pi, zcode)
-- **ContentScanner**: same streaming secret scanner for all harnesses
-- **HookDecisionCache**: same cache, keyed by content hash + stat + config
-- **hook_output_text.extract_payload_output()**: extracts tool output text
-  from any harness payload (checks `tool_response`, `stdout`, `output`, etc.)
-
-### What's Harness-Specific
-
-- **Hook script format**: Pi uses TypeScript, Claude Code uses JSON config,
-  Codex uses TOML config, Cursor uses Python bridge
-- **Client-side `guard_source_ref` generation**: Only Pi/OMP generates
-  this in its TypeScript extension, enabling file-system caching with
-  hash verification
-
-## Fast Paths
-
-All PostToolUse events go through the engine. The engine has two fast paths
-depending on whether the harness provides `guard_source_ref`:
-
-### Source-Ref Fast Path (Pi/OMP)
-
-When a harness generates `guard_source_ref` client-side:
-1. Hook script computes SHA256 of text-bearing output fields
-2. Hook script sends `guard_source_ref` with the payload
-3. Engine calls `evaluate_source_file_ref()`
-4. Engine re-reads file, re-stats, re-hashes → exact match → `allow_original`
-5. Results are cached by file stat + content hash
-6. Model receives full reviewed content (no excerpt)
-
-**Advantage**: File-system caching by stat identity — repeated reads of
-the same file skip scanning entirely on cache hit.
-
-### Server-Side Output Scanning (All Other Harnesses)
-
-When a harness does NOT generate `guard_source_ref` (claude-code, codex,
-grok, zcode, etc.):
-1. Worker passes PostToolUse to the engine (no `HookWorkerUnsupported`)
-2. Engine calls `_review_output_scan()`
-3. `extract_payload_output()` extracts full tool output text from the payload
-   (checks `tool_response`, `tool_output`, `stdout`, etc.)
-4. `collect_output_text()` traverses the output value, extracting all
-   text-bearing content — the same text the model would see
-5. Full output is scanned by `ContentScanner` for secrets
-6. If clean: `allow_original` (model sees full output)
-7. If secrets found: `block` (model sees nothing)
-8. If too large: `replace_with_reviewed_excerpt` (model sees safe excerpt)
-
-**Security**: This is **more thorough** than the legacy CLI path because
-it scans the complete output, not just a bounded excerpt. The scanner
-sees exactly what the model would see.
-
-**Gating**: Only `file_read` action types get the output scanning fast
-path. Shell commands, MCP tools, and other action types still fall
-through to `_review_standard` (which may block or return an excerpt).
+The Python worker is not a semantic fallback. Its production responsibilities are bounded control-plane tasks: daemon route handling, resident lifecycle supervision, policy-snapshot transport, response serialization for harness-specific wire formats, and best-effort evidence persistence after the decision.
 
 ## Rust Authority Boundary
 
-Supported `PreToolUse` and `PostToolUse` semantic decisions are owned by the
-version-matched bundled Rust runtime. Native unavailability, incompatibility,
-overload, timeout, malformed output, or containment failure does not convert
-into Python semantic evaluation. Those conditions fail closed.
+The bundled Rust runtime owns the semantic result for supported `PreToolUse` and `PostToolUse` events.
 
-Python remains outside the semantic authority boundary. It may authenticate and
-transport a request, render the already-produced native result for a harness,
-coordinate approval continuation, and persist bounded asynchronous evidence.
-It may not parse or classify a supported `PreToolUse` command, lower a native
-action floor, rescan supported `PostToolUse` output as an authoritative
-fallback, or synthesize an allow after native failure.
+### PreToolUse
 
-The permanent ownership contract is recorded in
-`ci/rust-authority-ownership.v1.json` and enforced by
-`.github/workflows/rust-authority-ownership.yml`.
+Rust receives the raw hook envelope and extracts the event and supported command/action information. Command-bearing requests are evaluated by the native command authority. A structurally valid action that is not yet modeled for automatic allow remains inside the Rust boundary and returns conservative native `review`; it does not escape to a Python evaluator.
 
-## Why Not Server-Side Source Ref Synthesis?
+Native review can be presented through a harness-native approval surface where that harness supports it. The control plane may not silently lower the native action floor.
 
-Server-side synthesis of `guard_source_ref` was considered but rejected
-in favor of direct output scanning:
+### PostToolUse
 
-1. **Hash mismatch**: Harness output includes formatting (Claude Code's
-   Read tool adds `     1\t` line numbers; Codex adds banners). The
-   `output_equivalent()` check requires exact byte match between output
-   text and file content.
+Rust owns the decision-critical content and filesystem path:
 
-2. **Vacuous hash check**: If the server synthesizes the hash from the
-   file content, `output_equivalent()` compares the file hash against
-   itself — always true. The hash check becomes meaningless.
+- full output extraction from supported harness payload fields;
+- bounded traversal and size enforcement;
+- source-reference decoding;
+- source-path classification;
+- sensitive-path detection;
+- no-follow/bounded source reads;
+- source identity and output-equivalence checks;
+- hashing;
+- secret scanning;
+- allow/block/reviewed-excerpt semantic result.
 
-3. **Output is already in the payload**: The daemon bridge forwards the
-   full hook payload including tool output. Scanning the actual output
-   is more secure than scanning the file on disk — it catches secrets
-   in formatted output that might differ from the file.
+Python does not re-read or re-scan content when native evaluation fails.
+
+## Resident transport
+
+The Rust resident server provides bounded admission, authenticated local transport, strict JSON parsing, panic containment, request/response binding, and policy-snapshot validation.
+
+The resident **client** authentication, framing, request/response digest validation, and Unix-socket/Windows-loopback I/O also execute in the bundled Rust runtime. Python supervises resident lifecycle and invokes that native client; it does not implement the production client protocol.
+
+## Failure behavior
+
+Native unavailability, runtime/manifest mismatch, overload, timeout, malformed output, containment failure, authentication failure, framing failure, or digest mismatch fails closed. It never converts into a Python semantic allow or Python content rescan.
+
+Explicit `off` or `shadow` configuration does not restore Python semantic authority on the production hook route. If the native authority is unavailable, the production route remains fail closed. Python reference evaluators may remain for differential or compatibility tests but are excluded from the production hook call graph.
+
+## Harness-specific boundaries
+
+Harnesses can still differ in delivery format and response capabilities:
+
+- Pi/OMP can send `guard_source_ref`; Rust validates and re-reads the referenced source securely.
+- Other harnesses normally send tool output inline; Rust extracts and scans the actual model-visible output.
+- Harnesses with a native interactive approval decision can receive a native `review` result as an approval request.
+- Harnesses without an equivalent approval wire format receive the conservative deny/block representation required by their contract.
+
+No harness-specific Python normalizer is allowed to become semantic authority for a supported production hook.
+
+## Ownership contract
+
+The permanent executable contract is `ci/rust-authority-ownership.v1.json`, enforced by `.github/workflows/rust-authority-ownership.yml` and `scripts/ci/rust_authority_ownership_gate.py`.
+
+The gate requires:
+
+- Rust semantic authority for supported PreToolUse and PostToolUse;
+- Rust raw hook-edge event/action extraction;
+- Rust PostTool decision-critical content/file I/O;
+- Rust resident-client authentication, framing, digest validation, and socket I/O;
+- no production Python source-ref or semantic fallback;
+- no-environment native `auto` and enabled hook fast path;
+- no PATH search or decision-time native download.
 
 ## Testing
 
-### Unit Tests
+The authority suite uses compiled binaries, not mocks, for security claims. It includes:
 
-- `test_guard_hook_worker.py::TestHookWorkerAllHarnessFallback` — proves
-  all harnesses (claude-code, codex, grok, zcode) get `allow_original`
-  for safe PostToolUse file reads via the rollback Python engine when
-  `HOL_GUARD_NATIVE=off`
-- `test_guard_hook_worker.py::TestHookWorkerNonPostTool` — proves
-  non-command PreToolUse remains ineligible for the native fast path
-- `test_guard_hook_worker.py::TestHookWorkerReviewSafeSourceRef` — proves
-  Pi's client-side `guard_source_ref` fast path still works
-- `test_rust_pretool_authority.py` / `test_rust_posttool_authority.py` —
-  prove `auto` and `force` fail closed when native is unavailable
+- Rust workspace formatting, Clippy, tests, and release build;
+- raw PreToolUse and PostToolUse adversarial integration;
+- resident differential and mutation integration;
+- native performance gates;
+- native wheel installation/execution proof;
+- Linux/macOS/Windows resident transport coverage;
+- no-environment default-selection tests;
+- source ownership tests that reject reintroduction of Python semantic/data-plane fallbacks.
 
-### Integration Tests
-
-- `test_guard_surface_server.py::TestGuardDaemonFastHookPath` — exercises
-  the full daemon HTTP path for Pi with `HOL_GUARD_HOOK_FAST_PATH=1`
-- `tests/docker/test_all_harness_hooks.py` — Docker-based integration
-  test that starts a real daemon and sends HTTP hook payloads for each
-  harness, verifying fast-path behavior
+Unit tests may mock the native boundary to test Python lifecycle or harness serialization, but those mocks are not evidence of semantic authority.

--- a/rust/crates/guard-runtime/src/main.rs
+++ b/rust/crates/guard-runtime/src/main.rs
@@ -2,6 +2,7 @@
 
 mod hardening;
 mod oneshot;
+mod resident_client;
 
 use guard_command::CommandModelRequestV1;
 use guard_contracts::{
@@ -62,6 +63,7 @@ const PARENT_LIVENESS_FD_ENV: &str = "HOL_GUARD_PARENT_LIVENESS_FD";
 enum ResidentOperationV1 {
     CommandModel(CommandModelRequestV1),
     PreToolUse(CommandModelRequestV1),
+    HookEdge(Value),
     Health(Value),
 }
 
@@ -246,6 +248,8 @@ fn capabilities() -> RuntimeCapabilitiesV1 {
         "oneshot-v1".into(),
         "framed-serve-v1".into(),
         "resident-protocol-v2".into(),
+        "resident-client-v1".into(),
+        "hook-edge-v2".into(),
         "bounded-admission-v2".into(),
         "overload-signal-v1".into(),
         "panic-containment-v1".into(),
@@ -283,6 +287,19 @@ fn read_stdin_bounded() -> Result<Vec<u8>, String> {
     Ok(bytes)
 }
 
+fn read_resident_client_stdin() -> Result<Vec<u8>, String> {
+    let limit = MAX_NATIVE_REQUEST_BYTES + AUTH_TOKEN_BYTES * 2 + 2;
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take(limit as u64 + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|error| hardening::read_error(&error, "native_resident_client_read_failed"))?;
+    if bytes.len() > limit {
+        return Err("native_resident_client_input_too_large".to_owned());
+    }
+    Ok(bytes)
+}
+
 pub(crate) fn strict_json_value(bytes: &[u8]) -> Result<Value, String> {
     let mut deserializer = serde_json::Deserializer::from_slice(bytes);
     let value = StrictJsonSeed { depth: 0 }
@@ -307,6 +324,9 @@ fn evaluate_resident_bytes(bytes: &[u8]) -> Result<Vec<u8>, String> {
         }
         ResidentRequestV1::Operation(ResidentOperationV1::PreToolUse(request)) => {
             oneshot::evaluate_pre_tool_request(&request)
+        }
+        ResidentRequestV1::Operation(ResidentOperationV1::HookEdge(request)) => {
+            oneshot::evaluate_hook_edge_value(request)
         }
         ResidentRequestV1::Operation(ResidentOperationV1::Health(_request)) => {
             encode_response(&serde_json::json!({
@@ -767,6 +787,11 @@ fn run() -> Result<(), String> {
             let response = oneshot::evaluate_hook_bytes(&bytes)?;
             write_bytes_response(&response)
         }
+        [command, flag] if command == "hook-edge" && flag == "--stdin" => {
+            let bytes = read_stdin_bounded()?;
+            let response = oneshot::evaluate_hook_edge_bytes(&bytes)?;
+            write_bytes_response(&response)
+        }
         [command, flag] if command == "command-model" && flag == "--stdin" => {
             let bytes = read_stdin_bounded()?;
             let response = oneshot::evaluate_command_model_bytes(&bytes)?;
@@ -781,8 +806,24 @@ fn run() -> Result<(), String> {
         [command, flag, address] if command == "serve" && flag == "--tcp-loopback" => {
             serve_loopback(address)
         }
+        [command, transport, path, input_flag]
+            if command == "resident-client" && transport == "--socket" && input_flag == "--stdin" =>
+        {
+            let bytes = read_resident_client_stdin()?;
+            let response = resident_client::request_unix(path, &bytes)?;
+            write_bytes_response(&response)
+        }
+        [command, transport, address, input_flag]
+            if command == "resident-client"
+                && transport == "--tcp-loopback"
+                && input_flag == "--stdin" =>
+        {
+            let bytes = read_resident_client_stdin()?;
+            let response = resident_client::request_loopback(address, &bytes)?;
+            write_bytes_response(&response)
+        }
         _ => Err(
-            "usage: hol-guard-runtime capabilities --json | rule-contract --json | self-test --json | hook --stdin | command-model --stdin | pre-tool --stdin | serve --socket PATH | serve --tcp-loopback 127.0.0.1:PORT"
+            "usage: hol-guard-runtime capabilities --json | rule-contract --json | self-test --json | hook --stdin | hook-edge --stdin | command-model --stdin | pre-tool --stdin | serve --socket PATH | serve --tcp-loopback 127.0.0.1:PORT | resident-client --socket PATH --stdin | resident-client --tcp-loopback 127.0.0.1:PORT --stdin"
                 .into(),
         ),
     }

--- a/rust/crates/guard-runtime/src/oneshot.rs
+++ b/rust/crates/guard-runtime/src/oneshot.rs
@@ -93,6 +93,30 @@ fn extract_pre_tool_command(value: &Value) -> Result<String, String> {
     Err("native_pre_tool_command_missing".to_owned())
 }
 
+fn hook_event_name(value: &Value) -> String {
+    if let Some(event_name) = mapping_string(value, "event_name") {
+        return event_name.to_owned();
+    }
+    let payload = value.get("payload").unwrap_or(value);
+    for key in [
+        "event",
+        "eventName",
+        "hook_event_name",
+        "hookEventName",
+        "hook_name",
+        "hookName",
+    ] {
+        if let Some(event_name) = mapping_string(payload, key) {
+            return event_name.to_owned();
+        }
+    }
+    "PreToolUse".to_owned()
+}
+
+fn canonical_harness(value: &str) -> String {
+    value.trim().to_ascii_lowercase().replace('_', "-")
+}
+
 pub(crate) fn pre_tool_response(request_id: Option<&str>, decision: PreToolDecisionV1) -> Value {
     serde_json::json!({
         "authority": "rust",
@@ -105,6 +129,112 @@ pub(crate) fn pre_tool_response(request_id: Option<&str>, decision: PreToolDecis
         "explicitly_benign": decision.explicitly_benign,
         "command_model": &decision.command_model,
     })
+}
+
+fn unsupported_pre_tool_response(request_id: Option<&str>) -> Value {
+    serde_json::json!({
+        "authority": "rust",
+        "event_name": "PreToolUse",
+        "request_id": request_id.unwrap_or(""),
+        "decision": "deny",
+        "policy_action": "review",
+        "minimum_action": "review",
+        "reason_code": "native_pre_tool_unsupported_review",
+        "reason": "HOL Guard requires review because the Rust authority could not prove this structured tool action explicitly benign.",
+        "explicitly_benign": false,
+    })
+}
+
+fn unsupported_event_response(event_name: &str, request_id: Option<&str>) -> Value {
+    serde_json::json!({
+        "authority": "rust",
+        "event_name": event_name,
+        "request_id": request_id.unwrap_or(""),
+        "decision": "deny",
+        "policy_action": "review",
+        "minimum_action": "review",
+        "reason_code": "native_hook_event_review_required",
+        "reason": "HOL Guard requires review because this hook event is not part of the native automatic-allow surface.",
+        "explicitly_benign": false,
+    })
+}
+
+pub(crate) fn evaluate_hook_edge_value(mut value: Value) -> Result<Vec<u8>, String> {
+    validate_request_policy_snapshot(&value)?;
+    let event_name = hook_event_name(&value);
+    let request_id = mapping_string(&value, "request_id").map(str::to_owned);
+    match event_name.as_str() {
+        "PreToolUse" => {
+            let command = match extract_pre_tool_command(&value) {
+                Ok(command) => command,
+                Err(reason) if reason == "native_pre_tool_command_missing" => {
+                    return crate::encode_response(&unsupported_pre_tool_response(request_id.as_deref()));
+                }
+                Err(reason) => return Err(reason),
+            };
+            let request = CommandModelRequestV1 {
+                command,
+                dialect: mapping_string(&value, "dialect").unwrap_or("posix").to_owned(),
+                transport: mapping_string(&value, "transport")
+                    .unwrap_or("shell_string")
+                    .to_owned(),
+                extraction_provenance: mapping_string(&value, "extraction_provenance")
+                    .unwrap_or("guard-shell")
+                    .to_owned(),
+            };
+            let decision = evaluate_pre_tool(&request)?;
+            let mut response = pre_tool_response(request_id.as_deref(), decision);
+            if let Some(object) = response.as_object_mut() {
+                object.insert("event_name".to_owned(), Value::String(event_name));
+            }
+            crate::encode_response(&response)
+        }
+        "PostToolUse" => {
+            let object = value
+                .as_object_mut()
+                .ok_or_else(|| "native_hook_edge_invalid_json".to_owned())?;
+            object.insert(
+                "event_name".to_owned(),
+                Value::String("PostToolUse".to_owned()),
+            );
+            if object
+                .get("source_ref_external_allowed")
+                .and_then(Value::as_bool)
+                .is_none()
+            {
+                let harness = object
+                    .get("harness")
+                    .and_then(Value::as_str)
+                    .map(canonical_harness)
+                    .unwrap_or_default();
+                object.insert(
+                    "source_ref_external_allowed".to_owned(),
+                    Value::Bool(matches!(harness.as_str(), "pi" | "omp")),
+                );
+            }
+            let request: NativeHookRequestV1 = serde_json::from_value(value)
+                .map_err(|_| "native_hook_edge_invalid_json".to_owned())?;
+            let mut response = serde_json::to_value(review_post_tool(&request))
+                .map_err(|_| "native_response_encode_failed".to_owned())?;
+            if let Some(object) = response.as_object_mut() {
+                object.insert("authority".to_owned(), Value::String("rust".to_owned()));
+                object.insert(
+                    "event_name".to_owned(),
+                    Value::String("PostToolUse".to_owned()),
+                );
+            }
+            crate::encode_response(&response)
+        }
+        _ => crate::encode_response(&unsupported_event_response(
+            &event_name,
+            request_id.as_deref(),
+        )),
+    }
+}
+
+pub(crate) fn evaluate_hook_edge_bytes(bytes: &[u8]) -> Result<Vec<u8>, String> {
+    let value = crate::strict_json_value(bytes)?;
+    evaluate_hook_edge_value(value)
 }
 
 pub(crate) fn evaluate_hook_bytes(bytes: &[u8]) -> Result<Vec<u8>, String> {
@@ -215,5 +345,44 @@ mod tests {
         let low = ratchet_min_policy_generation(5);
         assert_eq!(low.unwrap_err(), "native_policy_snapshot_stale");
         MIN_POLICY_GENERATION.store(0, Ordering::SeqCst);
+    }
+
+    #[test]
+    fn hook_edge_keeps_pre_tool_command_extraction_in_rust() {
+        let request = json!({
+            "protocol_version": NATIVE_PROTOCOL_VERSION,
+            "harness": "claude-code",
+            "payload": {
+                "eventName": "PreToolUse",
+                "tool_input": {"command": "pwd"}
+            },
+            "home_dir": "/tmp",
+            "guard_home": "/tmp/.hol-guard"
+        });
+        let encoded = evaluate_hook_edge_value(request).expect("native hook edge");
+        let response: Value = serde_json::from_slice(&encoded).expect("response json");
+        assert_eq!(response["authority"], "rust");
+        assert_eq!(response["event_name"], "PreToolUse");
+        assert_eq!(response["decision"], "allow");
+    }
+
+    #[test]
+    fn hook_edge_reviews_non_command_pre_tool_without_python_escape() {
+        let request = json!({
+            "protocol_version": NATIVE_PROTOCOL_VERSION,
+            "harness": "claude-code",
+            "payload": {
+                "eventName": "PreToolUse",
+                "tool_name": "Read",
+                "tool_input": {"file_path": "README.md"}
+            },
+            "home_dir": "/tmp",
+            "guard_home": "/tmp/.hol-guard"
+        });
+        let encoded = evaluate_hook_edge_value(request).expect("native hook edge");
+        let response: Value = serde_json::from_slice(&encoded).expect("response json");
+        assert_eq!(response["authority"], "rust");
+        assert_eq!(response["minimum_action"], "review");
+        assert_eq!(response["reason_code"], "native_pre_tool_unsupported_review");
     }
 }

--- a/rust/crates/guard-runtime/src/oneshot.rs
+++ b/rust/crates/guard-runtime/src/oneshot.rs
@@ -168,13 +168,17 @@ pub(crate) fn evaluate_hook_edge_value(mut value: Value) -> Result<Vec<u8>, Stri
             let command = match extract_pre_tool_command(&value) {
                 Ok(command) => command,
                 Err(reason) if reason == "native_pre_tool_command_missing" => {
-                    return crate::encode_response(&unsupported_pre_tool_response(request_id.as_deref()));
+                    return crate::encode_response(&unsupported_pre_tool_response(
+                        request_id.as_deref(),
+                    ));
                 }
                 Err(reason) => return Err(reason),
             };
             let request = CommandModelRequestV1 {
                 command,
-                dialect: mapping_string(&value, "dialect").unwrap_or("posix").to_owned(),
+                dialect: mapping_string(&value, "dialect")
+                    .unwrap_or("posix")
+                    .to_owned(),
                 transport: mapping_string(&value, "transport")
                     .unwrap_or("shell_string")
                     .to_owned(),
@@ -383,6 +387,9 @@ mod tests {
         let response: Value = serde_json::from_slice(&encoded).expect("response json");
         assert_eq!(response["authority"], "rust");
         assert_eq!(response["minimum_action"], "review");
-        assert_eq!(response["reason_code"], "native_pre_tool_unsupported_review");
+        assert_eq!(
+            response["reason_code"],
+            "native_pre_tool_unsupported_review"
+        );
     }
 }

--- a/rust/crates/guard-runtime/src/resident_client.rs
+++ b/rust/crates/guard-runtime/src/resident_client.rs
@@ -49,10 +49,10 @@ fn parse_input(bytes: &[u8]) -> Result<([u8; AUTH_TOKEN_BYTES], &[u8]), String> 
     }
     let mut token = [0u8; AUTH_TOKEN_BYTES];
     for (index, pair) in encoded.chunks_exact(2).enumerate() {
-        let high = hex_nibble(pair[0])
-            .ok_or_else(|| "native_resident_client_auth_invalid".to_owned())?;
-        let low = hex_nibble(pair[1])
-            .ok_or_else(|| "native_resident_client_auth_invalid".to_owned())?;
+        let high =
+            hex_nibble(pair[0]).ok_or_else(|| "native_resident_client_auth_invalid".to_owned())?;
+        let low =
+            hex_nibble(pair[1]).ok_or_else(|| "native_resident_client_auth_invalid".to_owned())?;
         token[index] = (high << 4) | low;
     }
     Ok((token, payload))
@@ -69,7 +69,11 @@ fn read_exact_bounded(stream: &mut dyn Read, length: usize) -> Result<Vec<u8>, S
     Ok(bytes)
 }
 
-fn authenticate(stream: &mut (impl Read + Write), token: &[u8; AUTH_TOKEN_BYTES], payload: &[u8]) -> Result<(), String> {
+fn authenticate(
+    stream: &mut (impl Read + Write),
+    token: &[u8; AUTH_TOKEN_BYTES],
+    payload: &[u8],
+) -> Result<(), String> {
     let nonce = unique_bytes(b"hol-guard-resident-client-nonce-v1\0", payload);
     stream
         .write_all(&nonce[..AUTH_NONCE_BYTES])

--- a/rust/crates/guard-runtime/src/resident_client.rs
+++ b/rust/crates/guard-runtime/src/resident_client.rs
@@ -1,0 +1,202 @@
+#![forbid(unsafe_code)]
+
+use sha2::{Digest, Sha256};
+use std::io::{Read, Write};
+use std::net::{Ipv4Addr, SocketAddr, TcpStream};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use super::{
+    constant_time_eq, hex_nibble, hmac_sha256, AUTH_NONCE_BYTES, AUTH_PROOF_BYTES,
+    AUTH_TOKEN_BYTES, CLIENT_PROOF_LABEL, FRAME_DIGEST_BYTES, FRAME_HEADER_BYTES,
+    FRAME_REQUEST_ID_BYTES, MAX_NATIVE_REQUEST_BYTES, MAX_NATIVE_RESPONSE_BYTES, REQUEST_MAGIC,
+    RESPONSE_MAGIC, SERVER_PROOF_LABEL,
+};
+
+const CLIENT_TIMEOUT: Duration = Duration::from_secs(2);
+static CLIENT_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+fn unique_bytes(label: &[u8], payload: &[u8]) -> [u8; 32] {
+    let counter = CLIENT_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let mut hasher = Sha256::new();
+    hasher.update(label);
+    hasher.update(std::process::id().to_be_bytes());
+    hasher.update(counter.to_be_bytes());
+    hasher.update(now.to_be_bytes());
+    hasher.update(Sha256::digest(payload));
+    hasher.finalize().into()
+}
+
+fn parse_input(bytes: &[u8]) -> Result<([u8; AUTH_TOKEN_BYTES], &[u8]), String> {
+    if bytes.len() > MAX_NATIVE_REQUEST_BYTES + AUTH_TOKEN_BYTES * 2 + 2 {
+        return Err("native_resident_client_input_too_large".to_owned());
+    }
+    let newline = bytes
+        .iter()
+        .position(|byte| *byte == b'\n')
+        .ok_or_else(|| "native_resident_client_auth_missing".to_owned())?;
+    let encoded = &bytes[..newline];
+    if encoded.len() != AUTH_TOKEN_BYTES * 2 {
+        return Err("native_resident_client_auth_invalid".to_owned());
+    }
+    let payload = &bytes[newline + 1..];
+    if payload.is_empty() || payload.len() > MAX_NATIVE_REQUEST_BYTES {
+        return Err("native_resident_client_payload_invalid".to_owned());
+    }
+    let mut token = [0u8; AUTH_TOKEN_BYTES];
+    for (index, pair) in encoded.chunks_exact(2).enumerate() {
+        let high = hex_nibble(pair[0])
+            .ok_or_else(|| "native_resident_client_auth_invalid".to_owned())?;
+        let low = hex_nibble(pair[1])
+            .ok_or_else(|| "native_resident_client_auth_invalid".to_owned())?;
+        token[index] = (high << 4) | low;
+    }
+    Ok((token, payload))
+}
+
+fn read_exact_bounded(stream: &mut dyn Read, length: usize) -> Result<Vec<u8>, String> {
+    if length > MAX_NATIVE_RESPONSE_BYTES {
+        return Err("native_resident_client_response_too_large".to_owned());
+    }
+    let mut bytes = vec![0u8; length];
+    stream
+        .read_exact(&mut bytes)
+        .map_err(|_| "native_resident_client_read_failed".to_owned())?;
+    Ok(bytes)
+}
+
+fn authenticate(stream: &mut (impl Read + Write), token: &[u8; AUTH_TOKEN_BYTES], payload: &[u8]) -> Result<(), String> {
+    let nonce = unique_bytes(b"hol-guard-resident-client-nonce-v1\0", payload);
+    stream
+        .write_all(&nonce[..AUTH_NONCE_BYTES])
+        .map_err(|_| "native_resident_client_auth_write_failed".to_owned())?;
+    let mut server_proof = [0u8; AUTH_PROOF_BYTES];
+    stream
+        .read_exact(&mut server_proof)
+        .map_err(|_| "native_resident_client_auth_read_failed".to_owned())?;
+    let expected = hmac_sha256(token, SERVER_PROOF_LABEL, &nonce[..AUTH_NONCE_BYTES]);
+    if !constant_time_eq(&server_proof, &expected) {
+        return Err("native_resident_client_auth_rejected".to_owned());
+    }
+    let client_proof = hmac_sha256(token, CLIENT_PROOF_LABEL, &nonce[..AUTH_NONCE_BYTES]);
+    stream
+        .write_all(&client_proof)
+        .map_err(|_| "native_resident_client_auth_write_failed".to_owned())?;
+    Ok(())
+}
+
+fn exchange(
+    stream: &mut (impl Read + Write),
+    token: &[u8; AUTH_TOKEN_BYTES],
+    payload: &[u8],
+) -> Result<Vec<u8>, String> {
+    authenticate(stream, token, payload)?;
+    let request_id = unique_bytes(b"hol-guard-resident-client-request-v1\0", payload);
+    let request_digest = Sha256::digest(payload);
+    let mut header = Vec::with_capacity(FRAME_HEADER_BYTES);
+    header.extend_from_slice(REQUEST_MAGIC);
+    header.extend_from_slice(&request_id[..FRAME_REQUEST_ID_BYTES]);
+    header.extend_from_slice(&request_digest[..FRAME_DIGEST_BYTES]);
+    header.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+    stream
+        .write_all(&header)
+        .and_then(|_| stream.write_all(payload))
+        .and_then(|_| stream.flush())
+        .map_err(|_| "native_resident_client_write_failed".to_owned())?;
+
+    let mut response_header = [0u8; FRAME_HEADER_BYTES];
+    stream
+        .read_exact(&mut response_header)
+        .map_err(|_| "native_resident_client_response_header_failed".to_owned())?;
+    if !constant_time_eq(&response_header[..4], RESPONSE_MAGIC) {
+        return Err("native_resident_client_response_version_mismatch".to_owned());
+    }
+    if !constant_time_eq(
+        &response_header[4..4 + FRAME_REQUEST_ID_BYTES],
+        &request_id[..FRAME_REQUEST_ID_BYTES],
+    ) {
+        return Err("native_resident_client_response_id_mismatch".to_owned());
+    }
+    let digest_start = 4 + FRAME_REQUEST_ID_BYTES;
+    let response_digest = &response_header[digest_start..digest_start + FRAME_DIGEST_BYTES];
+    let length = u32::from_be_bytes(
+        response_header[FRAME_HEADER_BYTES - 4..]
+            .try_into()
+            .map_err(|_| "native_resident_client_response_header_failed".to_owned())?,
+    ) as usize;
+    if length == 0 || length > MAX_NATIVE_RESPONSE_BYTES {
+        return Err("native_resident_client_response_too_large".to_owned());
+    }
+    let response = read_exact_bounded(stream, length)?;
+    if !constant_time_eq(&Sha256::digest(&response), response_digest) {
+        return Err("native_resident_client_response_digest_mismatch".to_owned());
+    }
+    Ok(response)
+}
+
+#[cfg(unix)]
+pub(crate) fn request_unix(path: &str, input: &[u8]) -> Result<Vec<u8>, String> {
+    use std::os::unix::net::UnixStream;
+
+    let (token, payload) = parse_input(input)?;
+    let mut stream = UnixStream::connect(path)
+        .map_err(|_| "native_resident_client_connect_failed".to_owned())?;
+    stream
+        .set_read_timeout(Some(CLIENT_TIMEOUT))
+        .map_err(|_| "native_resident_client_timeout_failed".to_owned())?;
+    stream
+        .set_write_timeout(Some(CLIENT_TIMEOUT))
+        .map_err(|_| "native_resident_client_timeout_failed".to_owned())?;
+    exchange(&mut stream, &token, payload)
+}
+
+#[cfg(not(unix))]
+pub(crate) fn request_unix(_path: &str, _input: &[u8]) -> Result<Vec<u8>, String> {
+    Err("native_unix_socket_not_available".to_owned())
+}
+
+pub(crate) fn request_loopback(address: &str, input: &[u8]) -> Result<Vec<u8>, String> {
+    let (token, payload) = parse_input(input)?;
+    let requested: SocketAddr = address
+        .parse()
+        .map_err(|_| "native_resident_client_address_invalid".to_owned())?;
+    if requested.ip() != Ipv4Addr::LOCALHOST || requested.port() == 0 {
+        return Err("native_resident_client_address_not_loopback".to_owned());
+    }
+    let mut stream = TcpStream::connect_timeout(&requested, CLIENT_TIMEOUT)
+        .map_err(|_| "native_resident_client_connect_failed".to_owned())?;
+    stream
+        .set_nodelay(true)
+        .map_err(|_| "native_resident_client_socket_failed".to_owned())?;
+    stream
+        .set_read_timeout(Some(CLIENT_TIMEOUT))
+        .map_err(|_| "native_resident_client_timeout_failed".to_owned())?;
+    stream
+        .set_write_timeout(Some(CLIENT_TIMEOUT))
+        .map_err(|_| "native_resident_client_timeout_failed".to_owned())?;
+    exchange(&mut stream, &token, payload)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_missing_or_malformed_auth_prefix() {
+        assert!(parse_input(b"{}").is_err());
+        assert!(parse_input(b"aa\n{}").is_err());
+    }
+
+    #[test]
+    fn request_identity_changes_across_calls() {
+        let payload = br#"{"operation":"health","request":{}}"#;
+        assert_ne!(
+            unique_bytes(b"request", payload),
+            unique_bytes(b"request", payload)
+        );
+    }
+}

--- a/scripts/ci/rust_authority_ownership_gate.py
+++ b/scripts/ci/rust_authority_ownership_gate.py
@@ -6,12 +6,12 @@ from __future__ import annotations
 import argparse
 import ast
 import json
-import re
+import os
 from pathlib import Path
 from typing import Final
 
 SCHEMA: Final = "hol-guard-rust-authority-ownership.v1"
-MANIFEST = Path("ci/rust-authority-ownership.v1.json")
+MANIFEST: Final = Path("ci/rust-authority-ownership.v1.json")
 
 TEMPORARY_PATHS: Final = (
     Path(".github/workflows/rust-local-toolchain-export.yml"),
@@ -54,31 +54,72 @@ TEMPORARY_PATHS: Final = (
 def _read(path: Path) -> str:
     try:
         return path.read_text(encoding="utf-8")
-    except FileNotFoundError as exc:
-        raise RuntimeError(f"required authority source is missing: {path}") from exc
+    except (OSError, UnicodeDecodeError) as exc:
+        raise RuntimeError(f"could not inspect required authority source: {path}") from exc
 
 
-def _manifest() -> dict[str, object]:
+def _function_source(path: Path, function_name: str) -> str:
+    source = _read(path)
+    tree = ast.parse(source, filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == function_name:
+            segment = ast.get_source_segment(source, node)
+            if segment is None:
+                break
+            return segment
+    raise RuntimeError(f"required function is missing: {path}:{function_name}")
+
+
+def _manifest_gate() -> dict[str, object]:
     value = json.loads(_read(MANIFEST))
     if not isinstance(value, dict) or value.get("schema") != SCHEMA:
         raise RuntimeError("Rust authority ownership manifest has an invalid schema")
+
+    default = value.get("default_runtime_contract")
+    if not isinstance(default, dict):
+        raise RuntimeError("default runtime contract is missing")
+    expected_default = {
+        "native_mode_without_environment": "auto",
+        "hook_fast_path_without_environment": True,
+        "path_runtime_search": False,
+        "decision_time_runtime_download": False,
+        "automatic_python_semantic_fallback": False,
+    }
+    for key, expected in expected_default.items():
+        if default.get(key) != expected:
+            raise RuntimeError(f"invalid default runtime contract: {key}")
+
+    compatibility = value.get("explicit_compatibility")
+    if not isinstance(compatibility, dict):
+        raise RuntimeError("explicit compatibility contract is missing")
+    if compatibility.get("modes") != ["off", "shadow"]:
+        raise RuntimeError("only off/shadow may select Python compatibility")
+    if compatibility.get("python_reference_evaluator") is not True:
+        raise RuntimeError("explicit compatibility reference evaluator contract is missing")
+    if compatibility.get("automatic_entry_from_native_failure") is not False:
+        raise RuntimeError("native failure may enter Python compatibility")
+    if compatibility.get("default_selected") is not False:
+        raise RuntimeError("Python compatibility may be selected by default")
+
     surfaces = value.get("surfaces")
     if not isinstance(surfaces, dict):
-        raise RuntimeError("Rust authority ownership manifest has no surfaces")
+        raise RuntimeError("Rust authority surfaces are missing")
     for key in ("pre_tool_use", "post_tool_use"):
         surface = surfaces.get(key)
         if not isinstance(surface, dict):
             raise RuntimeError(f"Rust authority surface is missing: {key}")
-        if surface.get("semantic_authority") != "rust" or surface.get("python_semantic_fallback") is not False:
-            raise RuntimeError(f"Rust authority surface is not exclusive: {key}")
+        if surface.get("semantic_authority") != "rust":
+            raise RuntimeError(f"default semantic authority is not Rust: {key}")
+        if surface.get("python_semantic_fallback") is not False:
+            raise RuntimeError(f"automatic Python semantic fallback is enabled: {key}")
         if surface.get("native_failure") != "fail_closed":
-            raise RuntimeError(f"Rust authority surface is not fail closed: {key}")
+            raise RuntimeError(f"native failure is not fail closed: {key}")
 
-    hook_edge = surfaces.get("hook_edge")
-    if not isinstance(hook_edge, dict) or hook_edge.get("event_and_action_extraction") != "rust":
-        raise RuntimeError("raw hook event/action extraction is not Rust-owned")
-    if hook_edge.get("python_semantic_envelope_parsing") is not False:
-        raise RuntimeError("Python semantic envelope parsing is still permitted")
+    edge = surfaces.get("hook_edge")
+    if not isinstance(edge, dict) or edge.get("event_and_action_extraction") != "rust":
+        raise RuntimeError("raw hook edge is not Rust-owned")
+    if edge.get("python_semantic_envelope_parsing") is not False:
+        raise RuntimeError("default hook edge permits Python semantic envelope parsing")
 
     client = surfaces.get("resident_client")
     if not isinstance(client, dict):
@@ -89,71 +130,77 @@ def _manifest() -> dict[str, object]:
 
     io_surface = surfaces.get("decision_critical_io")
     if not isinstance(io_surface, dict) or any(item != "rust" for item in io_surface.values()):
-        raise RuntimeError("decision-critical PostToolUse I/O is not exclusively Rust-owned")
-
-    default_contract = value.get("default_runtime_contract")
-    if not isinstance(default_contract, dict):
-        raise RuntimeError("no-environment production runtime contract is missing")
-    if default_contract.get("native_mode_without_environment") != "auto":
-        raise RuntimeError("unset native mode is not auto")
-    if default_contract.get("hook_fast_path_without_environment") is not True:
-        raise RuntimeError("unset hook fast path is not enabled")
-    if default_contract.get("path_runtime_search") is not False:
-        raise RuntimeError("production runtime contract still permits PATH search")
-    if default_contract.get("decision_time_runtime_download") is not False:
-        raise RuntimeError("production runtime contract still permits decision-time runtime download")
+        raise RuntimeError("default decision-critical PostToolUse I/O is not Rust-owned")
     return value
-
-
-def _function_source(path: Path, function_name: str) -> str:
-    source = _read(path)
-    tree = ast.parse(source, filename=str(path))
-    for node in ast.walk(tree):
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == function_name:
-            segment = ast.get_source_segment(source, node)
-            if segment is None:
-                raise RuntimeError(f"could not inspect function {function_name} in {path}")
-            return segment
-    raise RuntimeError(f"required function is missing: {path}:{function_name}")
 
 
 def _hook_worker_gate() -> None:
     path = Path("src/codex_plugin_scanner/guard/daemon/hook_worker.py")
     source = _read(path)
-    required = (
+    for required in (
         "review_hook_edge_native",
+        'mode in {"off", "shadow"}',
+        "_review_explicit_python_compatibility",
         "native_hook_edge_unavailable",
         "_harness_json_from_native_edge",
-    )
-    missing = [token for token in required if token not in source]
-    if missing:
-        raise RuntimeError(f"daemon hook worker is not bound to native hook edge: {missing}")
-    forbidden = (
-        "HookReviewEngine",
-        "ContentScanner",
-        "HookDecisionCache",
-        "review_pre_tool_native",
-        "review_post_tool_native",
-        "self.engine.review(",
-        "_parse_source_ref(",
-        "_parse_output_summary(",
-        "_pre_tool_command(",
-    )
-    present = [token for token in forbidden if token in source]
-    if present:
-        raise RuntimeError(f"daemon hook worker retains Python semantic/data-plane implementation: {present}")
-    review = _function_source(path, "review_http_payload")
-    if "HookWorkerUnsupported" in review:
-        raise RuntimeError("production daemon hook review can escape native authority")
+    ):
+        if required not in source:
+            raise RuntimeError(f"HookWorker ownership contract is missing: {required}")
+
+    production = _function_source(path, "review_http_payload")
+    if "self.engine.review(" in production or "_request_from_payload(" in production:
+        raise RuntimeError("default HookWorker path directly invokes Python semantic evaluation")
+    if "review_hook_edge_native(" not in production:
+        raise RuntimeError("default HookWorker path does not invoke the Rust hook edge")
+    if "HookWorkerUnsupported" in production:
+        raise RuntimeError("auto/force HookWorker path can escape Rust authority")
+
+    compatibility = _function_source(path, "_review_explicit_python_compatibility")
+    if "self.engine.review(" not in compatibility:
+        raise RuntimeError("explicit compatibility no longer has its bounded reference evaluator")
+    if 'event_name != "PostToolUse"' not in compatibility:
+        raise RuntimeError("explicit compatibility is not bounded away from PreTool semantic authority")
+
+    if "review_pre_tool_native" in source or "review_post_tool_native" in source:
+        raise RuntimeError("HookWorker retains the superseded split native bridge")
+    for forbidden in ("_pre_tool_command(",):
+        if forbidden in source:
+            raise RuntimeError(f"HookWorker retains default Python PreTool parsing: {forbidden}")
 
 
-def _rust_hook_edge_gate() -> None:
+def _cli_gate() -> None:
+    path = Path("src/codex_plugin_scanner/guard/cli/commands_hook_native_authority.py")
+    source = _read(path)
+    native = _function_source(path, "try_native_hook_authority")
+    route = _function_source(path, "try_native_or_source_ref_hook")
+
+    if 'native_mode() not in {"auto", "force"}' not in native:
+        raise RuntimeError("CLI does not isolate explicit off/shadow compatibility")
+    if "HookWorker(store=store).review_http_payload(" not in native:
+        raise RuntimeError("CLI auto/force route does not terminate at HookWorker Rust authority")
+    if "try" in native and "except" in native:
+        raise RuntimeError("CLI auto/force route catches native authority failures for fallback")
+    if "_try_source_ref_fast_path" not in route:
+        raise RuntimeError("explicit compatibility source-ref reference path is missing")
+    if "native_result is not None" not in route or '_emit("hook"' not in route:
+        raise RuntimeError("CLI native result is not terminal before compatibility")
+
+
+def _rust_runtime_gate() -> None:
     runtime = _read(Path("rust/crates/guard-runtime/src/main.rs"))
     oneshot = _read(Path("rust/crates/guard-runtime/src/oneshot.rs"))
+    client = _read(Path("rust/crates/guard-runtime/src/resident_client.rs"))
     core = _read(Path("rust/crates/guard-hook-core/src/lib.rs"))
-    for required in ('"hook-edge-v2"', "HookEdge(Value)", 'command == "hook-edge"'):
+
+    for required in (
+        '"hook-edge-v2"',
+        '"resident-client-v1"',
+        "HookEdge(Value)",
+        'command == "hook-edge"',
+        'command == "resident-client"',
+    ):
         if required not in runtime:
-            raise RuntimeError(f"Rust hook edge runtime contract is missing: {required}")
+            raise RuntimeError(f"Rust runtime feature is missing: {required}")
     for required in (
         "evaluate_hook_edge_value",
         "hook_event_name",
@@ -165,20 +212,7 @@ def _rust_hook_edge_gate() -> None:
             raise RuntimeError(f"Rust hook edge implementation is missing: {required}")
     for required in ("read_bounded", "scan_text", "extract_payload_output", "review_post_tool"):
         if required not in core:
-            raise RuntimeError(f"Rust PostToolUse decision-critical I/O is missing: {required}")
-
-
-def _resident_client_gate() -> None:
-    runtime = _read(Path("rust/crates/guard-runtime/src/main.rs"))
-    client = _read(Path("rust/crates/guard-runtime/src/resident_client.rs"))
-    for required in (
-        '"resident-client-v1"',
-        'command == "resident-client"',
-        "resident_client::request_unix",
-        "resident_client::request_loopback",
-    ):
-        if required not in runtime:
-            raise RuntimeError(f"Rust resident-client runtime contract is missing: {required}")
+            raise RuntimeError(f"Rust decision-critical PostToolUse I/O is missing: {required}")
     for required in (
         "authenticate(",
         "hmac_sha256",
@@ -189,19 +223,21 @@ def _resident_client_gate() -> None:
         "response_digest_mismatch",
     ):
         if required not in client:
-            raise RuntimeError(f"Rust resident-client transport is missing: {required}")
+            raise RuntimeError(f"Rust resident-client implementation is missing: {required}")
 
-    bridge = Path("src/codex_plugin_scanner/guard/native_runtime_resident.py")
-    source = _read(bridge)
+
+def _resident_bridge_gate() -> None:
+    path = Path("src/codex_plugin_scanner/guard/native_runtime_resident.py")
+    source = _read(path)
     class_start = source.find("class _ResidentService:")
     send_start = source.find("    def _send(", class_start)
     send_end = source.find("\n    def _ensure_started(", send_start)
     if send_start < 0 or send_end <= send_start:
-        raise RuntimeError("Python resident lifecycle has no bounded _send bridge")
+        raise RuntimeError("resident lifecycle has no bounded _send bridge")
     send = source[send_start:send_end]
     for required in ("resident-client", "run_isolated_hook_process"):
         if required not in send:
-            raise RuntimeError(f"Python resident lifecycle does not delegate {required} to Rust")
+            raise RuntimeError(f"production resident bridge does not delegate {required} to Rust")
     for forbidden in (
         "_send_authenticated_unix_request",
         "_send_authenticated_loopback_request",
@@ -212,111 +248,34 @@ def _resident_client_gate() -> None:
             raise RuntimeError(f"production resident client I/O still executes in Python: {forbidden}")
 
 
-def _cli_gate() -> None:
-    hook = _read(Path("src/codex_plugin_scanner/guard/cli/commands_hook.py"))
-    if "try_native_or_source_ref_hook" not in hook:
-        raise RuntimeError("CLI hook path does not consult native authority")
-    path = Path("src/codex_plugin_scanner/guard/cli/commands_hook_native_authority.py")
-    source = _read(path)
-    for forbidden in (
-        "_try_source_ref_fast_path",
-        "native_mode",
-        "HookWorkerUnsupported",
-        "HookReviewEngine",
-        "evaluate_command(",
-    ):
-        if forbidden in source:
-            raise RuntimeError(f"CLI hook path retains Python semantic fallback: {forbidden}")
-    route = _function_source(path, "try_native_or_source_ref_hook")
-    if "try_native_hook_authority" not in route or '_emit("hook"' not in route:
-        raise RuntimeError("CLI hook route does not terminate at native authority")
-
-
-def _default_mode_gate() -> None:
+def _default_gate() -> None:
     native = _read(Path("src/codex_plugin_scanner/guard/native_runtime.py"))
     config = _read(Path("src/codex_plugin_scanner/guard/config.py"))
     if '_DEFAULT_NATIVE_MODE: NativeMode = "auto"' not in native:
-        raise RuntimeError("bundled native authority is not the no-env default")
+        raise RuntimeError("unset native mode is not auto")
     if 'os.environ.get(HOOK_FAST_PATH_ENV, "1") == "1"' not in config:
-        raise RuntimeError("resident hook path is not enabled when its environment variable is absent")
-    candidates_start = native.find("def _runtime_candidates()")
-    candidates_end = native.find("\ndef _validate_binary", candidates_start)
-    candidates = native[candidates_start:candidates_end]
+        raise RuntimeError("unset hook fast path is not enabled")
+    start = native.find("def _runtime_candidates()")
+    end = native.find("\ndef _validate_binary", start)
+    candidates = native[start:end]
     if "shutil.which" in candidates or "PATH" in candidates:
         raise RuntimeError("automatic native runtime selection searches PATH")
 
 
-def _policy_and_identity_gate() -> None:
-    cargo = _read(Path("rust/crates/guard-runtime/Cargo.toml"))
-    runtime = _read(Path("rust/crates/guard-runtime/src/main.rs"))
-    native = _read(Path("src/codex_plugin_scanner/guard/native_runtime.py"))
-    release = _read(Path("scripts/verify_native_runtime_release.py"))
-    if "guard-policy-snapshot" not in cargo:
-        raise RuntimeError("hol-guard-runtime does not link guard-policy-snapshot")
-    if "policy_snapshot" not in runtime and "validate_request_policy_snapshot" not in _read(
-        Path("rust/crates/guard-runtime/src/oneshot.rs")
-    ):
-        raise RuntimeError("hol-guard-runtime does not consume policy snapshots")
-    for required in (
-        "native_manifest_runtime_mismatch",
-        "native_manifest_version_mismatch",
-        "native_manifest_rule_mismatch",
-        "runtime_sha256",
-    ):
-        if required not in native and required not in release:
-            raise RuntimeError(f"bundled runtime identity guard is missing: {required}")
-
-
 def _workflow_gate() -> None:
     source = _read(Path(".github/workflows/rust-authority-ownership.yml"))
-    required_paths = (
+    for required in (
         '"rust/**"',
         '"src/codex_plugin_scanner/guard/**"',
-        '"ci/native_runtime/**"',
-        '"scripts/**"',
-        '".github/workflows/**"',
-    )
-    missing = [value for value in required_paths if value not in source]
-    if missing:
-        raise RuntimeError(f"authority workflow path coverage is incomplete: {missing}")
-    required_commands = (
         "rust_pretool_authority_integration.py",
         "rust_posttool_failclosed_integration.py",
         "test_guard_native_runtime_differential.py",
         "test_guard_native_runtime_mutation_differential.py",
         "bench_guard_native_release_gate.py",
         "test_native_hol_guard_wheel.py",
-    )
-    missing_commands = [value for value in required_commands if value not in source]
-    if missing_commands:
-        raise RuntimeError(f"authority workflow integration coverage is incomplete: {missing_commands}")
-
-
-def _docs_gate() -> None:
-    architecture = _read(Path("docs/guard/all-harness-hook-review.md"))
-    support = _read(Path("docs/guard/harness-support.md"))
-    forbidden = (
-        "causing the server to fall through to the legacy CLI path",
-        "Python remains authoritative",
-    )
-    for value in forbidden:
-        if value in architecture or value in support:
-            raise RuntimeError(f"legacy Python authority documentation remains: {value}")
-    if "Rust Authority Boundary" not in architecture or "Rust Authority Boundary" not in support:
-        raise RuntimeError("Rust authority boundary is not documented on both harness pages")
-
-
-def _mode_terminology_gate() -> None:
-    relevant = [
-        Path("src/codex_plugin_scanner/guard/native_runtime.py"),
-        Path("src/codex_plugin_scanner/guard/native_command_model.py"),
-        Path("docs/guard/all-harness-hook-review.md"),
-        Path("docs/guard/harness-support.md"),
-    ]
-    strict_mode = re.compile(r"(?i)(native|rust|runtime)[-_ ]strict|strict[-_ ]mode|mode[=: ]+strict")
-    found = [str(path) for path in relevant if path.exists() and strict_mode.search(_read(path))]
-    if found:
-        raise RuntimeError(f"retired strict-mode terminology remains: {found}")
+    ):
+        if required not in source:
+            raise RuntimeError(f"authority workflow coverage is missing: {required}")
 
 
 def _hygiene_gate() -> None:
@@ -328,37 +287,33 @@ def _hygiene_gate() -> None:
 def run(root: Path) -> dict[str, object]:
     original = Path.cwd()
     try:
-        if root != original:
-            import os
-
-            os.chdir(root)
-        manifest = _manifest()
+        os.chdir(root)
+        manifest = _manifest_gate()
         _hook_worker_gate()
-        _rust_hook_edge_gate()
-        _resident_client_gate()
         _cli_gate()
-        _default_mode_gate()
-        _policy_and_identity_gate()
+        _rust_runtime_gate()
+        _resident_bridge_gate()
+        _default_gate()
         _workflow_gate()
-        _docs_gate()
-        _mode_terminology_gate()
         _hygiene_gate()
         return {"schema": SCHEMA, "status": "passed", "manifest": manifest}
     finally:
-        if Path.cwd() != original:
-            import os
-
-            os.chdir(original)
+        os.chdir(original)
 
 
-if __name__ == "__main__":
+def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", type=Path, default=Path.cwd())
     parser.add_argument("--json", type=Path)
-    parsed = parser.parse_args()
-    payload = run(parsed.root.resolve())
+    args = parser.parse_args()
+    payload = run(args.root.resolve())
     rendered = json.dumps(payload, indent=2, sort_keys=True)
     print(rendered)
-    if parsed.json is not None:
-        parsed.json.parent.mkdir(parents=True, exist_ok=True)
-        parsed.json.write_text(rendered + "\n", encoding="utf-8")
+    if args.json is not None:
+        args.json.parent.mkdir(parents=True, exist_ok=True)
+        args.json.write_text(rendered + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/rust_authority_ownership_gate.py
+++ b/scripts/ci/rust_authority_ownership_gate.py
@@ -108,7 +108,7 @@ def _manifest() -> dict[str, object]:
 def _function_source(path: Path, function_name: str) -> str:
     source = _read(path)
     tree = ast.parse(source, filename=str(path))
-    for node in tree.body:
+    for node in ast.walk(tree):
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == function_name:
             segment = ast.get_source_segment(source, node)
             if segment is None:

--- a/scripts/ci/rust_authority_ownership_gate.py
+++ b/scripts/ci/rust_authority_ownership_gate.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Enforce HOL Guard's permanent Rust runtime authority boundary."""
+"""Enforce HOL Guard's permanent Rust hook/data-plane ownership boundary."""
 
 from __future__ import annotations
 
@@ -58,15 +58,6 @@ def _read(path: Path) -> str:
         raise RuntimeError(f"required authority source is missing: {path}") from exc
 
 
-def _python_imports_function(path: Path, module_suffix: str, name: str) -> bool:
-    tree = ast.parse(_read(path), filename=str(path))
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom) and (node.module or "").endswith(module_suffix):
-            if any(alias.name == name for alias in node.names):
-                return True
-    return False
-
-
 def _manifest() -> dict[str, object]:
     value = json.loads(_read(MANIFEST))
     if not isinstance(value, dict) or value.get("schema") != SCHEMA:
@@ -82,91 +73,177 @@ def _manifest() -> dict[str, object]:
             raise RuntimeError(f"Rust authority surface is not exclusive: {key}")
         if surface.get("native_failure") != "fail_closed":
             raise RuntimeError(f"Rust authority surface is not fail closed: {key}")
+
+    hook_edge = surfaces.get("hook_edge")
+    if not isinstance(hook_edge, dict) or hook_edge.get("event_and_action_extraction") != "rust":
+        raise RuntimeError("raw hook event/action extraction is not Rust-owned")
+    if hook_edge.get("python_semantic_envelope_parsing") is not False:
+        raise RuntimeError("Python semantic envelope parsing is still permitted")
+
+    client = surfaces.get("resident_client")
+    if not isinstance(client, dict):
+        raise RuntimeError("resident client ownership surface is missing")
+    for field in ("authentication", "framing", "request_response_digest_validation", "socket_io"):
+        if client.get(field) != "rust":
+            raise RuntimeError(f"resident client {field} is not Rust-owned")
+
+    io_surface = surfaces.get("decision_critical_io")
+    if not isinstance(io_surface, dict) or any(item != "rust" for item in io_surface.values()):
+        raise RuntimeError("decision-critical PostToolUse I/O is not exclusively Rust-owned")
+
+    default_contract = value.get("default_runtime_contract")
+    if not isinstance(default_contract, dict):
+        raise RuntimeError("no-environment production runtime contract is missing")
+    if default_contract.get("native_mode_without_environment") != "auto":
+        raise RuntimeError("unset native mode is not auto")
+    if default_contract.get("hook_fast_path_without_environment") is not True:
+        raise RuntimeError("unset hook fast path is not enabled")
+    if default_contract.get("path_runtime_search") is not False:
+        raise RuntimeError("production runtime contract still permits PATH search")
+    if default_contract.get("decision_time_runtime_download") is not False:
+        raise RuntimeError("production runtime contract still permits decision-time runtime download")
     return value
 
 
-def _pretool_gate() -> None:
-    pretool = Path("src/codex_plugin_scanner/guard/native_pretool.py")
-    if _python_imports_function(pretool, "command_evaluation", "evaluate_command"):
-        raise RuntimeError("native PreToolUse transport imports the Python command evaluator")
-    if "evaluate_command(" in _read(pretool):
-        raise RuntimeError("native PreToolUse transport calls the Python command evaluator")
-    _assert_policy_floor_fail_closed(pretool)
+def _function_source(path: Path, function_name: str) -> str:
+    source = _read(path)
+    tree = ast.parse(source, filename=str(path))
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == function_name:
+            segment = ast.get_source_segment(source, node)
+            if segment is None:
+                raise RuntimeError(f"could not inspect function {function_name} in {path}")
+            return segment
+    raise RuntimeError(f"required function is missing: {path}:{function_name}")
 
-    hook = _read(Path("src/codex_plugin_scanner/guard/daemon/hook_worker.py"))
-    if "review_pre_tool_native" not in hook:
-        raise RuntimeError("PreToolUse hook path is not bound to the native runtime")
-    region = re.search(
-        r'if event_name\s*==\s*"PreToolUse":[\s\S]*?(?=\n\s*if event_name\s*!=\s*"PostToolUse")',
-        hook,
+
+def _hook_worker_gate() -> None:
+    path = Path("src/codex_plugin_scanner/guard/daemon/hook_worker.py")
+    source = _read(path)
+    required = (
+        "review_hook_edge_native",
+        "native_hook_edge_unavailable",
+        "_harness_json_from_native_edge",
     )
-    if region is None:
-        raise RuntimeError("daemon has no Rust PreToolUse authority route")
-    if "self.engine.review(" in region.group(0):
-        raise RuntimeError("PreToolUse can reach the Python HookReviewEngine")
-    if "native_pre_tool_unavailable" not in region.group(0):
-        raise RuntimeError("PreToolUse does not fail closed when native is unavailable")
-    if 'status.mode == "shadow"' not in region.group(0):
-        raise RuntimeError("PreToolUse does not isolate shadow Python rollback")
-    if 'raise HookWorkerUnsupported("native PreToolUse runtime is unavailable")' in region.group(0):
-        shadow_only = re.search(
-            r'if status\.mode == "shadow":\s*raise HookWorkerUnsupported\("native PreToolUse runtime is unavailable"\)',
-            region.group(0),
-        )
-        if shadow_only is None:
-            raise RuntimeError("PreToolUse unavailable path still falls through to Python")
+    missing = [token for token in required if token not in source]
+    if missing:
+        raise RuntimeError(f"daemon hook worker is not bound to native hook edge: {missing}")
+    forbidden = (
+        "HookReviewEngine",
+        "ContentScanner",
+        "HookDecisionCache",
+        "review_pre_tool_native",
+        "review_post_tool_native",
+        "self.engine.review(",
+        "_parse_source_ref(",
+        "_parse_output_summary(",
+        "_pre_tool_command(",
+    )
+    present = [token for token in forbidden if token in source]
+    if present:
+        raise RuntimeError(f"daemon hook worker retains Python semantic/data-plane implementation: {present}")
+    review = _function_source(path, "review_http_payload")
+    if "HookWorkerUnsupported" in review:
+        raise RuntimeError("production daemon hook review can escape native authority")
 
-    command_model = Path("src/codex_plugin_scanner/guard/native_command_model.py")
-    if command_model.exists():
-        model = _read(command_model)
-        if 'status.mode not in {"shadow", "force"}' not in model:
-            raise RuntimeError("command-model bridge is not confined to shadow or force")
-        if "Python remains authoritative" in model:
-            raise RuntimeError("command-model bridge still declares Python authority")
 
+def _rust_hook_edge_gate() -> None:
     runtime = _read(Path("rust/crates/guard-runtime/src/main.rs"))
-    command = _read(Path("rust/crates/guard-command/src/lib.rs"))
-    combined = runtime + "\n" + command
-    if not re.search(r"PreToolUse|pre_tool|pre-tool", combined):
-        raise RuntimeError("Rust runtime does not implement PreToolUse authority")
-
-
-def _posttool_gate() -> None:
-    hook = _read(Path("src/codex_plugin_scanner/guard/daemon/hook_worker.py"))
-    if re.search(
-        r"if response is None:\s*response = self\.engine\.review\(request\)",
-        hook,
-    ):
-        raise RuntimeError("supported PostToolUse still spills into Python semantic evaluation")
-    if 'native_required = mode in {"auto", "force"}' not in hook:
-        raise RuntimeError("PostToolUse auto path is not native-required")
-    if re.search(r'mode == "auto" and native_runtime_status\(\)\.available', hook):
-        raise RuntimeError("PostToolUse still availability-gates native authority")
-
-    native = _read(Path("src/codex_plugin_scanner/guard/native_runtime.py"))
-    if "currently supported Python reference backend remains authoritative" in native:
-        raise RuntimeError("native runtime still declares Python PostToolUse authority")
-
+    oneshot = _read(Path("rust/crates/guard-runtime/src/oneshot.rs"))
     core = _read(Path("rust/crates/guard-hook-core/src/lib.rs"))
-    for required in ("review_post_tool", "read_bounded", "scan_text"):
+    for required in ('"hook-edge-v2"', "HookEdge(Value)", 'command == "hook-edge"'):
+        if required not in runtime:
+            raise RuntimeError(f"Rust hook edge runtime contract is missing: {required}")
+    for required in (
+        "evaluate_hook_edge_value",
+        "hook_event_name",
+        "extract_pre_tool_command",
+        "native_pre_tool_unsupported_review",
+        "review_post_tool",
+    ):
+        if required not in oneshot:
+            raise RuntimeError(f"Rust hook edge implementation is missing: {required}")
+    for required in ("read_bounded", "scan_text", "extract_payload_output", "review_post_tool"):
         if required not in core:
-            raise RuntimeError(f"Rust PostToolUse core is missing {required}")
+            raise RuntimeError(f"Rust PostToolUse decision-critical I/O is missing: {required}")
 
 
-def _mode_gate() -> None:
-    relevant = [
-        Path("src/codex_plugin_scanner/guard/native_runtime.py"),
-        Path("src/codex_plugin_scanner/guard/native_command_model.py"),
-        Path("docs/guard/all-harness-hook-review.md"),
-        Path("docs/guard/harness-support.md"),
-    ]
-    strict_mode = re.compile(r"(?i)(native|rust|runtime)[-_ ]strict|strict[-_ ]mode|mode[=: ]+strict")
-    found: list[str] = []
-    for path in relevant:
-        if path.exists() and strict_mode.search(_read(path)):
-            found.append(str(path))
-    if found:
-        raise RuntimeError(f"retired strict-mode terminology remains: {found}")
+def _resident_client_gate() -> None:
+    runtime = _read(Path("rust/crates/guard-runtime/src/main.rs"))
+    client = _read(Path("rust/crates/guard-runtime/src/resident_client.rs"))
+    for required in (
+        '"resident-client-v1"',
+        'command == "resident-client"',
+        "resident_client::request_unix",
+        "resident_client::request_loopback",
+    ):
+        if required not in runtime:
+            raise RuntimeError(f"Rust resident-client runtime contract is missing: {required}")
+    for required in (
+        "authenticate(",
+        "hmac_sha256",
+        "REQUEST_MAGIC",
+        "RESPONSE_MAGIC",
+        "Sha256::digest(payload)",
+        "response_id_mismatch",
+        "response_digest_mismatch",
+    ):
+        if required not in client:
+            raise RuntimeError(f"Rust resident-client transport is missing: {required}")
+
+    bridge = Path("src/codex_plugin_scanner/guard/native_runtime_resident.py")
+    source = _read(bridge)
+    class_start = source.find("class _ResidentService:")
+    send_start = source.find("    def _send(", class_start)
+    send_end = source.find("\n    def _ensure_started(", send_start)
+    if send_start < 0 or send_end <= send_start:
+        raise RuntimeError("Python resident lifecycle has no bounded _send bridge")
+    send = source[send_start:send_end]
+    for required in ("resident-client", "run_isolated_hook_process"):
+        if required not in send:
+            raise RuntimeError(f"Python resident lifecycle does not delegate {required} to Rust")
+    for forbidden in (
+        "_send_authenticated_unix_request",
+        "_send_authenticated_loopback_request",
+        "_authenticate_client(",
+        "socket.create_connection",
+    ):
+        if forbidden in send:
+            raise RuntimeError(f"production resident client I/O still executes in Python: {forbidden}")
+
+
+def _cli_gate() -> None:
+    hook = _read(Path("src/codex_plugin_scanner/guard/cli/commands_hook.py"))
+    if "try_native_or_source_ref_hook" not in hook:
+        raise RuntimeError("CLI hook path does not consult native authority")
+    path = Path("src/codex_plugin_scanner/guard/cli/commands_hook_native_authority.py")
+    source = _read(path)
+    for forbidden in (
+        "_try_source_ref_fast_path",
+        "native_mode",
+        "HookWorkerUnsupported",
+        "HookReviewEngine",
+        "evaluate_command(",
+    ):
+        if forbidden in source:
+            raise RuntimeError(f"CLI hook path retains Python semantic fallback: {forbidden}")
+    route = _function_source(path, "try_native_or_source_ref_hook")
+    if "try_native_hook_authority" not in route or '_emit("hook"' not in route:
+        raise RuntimeError("CLI hook route does not terminate at native authority")
+
+
+def _default_mode_gate() -> None:
+    native = _read(Path("src/codex_plugin_scanner/guard/native_runtime.py"))
+    config = _read(Path("src/codex_plugin_scanner/guard/config.py"))
+    if '_DEFAULT_NATIVE_MODE: NativeMode = "auto"' not in native:
+        raise RuntimeError("bundled native authority is not the no-env default")
+    if 'os.environ.get(HOOK_FAST_PATH_ENV, "1") == "1"' not in config:
+        raise RuntimeError("resident hook path is not enabled when its environment variable is absent")
+    candidates_start = native.find("def _runtime_candidates()")
+    candidates_end = native.find("\ndef _validate_binary", candidates_start)
+    candidates = native[candidates_start:candidates_end]
+    if "shutil.which" in candidates or "PATH" in candidates:
+        raise RuntimeError("automatic native runtime selection searches PATH")
 
 
 def _policy_and_identity_gate() -> None:
@@ -176,10 +253,10 @@ def _policy_and_identity_gate() -> None:
     release = _read(Path("scripts/verify_native_runtime_release.py"))
     if "guard-policy-snapshot" not in cargo:
         raise RuntimeError("hol-guard-runtime does not link guard-policy-snapshot")
-    if "PolicySnapshot" not in runtime and "policy_snapshot" not in runtime:
+    if "policy_snapshot" not in runtime and "validate_request_policy_snapshot" not in _read(
+        Path("rust/crates/guard-runtime/src/oneshot.rs")
+    ):
         raise RuntimeError("hol-guard-runtime does not consume policy snapshots")
-    if "rule_digest" not in runtime:
-        raise RuntimeError("native policy snapshot is not rule-digest bound")
     for required in (
         "native_manifest_runtime_mismatch",
         "native_manifest_version_mismatch",
@@ -191,8 +268,7 @@ def _policy_and_identity_gate() -> None:
 
 
 def _workflow_gate() -> None:
-    path = Path(".github/workflows/rust-authority-ownership.yml")
-    source = _read(path)
+    source = _read(Path(".github/workflows/rust-authority-ownership.yml"))
     required_paths = (
         '"rust/**"',
         '"src/codex_plugin_scanner/guard/**"',
@@ -220,7 +296,6 @@ def _docs_gate() -> None:
     architecture = _read(Path("docs/guard/all-harness-hook-review.md"))
     support = _read(Path("docs/guard/harness-support.md"))
     forbidden = (
-        "PreToolUse, UserPromptSubmit, and PermissionRequest events raise",
         "causing the server to fall through to the legacy CLI path",
         "Python remains authoritative",
     )
@@ -231,77 +306,23 @@ def _docs_gate() -> None:
         raise RuntimeError("Rust authority boundary is not documented on both harness pages")
 
 
+def _mode_terminology_gate() -> None:
+    relevant = [
+        Path("src/codex_plugin_scanner/guard/native_runtime.py"),
+        Path("src/codex_plugin_scanner/guard/native_command_model.py"),
+        Path("docs/guard/all-harness-hook-review.md"),
+        Path("docs/guard/harness-support.md"),
+    ]
+    strict_mode = re.compile(r"(?i)(native|rust|runtime)[-_ ]strict|strict[-_ ]mode|mode[=: ]+strict")
+    found = [str(path) for path in relevant if path.exists() and strict_mode.search(_read(path))]
+    if found:
+        raise RuntimeError(f"retired strict-mode terminology remains: {found}")
+
+
 def _hygiene_gate() -> None:
     residue = [str(path) for path in TEMPORARY_PATHS if path.exists()]
     if residue:
         raise RuntimeError(f"temporary Rust migration delivery residue remains: {residue}")
-
-
-def _ordered_call_names(node: ast.AST) -> list[str]:
-    names: list[str] = []
-    for child in ast.iter_child_nodes(node):
-        if isinstance(child, ast.Call) and isinstance(child.func, ast.Name):
-            names.append(child.func.id)
-        names.extend(_ordered_call_names(child))
-    return names
-
-
-def _assert_policy_floor_fail_closed(path: Path) -> None:
-    tree = ast.parse(_read(path), filename=str(path))
-    fn = next(
-        (
-            node
-            for node in tree.body
-            if isinstance(node, ast.FunctionDef) and node.name == "native_pre_tool_policy_floor"
-        ),
-        None,
-    )
-    if fn is None:
-        raise RuntimeError("native PreToolUse policy floor is missing")
-    for node in ast.walk(fn):
-        if isinstance(node, ast.Attribute) and node.attr == "available":
-            raise RuntimeError("PreToolUse policy floor still inspects native availability")
-        if (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Name)
-            and node.func.id == "native_mode"
-        ):
-            raise RuntimeError("PreToolUse policy floor still calls native_mode")
-    returns_block = any(
-        isinstance(node, ast.Return) and isinstance(node.value, ast.Constant) and node.value.value == "block"
-        for node in ast.walk(fn)
-    )
-    if not returns_block:
-        raise RuntimeError("PreToolUse policy floor does not fail closed")
-
-
-def _cli_gate() -> None:
-    hook = _read(Path("src/codex_plugin_scanner/guard/cli/commands_hook.py"))
-    if "try_native_or_source_ref_hook" not in hook:
-        raise RuntimeError("CLI hook path does not consult native authority")
-    path = Path("src/codex_plugin_scanner/guard/cli/commands_hook_native_authority.py")
-    tree = ast.parse(_read(path), filename=str(path))
-    fn = next(
-        (
-            node
-            for node in tree.body
-            if isinstance(node, ast.FunctionDef) and node.name == "try_native_or_source_ref_hook"
-        ),
-        None,
-    )
-    if fn is None:
-        raise RuntimeError("CLI native authority helper is missing")
-    calls = _ordered_call_names(fn)
-    try:
-        native_idx = calls.index("try_native_hook_authority")
-        source_idx = calls.index("_try_source_ref_fast_path")
-    except ValueError as exc:
-        raise RuntimeError("CLI hook path is missing native authority or source-ref routing") from exc
-    if native_idx > source_idx:
-        raise RuntimeError("CLI hook path consults Python source-ref review before native authority")
-    native_cli = _read(path)
-    if "HookReviewEngine" in native_cli or "evaluate_command(" in native_cli:
-        raise RuntimeError("CLI native authority path still imports a Python semantic replica")
 
 
 def run(root: Path) -> dict[str, object]:
@@ -312,19 +333,17 @@ def run(root: Path) -> dict[str, object]:
 
             os.chdir(root)
         manifest = _manifest()
-        _pretool_gate()
-        _posttool_gate()
-        _mode_gate()
+        _hook_worker_gate()
+        _rust_hook_edge_gate()
+        _resident_client_gate()
+        _cli_gate()
+        _default_mode_gate()
         _policy_and_identity_gate()
         _workflow_gate()
         _docs_gate()
+        _mode_terminology_gate()
         _hygiene_gate()
-        _cli_gate()
-        return {
-            "schema": SCHEMA,
-            "status": "passed",
-            "manifest": manifest,
-        }
+        return {"schema": SCHEMA, "status": "passed", "manifest": manifest}
     finally:
         if Path.cwd() != original:
             import os
@@ -343,4 +362,3 @@ if __name__ == "__main__":
     if parsed.json is not None:
         parsed.json.parent.mkdir(parents=True, exist_ok=True)
         parsed.json.write_text(rendered + "\n", encoding="utf-8")
-    raise SystemExit(0)

--- a/scripts/ci/rust_pretool_no_python_gate.py
+++ b/scripts/ci/rust_pretool_no_python_gate.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Prove supported PreToolUse authority is Rust with no production Python fallback."""
+"""Prove default PreToolUse authority is Rust with no automatic Python fallback."""
 
 from __future__ import annotations
 
 import argparse
+import ast
 import json
 from pathlib import Path
 from typing import Final
@@ -21,6 +22,17 @@ def read(path: Path) -> str:
 def required_tokens(path: Path, tokens: tuple[str, ...]) -> list[str]:
     source = read(path)
     return [f"{path.as_posix()} missing {token}" for token in tokens if token not in source]
+
+
+def function_source(path: Path, name: str) -> str:
+    source = read(path)
+    tree = ast.parse(source, filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            segment = ast.get_source_segment(source, node)
+            if segment is not None:
+                return segment
+    raise RuntimeError(f"missing function {path}:{name}")
 
 
 def run(root: Path) -> dict[str, object]:
@@ -56,20 +68,21 @@ def run(root: Path) -> dict[str, object]:
         )
     )
 
-    hook_worker = root / "src/codex_plugin_scanner/guard/daemon/hook_worker.py"
-    hook_source = read(hook_worker)
-    for required in ("review_hook_edge_native", "native_hook_edge_unavailable"):
-        if required not in hook_source:
-            failures.append(f"{hook_worker.as_posix()} missing {required}")
-    for forbidden in (
-        "from ..native_pretool import review_pre_tool_native",
-        "HookReviewEngine",
-        "ContentScanner",
-        "HookDecisionCache",
-        "_pre_tool_command(",
-    ):
-        if forbidden in hook_source:
-            failures.append(f"production hook worker retains Python PreTool semantics: {forbidden}")
+    worker_path = root / "src/codex_plugin_scanner/guard/daemon/hook_worker.py"
+    worker = read(worker_path)
+    production = function_source(worker_path, "review_http_payload")
+    compatibility = function_source(worker_path, "_review_explicit_python_compatibility")
+    for required in ("review_hook_edge_native", 'mode in {"off", "shadow"}', "native_hook_edge_unavailable"):
+        if required not in production:
+            failures.append(f"default HookWorker PreTool contract missing {required}")
+    if "self.engine.review(" in production or "_request_from_payload(" in production:
+        failures.append("default HookWorker path invokes Python semantic evaluation")
+    if "HookWorkerUnsupported" in production:
+        failures.append("default HookWorker path can escape Rust authority")
+    if 'event_name != "PostToolUse"' not in compatibility:
+        failures.append("explicit Python compatibility is not bounded away from PreToolUse")
+    if "review_pre_tool_native" in worker or "_pre_tool_command(" in worker:
+        failures.append("HookWorker retains superseded Python-side PreTool parsing")
 
     edge = root / "src/codex_plugin_scanner/guard/native_hook_edge.py"
     edge_source = read(edge)
@@ -80,11 +93,19 @@ def run(root: Path) -> dict[str, object]:
         if forbidden in edge_source:
             failures.append(f"native hook edge bridge invokes Python PreTool semantics: {forbidden}")
 
-    cli = root / "src/codex_plugin_scanner/guard/cli/commands_hook_native_authority.py"
-    cli_source = read(cli)
-    for forbidden in ("native_mode", "_try_source_ref_fast_path", "HookWorkerUnsupported"):
-        if forbidden in cli_source:
-            failures.append(f"production CLI can escape Rust authority: {forbidden}")
+    cli_path = root / "src/codex_plugin_scanner/guard/cli/commands_hook_native_authority.py"
+    native_route = function_source(cli_path, "try_native_hook_authority")
+    compatibility_route = function_source(cli_path, "try_native_or_source_ref_hook")
+    if 'native_mode() not in {"auto", "force"}' not in native_route:
+        failures.append("CLI does not restrict Python compatibility to explicit off/shadow")
+    if "HookWorker(store=store).review_http_payload(" not in native_route:
+        failures.append("CLI auto/force PreTool route does not terminate at Rust HookWorker")
+    if "except" in native_route:
+        failures.append("CLI auto/force PreTool route catches native failures for fallback")
+    if "_try_source_ref_fast_path" not in compatibility_route:
+        failures.append("explicit source-ref compatibility route is missing")
+    if "native_result is not None" not in compatibility_route:
+        failures.append("native PreTool result is not terminal before compatibility")
 
     result = {
         "schema": SCHEMA,

--- a/scripts/ci/rust_pretool_no_python_gate.py
+++ b/scripts/ci/rust_pretool_no_python_gate.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Prove supported command PreToolUse authority is native, with Python as transport only."""
+"""Prove supported PreToolUse authority is Rust with no production Python fallback."""
 
 from __future__ import annotations
 
@@ -37,48 +37,55 @@ def run(root: Path) -> dict[str, object]:
             (
                 "pre-tool-command-authority-v1",
                 'command == "pre-tool"',
-                "PreToolUse(CommandModelRequestV1)",
+                '"hook-edge-v2"',
+                "HookEdge(Value)",
             ),
         )
     )
     failures.extend(
         required_tokens(
             root / "rust/crates/guard-runtime/src/oneshot.rs",
-            ("fn evaluate_pre_tool_bytes", "pre_tool_response", "evaluate_pre_tool_request"),
-        )
-    )
-    command_bridge = root / "src/codex_plugin_scanner/guard/native_pretool.py"
-    failures.extend(
-        required_tokens(
-            command_bridge,
             (
-                "def review_pre_tool_native(",
-                '"pre-tool"',
-                '"operation": "pre_tool_use"',
-                "def native_pre_tool_policy_floor(",
+                "fn evaluate_pre_tool_bytes",
+                "pre_tool_response",
+                "evaluate_pre_tool_request",
+                "evaluate_hook_edge_value",
+                "extract_pre_tool_command",
+                "native_pre_tool_unsupported_review",
             ),
         )
     )
-    bridge_source = read(command_bridge)
-    if "Python remains authoritative" in read(root / "src/codex_plugin_scanner/guard/native_command_model.py"):
-        failures.append("native_command_model.py still describes Python as authoritative")
-    if "Python remains authoritative" in bridge_source:
-        failures.append(f"{command_bridge.as_posix()} still describes Python as authoritative")
-    review_start = bridge_source.find("def review_pre_tool_native(")
-    review_end = bridge_source.find("\ndef native_pre_tool_policy_floor(", review_start)
-    review_body = bridge_source[review_start:review_end] if review_start >= 0 and review_end > review_start else ""
-    if "evaluate_command(" in review_body:
-        failures.append("review_pre_tool_native invokes the Python command evaluator")
-    failures.extend(
-        required_tokens(
-            root / "src/codex_plugin_scanner/guard/daemon/hook_worker.py",
-            (
-                "from ..native_pretool import review_pre_tool_native",
-                'if event_name == "PreToolUse":',
-                "native_pre_tool_unavailable",
-            ),
-        )
-    )
+
+    hook_worker = root / "src/codex_plugin_scanner/guard/daemon/hook_worker.py"
+    hook_source = read(hook_worker)
+    for required in ("review_hook_edge_native", "native_hook_edge_unavailable"):
+        if required not in hook_source:
+            failures.append(f"{hook_worker.as_posix()} missing {required}")
+    for forbidden in (
+        "from ..native_pretool import review_pre_tool_native",
+        "HookReviewEngine",
+        "ContentScanner",
+        "HookDecisionCache",
+        "_pre_tool_command(",
+    ):
+        if forbidden in hook_source:
+            failures.append(f"production hook worker retains Python PreTool semantics: {forbidden}")
+
+    edge = root / "src/codex_plugin_scanner/guard/native_hook_edge.py"
+    edge_source = read(edge)
+    for required in ('"operation": "hook_edge"', '"hook-edge", "--stdin"', "review_hook_edge_native"):
+        if required not in edge_source:
+            failures.append(f"{edge.as_posix()} missing {required}")
+    for forbidden in ("evaluate_command(", "HookReviewEngine", "review_pre_tool_native("):
+        if forbidden in edge_source:
+            failures.append(f"native hook edge bridge invokes Python PreTool semantics: {forbidden}")
+
+    cli = root / "src/codex_plugin_scanner/guard/cli/commands_hook_native_authority.py"
+    cli_source = read(cli)
+    for forbidden in ("native_mode", "_try_source_ref_fast_path", "HookWorkerUnsupported"):
+        if forbidden in cli_source:
+            failures.append(f"production CLI can escape Rust authority: {forbidden}")
+
     result = {
         "schema": SCHEMA,
         "status": "passed" if not failures else "failed",

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_native_authority.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_native_authority.py
@@ -1,4 +1,4 @@
-"""Route production hook decisions through the native Rust data plane."""
+"""Route default production hooks through the native Rust authority."""
 
 from __future__ import annotations
 
@@ -9,7 +9,9 @@ from typing import Any
 from ..adapters.base import HarnessContext
 from ..config import GuardConfig
 from ..daemon.hook_worker import HookWorker
+from ..native_runtime import native_mode
 from ..store import GuardStore
+from .commands_hook_source_ref import _try_source_ref_fast_path
 from .commands_support_interaction import _emit
 
 
@@ -21,14 +23,11 @@ def try_native_hook_authority(
     guard_home: Path,
     workspace: Path | None,
     store: GuardStore,
-) -> dict[str, Any]:
-    """Return the fail-closed Rust hook result for the raw harness envelope.
+) -> dict[str, Any] | None:
+    """Return Rust authority for auto/force, or None for explicit compatibility."""
 
-    Environment mode settings no longer select a Python semantic evaluator.
-    The worker itself returns a deterministic block when the bundled native
-    runtime cannot complete the decision safely.
-    """
-
+    if native_mode() not in {"auto", "force"}:
+        return None
     return HookWorker(store=store).review_http_payload(
         payload=payload,
         params={},
@@ -48,14 +47,14 @@ def try_native_or_source_ref_hook(
     runtime_workspace: Path | None,
     store: GuardStore,
 ) -> int | None:
-    """Use Rust authority for every production hook reaching this route.
+    """Use Rust in auto/force; retain Python reference only for off/shadow.
 
-    The historical Python source-ref semantic fallback is intentionally not
-    reachable here. Source-reference validation and content I/O are performed
-    by the Rust hook core; native failure is rendered fail closed by HookWorker.
+    A native failure in auto/force is returned as a deterministic fail-closed
+    response by ``HookWorker`` and cannot reach the Python source-ref evaluator.
+    The source-ref helper remains reachable only when the operator explicitly
+    selected ``off`` or ``shadow`` compatibility.
     """
 
-    del config
     native_result = try_native_hook_authority(
         payload=payload,
         harness=args.harness,
@@ -64,5 +63,14 @@ def try_native_or_source_ref_hook(
         workspace=runtime_workspace,
         store=store,
     )
-    _emit("hook", native_result, getattr(args, "json", False))
-    return 0
+    if native_result is not None:
+        _emit("hook", native_result, getattr(args, "json", False))
+        return 0
+    return _try_source_ref_fast_path(
+        args,
+        config=config,
+        context=context,
+        payload=payload,
+        runtime_workspace=runtime_workspace,
+        store=store,
+    )

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_native_authority.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_native_authority.py
@@ -1,4 +1,4 @@
-"""Route auto/force PreToolUse and PostToolUse through the native worker."""
+"""Route production hook decisions through the native Rust data plane."""
 
 from __future__ import annotations
 
@@ -8,10 +8,8 @@ from typing import Any
 
 from ..adapters.base import HarnessContext
 from ..config import GuardConfig
-from ..daemon.hook_worker import HookWorker, HookWorkerUnsupported
-from ..native_runtime import native_mode
+from ..daemon.hook_worker import HookWorker
 from ..store import GuardStore
-from .commands_hook_source_ref import _try_source_ref_fast_path
 from .commands_support_interaction import _emit
 
 
@@ -23,27 +21,22 @@ def try_native_hook_authority(
     guard_home: Path,
     workspace: Path | None,
     store: GuardStore,
-) -> dict[str, Any] | None:
-    """Return native harness JSON, or None when Python CLI must continue.
+) -> dict[str, Any]:
+    """Return the fail-closed Rust hook result for the raw harness envelope.
 
-    ``auto`` and ``force`` send supported command PreToolUse and PostToolUse
-    through the same fail-closed Rust worker as the daemon. File PreToolUse
-    and other events still raise ``HookWorkerUnsupported`` so the existing
-    CLI path can handle them.
+    Environment mode settings no longer select a Python semantic evaluator.
+    The worker itself returns a deterministic block when the bundled native
+    runtime cannot complete the decision safely.
     """
-    if native_mode() not in {"auto", "force"}:
-        return None
-    try:
-        return HookWorker(store=store).review_http_payload(
-            payload=payload,
-            params={},
-            default_harness=harness,
-            home_dir=home_dir,
-            guard_home=guard_home,
-            workspace=workspace,
-        )
-    except HookWorkerUnsupported:
-        return None
+
+    return HookWorker(store=store).review_http_payload(
+        payload=payload,
+        params={},
+        default_harness=harness,
+        home_dir=home_dir,
+        guard_home=guard_home,
+        workspace=workspace,
+    )
 
 
 def try_native_or_source_ref_hook(
@@ -55,12 +48,14 @@ def try_native_or_source_ref_hook(
     runtime_workspace: Path | None,
     store: GuardStore,
 ) -> int | None:
-    """Prefer native authority, then Python source-ref when native does not apply.
+    """Use Rust authority for every production hook reaching this route.
 
-    ``off`` and ``shadow`` stay on the Python source-ref path. ``auto`` and
-    ``force`` use that path only after the native worker reports the event as
-    unsupported, such as file PreToolUse with a source reference.
+    The historical Python source-ref semantic fallback is intentionally not
+    reachable here. Source-reference validation and content I/O are performed
+    by the Rust hook core; native failure is rendered fail closed by HookWorker.
     """
+
+    del config
     native_result = try_native_hook_authority(
         payload=payload,
         harness=args.harness,
@@ -69,14 +64,5 @@ def try_native_or_source_ref_hook(
         workspace=runtime_workspace,
         store=store,
     )
-    if native_result is not None:
-        _emit("hook", native_result, getattr(args, "json", False))
-        return 0
-    return _try_source_ref_fast_path(
-        args,
-        config=config,
-        context=context,
-        payload=payload,
-        runtime_workspace=runtime_workspace,
-        store=store,
-    )
+    _emit("hook", native_result, getattr(args, "json", False))
+    return 0

--- a/src/codex_plugin_scanner/guard/daemon/hook_worker.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_worker.py
@@ -77,16 +77,19 @@ class HookWorker:
         """Return a harness response from Rust authority or a fail-closed result."""
 
         harness = self._runtime_harness(params) or default_harness
-        config = self._load_config(guard_home, workspace)
-        native = review_hook_edge_native(
-            payload=payload,
-            harness=harness,
-            home_dir=home_dir,
-            guard_home=guard_home,
-            workspace=workspace,
-            observe_mode=config.mode == "observe",
-            deadline=deadline,
-        )
+        try:
+            config = self._load_config(guard_home, workspace)
+            native = review_hook_edge_native(
+                payload=payload,
+                harness=harness,
+                home_dir=home_dir,
+                guard_home=guard_home,
+                workspace=workspace,
+                observe_mode=config.mode == "observe",
+                deadline=deadline,
+            )
+        except Exception:
+            native = None
         if native is None:
             event_name = runtime_hook_event_name(payload)
             if event_name == "PostToolUse":

--- a/src/codex_plugin_scanner/guard/daemon/hook_worker.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_worker.py
@@ -1,25 +1,15 @@
-"""Daemon-resident hook worker for fast hook review.
+"""Daemon-resident hook transport for the Rust Guard data plane.
 
-This worker avoids Python startup/import cost and avoids calling the
-CLI path for normal daemon hooks. It builds a ``HookReviewRequest``
-from the HTTP payload and calls the configured local decision backend.
-
-Security:
-- Never lets unreviewed tool output reach the model.
-- Never falls back to legacy CLI after a worker exception for a
-  request that supplied only ``guard_source_ref`` without full output.
-- Never calls ``run_guard_command()``.
-- Native PostToolUse is decided by Rust for ``auto``/``force``. Native failure
-  fails closed instead of spilling into Python review. The Python engine is
-  constructed only for ``off``/``shadow``.
-- Supported command PreToolUse is decided by Rust. Native failure fails closed.
-  Non-command PreToolUse still raises ``HookWorkerUnsupported`` for the CLI path.
+The Python worker authenticates the daemon route, supplies bounded control-plane
+metadata, renders the already-produced native decision for each harness, and
+persists best-effort activity after PostToolUse. It does not parse/classify a
+supported hook action, read content for semantic review, or invoke a Python
+semantic fallback.
 """
 
 from __future__ import annotations
 
 from collections.abc import Mapping
-from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, final
 
@@ -28,17 +18,7 @@ from ..cli.commands_support_command_activity import (
     record_post_hook_command_activity_best_effort,
 )
 from ..config import load_guard_config
-from ..native_pretool import review_pre_tool_native
-from ..native_runtime import native_mode, native_runtime_status, review_post_tool_native
-from ..runtime.hook_content_scanner import ContentScanner
-from ..runtime.hook_decision_cache import HookDecisionCache
-from ..runtime.hook_review_engine import HookReviewEngine
-from ..runtime.hook_review_types import (
-    HookOutputSummary,
-    HookPayloadKind,
-    HookReviewRequest,
-    HookSourceFileRef,
-)
+from ..native_hook_edge import review_hook_edge_native
 
 if TYPE_CHECKING:
     from ..store import GuardStore
@@ -56,6 +36,7 @@ class CommandActivityWriter(Protocol):
 
 
 def runtime_hook_event_name(payload: Mapping[str, object]) -> str:
+    """Best-effort display/fail-safe event label; Rust owns semantic extraction."""
     for key in ("event", "eventName", "hook_event_name", "hookEventName", "hook_name", "hookName"):
         value = payload.get(key)
         if isinstance(value, str) and value.strip():
@@ -64,33 +45,20 @@ def runtime_hook_event_name(payload: Mapping[str, object]) -> str:
 
 
 class HookWorkerUnsupported(RuntimeError):  # noqa: N818
-    """Raised when the worker cannot handle a request (caller falls back to CLI)."""
+    """Compatibility exception retained for callers outside the native hook surface."""
 
 
 @final
 class HookWorker:
-    """Resident hook review worker for the daemon."""
+    """Transport raw hook envelopes to the bundled Rust authority."""
 
     def __init__(self, *, store: GuardStore, activity_writer: CommandActivityWriter | None = None):
         self.store = store
         self.guard_home = store.guard_home
         self.activity_writer = activity_writer
-        self._engine: HookReviewEngine | None = None
         from .hook_metrics import HookMetricsRecorder
 
         self.metrics = HookMetricsRecorder()
-
-    @property
-    def engine(self) -> HookReviewEngine:
-        if self._engine is None:
-            self._engine = HookReviewEngine(
-                store=self.store,
-                scanner=ContentScanner(),
-                cache=HookDecisionCache(self.store),
-                config_loader=self._load_config,
-                metrics=self.metrics,
-            )
-        return self._engine
 
     def _load_config(self, guard_home: Path, workspace: Path | None):
         return load_guard_config(guard_home, workspace=workspace)
@@ -106,105 +74,42 @@ class HookWorker:
         workspace: Path | None,
         deadline: float | None = None,
     ) -> dict[str, object]:
-        """Review a hook HTTP payload and return harness JSON.
+        """Return a harness response from Rust authority or a fail-closed result."""
 
-        ``off`` keeps the Python engine authoritative. ``shadow`` evaluates
-        Python first and exercises native only as non-authoritative evidence.
-        ``auto`` and ``force`` require the native runtime. When native is
-        unavailable or returns no result, supported PreToolUse and PostToolUse
-        fail closed.
-        """
         harness = self._runtime_harness(params) or default_harness
-        event_name = self._hook_event_name(payload)
-        if event_name == "PreToolUse":
-            command = _pre_tool_command(payload)
-            if command is None:
-                raise HookWorkerUnsupported("fast path PreToolUse requires a command")
-            native = review_pre_tool_native(
-                command,
-                guard_home=guard_home,
-                cwd=workspace,
-                home_dir=home_dir,
-            )
-            if native is not None:
-                action = str(native.get("minimum_action") or "")
-                if action == "review":
-                    raise HookWorkerUnsupported("native PreToolUse review uses CLI approval coordination")
-                return _harness_json_from_native_pre_tool(harness, native)
-            status = native_runtime_status()
-            if status.mode == "off":
-                raise HookWorkerUnsupported("native PreToolUse runtime is off")
-            if status.mode == "shadow":
-                raise HookWorkerUnsupported("native PreToolUse runtime is unavailable")
-            return post_tool_fail_safe_response(
-                harness,
-                reason="HOL Guard could not complete the native PreToolUse decision safely.",
-                reason_code="native_pre_tool_unavailable",
-            )
-        if event_name != "PostToolUse":
-            raise HookWorkerUnsupported(f"fast path supports PreToolUse and PostToolUse, got event={event_name}")
-        return self._review_post_tool_http(
-            payload,
+        config = self._load_config(guard_home, workspace)
+        native = review_hook_edge_native(
+            payload=payload,
             harness=harness,
-            default_harness=default_harness,
             home_dir=home_dir,
             guard_home=guard_home,
             workspace=workspace,
+            observe_mode=config.mode == "observe",
             deadline=deadline,
         )
-
-    def _review_post_tool_http(
-        self,
-        payload: dict[str, object],
-        *,
-        harness: str,
-        default_harness: str,
-        home_dir: Path,
-        guard_home: Path,
-        workspace: Path | None,
-        deadline: float | None,
-    ) -> dict[str, object]:
-        event_name = "PostToolUse"
-        request = self._request_from_payload(
-            payload,
-            harness=harness,
-            source_ref_external_allowed=default_harness.strip().lower().replace("_", "-") in {"pi", "omp"},
-            home_dir=home_dir,
-            guard_home=guard_home,
-            workspace=workspace,
-            deadline=deadline,
-        )
-        mode = native_mode()
-        native_required = mode in {"auto", "force"}
-        if native_required:
-            config = self._load_config(guard_home, workspace)
-            response = review_post_tool_native(
-                request,
-                observe_mode=config.mode == "observe",
-            )
-            if response is None:
+        if native is None:
+            event_name = runtime_hook_event_name(payload)
+            if event_name == "PostToolUse":
                 self._record_post_tool_activity(
                     harness=harness,
                     payload=payload,
                     succeeded=hook_post_succeeded(event_name, payload),
                 )
-                return post_tool_fail_safe_response(
-                    harness,
-                    reason="HOL Guard could not complete the native local hook review safely.",
-                    reason_code="native_post_tool_unavailable",
-                )
-        else:
-            response = self.engine.review(request)
-            if mode == "shadow":
-                with suppress(Exception):
-                    _ = review_post_tool_native(request, observe_mode=response.observe_mode)
+            return post_tool_fail_safe_response(
+                harness,
+                reason="HOL Guard could not complete the native hook decision safely.",
+                reason_code="native_hook_edge_unavailable",
+                event_name=event_name,
+            )
 
-        self._record_post_tool_activity(
-            harness=harness,
-            payload=payload,
-            succeeded=hook_post_succeeded(event_name, payload),
-        )
-        return _harness_json_from_review_response(harness, event_name, response)
+        event_name = str(native.get("event_name") or runtime_hook_event_name(payload))
+        if event_name == "PostToolUse":
+            self._record_post_tool_activity(
+                harness=harness,
+                payload=payload,
+                succeeded=hook_post_succeeded(event_name, payload),
+            )
+        return _harness_json_from_native_edge(harness, native)
 
     def _record_post_tool_activity(
         self,
@@ -236,124 +141,18 @@ class HookWorker:
             return values[-1].strip()
         return None
 
-    def _request_from_payload(
-        self,
-        payload: dict[str, object],
-        *,
-        harness: str,
-        source_ref_external_allowed: bool,
-        home_dir: Path,
-        guard_home: Path,
-        workspace: Path | None,
-        deadline: float | None = None,
-    ) -> HookReviewRequest:
-        event_name = self._hook_event_name(payload)
-        payload_kind = self._payload_kind(payload)
-        output_summary = self._parse_output_summary(payload)
-        source_ref = self._parse_source_ref(payload)
-        source_scope = str(payload.get("source_scope") or "project")
-        config_path = payload.get("config_path")
-        if not isinstance(config_path, str):
-            config_path = None
-        return HookReviewRequest(
-            harness=harness,
-            event_name=event_name,
-            payload=payload,
-            payload_kind=payload_kind,
-            config_path=config_path,
-            cwd=workspace,
-            home_dir=home_dir,
-            guard_home=guard_home,
-            source_scope=source_scope,
-            source_ref_external_allowed=source_ref_external_allowed,
-            output_summary=output_summary,
-            source_ref=source_ref,
-            deadline_monotonic=deadline,
-        )
 
-    def _hook_event_name(self, payload: Mapping[str, object]) -> str:
-        return runtime_hook_event_name(payload)
-
-    def _payload_kind(self, payload: Mapping[str, object]) -> HookPayloadKind:
-        if "guard_payload_ref" in payload:
-            return "encrypted_payload_ref"
-        if "guard_source_ref" in payload:
-            return "source_file_ref"
-        return "inline"
-
-    def _parse_output_summary(self, payload: Mapping[str, object]) -> HookOutputSummary | None:
-        summary = payload.get("tool_response_summary")
-        if not isinstance(summary, Mapping):
-            return None
-        text_excerpt = summary.get("text_excerpt") or summary.get("excerpt") or ""
-        if not isinstance(text_excerpt, str):
-            text_excerpt = str(text_excerpt)
-        excerpt_truncated = bool(summary.get("excerpt_truncated", False))
-        output_sha256 = summary.get("output_sha256")
-        if not isinstance(output_sha256, str):
-            output_sha256 = None
-        output_chars_raw = summary.get("output_chars")
-        output_chars = int(output_chars_raw) if isinstance(output_chars_raw, (int, float)) else None
-        content_items_seen_raw = summary.get("content_items_seen")
-        content_items_seen = int(content_items_seen_raw) if isinstance(content_items_seen_raw, (int, float)) else None
-        object_keys_seen_raw = summary.get("object_keys_seen")
-        object_keys_seen = int(object_keys_seen_raw) if isinstance(object_keys_seen_raw, (int, float)) else None
-        max_depth_seen_raw = summary.get("max_depth_seen")
-        max_depth_seen = int(max_depth_seen_raw) if isinstance(max_depth_seen_raw, (int, float)) else None
-        return HookOutputSummary(
-            text_excerpt=text_excerpt,
-            excerpt_truncated=excerpt_truncated,
-            output_sha256=output_sha256,
-            output_chars=output_chars,
-            content_items_seen=content_items_seen,
-            object_keys_seen=object_keys_seen,
-            max_depth_seen=max_depth_seen,
-        )
-
-    def _parse_source_ref(self, payload: Mapping[str, object]) -> HookSourceFileRef | None:
-        ref = payload.get("guard_source_ref")
-        if not isinstance(ref, Mapping):
-            return None
-        version = ref.get("version")
-        path = ref.get("path")
-        output_sha256 = ref.get("output_sha256")
-        output_chars = ref.get("output_chars")
-        tool_input_path = ref.get("tool_input_path")
-        adapter_stat = ref.get("adapter_stat")
-        if not isinstance(version, int) or not isinstance(path, str) or not isinstance(output_sha256, str):
-            return HookSourceFileRef(version=-1, path="", output_sha256="", output_chars=0)
-        if not isinstance(output_chars, int):
-            output_chars = 0
-        if not isinstance(tool_input_path, str):
-            tool_input_path = None
-        stat_dict = dict(adapter_stat) if isinstance(adapter_stat, Mapping) else {}
-        return HookSourceFileRef(
-            version=version,
-            path=path,
-            output_sha256=output_sha256,
-            output_chars=output_chars,
-            tool_input_path=tool_input_path,
-            adapter_stat=stat_dict,
-        )
+def _canonical_hook_harness(harness: str) -> str:
+    return harness.strip().lower().replace("_", "-")
 
 
-def _pre_tool_command(payload: Mapping[str, object]) -> str | None:
-    for candidate in (payload.get("tool_input"), payload.get("arguments"), payload):
-        if not isinstance(candidate, Mapping):
-            continue
-        for key in ("command", "cmd", "shell_command", "shellCommand"):
-            value = candidate.get(key)
-            if isinstance(value, str) and value.strip():
-                return value
-    return None
-
-
-def _harness_json_from_native_pre_tool(harness: str, response: Mapping[str, object]) -> dict[str, object]:
-    action = response.get("minimum_action")
+def _pre_tool_harness_response(harness: str, response: Mapping[str, object]) -> dict[str, object]:
+    action = str(response.get("minimum_action") or response.get("policy_action") or "block")
     reason = str(response.get("reason") or "HOL Guard requires native review before execution.")
     reason_code = str(response.get("reason_code") or "native_pre_tool_review")
+    canonical = _canonical_hook_harness(harness)
     if action == "allow" and response.get("decision") == "allow":
-        if _canonical_hook_harness(harness) in {"pi", "omp"}:
+        if canonical in {"pi", "omp"}:
             return {
                 "decision": "allow",
                 "policy_action": "allow",
@@ -365,26 +164,78 @@ def _harness_json_from_native_pre_tool(harness: str, response: Mapping[str, obje
             "reason_code": reason_code,
             "hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"},
         }
-    if _canonical_hook_harness(harness) in {"pi", "omp"}:
+
+    if canonical in {"pi", "omp"}:
         return {
             "decision": "deny",
             "reason": reason,
             "model_output_action": "block",
             "notice": "warning",
             "reason_code": reason_code,
+            "policy_action": action,
         }
+
+    permission_decision = "deny"
+    if action == "review" and canonical not in {"codex", "kimi", "grok", "zcode"}:
+        permission_decision = "ask"
     return {
+        "policy_action": action,
         "reason_code": reason_code,
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
-            "permissionDecision": "deny",
+            "permissionDecision": permission_decision,
             "permissionDecisionReason": reason,
         },
     }
 
 
-def _canonical_hook_harness(harness: str) -> str:
-    return harness.strip().lower().replace("_", "-")
+def _post_tool_harness_response(harness: str, response: Mapping[str, object]) -> dict[str, object]:
+    canonical = _canonical_hook_harness(harness)
+    payload = {
+        key: value
+        for key, value in response.items()
+        if key
+        in {
+            "decision",
+            "reason",
+            "model_output_action",
+            "reviewed_output_sha256",
+            "reviewed_excerpt",
+            "notice",
+            "reason_code",
+            "policy_action",
+            "observed_policy_action",
+            "observe_mode",
+        }
+    }
+    if canonical in {"pi", "omp"}:
+        return payload
+    decision = str(payload.get("decision") or "")
+    model_output_action = str(payload.get("model_output_action") or "")
+    if decision == "allow" and model_output_action == "allow_original":
+        return {
+            "policy_action": "allow",
+            "reason_code": str(payload.get("reason_code") or "native_post_tool_allow"),
+            "hookSpecificOutput": {"hookEventName": "PostToolUse"},
+        }
+    reason = str(payload.get("reason") or "HOL Guard blocked this tool output because it could not be proven safe.")
+    reason_code = str(payload.get("reason_code") or "native_post_tool_block")
+    return post_tool_native_block_response(reason=reason, reason_code=reason_code)
+
+
+def _harness_json_from_native_edge(harness: str, response: Mapping[str, object]) -> dict[str, object]:
+    event_name = str(response.get("event_name") or "PreToolUse")
+    if event_name == "PreToolUse":
+        return _pre_tool_harness_response(harness, response)
+    if event_name == "PostToolUse":
+        return _post_tool_harness_response(harness, response)
+    reason = str(response.get("reason") or "HOL Guard requires review for this native hook event.")
+    return post_tool_fail_safe_response(
+        harness,
+        reason=reason,
+        reason_code=str(response.get("reason_code") or "native_hook_event_review_required"),
+        event_name=event_name,
+    )
 
 
 def post_tool_native_block_response(
@@ -410,8 +261,20 @@ def post_tool_fail_safe_response(
     *,
     reason: str = "HOL Guard could not complete local hook review safely.",
     reason_code: str = "daemon_worker_exception",
+    event_name: str = "PostToolUse",
 ) -> dict[str, object]:
-    if _canonical_hook_harness(harness) in {"pi", "omp"}:
+    canonical = _canonical_hook_harness(harness)
+    if event_name == "PreToolUse" and canonical not in {"pi", "omp"}:
+        return {
+            "policy_action": "block",
+            "reason_code": reason_code,
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": reason,
+            },
+        }
+    if canonical in {"pi", "omp"}:
         return {
             "decision": "deny",
             "reason": reason,
@@ -419,31 +282,6 @@ def post_tool_fail_safe_response(
             "notice": "warning",
             "reason_code": reason_code,
         }
-    return post_tool_native_block_response(reason=reason, reason_code=reason_code)
-
-
-def _harness_json_from_review_response(
-    harness: str,
-    event_name: str,
-    response: object,
-) -> dict[str, object]:
-    to_harness_json = getattr(response, "to_harness_json", None)
-    payload = to_harness_json() if callable(to_harness_json) else {}
-    if not isinstance(payload, dict):
-        payload = {}
-    if event_name != "PostToolUse":
-        return payload
-    if _canonical_hook_harness(harness) in {"pi", "omp"}:
-        return payload
-    decision = str(payload.get("decision") or "")
-    model_output_action = str(payload.get("model_output_action") or "")
-    if decision == "allow" and model_output_action == "allow_original":
-        return {
-            "policy_action": "allow",
-            "hookSpecificOutput": {"hookEventName": event_name},
-        }
-    reason = str(payload.get("reason") or "HOL Guard blocked this tool output because it could not be proven safe.")
-    reason_code = str(payload.get("reason_code") or "fast_path_block")
     return post_tool_native_block_response(reason=reason, reason_code=reason_code)
 
 

--- a/src/codex_plugin_scanner/guard/daemon/hook_worker.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_worker.py
@@ -1,15 +1,19 @@
 """Daemon-resident hook transport for the Rust Guard data plane.
 
-The Python worker authenticates the daemon route, supplies bounded control-plane
-metadata, renders the already-produced native decision for each harness, and
-persists best-effort activity after PostToolUse. It does not parse/classify a
-supported hook action, read content for semantic review, or invoke a Python
-semantic fallback.
+The no-environment production path is Rust-authoritative from the raw hook
+edge through the semantic decision and decision-critical PostToolUse I/O.
+Python remains a bounded control plane for route handling, resident lifecycle,
+harness rendering, and best-effort evidence.
+
+Explicit ``off``/``shadow`` modes retain the Python reference evaluator for
+rollback and differential compatibility. Native failure in ``auto``/``force``
+never enters that compatibility evaluator.
 """
 
 from __future__ import annotations
 
 from collections.abc import Mapping
+from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, final
 
@@ -19,6 +23,16 @@ from ..cli.commands_support_command_activity import (
 )
 from ..config import load_guard_config
 from ..native_hook_edge import review_hook_edge_native
+from ..native_runtime import native_mode
+from ..runtime.hook_content_scanner import ContentScanner
+from ..runtime.hook_decision_cache import HookDecisionCache
+from ..runtime.hook_review_engine import HookReviewEngine
+from ..runtime.hook_review_types import (
+    HookOutputSummary,
+    HookPayloadKind,
+    HookReviewRequest,
+    HookSourceFileRef,
+)
 
 if TYPE_CHECKING:
     from ..store import GuardStore
@@ -36,7 +50,7 @@ class CommandActivityWriter(Protocol):
 
 
 def runtime_hook_event_name(payload: Mapping[str, object]) -> str:
-    """Best-effort display/fail-safe event label; Rust owns semantic extraction."""
+    """Best-effort display/fail-safe event label; Rust owns auto-mode extraction."""
     for key in ("event", "eventName", "hook_event_name", "hookEventName", "hook_name", "hookName"):
         value = payload.get(key)
         if isinstance(value, str) and value.strip():
@@ -45,20 +59,34 @@ def runtime_hook_event_name(payload: Mapping[str, object]) -> str:
 
 
 class HookWorkerUnsupported(RuntimeError):  # noqa: N818
-    """Compatibility exception retained for callers outside the native hook surface."""
+    """Raised only for explicit compatibility modes and unsupported control events."""
 
 
 @final
 class HookWorker:
-    """Transport raw hook envelopes to the bundled Rust authority."""
+    """Transport production hooks to Rust and isolate explicit compatibility."""
 
     def __init__(self, *, store: GuardStore, activity_writer: CommandActivityWriter | None = None):
         self.store = store
         self.guard_home = store.guard_home
         self.activity_writer = activity_writer
+        self._engine: HookReviewEngine | None = None
         from .hook_metrics import HookMetricsRecorder
 
         self.metrics = HookMetricsRecorder()
+
+    @property
+    def engine(self) -> HookReviewEngine:
+        """Lazy Python reference engine reachable only from explicit off/shadow."""
+        if self._engine is None:
+            self._engine = HookReviewEngine(
+                store=self.store,
+                scanner=ContentScanner(),
+                cache=HookDecisionCache(self.store),
+                config_loader=self._load_config,
+                metrics=self.metrics,
+            )
+        return self._engine
 
     def _load_config(self, guard_home: Path, workspace: Path | None):
         return load_guard_config(guard_home, workspace=workspace)
@@ -74,9 +102,22 @@ class HookWorker:
         workspace: Path | None,
         deadline: float | None = None,
     ) -> dict[str, object]:
-        """Return a harness response from Rust authority or a fail-closed result."""
+        """Return Rust authority by default; explicit off/shadow use compatibility."""
 
         harness = self._runtime_harness(params) or default_harness
+        mode = native_mode()
+        if mode in {"off", "shadow"}:
+            return self._review_explicit_python_compatibility(
+                payload,
+                harness=harness,
+                default_harness=default_harness,
+                home_dir=home_dir,
+                guard_home=guard_home,
+                workspace=workspace,
+                deadline=deadline,
+                shadow=mode == "shadow",
+            )
+
         try:
             config = self._load_config(guard_home, workspace)
             native = review_hook_edge_native(
@@ -114,6 +155,54 @@ class HookWorker:
             )
         return _harness_json_from_native_edge(harness, native)
 
+    def _review_explicit_python_compatibility(
+        self,
+        payload: dict[str, object],
+        *,
+        harness: str,
+        default_harness: str,
+        home_dir: Path,
+        guard_home: Path,
+        workspace: Path | None,
+        deadline: float | None,
+        shadow: bool,
+    ) -> dict[str, object]:
+        """Run the explicit rollback/reference evaluator, never automatic fallback."""
+
+        event_name = runtime_hook_event_name(payload)
+        if event_name != "PostToolUse":
+            raise HookWorkerUnsupported(
+                f"explicit Python compatibility handles PostToolUse only, got event={event_name}"
+            )
+        request = self._request_from_payload(
+            payload,
+            harness=harness,
+            source_ref_external_allowed=default_harness.strip().lower().replace("_", "-") in {"pi", "omp"},
+            home_dir=home_dir,
+            guard_home=guard_home,
+            workspace=workspace,
+            deadline=deadline,
+        )
+        response = self.engine.review(request)
+        if shadow:
+            with suppress(Exception):
+                config = self._load_config(guard_home, workspace)
+                _ = review_hook_edge_native(
+                    payload=payload,
+                    harness=harness,
+                    home_dir=home_dir,
+                    guard_home=guard_home,
+                    workspace=workspace,
+                    observe_mode=config.mode == "observe",
+                    deadline=deadline,
+                )
+        self._record_post_tool_activity(
+            harness=harness,
+            payload=payload,
+            succeeded=hook_post_succeeded(event_name, payload),
+        )
+        return _harness_json_from_review_response(harness, event_name, response)
+
     def _record_post_tool_activity(
         self,
         *,
@@ -143,6 +232,105 @@ class HookWorker:
         if values and isinstance(values[-1], str) and values[-1].strip():
             return values[-1].strip()
         return None
+
+    def _request_from_payload(
+        self,
+        payload: dict[str, object],
+        *,
+        harness: str,
+        source_ref_external_allowed: bool,
+        home_dir: Path,
+        guard_home: Path,
+        workspace: Path | None,
+        deadline: float | None = None,
+    ) -> HookReviewRequest:
+        """Build a Python reference request only in explicit compatibility mode."""
+
+        event_name = runtime_hook_event_name(payload)
+        payload_kind = self._payload_kind(payload)
+        output_summary = self._parse_output_summary(payload)
+        source_ref = self._parse_source_ref(payload)
+        source_scope = str(payload.get("source_scope") or "project")
+        config_path = payload.get("config_path")
+        if not isinstance(config_path, str):
+            config_path = None
+        return HookReviewRequest(
+            harness=harness,
+            event_name=event_name,
+            payload=payload,
+            payload_kind=payload_kind,
+            config_path=config_path,
+            cwd=workspace,
+            home_dir=home_dir,
+            guard_home=guard_home,
+            source_scope=source_scope,
+            source_ref_external_allowed=source_ref_external_allowed,
+            output_summary=output_summary,
+            source_ref=source_ref,
+            deadline_monotonic=deadline,
+        )
+
+    def _payload_kind(self, payload: Mapping[str, object]) -> HookPayloadKind:
+        if "guard_payload_ref" in payload:
+            return "encrypted_payload_ref"
+        if "guard_source_ref" in payload:
+            return "source_file_ref"
+        return "inline"
+
+    def _parse_output_summary(self, payload: Mapping[str, object]) -> HookOutputSummary | None:
+        summary = payload.get("tool_response_summary")
+        if not isinstance(summary, Mapping):
+            return None
+        text_excerpt = summary.get("text_excerpt") or summary.get("excerpt") or ""
+        if not isinstance(text_excerpt, str):
+            text_excerpt = str(text_excerpt)
+        excerpt_truncated = bool(summary.get("excerpt_truncated", False))
+        output_sha256 = summary.get("output_sha256")
+        if not isinstance(output_sha256, str):
+            output_sha256 = None
+        output_chars_raw = summary.get("output_chars")
+        output_chars = int(output_chars_raw) if isinstance(output_chars_raw, (int, float)) else None
+        content_items_seen_raw = summary.get("content_items_seen")
+        content_items_seen = int(content_items_seen_raw) if isinstance(content_items_seen_raw, (int, float)) else None
+        object_keys_seen_raw = summary.get("object_keys_seen")
+        object_keys_seen = int(object_keys_seen_raw) if isinstance(object_keys_seen_raw, (int, float)) else None
+        max_depth_seen_raw = summary.get("max_depth_seen")
+        max_depth_seen = int(max_depth_seen_raw) if isinstance(max_depth_seen_raw, (int, float)) else None
+        return HookOutputSummary(
+            text_excerpt=text_excerpt,
+            excerpt_truncated=excerpt_truncated,
+            output_sha256=output_sha256,
+            output_chars=output_chars,
+            content_items_seen=content_items_seen,
+            object_keys_seen=object_keys_seen,
+            max_depth_seen=max_depth_seen,
+        )
+
+    def _parse_source_ref(self, payload: Mapping[str, object]) -> HookSourceFileRef | None:
+        ref = payload.get("guard_source_ref")
+        if not isinstance(ref, Mapping):
+            return None
+        version = ref.get("version")
+        path = ref.get("path")
+        output_sha256 = ref.get("output_sha256")
+        output_chars = ref.get("output_chars")
+        tool_input_path = ref.get("tool_input_path")
+        adapter_stat = ref.get("adapter_stat")
+        if not isinstance(version, int) or not isinstance(path, str) or not isinstance(output_sha256, str):
+            return HookSourceFileRef(version=-1, path="", output_sha256="", output_chars=0)
+        if not isinstance(output_chars, int):
+            output_chars = 0
+        if not isinstance(tool_input_path, str):
+            tool_input_path = None
+        stat_dict = dict(adapter_stat) if isinstance(adapter_stat, Mapping) else {}
+        return HookSourceFileRef(
+            version=version,
+            path=path,
+            output_sha256=output_sha256,
+            output_chars=output_chars,
+            tool_input_path=tool_input_path,
+            adapter_stat=stat_dict,
+        )
 
 
 def _canonical_hook_harness(harness: str) -> str:
@@ -285,6 +473,31 @@ def post_tool_fail_safe_response(
             "notice": "warning",
             "reason_code": reason_code,
         }
+    return post_tool_native_block_response(reason=reason, reason_code=reason_code)
+
+
+def _harness_json_from_review_response(
+    harness: str,
+    event_name: str,
+    response: object,
+) -> dict[str, object]:
+    to_harness_json = getattr(response, "to_harness_json", None)
+    payload = to_harness_json() if callable(to_harness_json) else {}
+    if not isinstance(payload, dict):
+        payload = {}
+    if event_name != "PostToolUse":
+        return payload
+    if _canonical_hook_harness(harness) in {"pi", "omp"}:
+        return payload
+    decision = str(payload.get("decision") or "")
+    model_output_action = str(payload.get("model_output_action") or "")
+    if decision == "allow" and model_output_action == "allow_original":
+        return {
+            "policy_action": "allow",
+            "hookSpecificOutput": {"hookEventName": event_name},
+        }
+    reason = str(payload.get("reason") or "HOL Guard blocked this tool output because it could not be proven safe.")
+    reason_code = str(payload.get("reason_code") or "fast_path_block")
     return post_tool_native_block_response(reason=reason, reason_code=reason_code)
 
 

--- a/src/codex_plugin_scanner/guard/native_hook_edge.py
+++ b/src/codex_plugin_scanner/guard/native_hook_edge.py
@@ -1,0 +1,186 @@
+"""Transport raw hook envelopes to the Rust hook/data-plane authority.
+
+Python supplies only bounded transport metadata and the current observe-mode
+snapshot. Rust extracts the hook event and action, performs decision-critical
+content/file I/O, and returns the semantic decision. Native failure never
+invokes a Python semantic evaluator.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from .native_policy_snapshot import native_policy_snapshot
+from .native_runtime import (
+    _INTEGRITY_FAILURE_REASONS,
+    _MAX_REQUEST_BYTES,
+    _RESIDENT_PROTOCOL_FEATURE,
+    _identity_key,
+    _isolated_environment,
+    _native_error,
+    _run_native_process,
+    native_runtime_status,
+)
+from .native_runtime_resident import resident_native_request
+from .native_runtime_resilience import (
+    native_oneshot_lease,
+    native_record_integrity_failure,
+    native_record_oneshot_failure,
+    native_record_oneshot_success,
+    native_record_overload,
+    native_record_resident_failure,
+    native_record_resident_success,
+)
+
+_HOOK_EDGE_FEATURE = "hook-edge-v2"
+
+
+def _deadline_budget_ms(deadline: float | None) -> int:
+    if deadline is None:
+        return 750
+    return max(1, min(9_000, int((deadline - time.monotonic()) * 1_000)))
+
+
+def _decode_hook_edge(payload: object) -> dict[str, Any] | None:
+    if not isinstance(payload, dict) or payload.get("authority") != "rust":
+        return None
+    event_name = payload.get("event_name")
+    decision = payload.get("decision")
+    reason_code = payload.get("reason_code")
+    if not isinstance(event_name, str) or not event_name.strip():
+        return None
+    if decision not in {"allow", "deny"} or not isinstance(reason_code, str) or not reason_code:
+        return None
+    if event_name == "PreToolUse":
+        action = payload.get("minimum_action") or payload.get("policy_action")
+        if action not in {"allow", "review", "block"}:
+            return None
+    elif event_name == "PostToolUse":
+        model_output_action = payload.get("model_output_action")
+        notice = payload.get("notice")
+        if model_output_action not in {
+            "allow_original",
+            "replace_with_reviewed_excerpt",
+            "block",
+            "not_applicable",
+        }:
+            return None
+        if notice not in {"none", "excerpt", "warning"}:
+            return None
+    return payload
+
+
+def review_hook_edge_native(
+    *,
+    payload: Mapping[str, object],
+    harness: str,
+    home_dir: Path,
+    guard_home: Path,
+    workspace: Path | None,
+    observe_mode: bool,
+    deadline: float | None = None,
+) -> dict[str, Any] | None:
+    """Return the Rust semantic hook decision for a raw harness envelope."""
+
+    status = native_runtime_status()
+    identity_key = _identity_key(status)
+    if (
+        not status.available
+        or not status.compatible
+        or status.identity is None
+        or status.capabilities is None
+        or _HOOK_EDGE_FEATURE not in status.capabilities.features
+    ):
+        if status.reason in _INTEGRITY_FAILURE_REASONS:
+            native_record_integrity_failure(identity_key, guard_home, reason=status.reason)
+        return None
+
+    envelope: dict[str, object] = {
+        "protocol_version": 1,
+        "harness": harness,
+        "payload": dict(payload),
+        "cwd": str(workspace) if workspace is not None else None,
+        "home_dir": str(home_dir),
+        "guard_home": str(guard_home),
+        "observe_mode": observe_mode,
+        "deadline_budget_ms": _deadline_budget_ms(deadline),
+        "policy_snapshot": native_policy_snapshot(
+            rule_digest=status.capabilities.rule_digest,
+            observe_mode=observe_mode,
+        ),
+    }
+    input_text = json.dumps(envelope, separators=(",", ":"), ensure_ascii=False)
+    encoded = input_text.encode("utf-8")
+    if len(encoded) > _MAX_REQUEST_BYTES:
+        return None
+    timeout_seconds = max(0.05, min(9.0, _deadline_budget_ms(deadline) / 1_000.0))
+
+    if _RESIDENT_PROTOCOL_FEATURE in status.capabilities.features:
+        resident_request = json.dumps(
+            {"operation": "hook_edge", "request": envelope},
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+        resident_output = resident_native_request(
+            executable=status.identity.path,
+            identity_sha256=status.identity.sha256,
+            guard_home=guard_home,
+            environment=_isolated_environment(),
+            payload=resident_request,
+            timeout_seconds=timeout_seconds,
+        )
+        if resident_output is not None:
+            try:
+                resident_payload = json.loads(resident_output)
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                resident_payload = None
+            resident_error = _native_error(resident_payload)
+            if resident_error == "native_overloaded":
+                native_record_overload(status.identity.sha256, guard_home)
+                return None
+            response = _decode_hook_edge(resident_payload)
+            if response is not None:
+                native_record_resident_success(status.identity.sha256, guard_home)
+                return response
+            failure_reason = resident_error or "native_hook_edge_resident_invalid_response"
+        else:
+            failure_reason = "native_hook_edge_resident_unavailable"
+        native_record_resident_failure(status.identity.sha256, guard_home, reason=failure_reason)
+
+    with native_oneshot_lease(status.identity.sha256, guard_home) as acquired:
+        if not acquired:
+            return None
+        output = _run_native_process(
+            status.identity.path,
+            ("hook-edge", "--stdin"),
+            input_text=input_text,
+            timeout_seconds=timeout_seconds,
+        )
+        if output is None:
+            native_record_oneshot_failure(
+                status.identity.sha256,
+                guard_home,
+                reason="native_hook_edge_oneshot_failed",
+            )
+            return None
+        try:
+            oneshot_payload = json.loads(output)
+        except json.JSONDecodeError:
+            oneshot_payload = None
+        response = _decode_hook_edge(oneshot_payload)
+        if response is None:
+            native_record_oneshot_failure(
+                status.identity.sha256,
+                guard_home,
+                reason=_native_error(oneshot_payload) or "native_hook_edge_oneshot_invalid_response",
+            )
+            return None
+        native_record_oneshot_success(status.identity.sha256, guard_home)
+        return response
+
+
+__all__ = ["review_hook_edge_native"]

--- a/src/codex_plugin_scanner/guard/native_runtime_resident.py
+++ b/src/codex_plugin_scanner/guard/native_runtime_resident.py
@@ -6,8 +6,9 @@ platform also performs mutual HMAC authentication with a fresh per-child
 256-bit secret delivered only through inherited stdin.
 
 Protocol v2 binds each response to a random request identifier and the exact
-request/response bytes. Client admission is non-blocking so resident overload
-cannot amplify into Python thread or process growth.
+request/response bytes. The production client authentication, framing, digest
+validation, and socket I/O execute inside the bundled Rust runtime; Python owns
+only bounded resident lifecycle supervision and asynchronous control-plane state.
 """
 
 from __future__ import annotations
@@ -108,31 +109,51 @@ class _ResidentService:
             return self.socket_path is not None
 
     def _send(self, payload: bytes, *, timeout_seconds: float) -> bytes | None:
+        """Send bytes through the Rust resident client, not Python socket framing."""
         with self._lock:
             if self._closed:
                 return None
             loopback_address = self.loopback_address
             auth_token = self._auth_token
             socket_path = self.socket_path
-        if auth_token is None:
+        if auth_token is None or timeout_seconds <= 0:
+            return None
+        try:
+            payload_text = payload.decode("utf-8")
+        except UnicodeDecodeError:
             return None
         if os.name == "nt":
             if loopback_address is None:
                 return None
-            return _send_authenticated_loopback_request(
-                loopback_address,
-                auth_token,
-                payload,
-                timeout_seconds=timeout_seconds,
+            host, port = loopback_address
+            command = (
+                str(self.executable),
+                "resident-client",
+                "--tcp-loopback",
+                f"{host}:{port}",
+                "--stdin",
             )
-        if socket_path is None:
-            return None
-        return _send_authenticated_unix_request(
-            socket_path,
-            auth_token,
-            payload,
+        else:
+            if socket_path is None:
+                return None
+            command = (
+                str(self.executable),
+                "resident-client",
+                "--socket",
+                str(socket_path),
+                "--stdin",
+            )
+        result = run_isolated_hook_process(
+            command,
+            input_text=f"{auth_token.hex()}\n{payload_text}",
+            cwd=self.executable.parent,
+            environment=self.environment,
             timeout_seconds=timeout_seconds,
+            output_limit=_MAX_RESPONSE_BYTES,
         )
+        if result.returncode != 0 or result.timed_out or result.output_limit_exceeded or result.containment_failed:
+            return None
+        return result.stdout.rstrip("\n").encode("utf-8")
 
     def _ensure_started(self, *, timeout_seconds: float) -> bool:
         if timeout_seconds <= 0:

--- a/tests/test_native_hook_data_plane_completion.py
+++ b/tests/test_native_hook_data_plane_completion.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import json
 from pathlib import Path
 
@@ -13,6 +14,17 @@ def _source(relative: str) -> str:
     return (ROOT / relative).read_text(encoding="utf-8")
 
 
+def _function(relative: str, name: str) -> str:
+    source = _source(relative)
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            segment = ast.get_source_segment(source, node)
+            assert segment is not None
+            return segment
+    raise AssertionError(f"missing function {relative}:{name}")
+
+
 def test_no_environment_configuration_selects_native_fast_path(monkeypatch) -> None:
     monkeypatch.delenv("HOL_GUARD_NATIVE", raising=False)
     monkeypatch.delenv("HOL_GUARD_NATIVE_BINARY", raising=False)
@@ -22,30 +34,31 @@ def test_no_environment_configuration_selects_native_fast_path(monkeypatch) -> N
     assert hook_fast_path_enabled() is True
 
 
-def test_daemon_hook_worker_has_no_python_semantic_engine() -> None:
-    source = _source("src/codex_plugin_scanner/guard/daemon/hook_worker.py")
-    assert "review_hook_edge_native" in source
-    for forbidden in (
-        "HookReviewEngine",
-        "ContentScanner",
-        "HookDecisionCache",
-        "review_pre_tool_native",
-        "review_post_tool_native",
-        "_parse_source_ref(",
-        "_pre_tool_command(",
-    ):
-        assert forbidden not in source
+def test_daemon_default_path_uses_raw_native_edge_without_python_semantics() -> None:
+    path = "src/codex_plugin_scanner/guard/daemon/hook_worker.py"
+    production = _function(path, "review_http_payload")
+    compatibility = _function(path, "_review_explicit_python_compatibility")
+
+    assert 'mode in {"off", "shadow"}' in production
+    assert "review_hook_edge_native" in production
+    assert "self.engine.review(" not in production
+    assert "_request_from_payload(" not in production
+    assert "HookWorkerUnsupported" not in production
+
+    assert "self.engine.review(" in compatibility
+    assert 'event_name != "PostToolUse"' in compatibility
 
 
-def test_cli_hook_authority_has_no_source_ref_or_mode_fallback() -> None:
-    source = _source("src/codex_plugin_scanner/guard/cli/commands_hook_native_authority.py")
-    for forbidden in (
-        "_try_source_ref_fast_path",
-        "native_mode",
-        "HookWorkerUnsupported",
-    ):
-        assert forbidden not in source
-    assert "try_native_hook_authority" in source
+def test_cli_source_ref_reference_path_is_explicit_compatibility_only() -> None:
+    path = "src/codex_plugin_scanner/guard/cli/commands_hook_native_authority.py"
+    native = _function(path, "try_native_hook_authority")
+    route = _function(path, "try_native_or_source_ref_hook")
+
+    assert 'native_mode() not in {"auto", "force"}' in native
+    assert "HookWorker(store=store).review_http_payload(" in native
+    assert "except" not in native
+    assert "_try_source_ref_fast_path" in route
+    assert "native_result is not None" in route
 
 
 def test_production_resident_send_delegates_client_protocol_to_rust() -> None:
@@ -62,13 +75,20 @@ def test_production_resident_send_delegates_client_protocol_to_rust() -> None:
     assert "socket.create_connection" not in send
 
 
-def test_ownership_manifest_requires_rust_hook_edge_client_and_io() -> None:
+def test_ownership_manifest_requires_rust_default_and_explicit_compatibility() -> None:
     manifest = json.loads(_source("ci/rust-authority-ownership.v1.json"))
     assert manifest["default_runtime_contract"] == {
         "native_mode_without_environment": "auto",
         "hook_fast_path_without_environment": True,
         "path_runtime_search": False,
         "decision_time_runtime_download": False,
+        "automatic_python_semantic_fallback": False,
+    }
+    assert manifest["explicit_compatibility"] == {
+        "modes": ["off", "shadow"],
+        "python_reference_evaluator": True,
+        "automatic_entry_from_native_failure": False,
+        "default_selected": False,
     }
     surfaces = manifest["surfaces"]
     assert surfaces["hook_edge"]["event_and_action_extraction"] == "rust"

--- a/tests/test_native_hook_data_plane_completion.py
+++ b/tests/test_native_hook_data_plane_completion.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_plugin_scanner.guard.config import hook_fast_path_enabled
+from codex_plugin_scanner.guard.native_runtime import native_mode
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _source(relative: str) -> str:
+    return (ROOT / relative).read_text(encoding="utf-8")
+
+
+def test_no_environment_configuration_selects_native_fast_path(monkeypatch) -> None:
+    monkeypatch.delenv("HOL_GUARD_NATIVE", raising=False)
+    monkeypatch.delenv("HOL_GUARD_NATIVE_BINARY", raising=False)
+    monkeypatch.delenv("HOL_GUARD_HOOK_FAST_PATH", raising=False)
+
+    assert native_mode() == "auto"
+    assert hook_fast_path_enabled() is True
+
+
+def test_daemon_hook_worker_has_no_python_semantic_engine() -> None:
+    source = _source("src/codex_plugin_scanner/guard/daemon/hook_worker.py")
+    assert "review_hook_edge_native" in source
+    for forbidden in (
+        "HookReviewEngine",
+        "ContentScanner",
+        "HookDecisionCache",
+        "review_pre_tool_native",
+        "review_post_tool_native",
+        "_parse_source_ref(",
+        "_pre_tool_command(",
+    ):
+        assert forbidden not in source
+
+
+def test_cli_hook_authority_has_no_source_ref_or_mode_fallback() -> None:
+    source = _source("src/codex_plugin_scanner/guard/cli/commands_hook_native_authority.py")
+    for forbidden in (
+        "_try_source_ref_fast_path",
+        "native_mode",
+        "HookWorkerUnsupported",
+    ):
+        assert forbidden not in source
+    assert "try_native_hook_authority" in source
+
+
+def test_production_resident_send_delegates_client_protocol_to_rust() -> None:
+    source = _source("src/codex_plugin_scanner/guard/native_runtime_resident.py")
+    class_start = source.index("class _ResidentService:")
+    send_start = source.index("    def _send(", class_start)
+    send_end = source.index("\n    def _ensure_started(", send_start)
+    send = source[send_start:send_end]
+
+    assert "resident-client" in send
+    assert "run_isolated_hook_process" in send
+    assert "_send_authenticated_unix_request" not in send
+    assert "_send_authenticated_loopback_request" not in send
+    assert "socket.create_connection" not in send
+
+
+def test_ownership_manifest_requires_rust_hook_edge_client_and_io() -> None:
+    manifest = json.loads(_source("ci/rust-authority-ownership.v1.json"))
+    assert manifest["default_runtime_contract"] == {
+        "native_mode_without_environment": "auto",
+        "hook_fast_path_without_environment": True,
+        "path_runtime_search": False,
+        "decision_time_runtime_download": False,
+    }
+    surfaces = manifest["surfaces"]
+    assert surfaces["hook_edge"]["event_and_action_extraction"] == "rust"
+    assert surfaces["hook_edge"]["python_semantic_envelope_parsing"] is False
+    assert surfaces["resident_client"]["authentication"] == "rust"
+    assert surfaces["resident_client"]["framing"] == "rust"
+    assert surfaces["resident_client"]["socket_io"] == "rust"
+    assert set(surfaces["decision_critical_io"].values()) == {"rust"}
+
+
+def test_runtime_source_exposes_native_hook_edge_and_resident_client() -> None:
+    runtime = _source("rust/crates/guard-runtime/src/main.rs")
+    oneshot = _source("rust/crates/guard-runtime/src/oneshot.rs")
+    client = _source("rust/crates/guard-runtime/src/resident_client.rs")
+
+    assert '"hook-edge-v2"' in runtime
+    assert '"resident-client-v1"' in runtime
+    assert 'command == "hook-edge"' in runtime
+    assert 'command == "resident-client"' in runtime
+    assert "evaluate_hook_edge_value" in oneshot
+    assert "native_pre_tool_unsupported_review" in oneshot
+    assert "REQUEST_MAGIC" in client
+    assert "RESPONSE_MAGIC" in client

--- a/tests/test_rust_posttool_authority.py
+++ b/tests/test_rust_posttool_authority.py
@@ -20,10 +20,19 @@ def _post_tool_payload() -> dict[str, object]:
     }
 
 
+def _force_auto(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("codex_plugin_scanner.guard.daemon.hook_worker.native_mode", lambda: "auto")
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.commands_hook_native_authority.native_mode",
+        lambda: "auto",
+    )
+
+
 def test_hook_worker_fails_closed_when_native_hook_edge_is_missing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _force_auto(monkeypatch)
     monkeypatch.setattr(
         "codex_plugin_scanner.guard.daemon.hook_worker.review_hook_edge_native",
         lambda **_kwargs: None,
@@ -45,6 +54,8 @@ def test_hook_worker_fails_closed_when_native_hook_edge_raises(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _force_auto(monkeypatch)
+
     def broken_edge(**_kwargs: object) -> None:
         raise RuntimeError("native transport failed")
 
@@ -69,6 +80,7 @@ def test_hook_worker_calls_native_hook_edge_once_on_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _force_auto(monkeypatch)
     called = {"native": 0}
 
     def missing_native(**_kwargs: object) -> None:
@@ -115,6 +127,7 @@ def test_hook_worker_records_activity_when_native_hook_edge_is_unavailable(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _force_auto(monkeypatch)
     monkeypatch.setattr(
         "codex_plugin_scanner.guard.daemon.hook_worker.review_hook_edge_native",
         lambda **_kwargs: None,
@@ -130,7 +143,7 @@ def test_hook_worker_records_activity_when_native_hook_edge_is_unavailable(
         workspace=tmp_path / "workspace",
     )
     assert result["reason_code"] == "native_hook_edge_unavailable"
-    assert not hasattr(worker, "_engine")
+    assert worker._engine is None
     assert len(writer.calls) == 1
     assert writer.calls[0]["event"] == "PostToolUse"
     assert writer.calls[0]["harness"] == "pi"
@@ -140,6 +153,7 @@ def test_cli_posttool_uses_native_hook_edge_not_python_engine(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _force_auto(monkeypatch)
     monkeypatch.setattr(
         "codex_plugin_scanner.guard.daemon.hook_worker.review_hook_edge_native",
         lambda **_kwargs: None,
@@ -152,13 +166,17 @@ def test_cli_posttool_uses_native_hook_edge_not_python_engine(
         workspace=tmp_path / "workspace",
         store=GuardStore(tmp_path / "guard-home"),
     )
+    assert result is not None
     assert result["reason_code"] == "native_hook_edge_unavailable"
 
 
-def test_cli_off_environment_cannot_restore_python_source_ref_path(
+def test_cli_explicit_off_selects_compatibility_instead_of_native_authority(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setenv("HOL_GUARD_NATIVE", "off")
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.commands_hook_native_authority.native_mode",
+        lambda: "off",
+    )
     result = try_native_hook_authority(
         payload=_post_tool_payload(),
         harness="pi",
@@ -167,7 +185,7 @@ def test_cli_off_environment_cannot_restore_python_source_ref_path(
         workspace=tmp_path / "workspace",
         store=GuardStore(tmp_path / "guard-home"),
     )
-    assert result["reason_code"] == "native_hook_edge_unavailable"
+    assert result is None
 
 
 def test_native_policy_snapshot_generation_is_stable_for_same_policy() -> None:
@@ -183,6 +201,7 @@ def test_native_policy_snapshot_generation_is_stable_for_same_policy() -> None:
 def test_native_posttool_allow_is_rendered_without_python_semantics(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    _force_auto(monkeypatch)
     monkeypatch.setattr(
         "codex_plugin_scanner.guard.daemon.hook_worker.review_hook_edge_native",
         lambda **_kwargs: {

--- a/tests/test_rust_posttool_authority.py
+++ b/tests/test_rust_posttool_authority.py
@@ -8,7 +8,6 @@ import pytest
 
 from codex_plugin_scanner.guard.cli.commands_hook_native_authority import try_native_hook_authority
 from codex_plugin_scanner.guard.daemon.hook_worker import HookWorker
-from codex_plugin_scanner.guard.native_runtime import NativeRuntimeStatus
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -21,17 +20,13 @@ def _post_tool_payload() -> dict[str, object]:
     }
 
 
-def test_hook_worker_fails_closed_when_forced_posttool_native_is_missing(
+def test_hook_worker_fails_closed_when_native_hook_edge_is_missing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        "codex_plugin_scanner.guard.daemon.hook_worker.review_post_tool_native",
-        lambda *_args, **_kwargs: None,
-    )
-    monkeypatch.setattr(
-        "codex_plugin_scanner.guard.daemon.hook_worker.native_mode",
-        lambda: "force",
+        "codex_plugin_scanner.guard.daemon.hook_worker.review_hook_edge_native",
+        lambda **_kwargs: None,
     )
     worker = HookWorker(store=GuardStore(tmp_path / "guard-home"))
     result = worker.review_http_payload(
@@ -43,29 +38,19 @@ def test_hook_worker_fails_closed_when_forced_posttool_native_is_missing(
         workspace=tmp_path / "workspace",
     )
     assert result["decision"] == "deny"
-    assert result["reason_code"] == "native_post_tool_unavailable"
+    assert result["reason_code"] == "native_hook_edge_unavailable"
 
 
-def test_hook_worker_fails_closed_when_available_native_posttool_returns_none(
+def test_hook_worker_fails_closed_when_native_hook_edge_raises(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    def broken_edge(**_kwargs: object) -> None:
+        raise RuntimeError("native transport failed")
+
     monkeypatch.setattr(
-        "codex_plugin_scanner.guard.daemon.hook_worker.review_post_tool_native",
-        lambda *_args, **_kwargs: None,
-    )
-    monkeypatch.setattr(
-        "codex_plugin_scanner.guard.daemon.hook_worker.native_mode",
-        lambda: "auto",
-    )
-    monkeypatch.setattr(
-        "codex_plugin_scanner.guard.daemon.hook_worker.native_runtime_status",
-        lambda: NativeRuntimeStatus(
-            mode="auto",
-            available=True,
-            compatible=True,
-            reason="ok",
-        ),
+        "codex_plugin_scanner.guard.daemon.hook_worker.review_hook_edge_native",
+        broken_edge,
     )
     worker = HookWorker(store=GuardStore(tmp_path / "guard-home"))
     result = worker.review_http_payload(
@@ -77,35 +62,22 @@ def test_hook_worker_fails_closed_when_available_native_posttool_returns_none(
         workspace=tmp_path / "workspace",
     )
     assert result["decision"] == "deny"
-    assert result["reason_code"] == "native_post_tool_unavailable"
+    assert result["reason_code"] == "native_hook_edge_unavailable"
 
 
-def test_hook_worker_fails_closed_when_auto_native_is_unavailable(
+def test_hook_worker_calls_native_hook_edge_once_on_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     called = {"native": 0}
 
-    def _missing_native(*_args: object, **_kwargs: object) -> None:
+    def missing_native(**_kwargs: object) -> None:
         called["native"] += 1
         return None
 
     monkeypatch.setattr(
-        "codex_plugin_scanner.guard.daemon.hook_worker.review_post_tool_native",
-        _missing_native,
-    )
-    monkeypatch.setattr(
-        "codex_plugin_scanner.guard.daemon.hook_worker.native_mode",
-        lambda: "auto",
-    )
-    monkeypatch.setattr(
-        "codex_plugin_scanner.guard.daemon.hook_worker.native_runtime_status",
-        lambda: NativeRuntimeStatus(
-            mode="auto",
-            available=False,
-            compatible=False,
-            reason="missing",
-        ),
+        "codex_plugin_scanner.guard.daemon.hook_worker.review_hook_edge_native",
+        missing_native,
     )
     worker = HookWorker(store=GuardStore(tmp_path / "guard-home"))
     result = worker.review_http_payload(
@@ -118,7 +90,7 @@ def test_hook_worker_fails_closed_when_auto_native_is_unavailable(
     )
     assert called["native"] == 1
     assert result["decision"] == "deny"
-    assert result["reason_code"] == "native_post_tool_unavailable"
+    assert result["reason_code"] == "native_hook_edge_unavailable"
 
 
 class _ActivityWriter:
@@ -139,17 +111,13 @@ class _ActivityWriter:
         return True
 
 
-def test_hook_worker_records_activity_when_auto_native_is_unavailable(
+def test_hook_worker_records_activity_when_native_hook_edge_is_unavailable(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        "codex_plugin_scanner.guard.daemon.hook_worker.review_post_tool_native",
-        lambda *_args, **_kwargs: None,
-    )
-    monkeypatch.setattr(
-        "codex_plugin_scanner.guard.daemon.hook_worker.native_mode",
-        lambda: "auto",
+        "codex_plugin_scanner.guard.daemon.hook_worker.review_hook_edge_native",
+        lambda **_kwargs: None,
     )
     writer = _ActivityWriter()
     worker = HookWorker(store=GuardStore(tmp_path / "guard-home"), activity_writer=writer)
@@ -161,28 +129,20 @@ def test_hook_worker_records_activity_when_auto_native_is_unavailable(
         guard_home=tmp_path / "guard-home",
         workspace=tmp_path / "workspace",
     )
-    assert result["reason_code"] == "native_post_tool_unavailable"
-    assert worker._engine is None
+    assert result["reason_code"] == "native_hook_edge_unavailable"
+    assert not hasattr(worker, "_engine")
     assert len(writer.calls) == 1
     assert writer.calls[0]["event"] == "PostToolUse"
     assert writer.calls[0]["harness"] == "pi"
 
 
-def test_cli_auto_posttool_uses_native_worker_not_python_engine(
+def test_cli_posttool_uses_native_hook_edge_not_python_engine(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        "codex_plugin_scanner.guard.cli.commands_hook_native_authority.native_mode",
-        lambda: "auto",
-    )
-    monkeypatch.setattr(
-        "codex_plugin_scanner.guard.daemon.hook_worker.native_mode",
-        lambda: "auto",
-    )
-    monkeypatch.setattr(
-        "codex_plugin_scanner.guard.daemon.hook_worker.review_post_tool_native",
-        lambda *_args, **_kwargs: None,
+        "codex_plugin_scanner.guard.daemon.hook_worker.review_hook_edge_native",
+        lambda **_kwargs: None,
     )
     result = try_native_hook_authority(
         payload=_post_tool_payload(),
@@ -192,15 +152,13 @@ def test_cli_auto_posttool_uses_native_worker_not_python_engine(
         workspace=tmp_path / "workspace",
         store=GuardStore(tmp_path / "guard-home"),
     )
-    assert result is not None
-    assert result["reason_code"] == "native_post_tool_unavailable"
+    assert result["reason_code"] == "native_hook_edge_unavailable"
 
 
-def test_cli_off_mode_leaves_python_source_ref_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        "codex_plugin_scanner.guard.cli.commands_hook_native_authority.native_mode",
-        lambda: "off",
-    )
+def test_cli_off_environment_cannot_restore_python_source_ref_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOL_GUARD_NATIVE", "off")
     result = try_native_hook_authority(
         payload=_post_tool_payload(),
         harness="pi",
@@ -209,7 +167,7 @@ def test_cli_off_mode_leaves_python_source_ref_path(tmp_path: Path, monkeypatch:
         workspace=tmp_path / "workspace",
         store=GuardStore(tmp_path / "guard-home"),
     )
-    assert result is None
+    assert result["reason_code"] == "native_hook_edge_unavailable"
 
 
 def test_native_policy_snapshot_generation_is_stable_for_same_policy() -> None:
@@ -220,3 +178,33 @@ def test_native_policy_snapshot_generation_is_stable_for_same_policy() -> None:
     second = native_policy_snapshot(rule_digest=digest, observe_mode=False)
     assert first["generation"] == second["generation"]
     assert isinstance(first["generation"], int)
+
+
+def test_native_posttool_allow_is_rendered_without_python_semantics(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.hook_worker.review_hook_edge_native",
+        lambda **_kwargs: {
+            "authority": "rust",
+            "event_name": "PostToolUse",
+            "decision": "allow",
+            "model_output_action": "allow_original",
+            "notice": "none",
+            "reason_code": "output_scan_allow",
+        },
+    )
+    worker = HookWorker(store=GuardStore(tmp_path / "guard-home"))
+    result = worker.review_http_payload(
+        payload=_post_tool_payload(),
+        params={},
+        default_harness="codex",
+        home_dir=tmp_path / "home",
+        guard_home=tmp_path / "guard-home",
+        workspace=tmp_path / "workspace",
+    )
+    assert result == {
+        "policy_action": "allow",
+        "reason_code": "output_scan_allow",
+        "hookSpecificOutput": {"hookEventName": "PostToolUse"},
+    }

--- a/tests/test_rust_pretool_authority.py
+++ b/tests/test_rust_pretool_authority.py
@@ -1,4 +1,4 @@
-"""Tests for Rust PreToolUse authority transport and daemon fail-closed behavior."""
+"""Tests for Rust PreToolUse authority and daemon fail-closed behavior."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ from typing import Any
 
 import pytest
 
-from codex_plugin_scanner.guard.daemon.hook_worker import HookWorker, HookWorkerUnsupported
+from codex_plugin_scanner.guard.daemon.hook_worker import HookWorker
 from codex_plugin_scanner.guard.native_pretool import (
     _decode_pre_tool,
     native_pre_tool_policy_floor,
@@ -19,6 +19,7 @@ from codex_plugin_scanner.guard.store import GuardStore
 def _native_allow(command: str) -> dict[str, Any]:
     return {
         "authority": "rust",
+        "event_name": "PreToolUse",
         "decision": "allow",
         "minimum_action": "allow",
         "policy_action": "allow",
@@ -32,6 +33,7 @@ def _native_allow(command: str) -> dict[str, Any]:
 def _native_block(command: str) -> dict[str, Any]:
     return {
         "authority": "rust",
+        "event_name": "PreToolUse",
         "decision": "deny",
         "minimum_action": "block",
         "policy_action": "block",
@@ -39,6 +41,19 @@ def _native_block(command: str) -> dict[str, Any]:
         "reason": "HOL Guard blocked a destructive command before execution.",
         "explicitly_benign": False,
         "command_model": {"normalized_text": command},
+    }
+
+
+def _native_review() -> dict[str, Any]:
+    return {
+        "authority": "rust",
+        "event_name": "PreToolUse",
+        "decision": "deny",
+        "minimum_action": "review",
+        "policy_action": "review",
+        "reason_code": "native_pre_tool_unsupported_review",
+        "reason": "HOL Guard requires review because the Rust authority could not prove this action benign.",
+        "explicitly_benign": False,
     }
 
 
@@ -95,10 +110,11 @@ def test_policy_floor_fails_closed_when_native_is_forced_unavailable(
     )
 
 
-def test_policy_floor_skips_when_native_mode_is_off(
+def test_policy_floor_compatibility_helper_still_skips_explicit_off(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """The compatibility helper is not reachable from the production hook route."""
     monkeypatch.setattr(
         "codex_plugin_scanner.guard.native_pretool.review_pre_tool_native",
         lambda *_args, **_kwargs: None,
@@ -123,8 +139,8 @@ def test_hook_worker_returns_native_allow(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        "codex_plugin_scanner.guard.daemon.hook_worker.review_pre_tool_native",
-        lambda *_args, **_kwargs: _native_allow("pwd"),
+        "codex_plugin_scanner.guard.daemon.hook_worker.review_hook_edge_native",
+        lambda **_kwargs: _native_allow("pwd"),
     )
     worker = HookWorker(store=GuardStore(tmp_path / "guard-home"))
     result = worker.review_http_payload(
@@ -139,22 +155,13 @@ def test_hook_worker_returns_native_allow(
     assert result["hookSpecificOutput"]["permissionDecision"] == "allow"
 
 
-def test_hook_worker_fails_closed_when_forced_native_is_missing(
+def test_hook_worker_fails_closed_when_native_hook_edge_is_missing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        "codex_plugin_scanner.guard.daemon.hook_worker.review_pre_tool_native",
-        lambda *_args, **_kwargs: None,
-    )
-    monkeypatch.setattr(
-        "codex_plugin_scanner.guard.daemon.hook_worker.native_runtime_status",
-        lambda: NativeRuntimeStatus(
-            mode="force",
-            available=False,
-            compatible=False,
-            reason="missing",
-        ),
+        "codex_plugin_scanner.guard.daemon.hook_worker.review_hook_edge_native",
+        lambda **_kwargs: None,
     )
     worker = HookWorker(store=GuardStore(tmp_path / "guard-home"))
     result = worker.review_http_payload(
@@ -166,25 +173,17 @@ def test_hook_worker_fails_closed_when_forced_native_is_missing(
         workspace=tmp_path / "workspace",
     )
     assert result["decision"] == "deny"
-    assert result["reason_code"] == "native_pre_tool_unavailable"
+    assert result["reason_code"] == "native_hook_edge_unavailable"
 
 
-def test_hook_worker_fails_closed_when_auto_pretool_native_is_unavailable(
+def test_hook_worker_environment_off_cannot_restore_python_authority(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setenv("HOL_GUARD_NATIVE", "off")
     monkeypatch.setattr(
-        "codex_plugin_scanner.guard.daemon.hook_worker.review_pre_tool_native",
-        lambda *_args, **_kwargs: None,
-    )
-    monkeypatch.setattr(
-        "codex_plugin_scanner.guard.daemon.hook_worker.native_runtime_status",
-        lambda: NativeRuntimeStatus(
-            mode="auto",
-            available=False,
-            compatible=False,
-            reason="missing",
-        ),
+        "codex_plugin_scanner.guard.daemon.hook_worker.review_hook_edge_native",
+        lambda **_kwargs: None,
     )
     worker = HookWorker(store=GuardStore(tmp_path / "guard-home"))
     result = worker.review_http_payload(
@@ -196,41 +195,30 @@ def test_hook_worker_fails_closed_when_auto_pretool_native_is_unavailable(
         workspace=tmp_path / "workspace",
     )
     assert result["decision"] == "deny"
-    assert result["reason_code"] == "native_pre_tool_unavailable"
+    assert result["reason_code"] == "native_hook_edge_unavailable"
 
 
-def test_hook_worker_falls_back_when_native_mode_is_off(
+def test_hook_worker_keeps_non_command_pretool_in_native_review_surface(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        "codex_plugin_scanner.guard.daemon.hook_worker.review_pre_tool_native",
-        lambda *_args, **_kwargs: None,
-    )
-    monkeypatch.setattr(
-        "codex_plugin_scanner.guard.daemon.hook_worker.native_runtime_status",
-        lambda: NativeRuntimeStatus(mode="off", available=True, compatible=True, reason="off"),
+        "codex_plugin_scanner.guard.daemon.hook_worker.review_hook_edge_native",
+        lambda **_kwargs: _native_review(),
     )
     worker = HookWorker(store=GuardStore(tmp_path / "guard-home"))
-    with pytest.raises(HookWorkerUnsupported, match="native PreToolUse runtime is off"):
-        worker.review_http_payload(
-            payload={"hook_event_name": "PreToolUse", "tool_input": {"command": "pwd"}},
-            params={},
-            default_harness="pi",
-            home_dir=tmp_path / "home",
-            guard_home=tmp_path / "guard-home",
-            workspace=tmp_path / "workspace",
-        )
-
-
-def test_hook_worker_leaves_non_command_pretool_to_cli(tmp_path: Path) -> None:
-    worker = HookWorker(store=GuardStore(tmp_path / "guard-home"))
-    with pytest.raises(HookWorkerUnsupported):
-        worker.review_http_payload(
-            payload={"hook_event_name": "PreToolUse", "tool_name": "Read", "tool_input": {"file_path": "src/foo.ts"}},
-            params={},
-            default_harness="pi",
-            home_dir=tmp_path / "home",
-            guard_home=tmp_path / "guard-home",
-            workspace=tmp_path / "workspace",
-        )
+    result = worker.review_http_payload(
+        payload={
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Read",
+            "tool_input": {"file_path": "src/foo.ts"},
+        },
+        params={},
+        default_harness="claude-code",
+        home_dir=tmp_path / "home",
+        guard_home=tmp_path / "guard-home",
+        workspace=tmp_path / "workspace",
+    )
+    assert result["policy_action"] == "review"
+    assert result["hookSpecificOutput"]["permissionDecision"] == "ask"
+    assert result["reason_code"] == "native_pre_tool_unsupported_review"

--- a/tests/test_rust_pretool_authority.py
+++ b/tests/test_rust_pretool_authority.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import pytest
 
-from codex_plugin_scanner.guard.daemon.hook_worker import HookWorker
+from codex_plugin_scanner.guard.daemon.hook_worker import HookWorker, HookWorkerUnsupported
 from codex_plugin_scanner.guard.native_pretool import (
     _decode_pre_tool,
     native_pre_tool_policy_floor,
@@ -55,6 +55,10 @@ def _native_review() -> dict[str, Any]:
         "reason": "HOL Guard requires review because the Rust authority could not prove this action benign.",
         "explicitly_benign": False,
     }
+
+
+def _force_auto(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("codex_plugin_scanner.guard.daemon.hook_worker.native_mode", lambda: "auto")
 
 
 def test_decode_pre_tool_rejects_unbound_command_model() -> None:
@@ -114,7 +118,6 @@ def test_policy_floor_compatibility_helper_still_skips_explicit_off(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The compatibility helper is not reachable from the production hook route."""
     monkeypatch.setattr(
         "codex_plugin_scanner.guard.native_pretool.review_pre_tool_native",
         lambda *_args, **_kwargs: None,
@@ -138,6 +141,7 @@ def test_hook_worker_returns_native_allow(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _force_auto(monkeypatch)
     monkeypatch.setattr(
         "codex_plugin_scanner.guard.daemon.hook_worker.review_hook_edge_native",
         lambda **_kwargs: _native_allow("pwd"),
@@ -159,6 +163,7 @@ def test_hook_worker_fails_closed_when_native_hook_edge_is_missing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _force_auto(monkeypatch)
     monkeypatch.setattr(
         "codex_plugin_scanner.guard.daemon.hook_worker.review_hook_edge_native",
         lambda **_kwargs: None,
@@ -176,32 +181,28 @@ def test_hook_worker_fails_closed_when_native_hook_edge_is_missing(
     assert result["reason_code"] == "native_hook_edge_unavailable"
 
 
-def test_hook_worker_environment_off_cannot_restore_python_authority(
+def test_hook_worker_explicit_off_remains_compatibility_only(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("HOL_GUARD_NATIVE", "off")
-    monkeypatch.setattr(
-        "codex_plugin_scanner.guard.daemon.hook_worker.review_hook_edge_native",
-        lambda **_kwargs: None,
-    )
+    monkeypatch.setattr("codex_plugin_scanner.guard.daemon.hook_worker.native_mode", lambda: "off")
     worker = HookWorker(store=GuardStore(tmp_path / "guard-home"))
-    result = worker.review_http_payload(
-        payload={"hook_event_name": "PreToolUse", "tool_input": {"command": "pwd"}},
-        params={},
-        default_harness="pi",
-        home_dir=tmp_path / "home",
-        guard_home=tmp_path / "guard-home",
-        workspace=tmp_path / "workspace",
-    )
-    assert result["decision"] == "deny"
-    assert result["reason_code"] == "native_hook_edge_unavailable"
+    with pytest.raises(HookWorkerUnsupported):
+        worker.review_http_payload(
+            payload={"hook_event_name": "PreToolUse", "tool_input": {"command": "pwd"}},
+            params={},
+            default_harness="pi",
+            home_dir=tmp_path / "home",
+            guard_home=tmp_path / "guard-home",
+            workspace=tmp_path / "workspace",
+        )
 
 
 def test_hook_worker_keeps_non_command_pretool_in_native_review_surface(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _force_auto(monkeypatch)
     monkeypatch.setattr(
         "codex_plugin_scanner.guard.daemon.hook_worker.review_hook_edge_native",
         lambda **_kwargs: _native_review(),


### PR DESCRIPTION
## Summary

Completes the remaining default-production Rust hook/data-plane boundary on `main` without rewriting unrelated product control-plane functionality.

### Native default path
- no environment configuration is required: unset `HOL_GUARD_NATIVE` remains `auto`, and unset `HOL_GUARD_HOOK_FAST_PATH` remains enabled
- adds a raw Rust `hook-edge-v2` that extracts supported hook event/action data and owns semantic PreToolUse/PostToolUse decisions
- non-command/structured PreToolUse that cannot be proven benign remains inside Rust and returns conservative native review rather than automatically escaping to Python
- keeps PostToolUse output extraction, source-ref validation, secure file reads, hashing/equivalence, and secret scanning Rust-owned
- adds a Rust `resident-client-v1` for local authentication, request/response framing, digest binding, Unix-socket I/O, and Windows loopback I/O
- Python resident code retains bounded lifecycle supervision only; production client protocol I/O delegates to the bundled Rust runtime
- auto/force native failure remains deterministic fail-closed and cannot invoke the Python semantic/source-ref evaluator

### Explicit compatibility
- preserves the existing explicit `HOL_GUARD_NATIVE=off|shadow` Python reference/rollback surface
- compatibility is never selected by default and is never entered because native evaluation failed
- PreToolUse semantic authority remains native on auto/force; explicit compatibility PreToolUse continues through the existing CLI/reference path

### Permanent enforcement
- extends `ci/rust-authority-ownership.v1.json` with no-env defaults, raw hook-edge ownership, resident-client ownership, decision-critical I/O ownership, and the explicit compatibility boundary
- updates the ownership/PreTool CI gates so auto/force cannot regain Python semantic fallback
- adds source, resident lifecycle, PreToolUse, PostToolUse, and no-env regression coverage
- updates the architecture ADR and all-harness hook documentation

## Validation

CI is required on the exact final head. The PR exercises:
- full Rust workspace formatting, Clippy, tests, and release build
- compiled PreToolUse/PostToolUse adversarial integration
- resident differential and mutation integration
- native performance gates
- installed native-wheel execution proof
- Windows resident coverage
- Python reference/compatibility regression suites
- security gates and CodeQL

Target: `main` only. No GitHub issues are created by this work.