### PR TITLE
fix(review): keep pending cloud decisions actionable

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud_review.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud_review.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TextIO
@@ -28,8 +29,12 @@ def _refresh_cloud_review_worker(guard_home: Path) -> dict[str, object]:
         }
 
 
-def _requeue_pending_cloud_review_requests(store: GuardStore) -> int:
-    return store.requeue_pending_review_events(changed_at=datetime.now(timezone.utc).isoformat())
+def _requeue_pending_cloud_review_requests(store: GuardStore) -> tuple[int, str]:
+    try:
+        requeued = store.requeue_pending_review_events(changed_at=datetime.now(timezone.utc).isoformat())
+    except sqlite3.Error:
+        return 0, "retry_required"
+    return requeued, "requeued"
 
 
 def apply_connect_time_cloud_review_consent(
@@ -50,17 +55,23 @@ def apply_connect_time_cloud_review_consent(
         capability = enable_exact_cloud_review(store, issuer="connect-consent")
     except ExactCloudReviewError as error:
         return {**payload, "cloud_review": {"enabled": False, "reason": error.code}}
-    pending_requests_requeued = _requeue_pending_cloud_review_requests(store)
+    pending_requests_requeued, requeue_status = _requeue_pending_cloud_review_requests(store)
     worker = _refresh_cloud_review_worker(guard_home)
     ready = worker.get("status") == "refreshed"
+    reason = None
+    if requeue_status == "retry_required":
+        reason = "pending_request_requeue_failed"
+    elif not ready:
+        reason = "worker_restart_required"
     return {
         **payload,
         "cloud_review": {
             "capability": capability,
             "capability_enabled": True,
             "enabled": ready,
-            "reason": None if ready else "worker_restart_required",
+            "reason": reason,
             "pending_requests_requeued": pending_requests_requeued,
+            "pending_request_requeue_status": requeue_status,
             "worker": worker,
         },
     }
@@ -82,6 +93,7 @@ def _run_guard_cloud_review_command(
         raise RuntimeError("Cloud Review requires initialized Guard storage.")
     command = getattr(args, "cloud_review_command", None)
     pending_requests_requeued = 0
+    requeue_status = "not_requested"
     if command == "status":
         _emit("cloud-review", exact_cloud_review_status(store), bool(getattr(args, "json", False)))
         return 0
@@ -91,7 +103,7 @@ def _run_guard_cloud_review_command(
                 store,
                 ttl_seconds=int(getattr(args, "expires_in_days", 30)) * 24 * 60 * 60,
             )
-            pending_requests_requeued = _requeue_pending_cloud_review_requests(store)
+            pending_requests_requeued, requeue_status = _requeue_pending_cloud_review_requests(store)
             status = "enabled"
         elif command == "disable":
             capability = disable_exact_cloud_review(store)
@@ -107,7 +119,14 @@ def _run_guard_cloud_review_command(
         {
             "status": status,
             "capability": capability,
-            **({"pending_requests_requeued": pending_requests_requeued} if command == "enable" else {}),
+            **(
+                {
+                    "pending_requests_requeued": pending_requests_requeued,
+                    "pending_request_requeue_status": requeue_status,
+                }
+                if command == "enable"
+                else {}
+            ),
             "worker": _refresh_cloud_review_worker(guard_home),
         },
         bool(getattr(args, "json", False)),

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud_review.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud_review.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TextIO
 
@@ -27,6 +28,10 @@ def _refresh_cloud_review_worker(guard_home: Path) -> dict[str, object]:
         }
 
 
+def _requeue_pending_cloud_review_requests(store: GuardStore) -> int:
+    return store.requeue_pending_review_events(changed_at=datetime.now(timezone.utc).isoformat())
+
+
 def apply_connect_time_cloud_review_consent(
     *,
     args: argparse.Namespace,
@@ -45,6 +50,7 @@ def apply_connect_time_cloud_review_consent(
         capability = enable_exact_cloud_review(store, issuer="connect-consent")
     except ExactCloudReviewError as error:
         return {**payload, "cloud_review": {"enabled": False, "reason": error.code}}
+    pending_requests_requeued = _requeue_pending_cloud_review_requests(store)
     worker = _refresh_cloud_review_worker(guard_home)
     ready = worker.get("status") == "refreshed"
     return {
@@ -54,6 +60,7 @@ def apply_connect_time_cloud_review_consent(
             "capability_enabled": True,
             "enabled": ready,
             "reason": None if ready else "worker_restart_required",
+            "pending_requests_requeued": pending_requests_requeued,
             "worker": worker,
         },
     }
@@ -74,6 +81,7 @@ def _run_guard_cloud_review_command(
     if store is None or guard_home is None:
         raise RuntimeError("Cloud Review requires initialized Guard storage.")
     command = getattr(args, "cloud_review_command", None)
+    pending_requests_requeued = 0
     if command == "status":
         _emit("cloud-review", exact_cloud_review_status(store), bool(getattr(args, "json", False)))
         return 0
@@ -83,6 +91,7 @@ def _run_guard_cloud_review_command(
                 store,
                 ttl_seconds=int(getattr(args, "expires_in_days", 30)) * 24 * 60 * 60,
             )
+            pending_requests_requeued = _requeue_pending_cloud_review_requests(store)
             status = "enabled"
         elif command == "disable":
             capability = disable_exact_cloud_review(store)
@@ -98,6 +107,7 @@ def _run_guard_cloud_review_command(
         {
             "status": status,
             "capability": capability,
+            **({"pending_requests_requeued": pending_requests_requeued} if command == "enable" else {}),
             "worker": _refresh_cloud_review_worker(guard_home),
         },
         bool(getattr(args, "json", False)),

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud_review.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud_review.py
@@ -54,6 +54,7 @@ def apply_connect_time_cloud_review_consent(
         return payload
     if exit_code != 0:
         return {**payload, "cloud_review": {"enabled": False, "reason": "connect_not_completed"}}
+    previously_enabled = exact_cloud_review_status(store).get("enabled") is True
     try:
         pending_requests_requeued = _requeue_pending_cloud_review_requests(store)
         capability = enable_exact_cloud_review(store, issuer="connect-consent")
@@ -61,11 +62,12 @@ def apply_connect_time_cloud_review_consent(
         return {
             **payload,
             "cloud_review": {
-                "capability_enabled": False,
-                "enabled": False,
+                "capability_enabled": previously_enabled,
+                "enabled": previously_enabled,
                 "reason": "pending_request_requeue_failed",
                 "pending_requests_requeued": 0,
                 "pending_request_requeue_status": "retry_required",
+                "retained_existing_capability": previously_enabled,
             },
         }
     except ExactCloudReviewError as error:
@@ -102,11 +104,13 @@ def _run_guard_cloud_review_command(
         raise RuntimeError("Cloud Review requires initialized Guard storage.")
     command = getattr(args, "cloud_review_command", None)
     pending_requests_requeued = 0
+    previously_enabled = False
     if command == "status":
         _emit("cloud-review", exact_cloud_review_status(store), bool(getattr(args, "json", False)))
         return 0
     try:
         if command == "enable":
+            previously_enabled = exact_cloud_review_status(store).get("enabled") is True
             pending_requests_requeued = _requeue_pending_cloud_review_requests(store)
             capability = enable_exact_cloud_review(
                 store,
@@ -125,8 +129,10 @@ def _run_guard_cloud_review_command(
             {
                 "status": "error",
                 "error": "pending_request_requeue_failed",
+                "capability_enabled": previously_enabled,
                 "pending_requests_requeued": 0,
                 "pending_request_requeue_status": "retry_required",
+                "retained_existing_capability": previously_enabled,
             },
             bool(getattr(args, "json", False)),
         )

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud_review.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud_review.py
@@ -19,6 +19,10 @@ from ._commands_shared import GuardConfig, GuardStore, HarnessContext
 from .commands_support_interaction import _emit
 
 
+class PendingReviewRequeueError(RuntimeError):
+    """Cloud Review activation could not safely requeue existing requests."""
+
+
 def _refresh_cloud_review_worker(guard_home: Path) -> dict[str, object]:
     try:
         return {"status": "refreshed", **load_guard_surface_daemon_client(guard_home).refresh_command_queue_worker()}
@@ -29,12 +33,11 @@ def _refresh_cloud_review_worker(guard_home: Path) -> dict[str, object]:
         }
 
 
-def _requeue_pending_cloud_review_requests(store: GuardStore) -> tuple[int, str]:
+def _requeue_pending_cloud_review_requests(store: GuardStore) -> int:
     try:
-        requeued = store.requeue_pending_review_events(changed_at=datetime.now(timezone.utc).isoformat())
-    except sqlite3.Error:
-        return 0, "retry_required"
-    return requeued, "requeued"
+        return store.requeue_pending_review_events(changed_at=datetime.now(timezone.utc).isoformat())
+    except sqlite3.Error as error:
+        raise PendingReviewRequeueError from error
 
 
 def apply_connect_time_cloud_review_consent(
@@ -52,26 +55,32 @@ def apply_connect_time_cloud_review_consent(
     if exit_code != 0:
         return {**payload, "cloud_review": {"enabled": False, "reason": "connect_not_completed"}}
     try:
+        pending_requests_requeued = _requeue_pending_cloud_review_requests(store)
         capability = enable_exact_cloud_review(store, issuer="connect-consent")
+    except PendingReviewRequeueError:
+        return {
+            **payload,
+            "cloud_review": {
+                "capability_enabled": False,
+                "enabled": False,
+                "reason": "pending_request_requeue_failed",
+                "pending_requests_requeued": 0,
+                "pending_request_requeue_status": "retry_required",
+            },
+        }
     except ExactCloudReviewError as error:
         return {**payload, "cloud_review": {"enabled": False, "reason": error.code}}
-    pending_requests_requeued, requeue_status = _requeue_pending_cloud_review_requests(store)
     worker = _refresh_cloud_review_worker(guard_home)
     ready = worker.get("status") == "refreshed"
-    reason = None
-    if requeue_status == "retry_required":
-        reason = "pending_request_requeue_failed"
-    elif not ready:
-        reason = "worker_restart_required"
     return {
         **payload,
         "cloud_review": {
             "capability": capability,
             "capability_enabled": True,
             "enabled": ready,
-            "reason": reason,
+            "reason": None if ready else "worker_restart_required",
             "pending_requests_requeued": pending_requests_requeued,
-            "pending_request_requeue_status": requeue_status,
+            "pending_request_requeue_status": "requeued",
             "worker": worker,
         },
     }
@@ -93,17 +102,16 @@ def _run_guard_cloud_review_command(
         raise RuntimeError("Cloud Review requires initialized Guard storage.")
     command = getattr(args, "cloud_review_command", None)
     pending_requests_requeued = 0
-    requeue_status = "not_requested"
     if command == "status":
         _emit("cloud-review", exact_cloud_review_status(store), bool(getattr(args, "json", False)))
         return 0
     try:
         if command == "enable":
+            pending_requests_requeued = _requeue_pending_cloud_review_requests(store)
             capability = enable_exact_cloud_review(
                 store,
                 ttl_seconds=int(getattr(args, "expires_in_days", 30)) * 24 * 60 * 60,
             )
-            pending_requests_requeued, requeue_status = _requeue_pending_cloud_review_requests(store)
             status = "enabled"
         elif command == "disable":
             capability = disable_exact_cloud_review(store)
@@ -111,6 +119,18 @@ def _run_guard_cloud_review_command(
         else:
             _emit("cloud-review", {"status": "error", "error": "subcommand_required"}, bool(args.json))
             return 2
+    except PendingReviewRequeueError:
+        _emit(
+            "cloud-review",
+            {
+                "status": "error",
+                "error": "pending_request_requeue_failed",
+                "pending_requests_requeued": 0,
+                "pending_request_requeue_status": "retry_required",
+            },
+            bool(getattr(args, "json", False)),
+        )
+        return 2
     except ExactCloudReviewError as error:
         _emit("cloud-review", {"status": "error", "error": error.code}, bool(getattr(args, "json", False)))
         return 2
@@ -122,7 +142,7 @@ def _run_guard_cloud_review_command(
             **(
                 {
                     "pending_requests_requeued": pending_requests_requeued,
-                    "pending_request_requeue_status": requeue_status,
+                    "pending_request_requeue_status": "requeued",
                 }
                 if command == "enable"
                 else {}

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud_review.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud_review.py
@@ -63,7 +63,7 @@ def apply_connect_time_cloud_review_consent(
             **payload,
             "cloud_review": {
                 "capability_enabled": previously_enabled,
-                "enabled": previously_enabled,
+                "enabled": False,
                 "reason": "pending_request_requeue_failed",
                 "pending_requests_requeued": 0,
                 "pending_request_requeue_status": "retry_required",

--- a/src/codex_plugin_scanner/guard/runtime/exact_cloud_review.py
+++ b/src/codex_plugin_scanner/guard/runtime/exact_cloud_review.py
@@ -32,7 +32,6 @@ EXACT_CLOUD_REVIEW_CAPABILITY_STATE_KEY = "guard_exact_cloud_review_capability"
 EXACT_CLOUD_REVIEW_REVOCATION_STATE_KEY = "guard_exact_cloud_review_revocation"
 EXACT_CLOUD_REVIEW_MAX_TTL_SECONDS = 365 * 24 * 60 * 60
 EXACT_CLOUD_REVIEW_DEFAULT_TTL_SECONDS = 30 * 24 * 60 * 60
-EXACT_CLOUD_REVIEW_REQUEST_TTL_SECONDS = 10 * 60
 
 
 class ExactCloudReviewError(ValueError):
@@ -154,18 +153,6 @@ def _exact_action(value: object) -> str | None:
     if value == "block":
         return "block"
     return None
-
-
-def _request_expires_at(request: dict[str, object]) -> datetime | None:
-    observed_at = parse_utc_timestamp(request.get("last_seen_at") or request.get("created_at"))
-    return None if observed_at is None else observed_at + timedelta(seconds=EXACT_CLOUD_REVIEW_REQUEST_TTL_SECONDS)
-
-
-def _request_is_current(request: dict[str, object], *, now: datetime) -> bool:
-    expires_at = _request_expires_at(request)
-    if expires_at is None:
-        return False
-    return expires_at - timedelta(seconds=EXACT_CLOUD_REVIEW_REQUEST_TTL_SECONDS) <= now < expires_at
 
 
 def enable_exact_cloud_review(

--- a/src/codex_plugin_scanner/guard/runtime/exact_cloud_review_apply.py
+++ b/src/codex_plugin_scanner/guard/runtime/exact_cloud_review_apply.py
@@ -30,8 +30,6 @@ from .exact_cloud_review import (
     _oauth_metadata,
     _oauth_state,
     _reject,
-    _request_expires_at,
-    _request_is_current,
     _text,
     _verified_capability,
 )
@@ -81,10 +79,6 @@ def apply_exact_cloud_review(
     request = store.get_approval_request(request_id)
     if not isinstance(request, dict) or request.get("status") != "pending":
         raise _reject(store, "remote_exact_request_not_pending", now=current)
-    if not _request_is_current(request, now=current):
-        raise _reject(store, "remote_exact_request_expired", now=current)
-    request_expires_at = _request_expires_at(request)
-    assert request_expires_at is not None
     if expected_harness is not None and request.get("harness") != expected_harness:
         raise _reject(store, "remote_exact_harness_mismatch", now=current)
     action = _exact_action(envelope.get("decision"))
@@ -130,7 +124,6 @@ def apply_exact_cloud_review(
         },
         expected_request=request,
         receipt_expires_at=receipt_expires_at,
-        request_expires_at=request_expires_at.isoformat(),
     )
     return _resolution_from_result(
         store,

--- a/src/codex_plugin_scanner/guard/store_exact_cloud_review.py
+++ b/src/codex_plugin_scanner/guard/store_exact_cloud_review.py
@@ -205,7 +205,6 @@ class StoreExactCloudReviewMixin:
         expected_oauth_binding: dict[str, object],
         expected_request: dict[str, object],
         receipt_expires_at: str,
-        request_expires_at: str,
     ) -> dict[str, object]:
         """Claim and apply an exact receipt after rechecking all mutable state."""
 
@@ -246,9 +245,6 @@ class StoreExactCloudReviewMixin:
             expires_at = parse_utc_timestamp(receipt_expires_at)
             if expires_at is None or expires_at <= current:
                 return _exact_error("remote_approval_expired", now=resolved_at)
-            request_expires = parse_utc_timestamp(request_expires_at)
-            if request_expires is None or request_expires <= current:
-                return _exact_error("remote_exact_request_expired", now=resolved_at)
             request = load_approval_request(connection, request_id)
             if request is None or request.get("status") != "pending":
                 return _exact_error("remote_exact_request_not_pending", now=resolved_at)
@@ -302,7 +298,7 @@ class StoreExactCloudReviewMixin:
                     publisher=_optional_text(request.get("publisher")),
                     action="allow",
                     created_at=resolved_at,
-                    expires_at=min(capability_expires_at, expires_at, request_expires).isoformat(),
+                    expires_at=min(capability_expires_at, expires_at).isoformat(),
                     integrity_key=local_integrity_key,
                     integrity_key_id=local_integrity_key_id,
                 )

--- a/tests/test_guard_exact_cloud_review.py
+++ b/tests/test_guard_exact_cloud_review.py
@@ -307,9 +307,40 @@ def test_successful_connect_issues_cloud_review_capability_only_after_explicit_c
     cloud_review = connected["cloud_review"]
     assert isinstance(cloud_review, dict)
     assert cloud_review["enabled"] is True
+    assert cloud_review["pending_requests_requeued"] == 0
     assert cloud_review["worker"] == {"status": "refreshed"}
     assert isinstance(cloud_review["capability"], dict)
     assert exact_cloud_review_operations(store) == (EXACT_CLOUD_REVIEW_OPERATION,)
+
+
+def test_cloud_review_enable_requeues_existing_pending_requests(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    store = _connected_store(tmp_path)
+    request = _request("pending-before-consent")
+    _add_request(store, request)
+    monkeypatch.setattr(
+        cloud_review_dispatch,
+        "_refresh_cloud_review_worker",
+        lambda _guard_home: {"status": "refreshed"},
+    )
+
+    exit_code = cloud_review_dispatch._run_guard_cloud_review_command(
+        argparse.Namespace(
+            cloud_review_command="enable",
+            expires_in_days=30,
+            json=True,
+        ),
+        guard_home=store.guard_home,
+        store=store,
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["pending_requests_requeued"] == 1
+    assert payload["worker"] == {"status": "refreshed"}
 
 
 def test_exact_cloud_review_queue_job_requires_no_generic_capability_or_local_approval(tmp_path: Path) -> None:

--- a/tests/test_guard_exact_cloud_review.py
+++ b/tests/test_guard_exact_cloud_review.py
@@ -438,6 +438,38 @@ def test_cloud_review_enable_reports_requeue_retry_without_crashing(
     assert exact_cloud_review_operations(store) == ()
 
 
+def test_connect_consent_reports_retained_capability_as_failed_activation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _connected_store(tmp_path)
+    enable_exact_cloud_review(store)
+
+    def fail_requeue(_store: GuardStore) -> int:
+        raise cloud_review_dispatch.PendingReviewRequeueError
+
+    monkeypatch.setattr(
+        cloud_review_dispatch,
+        "_requeue_pending_cloud_review_requests",
+        fail_requeue,
+    )
+
+    connected = cloud_review_dispatch.apply_connect_time_cloud_review_consent(
+        args=argparse.Namespace(enable_cloud_review=True),
+        store=store,
+        guard_home=store.guard_home,
+        payload={"status": "connected"},
+        exit_code=0,
+    )
+
+    cloud_review = connected["cloud_review"]
+    assert isinstance(cloud_review, dict)
+    assert cloud_review["enabled"] is False
+    assert cloud_review["capability_enabled"] is True
+    assert cloud_review["retained_existing_capability"] is True
+    assert cloud_review["reason"] == "pending_request_requeue_failed"
+
+
 def test_cloud_review_enable_reports_retained_capability_when_requeue_retry_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_guard_exact_cloud_review.py
+++ b/tests/test_guard_exact_cloud_review.py
@@ -358,21 +358,23 @@ def test_cloud_review_requeue_database_failure_is_retryable(
 
     monkeypatch.setattr(store, "requeue_pending_review_events", fail_requeue)
 
-    assert cloud_review_dispatch._requeue_pending_cloud_review_requests(store) == (
-        0,
-        "retry_required",
-    )
+    with pytest.raises(cloud_review_dispatch.PendingReviewRequeueError):
+        cloud_review_dispatch._requeue_pending_cloud_review_requests(store)
 
 
-def test_connect_consent_preserves_enabled_capability_when_requeue_needs_retry(
+def test_connect_consent_does_not_enable_capability_when_requeue_needs_retry(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     store = _connected_store(tmp_path)
+
+    def fail_requeue(_store: GuardStore) -> int:
+        raise cloud_review_dispatch.PendingReviewRequeueError
+
     monkeypatch.setattr(
         cloud_review_dispatch,
         "_requeue_pending_cloud_review_requests",
-        lambda _store: (0, "retry_required"),
+        fail_requeue,
     )
     monkeypatch.setattr(
         cloud_review_dispatch,
@@ -390,11 +392,11 @@ def test_connect_consent_preserves_enabled_capability_when_requeue_needs_retry(
 
     cloud_review = connected["cloud_review"]
     assert isinstance(cloud_review, dict)
-    assert cloud_review["capability_enabled"] is True
-    assert cloud_review["enabled"] is True
+    assert cloud_review["capability_enabled"] is False
+    assert cloud_review["enabled"] is False
     assert cloud_review["reason"] == "pending_request_requeue_failed"
     assert cloud_review["pending_request_requeue_status"] == "retry_required"
-    assert exact_cloud_review_operations(store) == (EXACT_CLOUD_REVIEW_OPERATION,)
+    assert exact_cloud_review_operations(store) == ()
 
 
 def test_cloud_review_enable_reports_requeue_retry_without_crashing(
@@ -403,10 +405,14 @@ def test_cloud_review_enable_reports_requeue_retry_without_crashing(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     store = _connected_store(tmp_path)
+
+    def fail_requeue(_store: GuardStore) -> int:
+        raise cloud_review_dispatch.PendingReviewRequeueError
+
     monkeypatch.setattr(
         cloud_review_dispatch,
         "_requeue_pending_cloud_review_requests",
-        lambda _store: (0, "retry_required"),
+        fail_requeue,
     )
     monkeypatch.setattr(
         cloud_review_dispatch,
@@ -421,11 +427,12 @@ def test_cloud_review_enable_reports_requeue_retry_without_crashing(
     )
 
     payload = json.loads(capsys.readouterr().out)
-    assert exit_code == 0
-    assert payload["status"] == "enabled"
+    assert exit_code == 2
+    assert payload["status"] == "error"
+    assert payload["error"] == "pending_request_requeue_failed"
     assert payload["pending_requests_requeued"] == 0
     assert payload["pending_request_requeue_status"] == "retry_required"
-    assert exact_cloud_review_operations(store) == (EXACT_CLOUD_REVIEW_OPERATION,)
+    assert exact_cloud_review_operations(store) == ()
 
 
 def test_exact_cloud_review_queue_job_requires_no_generic_capability_or_local_approval(tmp_path: Path) -> None:

--- a/tests/test_guard_exact_cloud_review.py
+++ b/tests/test_guard_exact_cloud_review.py
@@ -396,6 +396,7 @@ def test_connect_consent_does_not_enable_capability_when_requeue_needs_retry(
     assert cloud_review["enabled"] is False
     assert cloud_review["reason"] == "pending_request_requeue_failed"
     assert cloud_review["pending_request_requeue_status"] == "retry_required"
+    assert cloud_review["retained_existing_capability"] is False
     assert exact_cloud_review_operations(store) == ()
 
 
@@ -432,7 +433,40 @@ def test_cloud_review_enable_reports_requeue_retry_without_crashing(
     assert payload["error"] == "pending_request_requeue_failed"
     assert payload["pending_requests_requeued"] == 0
     assert payload["pending_request_requeue_status"] == "retry_required"
+    assert payload["capability_enabled"] is False
+    assert payload["retained_existing_capability"] is False
     assert exact_cloud_review_operations(store) == ()
+
+
+def test_cloud_review_enable_reports_retained_capability_when_requeue_retry_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    store = _connected_store(tmp_path)
+    enable_exact_cloud_review(store)
+
+    def fail_requeue(_store: GuardStore) -> int:
+        raise cloud_review_dispatch.PendingReviewRequeueError
+
+    monkeypatch.setattr(
+        cloud_review_dispatch,
+        "_requeue_pending_cloud_review_requests",
+        fail_requeue,
+    )
+
+    exit_code = cloud_review_dispatch._run_guard_cloud_review_command(
+        argparse.Namespace(cloud_review_command="enable", expires_in_days=30, json=True),
+        guard_home=store.guard_home,
+        store=store,
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 2
+    assert payload["error"] == "pending_request_requeue_failed"
+    assert payload["capability_enabled"] is True
+    assert payload["retained_existing_capability"] is True
+    assert exact_cloud_review_operations(store) == (EXACT_CLOUD_REVIEW_OPERATION,)
 
 
 def test_exact_cloud_review_queue_job_requires_no_generic_capability_or_local_approval(tmp_path: Path) -> None:

--- a/tests/test_guard_exact_cloud_review.py
+++ b/tests/test_guard_exact_cloud_review.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sqlite3
 import threading
 from datetime import datetime, timezone
 from pathlib import Path
@@ -308,6 +309,7 @@ def test_successful_connect_issues_cloud_review_capability_only_after_explicit_c
     assert isinstance(cloud_review, dict)
     assert cloud_review["enabled"] is True
     assert cloud_review["pending_requests_requeued"] == 0
+    assert cloud_review["pending_request_requeue_status"] == "requeued"
     assert cloud_review["worker"] == {"status": "refreshed"}
     assert isinstance(cloud_review["capability"], dict)
     assert exact_cloud_review_operations(store) == (EXACT_CLOUD_REVIEW_OPERATION,)
@@ -340,7 +342,90 @@ def test_cloud_review_enable_requeues_existing_pending_requests(
     payload = json.loads(capsys.readouterr().out)
     assert exit_code == 0
     assert payload["pending_requests_requeued"] == 1
+    assert payload["pending_request_requeue_status"] == "requeued"
     assert payload["worker"] == {"status": "refreshed"}
+
+
+def test_cloud_review_requeue_database_failure_is_retryable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _connected_store(tmp_path)
+
+    def fail_requeue(*, changed_at: str) -> int:
+        del changed_at
+        raise sqlite3.OperationalError("database is busy")
+
+    monkeypatch.setattr(store, "requeue_pending_review_events", fail_requeue)
+
+    assert cloud_review_dispatch._requeue_pending_cloud_review_requests(store) == (
+        0,
+        "retry_required",
+    )
+
+
+def test_connect_consent_preserves_enabled_capability_when_requeue_needs_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _connected_store(tmp_path)
+    monkeypatch.setattr(
+        cloud_review_dispatch,
+        "_requeue_pending_cloud_review_requests",
+        lambda _store: (0, "retry_required"),
+    )
+    monkeypatch.setattr(
+        cloud_review_dispatch,
+        "_refresh_cloud_review_worker",
+        lambda _guard_home: {"status": "refreshed"},
+    )
+
+    connected = cloud_review_dispatch.apply_connect_time_cloud_review_consent(
+        args=argparse.Namespace(enable_cloud_review=True),
+        store=store,
+        guard_home=store.guard_home,
+        payload={"status": "connected"},
+        exit_code=0,
+    )
+
+    cloud_review = connected["cloud_review"]
+    assert isinstance(cloud_review, dict)
+    assert cloud_review["capability_enabled"] is True
+    assert cloud_review["enabled"] is True
+    assert cloud_review["reason"] == "pending_request_requeue_failed"
+    assert cloud_review["pending_request_requeue_status"] == "retry_required"
+    assert exact_cloud_review_operations(store) == (EXACT_CLOUD_REVIEW_OPERATION,)
+
+
+def test_cloud_review_enable_reports_requeue_retry_without_crashing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    store = _connected_store(tmp_path)
+    monkeypatch.setattr(
+        cloud_review_dispatch,
+        "_requeue_pending_cloud_review_requests",
+        lambda _store: (0, "retry_required"),
+    )
+    monkeypatch.setattr(
+        cloud_review_dispatch,
+        "_refresh_cloud_review_worker",
+        lambda _guard_home: {"status": "refreshed"},
+    )
+
+    exit_code = cloud_review_dispatch._run_guard_cloud_review_command(
+        argparse.Namespace(cloud_review_command="enable", expires_in_days=30, json=True),
+        guard_home=store.guard_home,
+        store=store,
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["status"] == "enabled"
+    assert payload["pending_requests_requeued"] == 0
+    assert payload["pending_request_requeue_status"] == "retry_required"
+    assert exact_cloud_review_operations(store) == (EXACT_CLOUD_REVIEW_OPERATION,)
 
 
 def test_exact_cloud_review_queue_job_requires_no_generic_capability_or_local_approval(tmp_path: Path) -> None:

--- a/tests/test_guard_exact_cloud_review_adversarial.py
+++ b/tests/test_guard_exact_cloud_review_adversarial.py
@@ -157,16 +157,18 @@ def test_exact_cloud_review_receipt_expiry_boundary_and_strict_wire(
         )
 
 
-def test_exact_cloud_review_rejects_stale_requests_and_durable_binding_drift(tmp_path: Path) -> None:
+def test_exact_cloud_review_keeps_pending_requests_durable_and_rejects_binding_drift(tmp_path: Path) -> None:
     store = _connected_store(tmp_path)
     stale = _request("exact-stale-request")
     store.add_approval_request(stale, "2020-01-01T00:00:00+00:00")
     enable_exact_cloud_review(store)
-    with pytest.raises(ExactCloudReviewError, match="remote_exact_request_expired"):
-        apply_exact_cloud_review(
-            store,
-            remote_approval=_remote_approval(store, stale.request_id, receipt_id="exact-stale-request"),
-        )
+    resolution = apply_exact_cloud_review(
+        store,
+        remote_approval=_remote_approval(store, stale.request_id, receipt_id="exact-stale-request"),
+    )
+    assert resolution.request_id == stale.request_id
+    resolved = store.get_approval_request(stale.request_id)
+    assert resolved is not None and resolved["status"] == "resolved"
 
     fresh = _request("exact-binding-drift")
     _add_request(store, fresh)


### PR DESCRIPTION
## Summary\n\n- keep pending Cloud Review requests actionable until a decision is applied\n- revalidate decisions against current capability, runtime grant, exact binding, and signed receipt authority\n- requeue pending review events when Cloud Review is enabled again\n- preserve retry guidance without terminalizing requests when an agent wait ends\n\n## Verification\n\n- 102 focused Cloud Review, outbox, and command queue tests passed\n- Ruff check and format verification passed\n- BasedPyright reported zero errors\n-  passed