### PR TITLE
docs(extensions): add contribution model and directory

### DIFF
--- a/.github/ISSUE_TEMPLATE/command-extension-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/command-extension-proposal.yml
@@ -1,0 +1,95 @@
+name: Command Extension proposal
+description: Propose new or expanded command protection for HOL Guard 3.
+title: "[extension] "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for new command safety Extensions and material coverage expansions. Do not include secrets, private command history, local paths, or vulnerability details. Report vulnerabilities through SECURITY.md.
+  - type: dropdown
+    id: contribution_type
+    attributes:
+      label: Contribution type
+      options:
+        - New Extension
+        - Existing Extension coverage
+        - False-positive or safe-variant improvement
+    validations:
+      required: true
+  - type: input
+    id: extension_identity
+    attributes:
+      label: Proposed or existing Extension ID
+      description: Use a stable command.<domain> or command.<domain>.<tool> identity.
+      placeholder: command.example
+    validations:
+      required: true
+  - type: textarea
+    id: capability_boundary
+    attributes:
+      label: Capability boundary
+      description: Describe what the Extension owns, what remains out of scope, and any overlap with the current directory.
+    validations:
+      required: true
+  - type: textarea
+    id: command_surface
+    attributes:
+      label: Command surface
+      description: List executables, dialects, transports, subcommands, flags, wrappers, and supported version assumptions.
+    validations:
+      required: true
+  - type: textarea
+    id: destructive_examples
+    attributes:
+      label: Destructive or sensitive examples
+      description: Provide redacted, reproducible commands for every operation family that should reach review or enforcement.
+    validations:
+      required: true
+  - type: textarea
+    id: safe_counterparts
+    attributes:
+      label: Safe counterparts
+      description: Pair every destructive family with preview, read-only, help, or otherwise safe commands that must remain non-reviewable.
+    validations:
+      required: true
+  - type: textarea
+    id: edge_cases
+    attributes:
+      label: Parser and composition edge cases
+      description: Cover quoting, reordered flags, paths with spaces, wrappers, separators, pipelines, suffixes, and malformed input.
+    validations:
+      required: true
+  - type: textarea
+    id: authority_model
+    attributes:
+      label: Risk and authority model
+      description: Propose risk/action classes, severity, default mode, safer alternatives, and explain why the Extension cannot weaken another match.
+    validations:
+      required: true
+  - type: textarea
+    id: privacy_performance
+    attributes:
+      label: Privacy and performance
+      description: Identify sensitive inputs, redaction needs, matcher bounds, and likely benign hot paths.
+    validations:
+      required: true
+  - type: textarea
+    id: references
+    attributes:
+      label: Authoritative references
+      description: Link official CLI or API documentation for the proposed command semantics.
+    validations:
+      required: true
+  - type: checkboxes
+    id: readiness
+    attributes:
+      label: Readiness checklist
+      options:
+        - label: I searched the Extension directory and existing issues for overlapping coverage.
+          required: true
+        - label: I removed secrets, credentials, private command history, and local paths from these examples.
+          required: true
+        - label: I can contribute or help validate destructive and safe-counterpart tests.
+          required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,16 @@ python -m build
 5. Run the validation commands above.
 6. Open a pull request against `main` with a clear summary of what changed and why.
 
+## Command Extension Contributions
+
+HOL Guard 3 command safety Extensions have additional security, compatibility, privacy, and test requirements.
+Browse the [Extension directory](docs/guard/extensions/README.md), then follow the
+[Extension contribution guide](docs/guard/extensions/contributing.md) before proposing or implementing coverage.
+
+Open the dedicated Extension proposal form for a new capability boundary or a material authority change. Focused
+coverage expansions and false-positive fixes should still include destructive and safe-counterpart regression cases
+and keep the generated directory synchronized with the canonical runtime registry.
+
 ## Contribution Expectations
 
 - Python code should remain compatible with the versions declared in `pyproject.toml`.

