### PR TITLE
fix(guard): keep watch mode from native PreToolUse deny

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
-  "maximum_collected_cases": 16309,
-  "maximum_test_source_lines": 352692
+  "maximum_collected_cases": 16310,
+  "maximum_test_source_lines": 352733
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
-  "maximum_collected_cases": 16297,
-  "maximum_test_source_lines": 352420
+  "maximum_collected_cases": 16309,
+  "maximum_test_source_lines": 352692
 }

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -53,7 +53,7 @@ from ..codex_hook_manifest import (
 )
 from ..codex_hook_registration import (
     exact_legacy_hook_bindings,
-    prune_foreign_guard_codex_hook_groups,
+    install_managed_codex_hook_groups,
 )
 from ..codex_hook_registration import (
     remove_manifest_bound_hook_events as _remove_manifest_bound_hook_events,
@@ -1669,16 +1669,11 @@ class CodexHarnessAdapter(HarnessAdapter):
         cleaned_hooks, _ = _remove_manifest_bound_hook_events(hooks, owned_bindings)
         legacy_bindings = _current_install_legacy_bindings(context, cleaned_hooks)
         cleaned_hooks, _ = _remove_manifest_bound_hook_events(cleaned_hooks, legacy_bindings)
-        for event_name, managed_group in _managed_hook_groups(context).items():
-            existing_groups = cleaned_hooks.get(event_name)
-            kept_groups = prune_foreign_guard_codex_hook_groups(
-                existing_groups if isinstance(existing_groups, list) else [],
-                current_guard_home=context.guard_home,
-            )
-            cleaned_hooks[event_name] = [
-                *kept_groups,
-                managed_group,
-            ]
+        install_managed_codex_hook_groups(
+            cleaned_hooks,
+            _managed_hook_groups(context),
+            current_guard_home=context.guard_home,
+        )
         payload["hooks"] = cleaned_hooks
 
     @staticmethod

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -53,7 +53,7 @@ from ..codex_hook_manifest import (
 )
 from ..codex_hook_registration import (
     exact_legacy_hook_bindings,
-    is_foreign_guard_codex_hook_group,
+    prune_foreign_guard_codex_hook_groups,
 )
 from ..codex_hook_registration import (
     remove_manifest_bound_hook_events as _remove_manifest_bound_hook_events,
@@ -1671,14 +1671,10 @@ class CodexHarnessAdapter(HarnessAdapter):
         cleaned_hooks, _ = _remove_manifest_bound_hook_events(cleaned_hooks, legacy_bindings)
         for event_name, managed_group in _managed_hook_groups(context).items():
             existing_groups = cleaned_hooks.get(event_name)
-            kept_groups = [
-                group
-                for group in (existing_groups if isinstance(existing_groups, list) else [])
-                if not is_foreign_guard_codex_hook_group(
-                    group,
-                    current_guard_home=context.guard_home,
-                )
-            ]
+            kept_groups = prune_foreign_guard_codex_hook_groups(
+                existing_groups if isinstance(existing_groups, list) else [],
+                current_guard_home=context.guard_home,
+            )
             cleaned_hooks[event_name] = [
                 *kept_groups,
                 managed_group,

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -53,6 +53,7 @@ from ..codex_hook_manifest import (
 )
 from ..codex_hook_registration import (
     exact_legacy_hook_bindings,
+    is_foreign_guard_codex_hook_group,
 )
 from ..codex_hook_registration import (
     remove_manifest_bound_hook_events as _remove_manifest_bound_hook_events,
@@ -1670,8 +1671,16 @@ class CodexHarnessAdapter(HarnessAdapter):
         cleaned_hooks, _ = _remove_manifest_bound_hook_events(cleaned_hooks, legacy_bindings)
         for event_name, managed_group in _managed_hook_groups(context).items():
             existing_groups = cleaned_hooks.get(event_name)
+            kept_groups = [
+                group
+                for group in (existing_groups if isinstance(existing_groups, list) else [])
+                if not is_foreign_guard_codex_hook_group(
+                    group,
+                    current_guard_home=context.guard_home,
+                )
+            ]
             cleaned_hooks[event_name] = [
-                *(existing_groups if isinstance(existing_groups, list) else []),
+                *kept_groups,
                 managed_group,
             ]
         payload["hooks"] = cleaned_hooks

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_tail.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_tail.py
@@ -2,7 +2,30 @@
 
 from __future__ import annotations
 
-HOOK_SCRIPT_TEMPLATE_TAIL = """def _emit_cursor_response(
+HOOK_SCRIPT_TEMPLATE_TAIL = """def _recording_only_from_guard_home() -> bool:
+    try:
+        from codex_plugin_scanner.guard.protection_posture import recording_only_from_config_text
+
+        text = Path(GUARD_HOME).joinpath("config.toml").read_text(encoding="utf-8")
+        return recording_only_from_config_text(text)
+    except Exception:
+        return False
+
+
+def _cursor_permission(policy_action: str, guard_payload: dict[str, object]) -> str:
+    del guard_payload
+    if _recording_only_from_guard_home():
+        return "allow"
+    if policy_action not in GUARD_ACTIONS:
+        return "deny"
+    if policy_action in {"block", "sandbox-required"}:
+        return "deny"
+    if policy_action in {"require-reapproval", "review"}:
+        return "ask"
+    return "allow"
+
+
+def _emit_cursor_response(
     *,
     hook_event_name: str,
     policy_action: str,
@@ -315,6 +338,9 @@ def main() -> int:
         return 0
     raw_policy_action = guard_payload.get("policy_action")
     if not isinstance(raw_policy_action, str) or raw_policy_action not in GUARD_ACTIONS:
+        if _recording_only_from_guard_home():
+            print(json.dumps({"permission": "allow"}))
+            return 0
         print(
             json.dumps(
                 {

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_tail.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_tail.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 HOOK_SCRIPT_TEMPLATE_TAIL = """def _recording_only_from_guard_home() -> bool:
     try:
-        from codex_plugin_scanner.guard.protection_posture import recording_only_from_config_text
+        from codex_plugin_scanner.guard.config import load_guard_config
+        from codex_plugin_scanner.guard.protection_posture import protection_is_off
 
-        text = Path(GUARD_HOME).joinpath("config.toml").read_text(encoding="utf-8")
-        return recording_only_from_config_text(text)
+        config = load_guard_config(Path(GUARD_HOME))
+        return protection_is_off(posture=config.protection_posture, mode=config.mode)
     except Exception:
         return False
 

--- a/src/codex_plugin_scanner/guard/codex_hook_registration.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_registration.py
@@ -2,11 +2,22 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
+from pathlib import Path
 
 from .codex_hook_file_integrity import split_hook_command
 from .codex_hook_manifest import MANAGED_CODEX_HOOK_EVENTS
+
+_GUARD_CODEX_HOOK_MARKERS = (
+    "codex_daemon_hook_bridge.py",
+    "hol-guard hook",
+    "codex_plugin_scanner.cli",
+)
+_GUARD_HOME_FLAG_RE = re.compile(r"--guard-home(?:\s+|=)(\S+)")
+_STATE_PATH_RE = re.compile(r'"state_path"\s*:\s*"([^"]+)"')
+_GUARD_HOME_QUERY_RE = re.compile(r"guard-home=([^&\"'\s]+)")
 
 
 def remove_manifest_bound_hook_events(
@@ -105,4 +116,76 @@ def exact_legacy_hook_bindings(
     return bindings
 
 
-__all__ = ["exact_legacy_hook_bindings", "remove_manifest_bound_hook_events"]
+def _hook_group_command_blob(group: object) -> str:
+    if not isinstance(group, Mapping):
+        return ""
+    parts: list[str] = []
+    command = group.get("command")
+    if isinstance(command, str):
+        parts.append(command)
+    hooks = group.get("hooks")
+    if isinstance(hooks, list):
+        for hook in hooks:
+            if isinstance(hook, Mapping):
+                hook_command = hook.get("command")
+                if isinstance(hook_command, str):
+                    parts.append(hook_command)
+    return "\n".join(parts)
+
+
+def _looks_like_guard_codex_hook(blob: str) -> bool:
+    return any(marker in blob for marker in _GUARD_CODEX_HOOK_MARKERS)
+
+
+def _normalize_guard_home_path(value: str) -> Path | None:
+    stripped = value.strip().strip("'\"")
+    if not stripped:
+        return None
+    return Path(stripped).expanduser()
+
+
+def _extract_guard_homes_from_hook_blob(blob: str) -> tuple[Path, ...]:
+    decoded = blob.replace('\\"', '"')
+    homes: list[Path] = []
+    for match in _GUARD_HOME_FLAG_RE.finditer(decoded):
+        parsed = _normalize_guard_home_path(match.group(1))
+        if parsed is not None:
+            homes.append(parsed)
+    for match in _STATE_PATH_RE.finditer(decoded):
+        state_path = Path(match.group(1))
+        if state_path.name == "daemon-state.json":
+            homes.append(state_path.parent)
+    for match in _GUARD_HOME_QUERY_RE.finditer(decoded):
+        token = match.group(1)
+        if token.startswith("/") or token.startswith("~"):
+            parsed = _normalize_guard_home_path(token)
+            if parsed is not None:
+                homes.append(parsed)
+    return tuple(homes)
+
+
+def _resolved_guard_home(path: Path) -> Path:
+    try:
+        return path.resolve()
+    except OSError:
+        return path
+
+
+def is_foreign_guard_codex_hook_group(group: object, *, current_guard_home: Path) -> bool:
+    """Return True when a Guard Codex hook is bound to a different Guard home."""
+
+    blob = _hook_group_command_blob(group)
+    if not _looks_like_guard_codex_hook(blob):
+        return False
+    extracted = _extract_guard_homes_from_hook_blob(blob)
+    if not extracted:
+        return False
+    current = _resolved_guard_home(current_guard_home.expanduser())
+    return all(_resolved_guard_home(home) != current for home in extracted)
+
+
+__all__ = [
+    "exact_legacy_hook_bindings",
+    "is_foreign_guard_codex_hook_group",
+    "remove_manifest_bound_hook_events",
+]

--- a/src/codex_plugin_scanner/guard/codex_hook_registration.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_registration.py
@@ -248,8 +248,26 @@ def prune_foreign_guard_codex_hook_groups(
     return pruned
 
 
+def install_managed_codex_hook_groups(
+    hooks: dict[str, object],
+    managed_groups: Mapping[str, dict[str, object]],
+    *,
+    current_guard_home: Path,
+) -> None:
+    for event_name, managed_group in managed_groups.items():
+        existing = hooks.get(event_name)
+        hooks[event_name] = [
+            *prune_foreign_guard_codex_hook_groups(
+                existing if isinstance(existing, list) else [],
+                current_guard_home=current_guard_home,
+            ),
+            managed_group,
+        ]
+
+
 __all__ = [
     "exact_legacy_hook_bindings",
+    "install_managed_codex_hook_groups",
     "is_foreign_guard_codex_hook_group",
     "prune_foreign_guard_codex_hook_groups",
     "remove_manifest_bound_hook_events",

--- a/src/codex_plugin_scanner/guard/codex_hook_registration.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_registration.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import shlex
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from pathlib import Path
@@ -10,12 +11,6 @@ from pathlib import Path
 from .codex_hook_file_integrity import split_hook_command
 from .codex_hook_manifest import MANAGED_CODEX_HOOK_EVENTS
 
-_GUARD_CODEX_HOOK_MARKERS = (
-    "codex_daemon_hook_bridge.py",
-    "hol-guard hook",
-    "codex_plugin_scanner.cli",
-)
-_GUARD_HOME_FLAG_RE = re.compile(r"--guard-home(?:\s+|=)(\S+)")
 _STATE_PATH_RE = re.compile(r'"state_path"\s*:\s*"([^"]+)"')
 _GUARD_HOME_QUERY_RE = re.compile(r"guard-home=([^&\"'\s]+)")
 
@@ -133,8 +128,24 @@ def _hook_group_command_blob(group: object) -> str:
     return "\n".join(parts)
 
 
+def _has_codex_harness(blob: str) -> bool:
+    compact = blob.replace(" ", "")
+    return (
+        "--harness codex" in blob
+        or "--harness=codex" in blob
+        or '"--harness","codex"' in compact
+        or "'--harness','codex'" in compact
+    )
+
+
 def _looks_like_guard_codex_hook(blob: str) -> bool:
-    return any(marker in blob for marker in _GUARD_CODEX_HOOK_MARKERS)
+    if "codex_daemon_hook_bridge.py" in blob:
+        return True
+    if not _has_codex_harness(blob):
+        return False
+    if "hol-guard hook" in blob:
+        return True
+    return "codex_plugin_scanner.cli" in blob and "guard hook" in blob
 
 
 def _normalize_guard_home_path(value: str) -> Path | None:
@@ -144,13 +155,34 @@ def _normalize_guard_home_path(value: str) -> Path | None:
     return Path(stripped).expanduser()
 
 
+def _extract_guard_home_flags(command: str) -> list[Path]:
+    homes: list[Path] = []
+    try:
+        tokens = shlex.split(command, posix=True, comments=False)
+    except ValueError:
+        tokens = command.split()
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "--guard-home" and index + 1 < len(tokens):
+            parsed = _normalize_guard_home_path(tokens[index + 1])
+            if parsed is not None:
+                homes.append(parsed)
+            index += 2
+            continue
+        if token.startswith("--guard-home="):
+            parsed = _normalize_guard_home_path(token.split("=", 1)[1])
+            if parsed is not None:
+                homes.append(parsed)
+        index += 1
+    return homes
+
+
 def _extract_guard_homes_from_hook_blob(blob: str) -> tuple[Path, ...]:
     decoded = blob.replace('\\"', '"')
     homes: list[Path] = []
-    for match in _GUARD_HOME_FLAG_RE.finditer(decoded):
-        parsed = _normalize_guard_home_path(match.group(1))
-        if parsed is not None:
-            homes.append(parsed)
+    for command in decoded.split("\n"):
+        homes.extend(_extract_guard_home_flags(command))
     for match in _STATE_PATH_RE.finditer(decoded):
         state_path = Path(match.group(1))
         if state_path.name == "daemon-state.json":

--- a/src/codex_plugin_scanner/guard/codex_hook_registration.py
+++ b/src/codex_plugin_scanner/guard/codex_hook_registration.py
@@ -216,8 +216,41 @@ def is_foreign_guard_codex_hook_group(group: object, *, current_guard_home: Path
     return all(_resolved_guard_home(home) != current for home in extracted)
 
 
+def prune_foreign_guard_codex_hook_groups(
+    groups: Sequence[object],
+    *,
+    current_guard_home: Path,
+) -> list[object]:
+    """Drop foreign Guard handlers while keeping current-home and non-Guard hooks."""
+
+    pruned: list[object] = []
+    for group in groups:
+        if not isinstance(group, Mapping):
+            pruned.append(group)
+            continue
+        handlers = group.get("hooks")
+        if isinstance(handlers, list) and handlers:
+            kept_handlers: list[object] = []
+            for handler in handlers:
+                probe = {"hooks": [handler]} if isinstance(handler, Mapping) else handler
+                if is_foreign_guard_codex_hook_group(probe, current_guard_home=current_guard_home):
+                    continue
+                kept_handlers.append(handler)
+            if not kept_handlers:
+                continue
+            updated = dict(group)
+            updated["hooks"] = kept_handlers
+            pruned.append(updated)
+            continue
+        if is_foreign_guard_codex_hook_group(group, current_guard_home=current_guard_home):
+            continue
+        pruned.append(group)
+    return pruned
+
+
 __all__ = [
     "exact_legacy_hook_bindings",
     "is_foreign_guard_codex_hook_group",
+    "prune_foreign_guard_codex_hook_groups",
     "remove_manifest_bound_hook_events",
 ]

--- a/src/codex_plugin_scanner/guard/daemon/hook_worker.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_worker.py
@@ -12,7 +12,8 @@ Security:
 - Native PostToolUse is decided by Rust for ``auto``/``force``. Native failure
   fails closed instead of spilling into Python review. The Python engine is
   constructed only for ``off``/``shadow``.
-- Supported command PreToolUse is decided by Rust. Native failure fails closed.
+- Supported command PreToolUse is decided by Rust. Native failure fails closed
+  except when protection is off (watch/observe), which records via the CLI path.
   Non-command PreToolUse still raises ``HookWorkerUnsupported`` for the CLI path.
 """
 
@@ -31,6 +32,7 @@ from ..config import load_guard_config
 from ..native_pretool import review_pre_tool_native
 from ..native_route_receipt import record_python_semantic_hook_route
 from ..native_runtime import native_mode, native_runtime_status, review_post_tool_native
+from ..protection_posture import protection_is_off
 from ..runtime.hook_content_scanner import ContentScanner
 from ..runtime.hook_decision_cache import HookDecisionCache
 from ..runtime.hook_review_engine import HookReviewEngine
@@ -121,6 +123,11 @@ class HookWorker:
             command = _pre_tool_command(payload)
             if command is None:
                 raise HookWorkerUnsupported("fast path PreToolUse requires a command")
+            config = self._load_config(guard_home, workspace)
+            recording_only = protection_is_off(
+                posture=config.protection_posture,
+                mode=config.mode,
+            )
             native = review_pre_tool_native(
                 command,
                 guard_home=guard_home,
@@ -129,12 +136,15 @@ class HookWorker:
             )
             if native is not None:
                 action = str(native.get("minimum_action") or "")
-                if action == "review":
+                if action == "review" or (recording_only and action != "allow"):
                     # Native established the minimum floor, but the CLI approval
-                    # path still owns the terminal semantic decision.
+                    # path still owns the terminal semantic decision. Watch/observe
+                    # also records through that path instead of harness deny.
                     record_python_semantic_hook_route()
                     raise HookWorkerUnsupported("native PreToolUse review uses CLI approval coordination")
                 return _harness_json_from_native_pre_tool(harness, native)
+            if recording_only:
+                raise HookWorkerUnsupported("observe PreToolUse uses CLI recording")
             status = native_runtime_status()
             if status.mode == "off":
                 raise HookWorkerUnsupported("native PreToolUse runtime is off")

--- a/src/codex_plugin_scanner/guard/protection_posture.py
+++ b/src/codex_plugin_scanner/guard/protection_posture.py
@@ -168,27 +168,6 @@ def protection_is_off(*, posture: str, mode: str) -> bool:
     return posture == "watch" or mode == "observe"
 
 
-def recording_only_from_config_text(text: str) -> bool:
-    """Parse top-level Guard config text for watch/observe recording-only mode."""
-
-    mode = ""
-    posture = ""
-    for raw_line in text.splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith("#") or line.startswith("["):
-            continue
-        if "=" not in line:
-            continue
-        key, value = line.split("=", 1)
-        key = key.strip()
-        value = value.strip().strip('"').strip("'")
-        if key == "mode":
-            mode = value
-        elif key == "protection_posture":
-            posture = value
-    return protection_is_off(posture=posture, mode=mode)
-
-
 def protection_status_fields(*, posture: str, mode: str) -> dict[str, object]:
     off = protection_is_off(posture=posture, mode=mode)
     return {

--- a/src/codex_plugin_scanner/guard/protection_posture.py
+++ b/src/codex_plugin_scanner/guard/protection_posture.py
@@ -168,6 +168,27 @@ def protection_is_off(*, posture: str, mode: str) -> bool:
     return posture == "watch" or mode == "observe"
 
 
+def recording_only_from_config_text(text: str) -> bool:
+    """Parse top-level Guard config text for watch/observe recording-only mode."""
+
+    mode = ""
+    posture = ""
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or line.startswith("["):
+            continue
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key == "mode":
+            mode = value
+        elif key == "protection_posture":
+            posture = value
+    return protection_is_off(posture=posture, mode=mode)
+
+
 def protection_status_fields(*, posture: str, mode: str) -> dict[str, object]:
     off = protection_is_off(posture=posture, mode=mode)
     return {

--- a/tests/test_codex_foreign_hook_prune.py
+++ b/tests/test_codex_foreign_hook_prune.py
@@ -1,0 +1,77 @@
+"""Codex install must drop Guard hooks bound to a different Guard home."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.codex import CodexHarnessAdapter
+from codex_plugin_scanner.guard.codex_hook_registration import is_foreign_guard_codex_hook_group
+
+
+def _command_group(command: str) -> dict[str, object]:
+    return {
+        "matcher": "Bash",
+        "hooks": [{"type": "command", "command": command}],
+    }
+
+
+def test_foreign_hook_detects_pytest_guard_home(tmp_path: Path) -> None:
+    current = tmp_path / "guard-home"
+    foreign = tmp_path / "pytest-of-user" / "test_repair" / "guard-home"
+    group = _command_group(
+        "python -m codex_plugin_scanner.cli guard hook --harness codex "
+        f"--guard-home {foreign}"
+    )
+    assert is_foreign_guard_codex_hook_group(group, current_guard_home=current) is True
+
+
+def test_same_guard_home_legacy_bridge_is_not_foreign(tmp_path: Path) -> None:
+    current = tmp_path / "guard-home"
+    group = _command_group(
+        "python -I /opt/uv/hol-guard/adapters/codex_daemon_hook_bridge.py "
+        '{"state_path":"' + str(current / "daemon-state.json") + '"}'
+    )
+    assert is_foreign_guard_codex_hook_group(group, current_guard_home=current) is False
+
+
+def test_non_guard_hooks_are_not_foreign() -> None:
+    group = _command_group("lean-ctx hook observe")
+    assert is_foreign_guard_codex_hook_group(group, current_guard_home=Path("guard-home")) is False
+
+
+def test_install_config_hooks_drops_foreign_home_and_keeps_other_hooks(tmp_path: Path) -> None:
+    current = tmp_path / "guard-home"
+    current.mkdir()
+    foreign = tmp_path / "pytest-of-user" / "guard-home"
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=tmp_path / "workspace",
+        guard_home=current,
+    )
+    payload: dict[str, object] = {
+        "hooks": {
+            "PreToolUse": [
+                _command_group(
+                    "python -m codex_plugin_scanner.cli guard hook --harness codex "
+                    f"--guard-home {foreign}"
+                ),
+                _command_group("lean-ctx hook observe"),
+            ]
+        }
+    }
+    CodexHarnessAdapter._install_config_hooks(payload, context)
+    hooks = payload["hooks"]
+    assert isinstance(hooks, dict)
+    groups = hooks["PreToolUse"]
+    assert isinstance(groups, list)
+    commands = [
+        hook["command"]
+        for group in groups
+        if isinstance(group, dict)
+        for hook in group.get("hooks", [])
+        if isinstance(hook, dict) and isinstance(hook.get("command"), str)
+    ]
+    assert all("pytest-of-user" not in command for command in commands)
+    assert any("lean-ctx hook observe" in command for command in commands)
+    assert any("codex_daemon_hook_bridge.py" in command for command in commands)

--- a/tests/test_codex_foreign_hook_prune.py
+++ b/tests/test_codex_foreign_hook_prune.py
@@ -7,7 +7,10 @@ from pathlib import Path
 
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.codex import CodexHarnessAdapter
-from codex_plugin_scanner.guard.codex_hook_registration import is_foreign_guard_codex_hook_group
+from codex_plugin_scanner.guard.codex_hook_registration import (
+    is_foreign_guard_codex_hook_group,
+    prune_foreign_guard_codex_hook_groups,
+)
 
 
 def _command_group(command: str) -> dict[str, object]:
@@ -56,6 +59,44 @@ def test_quoted_same_home_path_with_spaces_is_not_foreign(tmp_path: Path) -> Non
         f"--guard-home {shlex.quote(str(current))}"
     )
     assert is_foreign_guard_codex_hook_group(group, current_guard_home=current) is False
+
+
+def test_mixed_home_group_keeps_current_handler_only(tmp_path: Path) -> None:
+    current = tmp_path / "guard-home"
+    current.mkdir()
+    foreign = tmp_path / "pytest-of-user" / "guard-home"
+    mixed = {
+        "matcher": "Bash",
+        "hooks": [
+            {
+                "type": "command",
+                "command": (
+                    "python -m codex_plugin_scanner.cli guard hook --harness codex "
+                    f"--guard-home {current}"
+                ),
+            },
+            {
+                "type": "command",
+                "command": (
+                    "python -m codex_plugin_scanner.cli guard hook --harness codex "
+                    f"--guard-home {foreign}"
+                ),
+            },
+        ],
+    }
+    pruned = prune_foreign_guard_codex_hook_groups([mixed], current_guard_home=current)
+    assert len(pruned) == 1
+    remaining = pruned[0]
+    assert isinstance(remaining, dict)
+    handlers = remaining.get("hooks")
+    assert isinstance(handlers, list)
+    assert len(handlers) == 1
+    handler = handlers[0]
+    assert isinstance(handler, dict)
+    command = handler.get("command")
+    assert isinstance(command, str)
+    assert str(current) in command
+    assert "pytest-of-user" not in command
 
 
 def test_install_config_hooks_drops_foreign_home_and_keeps_other_hooks(tmp_path: Path) -> None:

--- a/tests/test_codex_foreign_hook_prune.py
+++ b/tests/test_codex_foreign_hook_prune.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 from pathlib import Path
 
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
@@ -38,6 +39,23 @@ def test_same_guard_home_legacy_bridge_is_not_foreign(tmp_path: Path) -> None:
 def test_non_guard_hooks_are_not_foreign() -> None:
     group = _command_group("lean-ctx hook observe")
     assert is_foreign_guard_codex_hook_group(group, current_guard_home=Path("guard-home")) is False
+
+
+def test_unrelated_scanner_cli_hook_is_not_foreign(tmp_path: Path) -> None:
+    current = tmp_path / "guard-home"
+    foreign = tmp_path / "other-home"
+    group = _command_group(f"python -m codex_plugin_scanner.cli scan --guard-home {foreign}")
+    assert is_foreign_guard_codex_hook_group(group, current_guard_home=current) is False
+
+
+def test_quoted_same_home_path_with_spaces_is_not_foreign(tmp_path: Path) -> None:
+    current = tmp_path / "Application Support" / "guard-home"
+    current.mkdir(parents=True)
+    group = _command_group(
+        "python -m codex_plugin_scanner.cli guard hook --harness codex "
+        f"--guard-home {shlex.quote(str(current))}"
+    )
+    assert is_foreign_guard_codex_hook_group(group, current_guard_home=current) is False
 
 
 def test_install_config_hooks_drops_foreign_home_and_keeps_other_hooks(tmp_path: Path) -> None:

--- a/tests/test_cursor_watch_hook_script.py
+++ b/tests/test_cursor_watch_hook_script.py
@@ -2,60 +2,54 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.cursor_hooks import cursor_hook_script_source
-from codex_plugin_scanner.guard.protection_posture import recording_only_from_config_text
 
 
-def test_recording_only_from_config_text_watch() -> None:
-    assert (
-        recording_only_from_config_text('mode = "observe"\nprotection_posture = "watch"\n')
-        is True
-    )
-    assert recording_only_from_config_text('mode = "prompt"\nprotection_posture = "protected"\n') is False
-    assert recording_only_from_config_text('mode = "observe"\n') is True
-
-
-def test_generated_cursor_hook_allows_block_in_watch(tmp_path: Path) -> None:
+def _cursor_permission(tmp_path: Path, config_text: str) -> Callable[..., Any]:
     guard_home = tmp_path / "guard"
     guard_home.mkdir()
-    (guard_home / "config.toml").write_text(
-        'mode = "observe"\nprotection_posture = "watch"\n',
-        encoding="utf-8",
-    )
+    (guard_home / "config.toml").write_text(config_text, encoding="utf-8")
     context = HarnessContext(
         home_dir=tmp_path / "home",
         guard_home=guard_home,
         workspace_dir=tmp_path,
     )
     source = cursor_hook_script_source(context)
-    assert "_recording_only_from_guard_home" in source
+    assert "load_guard_config" in source
     script_globals: dict[str, object] = {"__name__": "cursor_hook"}
     exec(compile(source, "hol-guard-cursor-hook.py", "exec"), script_globals)
     permission = script_globals["_cursor_permission"]
     assert callable(permission)
+    return permission
+
+
+def test_generated_cursor_hook_allows_block_in_watch(tmp_path: Path) -> None:
+    permission = _cursor_permission(
+        tmp_path,
+        'mode = "observe"\nprotection_posture = "watch"\n',
+    )
     assert permission("block", {}) == "allow"
     assert permission("review", {}) == "allow"
 
 
 def test_generated_cursor_hook_still_denies_block_when_protected(tmp_path: Path) -> None:
-    guard_home = tmp_path / "guard"
-    guard_home.mkdir()
-    (guard_home / "config.toml").write_text(
+    permission = _cursor_permission(
+        tmp_path,
         'mode = "prompt"\nprotection_posture = "protected"\n',
-        encoding="utf-8",
     )
-    context = HarnessContext(
-        home_dir=tmp_path / "home",
-        guard_home=guard_home,
-        workspace_dir=tmp_path,
-    )
-    source = cursor_hook_script_source(context)
-    script_globals: dict[str, object] = {"__name__": "cursor_hook"}
-    exec(compile(source, "hol-guard-cursor-hook.py", "exec"), script_globals)
-    permission = script_globals["_cursor_permission"]
-    assert callable(permission)
     assert permission("block", {}) == "deny"
     assert permission("review", {}) == "ask"
+
+
+def test_generated_cursor_hook_ignores_nested_observe_keys(tmp_path: Path) -> None:
+    permission = _cursor_permission(
+        tmp_path,
+        'mode = "prompt"\nprotection_posture = "protected"\n\n[extensions]\n'
+        'mode = "observe"\nprotection_posture = "watch"\n',
+    )
+    assert permission("block", {}) == "deny"

--- a/tests/test_cursor_watch_hook_script.py
+++ b/tests/test_cursor_watch_hook_script.py
@@ -1,0 +1,61 @@
+"""Generated Cursor hook must allow when Guard is watch/observe-only."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.cursor_hooks import cursor_hook_script_source
+from codex_plugin_scanner.guard.protection_posture import recording_only_from_config_text
+
+
+def test_recording_only_from_config_text_watch() -> None:
+    assert (
+        recording_only_from_config_text('mode = "observe"\nprotection_posture = "watch"\n')
+        is True
+    )
+    assert recording_only_from_config_text('mode = "prompt"\nprotection_posture = "protected"\n') is False
+    assert recording_only_from_config_text('mode = "observe"\n') is True
+
+
+def test_generated_cursor_hook_allows_block_in_watch(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard"
+    guard_home.mkdir()
+    (guard_home / "config.toml").write_text(
+        'mode = "observe"\nprotection_posture = "watch"\n',
+        encoding="utf-8",
+    )
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        guard_home=guard_home,
+        workspace_dir=tmp_path,
+    )
+    source = cursor_hook_script_source(context)
+    assert "_recording_only_from_guard_home" in source
+    script_globals: dict[str, object] = {"__name__": "cursor_hook"}
+    exec(compile(source, "hol-guard-cursor-hook.py", "exec"), script_globals)
+    permission = script_globals["_cursor_permission"]
+    assert callable(permission)
+    assert permission("block", {}) == "allow"
+    assert permission("review", {}) == "allow"
+
+
+def test_generated_cursor_hook_still_denies_block_when_protected(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard"
+    guard_home.mkdir()
+    (guard_home / "config.toml").write_text(
+        'mode = "prompt"\nprotection_posture = "protected"\n',
+        encoding="utf-8",
+    )
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        guard_home=guard_home,
+        workspace_dir=tmp_path,
+    )
+    source = cursor_hook_script_source(context)
+    script_globals: dict[str, object] = {"__name__": "cursor_hook"}
+    exec(compile(source, "hol-guard-cursor-hook.py", "exec"), script_globals)
+    permission = script_globals["_cursor_permission"]
+    assert callable(permission)
+    assert permission("block", {}) == "deny"
+    assert permission("review", {}) == "ask"

--- a/tests/test_hook_worker_observe_pretool.py
+++ b/tests/test_hook_worker_observe_pretool.py
@@ -1,0 +1,122 @@
+"""Watch/observe PreToolUse must not harness-deny when native blocks or is missing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from codex_plugin_scanner.guard.daemon.hook_worker import HookWorker, HookWorkerUnsupported
+from codex_plugin_scanner.guard.native_runtime import NativeRuntimeStatus
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _native_allow(command: str) -> dict[str, Any]:
+    return {
+        "authority": "rust",
+        "decision": "allow",
+        "minimum_action": "allow",
+        "policy_action": "allow",
+        "reason_code": "native_exact_safe_command",
+        "reason": "The Rust command authority proved this bounded command explicitly benign.",
+        "explicitly_benign": True,
+        "command_model": {"normalized_text": command},
+    }
+
+
+def _native_block(command: str) -> dict[str, Any]:
+    return {
+        "authority": "rust",
+        "decision": "deny",
+        "minimum_action": "block",
+        "policy_action": "block",
+        "reason_code": "native_destructive_command",
+        "reason": "HOL Guard blocked a destructive command before execution.",
+        "explicitly_benign": False,
+        "command_model": {"normalized_text": command},
+    }
+
+
+def _write_watch_config(guard_home: Path) -> None:
+    guard_home.mkdir(parents=True, exist_ok=True)
+    (guard_home / "config.toml").write_text(
+        'mode = "observe"\nprotection_posture = "watch"\n',
+        encoding="utf-8",
+    )
+
+
+def test_hook_worker_watch_native_block_uses_cli_recording(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    _write_watch_config(guard_home)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.hook_worker.review_pre_tool_native",
+        lambda *_args, **_kwargs: _native_block("rm -rf /"),
+    )
+    worker = HookWorker(store=GuardStore(guard_home))
+    with pytest.raises(HookWorkerUnsupported, match="CLI approval coordination"):
+        worker.review_http_payload(
+            payload={"hook_event_name": "PreToolUse", "tool_input": {"command": "rm -rf /"}},
+            params={},
+            default_harness="cursor",
+            home_dir=tmp_path / "home",
+            guard_home=guard_home,
+            workspace=tmp_path / "workspace",
+        )
+
+
+def test_hook_worker_watch_native_unavailable_uses_cli_recording(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    _write_watch_config(guard_home)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.hook_worker.review_pre_tool_native",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.hook_worker.native_runtime_status",
+        lambda: NativeRuntimeStatus(
+            mode="auto",
+            available=False,
+            compatible=False,
+            reason="missing",
+        ),
+    )
+    worker = HookWorker(store=GuardStore(guard_home))
+    with pytest.raises(HookWorkerUnsupported, match="CLI recording"):
+        worker.review_http_payload(
+            payload={"hook_event_name": "PreToolUse", "tool_input": {"command": "pwd"}},
+            params={},
+            default_harness="cursor",
+            home_dir=tmp_path / "home",
+            guard_home=guard_home,
+            workspace=tmp_path / "workspace",
+        )
+
+
+def test_hook_worker_watch_native_allow_still_allows(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    _write_watch_config(guard_home)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.hook_worker.review_pre_tool_native",
+        lambda *_args, **_kwargs: _native_allow("pwd"),
+    )
+    worker = HookWorker(store=GuardStore(guard_home))
+    result = worker.review_http_payload(
+        payload={"hook_event_name": "PreToolUse", "tool_input": {"command": "pwd"}},
+        params={},
+        default_harness="codex",
+        home_dir=tmp_path / "home",
+        guard_home=guard_home,
+        workspace=tmp_path / "workspace",
+    )
+    assert result["policy_action"] == "allow"
+    assert result["hookSpecificOutput"]["permissionDecision"] == "allow"


### PR DESCRIPTION
## Summary
- Watch and observe no longer map native PreToolUse block or native-unavailable fail-closed into a harness deny. Those cases continue through the CLI recorder instead of stopping the tool.
- Codex hook install drops Guard-managed hook groups bound to a different Guard home. Same-home legacy Guard entries and non-Guard hooks stay in place.
- The generated Cursor hook allows when Guard is watch or observe, including invalid policy-action fail-closed payloads.

## Testing
- `uv run pytest tests/test_hook_worker_observe_pretool.py tests/test_codex_foreign_hook_prune.py tests/test_cursor_watch_hook_script.py -q`
- `uv run pytest tests/test_rust_pretool_authority.py tests/test_guard_codex_install.py::test_guard_install_and_repair_codex_preserve_ambiguous_legacy_post_tool_hooks tests/test_cursor_hooks.py::test_generated_cursor_hook_fails_closed_for_missing_or_unknown_guard_action tests/test_hook_review_observe_mode.py tests/test_codex_hook_approval_url.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recording-only and observe/watch modes across Codex and Cursor integrations.
  * Requests are allowed in recording-only mode while activity continues to be captured.
  * Native tool decisions are routed appropriately for recording or approval coordination.

* **Bug Fixes**
  * Prevented hooks from another Guard configuration from being retained during registration.
  * Improved handling of unavailable or invalid policy decisions in observe/watch mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->