### PR TITLE
fix(update): prefer newer stable releases on alpha channel

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
-  "maximum_collected_cases": 16297,
-  "maximum_test_source_lines": 352420
+  "maximum_collected_cases": 16300,
+  "maximum_test_source_lines": 352489
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
   "maximum_collected_cases": 16300,
-  "maximum_test_source_lines": 352489
+  "maximum_test_source_lines": 352495
 }

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -1295,7 +1295,7 @@ def _version_check_payload(
         compatible_version = _latest_compatible_release_version(
             current_version,
             runtime_python,
-            alpha_only=include_alpha,
+            include_alpha=include_alpha,
         )
         if compatible_version is not None:
             return {
@@ -1320,7 +1320,9 @@ def _version_check_payload(
             "required_python": _format_python_requirements(required_python_requirements),
             "runtime_python": runtime_python,
         }
-    reserved_alpha = _newest_reserved_alpha_version(latest_pypi=latest_version) if include_alpha else None
+    reserved_alpha = (
+        _newest_reserved_alpha_version(latest_pypi=_latest_published_alpha_version()) if include_alpha else None
+    )
     return {
         "source": "pypi",
         **({"release_channel": "alpha"} if include_alpha else {}),
@@ -1367,14 +1369,38 @@ def _latest_version_from_pypi() -> str | None:
 
 
 def _latest_alpha_version_from_pypi(current_version: str) -> str | None:
-    """Return the newest non-yanked alpha on PyPI, including newer majors.
+    """Return the newest non-yanked stable or alpha release on PyPI.
 
-    ``current_version`` is retained for call-site compatibility. Alpha channel
-    intentionally tracks the global newest alpha so ``hol-guard update --alpha``
-    can move installs across major lines (for example 2.x stable -> 3.0.0aN).
+    ``current_version`` is retained for call-site compatibility. Opting into
+    alpha releases widens the candidate set; it must not hide a newer stable
+    release after an alpha train graduates.
     """
     _ = current_version
     _ = _latest_version_from_pypi()
+    payload = _last_pypi_payload
+    if not isinstance(payload, dict):
+        return None
+    releases = payload.get("releases")
+    if not isinstance(releases, dict):
+        return None
+    candidates: list[tuple[Version, str]] = []
+    for version_text, files in releases.items():
+        if not isinstance(version_text, str) or not version_text.strip():
+            continue
+        try:
+            parsed_version = Version(version_text)
+        except InvalidVersion:
+            continue
+        if parsed_version.is_prerelease and (parsed_version.pre is None or parsed_version.pre[0] != "a"):
+            continue
+        if _release_has_non_yanked_file(files):
+            candidates.append((parsed_version, version_text.strip()))
+    if not candidates:
+        return None
+    return max(candidates, key=lambda candidate: candidate[0])[1]
+
+
+def _latest_published_alpha_version() -> str | None:
     payload = _last_pypi_payload
     if not isinstance(payload, dict):
         return None
@@ -1519,7 +1545,7 @@ def _latest_compatible_release_version(
     current_version: str,
     runtime_python: str,
     *,
-    alpha_only: bool = False,
+    include_alpha: bool = False,
 ) -> str | None:
     payload = _last_pypi_payload
     if not isinstance(payload, dict):
@@ -1535,7 +1561,9 @@ def _latest_compatible_release_version(
             parsed_version = Version(version_text)
         except InvalidVersion:
             continue
-        if alpha_only and (parsed_version.pre is None or parsed_version.pre[0] != "a"):
+        if parsed_version.is_prerelease and (
+            not include_alpha or parsed_version.pre is None or parsed_version.pre[0] != "a"
+        ):
             continue
         if _is_newer_version(version_text, current_version) is not True:
             continue
@@ -1546,10 +1574,7 @@ def _latest_compatible_release_version(
             candidates.append((parsed_version, version_text.strip()))
     if not candidates:
         return None
-    if alpha_only:
-        return max(candidates, key=lambda candidate: candidate[0])[1]
-    stable_candidates = [candidate for candidate in candidates if not candidate[0].is_prerelease]
-    return max(stable_candidates or candidates, key=lambda candidate: candidate[0])[1]
+    return max(candidates, key=lambda candidate: candidate[0])[1]
 
 
 def _release_has_non_yanked_file(files: object) -> bool:

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -65,6 +65,7 @@ from .update_desktop_apply import (
 from .update_desktop_core import is_desktop_managed_runtime
 from .update_grok_repair import append_grok_repair
 from .update_install_verify import verify_installed_distribution
+from .update_release_candidates import newest_pypi_version
 from .update_subprocess import (
     InstalledDistribution,
     TrustedUpdateContext,
@@ -1320,9 +1321,8 @@ def _version_check_payload(
             "required_python": _format_python_requirements(required_python_requirements),
             "runtime_python": runtime_python,
         }
-    reserved_alpha = (
-        _newest_reserved_alpha_version(latest_pypi=_latest_published_alpha_version()) if include_alpha else None
-    )
+    published_alpha = newest_pypi_version(_last_pypi_payload, include_stable=False, include_alpha=True)
+    reserved_alpha = _newest_reserved_alpha_version(latest_pypi=published_alpha) if include_alpha else None
     return {
         "source": "pypi",
         **({"release_channel": "alpha"} if include_alpha else {}),
@@ -1369,59 +1369,10 @@ def _latest_version_from_pypi() -> str | None:
 
 
 def _latest_alpha_version_from_pypi(current_version: str) -> str | None:
-    """Return the newest non-yanked stable or alpha release on PyPI.
-
-    ``current_version`` is retained for call-site compatibility. Opting into
-    alpha releases widens the candidate set; it must not hide a newer stable
-    release after an alpha train graduates.
-    """
+    """Return the newest non-yanked stable or alpha release on PyPI."""
     _ = current_version
     _ = _latest_version_from_pypi()
-    payload = _last_pypi_payload
-    if not isinstance(payload, dict):
-        return None
-    releases = payload.get("releases")
-    if not isinstance(releases, dict):
-        return None
-    candidates: list[tuple[Version, str]] = []
-    for version_text, files in releases.items():
-        if not isinstance(version_text, str) or not version_text.strip():
-            continue
-        try:
-            parsed_version = Version(version_text)
-        except InvalidVersion:
-            continue
-        if parsed_version.is_prerelease and (parsed_version.pre is None or parsed_version.pre[0] != "a"):
-            continue
-        if _release_has_non_yanked_file(files):
-            candidates.append((parsed_version, version_text.strip()))
-    if not candidates:
-        return None
-    return max(candidates, key=lambda candidate: candidate[0])[1]
-
-
-def _latest_published_alpha_version() -> str | None:
-    payload = _last_pypi_payload
-    if not isinstance(payload, dict):
-        return None
-    releases = payload.get("releases")
-    if not isinstance(releases, dict):
-        return None
-    candidates: list[tuple[Version, str]] = []
-    for version_text, files in releases.items():
-        if not isinstance(version_text, str) or not version_text.strip():
-            continue
-        try:
-            parsed_version = Version(version_text)
-        except InvalidVersion:
-            continue
-        if parsed_version.pre is None or parsed_version.pre[0] != "a":
-            continue
-        if _release_has_non_yanked_file(files):
-            candidates.append((parsed_version, version_text.strip()))
-    if not candidates:
-        return None
-    return max(candidates, key=lambda candidate: candidate[0])[1]
+    return newest_pypi_version(_last_pypi_payload, include_stable=True, include_alpha=True)
 
 
 def already_current_update_message(version_check: Mapping[str, object] | None) -> str:

--- a/src/codex_plugin_scanner/guard/cli/update_desktop_core.py
+++ b/src/codex_plugin_scanner/guard/cli/update_desktop_core.py
@@ -183,8 +183,9 @@ def apply_desktop_core_update(
         raise DesktopCoreUpdateError("desktop_core_channel_unsupported") from error
     if not _version_matches_channel(parsed_target, include_alpha=include_alpha):
         raise DesktopCoreUpdateError("desktop_core_channel_unsupported")
-    channel = "alpha" if include_alpha else "stable"
-    tag = f"alpha/v{normalized_target}" if include_alpha else f"v{normalized_target}"
+    target_is_alpha = parsed_target.pre is not None and parsed_target.pre[0] == "a"
+    channel = "alpha" if target_is_alpha else "stable"
+    tag = f"alpha/v{normalized_target}" if target_is_alpha else f"v{normalized_target}"
     artifact = f"hol-guard-core-{normalized_target}-{target}"
 
     def _default_download(url: str, limit: int) -> bytes:
@@ -244,9 +245,9 @@ def executable_is_desktop_core(executable: Path) -> bool:
 
 
 def _version_matches_channel(version: Version, *, include_alpha: bool) -> bool:
-    if include_alpha:
-        return version.pre is not None and version.pre[0] == "a"
-    return not version.is_prerelease
+    if not version.is_prerelease:
+        return True
+    return include_alpha and version.pre is not None and version.pre[0] == "a"
 
 
 def _version_is_not_newer(target_version: str, current_version: str) -> bool:

--- a/src/codex_plugin_scanner/guard/cli/update_release_candidates.py
+++ b/src/codex_plugin_scanner/guard/cli/update_release_candidates.py
@@ -1,0 +1,46 @@
+"""Pure release-candidate selection for Guard update channels."""
+
+from __future__ import annotations
+
+from packaging.version import InvalidVersion, Version
+
+
+def newest_pypi_version(
+    payload: object,
+    *,
+    include_stable: bool,
+    include_alpha: bool,
+) -> str | None:
+    """Return the newest available release admitted by the requested channels."""
+
+    if not isinstance(payload, dict):
+        return None
+    releases = payload.get("releases")
+    if not isinstance(releases, dict):
+        return None
+    candidates: list[tuple[Version, str]] = []
+    for version_text, files in releases.items():
+        if not isinstance(version_text, str) or not version_text.strip() or not _release_is_available(files):
+            continue
+        try:
+            version = Version(version_text)
+        except InvalidVersion:
+            continue
+        if version.is_prerelease:
+            if not include_alpha or version.pre is None or version.pre[0] != "a":
+                continue
+        elif not include_stable:
+            continue
+        candidates.append((version, version_text.strip()))
+    if not candidates:
+        return None
+    return max(candidates, key=lambda candidate: candidate[0])[1]
+
+
+def _release_is_available(files: object) -> bool:
+    return isinstance(files, list) and any(
+        isinstance(file_payload, dict) and not file_payload.get("yanked") for file_payload in files
+    )
+
+
+__all__ = ["newest_pypi_version"]

--- a/tests/test_guard_phase03_remainder.py
+++ b/tests/test_guard_phase03_remainder.py
@@ -169,37 +169,6 @@ def test_latest_alpha_version_selects_newest_alpha_across_majors_and_skips_yanke
     assert update_commands._latest_alpha_version_from_pypi("2.2.15") == "3.1.0a1"
 
 
-def test_alpha_channel_selects_newer_stable_release(monkeypatch: pytest.MonkeyPatch) -> None:
-    reserved_calls: list[str | None] = []
-    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "3.0.20")
-    monkeypatch.setattr(
-        update_commands,
-        "_newest_reserved_alpha_version",
-        lambda *, latest_pypi: reserved_calls.append(latest_pypi) or "3.0.1a3",
-    )
-    monkeypatch.setattr(
-        update_commands,
-        "_last_pypi_payload",
-        {
-            "releases": {
-                "3.0.1a2": [{"yanked": False}],
-                "3.0.20": [{"yanked": False}],
-            }
-        },
-    )
-
-    assert update_commands._latest_alpha_version_from_pypi("3.0.11") == "3.0.20"
-
-    payload = update_commands._version_check_payload("3.0.11", include_alpha=True)
-
-    assert payload["release_channel"] == "alpha"
-    assert payload["status"] == "stale"
-    assert payload["latest_version"] == "3.0.20"
-    assert payload["update_available"] is True
-    assert payload["reserved_alpha_version"] == "3.0.1a3"
-    assert reserved_calls == ["3.0.1a2"]
-
-
 def test_alpha_python_fallback_stays_on_alpha_channel(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.2.20")
     monkeypatch.setattr(update_commands, "_runtime_python_version", lambda: "3.12.0")
@@ -226,29 +195,6 @@ def test_alpha_python_fallback_stays_on_alpha_channel(monkeypatch: pytest.Monkey
     assert payload["status"] == "stale"
     assert payload["latest_version"] == "3.0.0a8"
     assert payload["pypi_latest_version"] == "3.0.0a9"
-    assert payload["pypi_latest_python_incompatible"] is True
-
-
-def test_stable_python_fallback_excludes_prereleases(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "3.0.20")
-    monkeypatch.setattr(update_commands, "_runtime_python_version", lambda: "3.12.0")
-    monkeypatch.setattr(
-        update_commands,
-        "_last_pypi_payload",
-        {
-            "releases": {
-                "3.0.18": [{"yanked": False, "requires_python": ">=3.10"}],
-                "3.0.19rc1": [{"yanked": False, "requires_python": ">=3.10"}],
-                "3.0.20": [{"yanked": False, "requires_python": ">=3.13"}],
-            }
-        },
-    )
-
-    payload = update_commands._version_check_payload("3.0.11")
-
-    assert payload["status"] == "stale"
-    assert payload["latest_version"] == "3.0.18"
-    assert payload["pypi_latest_version"] == "3.0.20"
     assert payload["pypi_latest_python_incompatible"] is True
 
 

--- a/tests/test_guard_phase03_remainder.py
+++ b/tests/test_guard_phase03_remainder.py
@@ -169,6 +169,37 @@ def test_latest_alpha_version_selects_newest_alpha_across_majors_and_skips_yanke
     assert update_commands._latest_alpha_version_from_pypi("2.2.15") == "3.1.0a1"
 
 
+def test_alpha_channel_selects_newer_stable_release(monkeypatch: pytest.MonkeyPatch) -> None:
+    reserved_calls: list[str | None] = []
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "3.0.20")
+    monkeypatch.setattr(
+        update_commands,
+        "_newest_reserved_alpha_version",
+        lambda *, latest_pypi: reserved_calls.append(latest_pypi) or "3.0.1a3",
+    )
+    monkeypatch.setattr(
+        update_commands,
+        "_last_pypi_payload",
+        {
+            "releases": {
+                "3.0.1a2": [{"yanked": False}],
+                "3.0.20": [{"yanked": False}],
+            }
+        },
+    )
+
+    assert update_commands._latest_alpha_version_from_pypi("3.0.11") == "3.0.20"
+
+    payload = update_commands._version_check_payload("3.0.11", include_alpha=True)
+
+    assert payload["release_channel"] == "alpha"
+    assert payload["status"] == "stale"
+    assert payload["latest_version"] == "3.0.20"
+    assert payload["update_available"] is True
+    assert payload["reserved_alpha_version"] == "3.0.1a3"
+    assert reserved_calls == ["3.0.1a2"]
+
+
 def test_alpha_python_fallback_stays_on_alpha_channel(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.2.20")
     monkeypatch.setattr(update_commands, "_runtime_python_version", lambda: "3.12.0")
@@ -195,6 +226,29 @@ def test_alpha_python_fallback_stays_on_alpha_channel(monkeypatch: pytest.Monkey
     assert payload["status"] == "stale"
     assert payload["latest_version"] == "3.0.0a8"
     assert payload["pypi_latest_version"] == "3.0.0a9"
+    assert payload["pypi_latest_python_incompatible"] is True
+
+
+def test_stable_python_fallback_excludes_prereleases(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "3.0.20")
+    monkeypatch.setattr(update_commands, "_runtime_python_version", lambda: "3.12.0")
+    monkeypatch.setattr(
+        update_commands,
+        "_last_pypi_payload",
+        {
+            "releases": {
+                "3.0.18": [{"yanked": False, "requires_python": ">=3.10"}],
+                "3.0.19rc1": [{"yanked": False, "requires_python": ">=3.10"}],
+                "3.0.20": [{"yanked": False, "requires_python": ">=3.13"}],
+            }
+        },
+    )
+
+    payload = update_commands._version_check_payload("3.0.11")
+
+    assert payload["status"] == "stale"
+    assert payload["latest_version"] == "3.0.18"
+    assert payload["pypi_latest_version"] == "3.0.20"
     assert payload["pypi_latest_python_incompatible"] is True
 
 

--- a/tests/test_update_desktop_core_stable.py
+++ b/tests/test_update_desktop_core_stable.py
@@ -31,7 +31,12 @@ def _stable_manifest(*, sha256: str, size: int) -> dict[str, object]:
     }
 
 
-def test_apply_installs_stable_sidecar_from_stable_tag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("include_alpha", [False, True])
+def test_apply_installs_stable_sidecar_from_stable_tag(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    include_alpha: bool,
+) -> None:
     monkeypatch.setattr(update_desktop_core, "platform_target", lambda: "aarch64-apple-darwin")
     monkeypatch.setattr(update_desktop_core, "desktop_core_root", lambda: tmp_path / "core")
     monkeypatch.setattr(update_desktop_core, "_macos_codesign_ok", lambda _path: True)
@@ -48,7 +53,7 @@ def test_apply_installs_stable_sidecar_from_stable_tag(tmp_path: Path, monkeypat
     result = update_desktop_core.apply_desktop_core_update(
         current_version="3.0.0a239",
         target_version="3.0.7",
-        include_alpha=False,
+        include_alpha=include_alpha,
         fetch_bytes=fetch_bytes,
     )
 
@@ -75,7 +80,7 @@ def test_stable_channel_rejects_prerelease_targets(
     assert error.value.reason_code == "desktop_core_channel_unsupported"
 
 
-def test_pypi_versions_separate_stable_and_alpha() -> None:
+def test_pypi_versions_stable_channel_excludes_alpha_and_alpha_channel_includes_stable() -> None:
     payload = {
         "releases": {
             "3.0.7": [{"yanked": False}],
@@ -86,7 +91,15 @@ def test_pypi_versions_separate_stable_and_alpha() -> None:
         }
     }
     assert update_desktop_core.pypi_desktop_core_versions(payload, include_alpha=False) == ["3.0.7"]
-    assert update_desktop_core.pypi_desktop_core_versions(payload, include_alpha=True) == ["3.0.8a1"]
+    assert update_desktop_core.pypi_desktop_core_versions(payload, include_alpha=True) == ["3.0.7", "3.0.8a1"]
+    assert (
+        update_desktop_core.select_desktop_core_latest(
+            "3.0.6",
+            ["3.0.1a2", "3.0.7"],
+            include_alpha=True,
+        )
+        == "3.0.7"
+    )
 
 
 def test_status_migrates_embedded_alpha_core_to_stable(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -110,6 +123,7 @@ def test_status_migrates_embedded_alpha_core_to_stable(monkeypatch: pytest.Monke
         }
     )
     monkeypatch.setattr(update_commands, "_version_check_payload", version_check)
+    monkeypatch.setattr(update_commands, "_last_pypi_payload", None)
     monkeypatch.setattr(
         "codex_plugin_scanner.guard.cli.update_desktop_apply.desktop_core_updates_supported",
         lambda: True,
@@ -129,6 +143,7 @@ def test_status_migrates_embedded_alpha_core_to_stable(monkeypatch: pytest.Monke
 def test_status_supports_current_stable_core(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(update_desktop_core, "is_frozen_runtime", lambda: True)
     monkeypatch.setattr(update_commands, "_is_frozen_runtime", lambda: True)
+    monkeypatch.setattr(update_commands, "_last_pypi_payload", None)
     monkeypatch.setattr(update_commands, "_current_version", lambda: "3.0.7")
     monkeypatch.setenv("HOL_GUARD_DESKTOP", "1")
     monkeypatch.setattr(

--- a/tests/test_update_release_channels.py
+++ b/tests/test_update_release_channels.py
@@ -1,0 +1,60 @@
+"""Release-channel selection regressions for Guard updates."""
+
+from __future__ import annotations
+
+import pytest
+
+from codex_plugin_scanner.guard.cli import update_commands
+
+
+def test_alpha_channel_selects_newer_stable_release(monkeypatch: pytest.MonkeyPatch) -> None:
+    reserved_calls: list[str | None] = []
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "3.0.20")
+    monkeypatch.setattr(
+        update_commands,
+        "_newest_reserved_alpha_version",
+        lambda *, latest_pypi: reserved_calls.append(latest_pypi) or "3.0.1a3",
+    )
+    monkeypatch.setattr(
+        update_commands,
+        "_last_pypi_payload",
+        {
+            "releases": {
+                "3.0.1a2": [{"yanked": False}],
+                "3.0.20": [{"yanked": False}],
+            }
+        },
+    )
+
+    assert update_commands._latest_alpha_version_from_pypi("3.0.11") == "3.0.20"
+    payload = update_commands._version_check_payload("3.0.11", include_alpha=True)
+
+    assert payload["release_channel"] == "alpha"
+    assert payload["status"] == "stale"
+    assert payload["latest_version"] == "3.0.20"
+    assert payload["update_available"] is True
+    assert payload["reserved_alpha_version"] == "3.0.1a3"
+    assert reserved_calls == ["3.0.1a2"]
+
+
+def test_stable_python_fallback_excludes_prereleases(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "3.0.20")
+    monkeypatch.setattr(update_commands, "_runtime_python_version", lambda: "3.12.0")
+    monkeypatch.setattr(
+        update_commands,
+        "_last_pypi_payload",
+        {
+            "releases": {
+                "3.0.18": [{"yanked": False, "requires_python": ">=3.10"}],
+                "3.0.19rc1": [{"yanked": False, "requires_python": ">=3.10"}],
+                "3.0.20": [{"yanked": False, "requires_python": ">=3.13"}],
+            }
+        },
+    )
+
+    payload = update_commands._version_check_payload("3.0.11")
+
+    assert payload["status"] == "stale"
+    assert payload["latest_version"] == "3.0.18"
+    assert payload["pypi_latest_version"] == "3.0.20"
+    assert payload["pypi_latest_python_incompatible"] is True


### PR DESCRIPTION
## Summary
- let alpha-channel updates select newer stable releases instead of remaining pinned to an older alpha
- keep stable and alpha Desktop Core artifact routing correct for the selected target
- exclude beta and release-candidate builds from stable and alpha compatibility fallbacks

## Testing
- `uv run --no-sync pytest tests/test_guard_phase03_remainder.py tests/test_guard_phase03_local_install.py tests/test_update_release_channels.py tests/test_update_desktop_core.py tests/test_update_desktop_core_stable.py -q --tb=short`
- `uv run --no-sync pytest tests/test_dashboard_update.py tests/test_guard_cli.py tests/test_guard_phase03_local_install.py tests/test_guard_phase03_remainder.py tests/test_guard_update_install_verify.py tests/test_update_release_channels.py tests/test_update_desktop_core.py tests/test_update_desktop_core_stable.py --tb=short -q`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/cli/update_commands.py src/codex_plugin_scanner/guard/cli/update_desktop_core.py tests/test_guard_phase03_remainder.py tests/test_update_desktop_core_stable.py`
- `uv run --no-sync python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory test-inventory.json`
- `uv run --no-sync python scripts/ci/code_quality_audit.py --root . --baseline ci/code-quality-baseline.json --json-output code-quality-audit.json`
- `uv build`