--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ hol-guard command explain 'grep "rm -rf|git clean" README.md'
 hol-guard command extensions command.git --json
 ```
 
+[Explore built-in Extensions](docs/guard/extensions/README.md) ·
+[Contribute an Extension](docs/guard/extensions/contributing.md)
+
 Structured core rules preserve every match in a compound command. A Git preview such as `git clean -ndx` remains
 safe, while an unrelated destructive segment still produces review. New structured coverage feeds the same runtime
 artifact and policy pipeline as existing command classifications.

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
-  "maximum_collected_cases": 16223,
-  "maximum_test_source_lines": 350527
+  "maximum_collected_cases": 16224,
+  "maximum_test_source_lines": 350533
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
-  "maximum_collected_cases": 16221,
-  "maximum_test_source_lines": 350455
+  "maximum_collected_cases": 16223,
+  "maximum_test_source_lines": 350527
 }

--- a/docs/guard/extensions/README.md
+++ b/docs/guard/extensions/README.md
@@ -1,0 +1,141 @@
+# HOL Guard extension directory
+
+HOL Guard 3 groups command protection into inspectable Extensions. Each Extension owns a stable capability boundary,
+its rule metadata, safer alternatives, and the evidence it contributes to Guard's policy decision. Extensions detect
+and explain command facts; they do not grant authority, execute commands, or replace Guard policy.
+
+Use this directory to discover the built-in coverage shipped by the current source tree. The tables are generated
+from the same validated registry used by runtime hooks, `command explain`, the local dashboard, and catalog APIs, so
+the documentation cannot silently drift from the product.
+
+```bash
+# List every Extension.
+hol-guard command extensions
+
+# Inspect one Extension and its stable rules.
+hol-guard command extensions command.git --json
+
+# Test a command without executing it or creating an approval.
+hol-guard command explain 'git reset --hard HEAD~1'
+```
+
+Protection model meanings:
+
+- **Required core**: an immutable minimum protection floor shipped by HOL Guard.
+- **Built in**: a reviewed detector in the canonical local registry.
+- **Package Firewall**: package operations delegated to Guard's supply-chain enforcement surface.
+
+<!-- BEGIN GENERATED EXTENSION DIRECTORY -->
+
+### Core safety
+
+| Extension | What it protects | Rules | Protection model |
+| :--- | :--- | ---: | :--- |
+| `command.container-runtime` | Reviews container operations that can expose credentials, publish data, or mutate host state. | 5 | Built in |
+| `command.data-protection` | Detects shell flows that can send credentials or local file contents to a network destination. | 2 | Built in |
+| `command.encoded-execution` | Reviews decode-and-execute flows whose effective program is hidden from normal command inspection. | 1 | Built in |
+| `command.filesystem` | Reviews recursive deletion and access-control changes across filesystem trees. | 2 | Required core |
+| `command.git` | Reviews everyday Git porcelain plus local and remote operations that can discard work, replace history, refresh a remote Guard cannot verify, or read a staged index Guard cannot bound. | 39 | Required core |
+| `command.guard-self-protection` | Prevents commands from authorizing their own Guard approval or weakening protected Guard state. | 1 | Required core |
+| `command.kubernetes-secrets` | Reviews Kubernetes CLI operations that can reveal cluster or application secrets. | 1 | Built in |
+| `command.shell-mutations` | Reviews destructive shell, Git, filesystem, redirection, and protected configuration mutations. | 5 | Built in |
+| `command.system` | Reviews storage formatting and operating-system power-state mutations. | 1 | Required core |
+| `command.windows` | Reviews destructive Windows storage and operating-system commands. | 1 | Required core |
+
+### Cloud and infrastructure
+
+| Extension | What it protects | Rules | Protection model |
+| :--- | :--- | ---: | :--- |
+| `command.api-gateway` | Reviews API and gateway deletion through supported cloud CLIs. | 1 | Built in |
+| `command.cdn` | Reviews distribution, profile, and endpoint deletion through supported cloud CLIs. | 1 | Built in |
+| `command.cloud.aws` | Reviews a validated AWS CLI operation matrix for permanent resource deletion and service termination. | 1 | Built in |
+| `command.cloud.azure` | Reviews a validated Azure CLI operation matrix for permanent resource deletion across subscription, identity, network, compute, application, data, messaging, and AI services. | 1 | Built in |
+| `command.cloud.gcp` | Reviews a validated gcloud operation matrix for permanent resource deletion across stable and supported release tracks. | 1 | Built in |
+| `command.dns` | Reviews hosted-zone deletion through supported cloud CLIs. | 1 | Built in |
+| `command.infrastructure-as-code` | Reviews infrastructure teardown through Terraform, OpenTofu, and Pulumi. | 1 | Built in |
+| `command.kubernetes-operations` | Reviews cluster operations that delete resources, evict workloads, or remove releases. | 3 | Built in |
+| `command.load-balancer` | Reviews load-balancer and forwarding-rule deletion through supported cloud CLIs. | 1 | Built in |
+
+### Data and resilience
+
+| Extension | What it protects | Rules | Protection model |
+| :--- | :--- | ---: | :--- |
+| `command.backup.borg` | Reviews Borg operations that delete, prune, or recreate archives. | 1 | Built in |
+| `command.backup.rclone` | Reviews rclone operations that delete, move, purge, or synchronize data. | 1 | Built in |
+| `command.backup.restic` | Reviews restic operations that remove snapshots or repository data. | 1 | Built in |
+| `command.backup.velero` | Reviews Velero operations that delete backup data or recovery records. | 1 | Built in |
+| `command.database.mongodb` | Reviews restore operations that drop and replace collections. | 1 | Built in |
+| `command.database.mysql` | Reviews mysqladmin database removal operations. | 1 | Built in |
+| `command.database.postgresql` | Reviews explicit PostgreSQL database removal commands. | 1 | Built in |
+| `command.database.redis` | Reviews Redis key deletion and database flush commands. | 1 | Built in |
+| `command.database.sqlite` | Reviews SQLite restore operations that replace database content. | 1 | Built in |
+| `command.database.supabase` | Reviews database reset and migration rollback commands. | 1 | Built in |
+| `command.storage.aws-s3` | Reviews AWS CLI S3 commands including copy, list, sync, website, and deletion. | 8 | Built in |
+| `command.storage.azure-blob` | Reviews Azure CLI storage commands including upload, list, copy, and deletion. | 6 | Built in |
+| `command.storage.google-cloud` | Reviews Google CLI storage commands including copy, list, sync, and deletion. | 7 | Built in |
+| `command.storage.minio` | Reviews MinIO Client commands including copy, list, mirror, and deletion. | 7 | Built in |
+
+### Delivery and remote operations
+
+| Extension | What it protects | Rules | Protection model |
+| :--- | :--- | ---: | :--- |
+| `command.cicd.circleci` | Reviews remote pipeline execution through CircleCI CLI. | 1 | Built in |
+| `command.cicd.github` | Reviews workflow-run cancellation, deletion, and workflow disabling through GitHub CLI. | 2 | Built in |
+| `command.cicd.gitlab` | Reviews remote pipeline cancellation through GitLab CLI. | 1 | Built in |
+| `command.github` | Reviews distinct GitHub maintenance, content, merge, publication, workflow, and control effects. | 15 | Built in |
+| `command.platform.heroku` | Reviews app destruction, pipeline promotion, and release rollback. | 2 | Built in |
+| `command.platform.netlify` | Reviews site deletion and production deployments. | 2 | Built in |
+| `command.platform.vercel` | Reviews deployment and project deletion plus production deployment, promotion, and rollback. | 2 | Built in |
+| `command.remote.rsync` | Reviews rsync options that delete destination data or remove synchronized source files. | 2 | Built in |
+| `command.remote.scp` | Reviews SCP transfers that can overwrite local or remote destination files. | 1 | Built in |
+| `command.remote.ssh` | Reviews SSH invocations that explicitly execute a remote command. | 2 | Built in |
+
+### Managed services
+
+| Extension | What it protects | Rules | Protection model |
+| :--- | :--- | ---: | :--- |
+| `command.email` | Reviews email identity and contact-list deletion through AWS CLI. | 1 | Built in |
+| `command.feature-flags` | Reviews permanent feature-flag deletion through LaunchDarkly CLI. | 1 | Built in |
+| `command.messaging.kafka` | Reviews Kafka topic, group, offset, and record deletion operations. | 1 | Built in |
+| `command.messaging.nats` | Reviews NATS stream, consumer, key-value, and object-store removal operations. | 1 | Built in |
+| `command.messaging.rabbitmq` | Reviews RabbitMQ deletion and broker reset operations. | 1 | Built in |
+| `command.monitoring` | Reviews alarm and alert deletion through supported cloud CLIs. | 1 | Built in |
+| `command.payment` | Reviews product, coupon, customer, and webhook endpoint deletion through Stripe CLI. | 1 | Built in |
+| `command.search.elasticsearch` | Reviews explicit DELETE requests to recognizable Elasticsearch API targets. | 1 | Built in |
+
+### Package supply chain
+
+| Extension | What it protects | Rules | Protection model |
+| :--- | :--- | ---: | :--- |
+| `command.package.go` | Routes Go module and tool installation requests through Guard's package firewall. | 0 | Package Firewall |
+| `command.package.jvm` | Routes Maven and Gradle dependency operations through Guard's package firewall. | 0 | Package Firewall |
+| `command.package.node` | Routes Node package installs and one-shot execution through Guard's package firewall. | 0 | Package Firewall |
+| `command.package.php` | Routes Composer dependency operations through Guard's package firewall. | 0 | Package Firewall |
+| `command.package.python` | Routes Python dependency installs and isolated package execution through Guard's package firewall. | 0 | Package Firewall |
+| `command.package.ruby` | Routes RubyGem and Bundler dependency operations through Guard's package firewall. | 0 | Package Firewall |
+| `command.package.rust` | Routes Cargo dependency and binary installation requests through Guard's package firewall. | 0 | Package Firewall |
+| `command.package.system` | Routes operating-system package installation requests through Guard's package firewall. | 0 | Package Firewall |
+
+### Specialized tools
+
+| Extension | What it protects | Rules | Protection model |
+| :--- | :--- | ---: | :--- |
+| `command.skill-sunset` | Reviews the canonical Skill Sunset audit surface and its local report and viewer side effects. Experiment execution and npm launcher policy remain outside this extension. | 1 | Built in |
+
+<!-- END GENERATED EXTENSION DIRECTORY -->
+
+## Contribute
+
+Start with the [Extension contribution guide](contributing.md). It covers proposal quality, stable identity design,
+matcher constraints, safe-counterpart tests, privacy, validation, and the review rubric. New command coverage enters
+the vetted built-in registry; Guard does not import executable detector code from workspaces or downloaded bundles.
+
+Use the [Extension proposal issue form](../../../.github/ISSUE_TEMPLATE/command-extension-proposal.yml) before a
+large implementation so maintainers can confirm scope and avoid overlapping IDs.
+
+## Architecture and authority
+
+- [Command Extension architecture](../command-extension-architecture.md)
+- [Extension precedence and minimum actions](../command-extension-precedence.md)
+- [Command Extension threat model](../command-extension-threat-model.md)
+- [Local Extensions and protection settings](../managed-controls-local-extensions.md)

--- a/docs/guard/extensions/contributing.md
+++ b/docs/guard/extensions/contributing.md
@@ -44,6 +44,11 @@ Use the narrowest existing module that owns the domain:
 - Package-manager coverage lives in `command_package_extensions.py` and delegates decisions to Package Firewall.
 - Shared typed contracts live in `command_extension_specs.py`, `command_rules.py`, and `command_extensions.py`.
 
+Directory categories are presentation-only and never affect runtime authority. The renderer assigns known families to
+curated sections and places every otherwise-valid new ID in **Other extensions**, so a registry addition cannot break
+documentation generation. Add an explicit category rule when the new family has a durable public taxonomy; do not
+add documentation-only fields to the runtime security contract.
+
 Do not add a second parser, retokenize raw shell text inside a matcher, import workspace code, or let an Extension
 emit an allow/approval decision. Matchers return structured evidence; Guard policy retains final authority.
 

--- a/docs/guard/extensions/contributing.md
+++ b/docs/guard/extensions/contributing.md
@@ -1,0 +1,101 @@
+# Contributing a command safety Extension
+
+HOL Guard Extensions are security boundaries, not downloadable regex packs. A contribution must preserve parse-once
+command semantics, evidence-only detection, monotonic policy authority, stable public IDs, privacy, and predictable
+latency. This guide makes those requirements reviewable and gives contributors one path from idea to merge.
+
+## Choose the contribution type
+
+| Contribution | Use it for | Expected scope |
+| :--- | :--- | :--- |
+| New Extension | A distinct command capability with its own stable identity | Metadata, rules, fixtures, docs, and registry coverage |
+| Coverage expansion | A dangerous operation owned by an existing Extension | Matcher/rule updates plus destructive and safe-counterpart cases |
+| False-positive fix | Preview, read-only, help, or bounded behavior incorrectly reaches review | A positive safe predicate and regression cases; never a global suppression |
+| Documentation | Better examples, references, or operator guidance | Documentation plus directory validation when catalog metadata changes |
+
+For a new Extension or a material authority change, open an
+[Extension proposal](https://github.com/hashgraph-online/hol-guard/issues/new?template=command-extension-proposal.yml)
+before implementation. Security vulnerabilities belong in the private process documented by
+[`SECURITY.md`](../../../SECURITY.md), not a public proposal.
+
+## Proposal quality bar
+
+A reviewable proposal includes:
+
+1. The capability boundary and proposed `command.<domain>[.<tool>]` ID.
+2. Supported executables, dialects, transports, subcommands, and version assumptions.
+3. Representative destructive commands and a safe counterpart for every operation family.
+4. Compound-command, wrapper, quoting, reordered-flag, and malformed-input cases.
+5. Risk and action classes, default severity/mode, and safer alternatives.
+6. Overlap with existing Extensions and why a new identity is preferable to extending one.
+7. Privacy and performance considerations, with authoritative CLI references.
+
+Maintainers may redirect a proposal to existing coverage when the capability boundary overlaps. Stable IDs are part
+of receipts, remembered decisions, managed controls, and automation contracts, so naming is reviewed before merge.
+
+## Implementation map
+
+Use the narrowest existing module that owns the domain:
+
+- Core specs live in `command_builtin_extension_registry.py`; core compatibility rules live in
+  `command_builtin_rules.py`.
+- Domain specs and rules live together in the matching `command_*_extensions.py` module and are assembled by
+  `command_builtin_extension_catalog.py`.
+- Package-manager coverage lives in `command_package_extensions.py` and delegates decisions to Package Firewall.
+- Shared typed contracts live in `command_extension_specs.py`, `command_rules.py`, and `command_extensions.py`.
+
+Do not add a second parser, retokenize raw shell text inside a matcher, import workspace code, or let an Extension
+emit an allow/approval decision. Matchers return structured evidence; Guard policy retains final authority.
+
+## Required test matrix
+
+Every new rule needs table-driven cases that prove:
+
+- destructive examples reach both side-effect-free inspection and runtime review;
+- safe previews, read-only variants, and help commands remain non-reviewable;
+- reordered flags, quoting, paths with spaces, wrappers, separators, pipelines, and suffixes preserve meaning;
+- malformed or unsupported input produces uncertainty and never implies safety;
+- overlapping Extensions retain all evidence and the strongest controlling requirement;
+- rule IDs, risk classes, action classes, executables, and permissions remain owned by the declared Extension;
+- evidence and persisted catalog fields contain no command text, local paths, environment values, or secrets.
+
+Reuse the assertions in `tests/command_extension_contracts.py`. Put focused tests beside the owning domain suite, for
+example `tests/test_guard_command_storage_extensions.py`, rather than growing one universal test file.
+
+## Local validation
+
+Run the focused domain suite first, then the registry and documentation contracts:
+
+```bash
+uv run pytest -q tests/test_guard_command_<domain>_extensions.py
+uv run pytest -q \
+  tests/test_guard_command_extension_registry.py \
+  tests/test_guard_command_extension_directory.py
+uv run python scripts/render_command_extension_directory.py --check
+uv run ruff check <changed-python-files>
+uv run ruff format --check <changed-python-files>
+```
+
+When metadata changes, regenerate the directory and commit the result:
+
+```bash
+uv run python scripts/render_command_extension_directory.py
+```
+
+Broader parser, policy, persistence, or authority changes require their affected suites and the full release gates.
+Document the exact commands and results in the pull request.
+
+## Review rubric
+
+Maintainers evaluate Extension changes against these merge gates:
+
+- **Boundary**: one coherent capability, canonical ID, no ownership ambiguity.
+- **Detection**: structured matchers, bounded complexity, complete index hints, deterministic output.
+- **Safety**: destructive coverage and explicit safe counterparts without cross-rule suppression.
+- **Authority**: evidence cannot weaken required floors, managed restrictions, or another match.
+- **Compatibility**: stable IDs and declared action/risk classes preserve existing receipts and controls.
+- **Privacy**: no raw command, secret, path, or environment persistence in catalog/evidence fields.
+- **Performance**: representative benign and destructive cases stay within parser and matcher budgets.
+- **Operability**: clear safer alternatives, authoritative references, directory entry, and focused tests.
+
+A change is complete only when code, catalog, documentation, and tests describe the same protection boundary.

--- a/scripts/render_command_extension_directory.py
+++ b/scripts/render_command_extension_directory.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Render the contributor-facing directory from Guard's canonical registry."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from codex_plugin_scanner.guard.runtime.command_extensions import (
+    BUILT_IN_COMMAND_EXTENSION_REGISTRY,
+    CommandSafetyExtension,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DIRECTORY_PATH = REPO_ROOT / "docs" / "guard" / "extensions" / "README.md"
+START_MARKER = "<!-- BEGIN GENERATED EXTENSION DIRECTORY -->"
+END_MARKER = "<!-- END GENERATED EXTENSION DIRECTORY -->"
+
+CATEGORY_ORDER = (
+    "Core safety",
+    "Cloud and infrastructure",
+    "Data and resilience",
+    "Delivery and remote operations",
+    "Managed services",
+    "Package supply chain",
+    "Specialized tools",
+)
+
+CORE_EXTENSION_IDS = frozenset(
+    {
+        "command.container-runtime",
+        "command.data-protection",
+        "command.encoded-execution",
+        "command.filesystem",
+        "command.git",
+        "command.guard-self-protection",
+        "command.kubernetes-secrets",
+        "command.shell-mutations",
+        "command.system",
+        "command.windows",
+    }
+)
+
+
+def _category(extension_id: str) -> str:
+    if extension_id in CORE_EXTENSION_IDS:
+        return "Core safety"
+    if extension_id in {
+        "command.api-gateway",
+        "command.cdn",
+        "command.dns",
+        "command.infrastructure-as-code",
+        "command.kubernetes-operations",
+        "command.load-balancer",
+    } or extension_id.startswith("command.cloud."):
+        return "Cloud and infrastructure"
+    if extension_id.startswith(("command.backup.", "command.database.", "command.storage.")):
+        return "Data and resilience"
+    if extension_id == "command.github" or extension_id.startswith(
+        ("command.cicd.", "command.platform.", "command.remote.")
+    ):
+        return "Delivery and remote operations"
+    if extension_id in {
+        "command.email",
+        "command.feature-flags",
+        "command.monitoring",
+        "command.payment",
+    } or extension_id.startswith(("command.messaging.", "command.search.")):
+        return "Managed services"
+    if extension_id.startswith("command.package."):
+        return "Package supply chain"
+    if extension_id == "command.skill-sunset":
+        return "Specialized tools"
+    raise ValueError(f"Extension directory category is missing for {extension_id}")
+
+
+def _escape_cell(value: str) -> str:
+    return " ".join(value.split()).replace("|", "\\|")
+
+
+def _protection_model(extension: CommandSafetyExtension) -> str:
+    if extension.required:
+        return "Required core"
+    if extension.delegated_protection == "package-firewall":
+        return "Package Firewall"
+    return "Built in"
+
+
+def render_catalog() -> str:
+    """Return the deterministic Markdown catalog for all built-in extensions."""
+
+    grouped: dict[str, list[CommandSafetyExtension]] = {category: [] for category in CATEGORY_ORDER}
+    for extension in BUILT_IN_COMMAND_EXTENSION_REGISTRY.extensions:
+        grouped[_category(extension.extension_id)].append(extension)
+
+    sections: list[str] = []
+    for category in CATEGORY_ORDER:
+        rows = [
+            f"### {category}",
+            "",
+            "| Extension | What it protects | Rules | Protection model |",
+            "| :--- | :--- | ---: | :--- |",
+        ]
+        for extension in grouped[category]:
+            description = _escape_cell(extension.description)
+            protection_model = _protection_model(extension)
+            rows.append(f"| `{extension.extension_id}` | {description} | {len(extension.rules)} | {protection_model} |")
+        sections.append("\n".join(rows))
+    return "\n\n".join(sections)
+
+
+def render_document(current: str) -> str:
+    """Replace the generated catalog while preserving hand-authored guidance."""
+
+    if current.count(START_MARKER) != 1 or current.count(END_MARKER) != 1:
+        raise ValueError("Extension directory must contain exactly one generated marker pair")
+    prefix, remainder = current.split(START_MARKER, 1)
+    _generated, suffix = remainder.split(END_MARKER, 1)
+    return f"{prefix}{START_MARKER}\n\n{render_catalog()}\n\n{END_MARKER}{suffix}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail when the committed directory does not match the runtime registry.",
+    )
+    args = parser.parse_args(argv)
+
+    current = DIRECTORY_PATH.read_text(encoding="utf-8")
+    rendered = render_document(current)
+    if args.check:
+        if current != rendered:
+            parser.error(
+                "extension directory is stale; run `uv run python scripts/render_command_extension_directory.py`"
+            )
+        return 0
+    DIRECTORY_PATH.write_text(rendered, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_command_extension_directory.py
+++ b/scripts/render_command_extension_directory.py
@@ -24,6 +24,7 @@ CATEGORY_ORDER = (
     "Managed services",
     "Package supply chain",
     "Specialized tools",
+    "Other extensions",
 )
 
 CORE_EXTENSION_IDS = frozenset(
@@ -71,7 +72,7 @@ def _category(extension_id: str) -> str:
         return "Package supply chain"
     if extension_id == "command.skill-sunset":
         return "Specialized tools"
-    raise ValueError(f"Extension directory category is missing for {extension_id}")
+    return "Other extensions"
 
 
 def _escape_cell(value: str) -> str:
@@ -95,6 +96,8 @@ def render_catalog() -> str:
 
     sections: list[str] = []
     for category in CATEGORY_ORDER:
+        if not grouped[category]:
+            continue
         rows = [
             f"### {category}",
             "",

--- a/tests/test_guard_command_extension_directory.py
+++ b/tests/test_guard_command_extension_directory.py
@@ -1,0 +1,72 @@
+"""Contributor-facing command Extension directory contract tests."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import yaml
+
+from codex_plugin_scanner.guard.runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "render_command_extension_directory.py"
+DIRECTORY_PATH = REPO_ROOT / "docs" / "guard" / "extensions" / "README.md"
+
+
+def _load_renderer() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("render_command_extension_directory", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_extension_directory_matches_canonical_registry() -> None:
+    renderer = _load_renderer()
+    current = DIRECTORY_PATH.read_text(encoding="utf-8")
+
+    assert renderer.render_document(current) == current
+    for extension in BUILT_IN_COMMAND_EXTENSION_REGISTRY.extensions:
+        assert current.count(f"`{extension.extension_id}`") == 1
+
+
+def test_readme_and_contribution_guide_expose_complete_entry_path() -> None:
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    contributing = (REPO_ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+    guide = (REPO_ROOT / "docs" / "guard" / "extensions" / "contributing.md").read_text(encoding="utf-8")
+    proposal = (REPO_ROOT / ".github" / "ISSUE_TEMPLATE" / "command-extension-proposal.yml").read_text(encoding="utf-8")
+    proposal_data = yaml.safe_load(proposal)
+
+    assert "docs/guard/extensions/README.md" in readme
+    assert "docs/guard/extensions/contributing.md" in readme
+    assert "docs/guard/extensions/contributing.md" in contributing
+    for requirement in (
+        "destructive examples reach both side-effect-free inspection and runtime review",
+        "safe previews",
+        "privacy",
+        "Extension proposal",
+    ):
+        assert requirement.lower() in guide.lower()
+    for field in (
+        "extension_identity",
+        "destructive_examples",
+        "safe_counterparts",
+        "authority_model",
+        "privacy_performance",
+    ):
+        assert f"id: {field}" in proposal
+    proposal_fields = {item["id"]: item for item in proposal_data["body"] if isinstance(item, dict) and "id" in item}
+    for field in (
+        "extension_identity",
+        "capability_boundary",
+        "command_surface",
+        "destructive_examples",
+        "safe_counterparts",
+        "edge_cases",
+        "authority_model",
+        "privacy_performance",
+        "references",
+    ):
+        assert proposal_fields[field]["validations"]["required"] is True

--- a/tests/test_guard_command_extension_directory.py
+++ b/tests/test_guard_command_extension_directory.py
@@ -32,6 +32,12 @@ def test_extension_directory_matches_canonical_registry() -> None:
         assert current.count(f"`{extension.extension_id}`") == 1
 
 
+def test_future_extension_ids_use_a_non_breaking_directory_fallback() -> None:
+    renderer = _load_renderer()
+
+    assert renderer._category("command.future-capability") == "Other extensions"
+
+
 def test_readme_and_contribution_guide_expose_complete_entry_path() -> None:
     readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
     contributing = (REPO_ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add an explorable command Extension directory generated from the canonical runtime registry
- document a security-focused contribution path and maintainer review rubric
- add a structured Extension proposal form and drift tests for the public contribution surfaces

## Testing
- `uv run --frozen pytest -q tests/test_ci_test_suite_ratchet.py tests/test_guard_command_extension_directory.py tests/test_guard_command_extension_registry.py tests/test_guard_docs.py`
- `uv run --no-sync python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory <test-inventory.json>`
- `uv run --frozen python scripts/render_command_extension_directory.py --check`
- `uv run --frozen ruff check scripts/render_command_extension_directory.py tests/test_guard_command_extension_directory.py`
- `uv run --frozen ruff format --check scripts/render_command_extension_directory.py tests/test_guard_command_extension_directory.py`
