### PR TITLE
fix(guard): honor broad harness and global allow for hermes skills

### DIFF
--- a/ci/code-quality-baseline.json
+++ b/ci/code-quality-baseline.json
@@ -534,7 +534,7 @@
     "src/codex_plugin_scanner/guard/cli/update_subprocess.py": 2087,
     "src/codex_plugin_scanner/guard/codex_app_server.py": 646,
     "src/codex_plugin_scanner/guard/config.py": 1406,
-    "src/codex_plugin_scanner/guard/consumer/service.py": 1859,
+    "src/codex_plugin_scanner/guard/consumer/service.py": 1862,
     "src/codex_plugin_scanner/guard/daemon/dashboard_update.py": 667,
     "src/codex_plugin_scanner/guard/daemon/hook_process_runner.py": 608,
     "src/codex_plugin_scanner/guard/daemon/manager.py": 3178,

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
-  "maximum_collected_cases": 16466,
-  "maximum_test_source_lines": 355987
+  "maximum_collected_cases": 16473,
+  "maximum_test_source_lines": 356166
 }

--- a/src/codex_plugin_scanner/guard/consumer/service.py
+++ b/src/codex_plugin_scanner/guard/consumer/service.py
@@ -773,7 +773,7 @@ def _consumer_saved_allow_validation_reason(
     if decision.get("action") != "allow":
         return None
     saved_hash = decision.get("artifact_hash")
-    if saved_hash is None:
+    if saved_hash is None and str(decision.get("scope") or "") in {"harness", "global"}:
         return None
     return cast(
         ApprovalReuseValidationFailure,

--- a/src/codex_plugin_scanner/guard/consumer/service.py
+++ b/src/codex_plugin_scanner/guard/consumer/service.py
@@ -772,10 +772,13 @@ def _consumer_saved_allow_validation_reason(
 ) -> ApprovalReuseValidationFailure | None:
     if decision.get("action") != "allow":
         return None
+    saved_hash = decision.get("artifact_hash")
+    if saved_hash is None:
+        return None
     return cast(
         ApprovalReuseValidationFailure,
         approval_context_tokens_validation_reason(
-            decision.get("artifact_hash"),
+            saved_hash,
             approval_context_hash,
         ),
     )

--- a/tests/test_guard_broad_allow_consumer.py
+++ b/tests/test_guard_broad_allow_consumer.py
@@ -1,0 +1,179 @@
+"""Broad harness/global allows must not skip artifact-scoped hash checks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.consumer import evaluate_detection
+from codex_plugin_scanner.guard.consumer.service import _consumer_saved_allow_validation_reason
+from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection, PolicyDecision
+from codex_plugin_scanner.guard.store import GuardStore
+
+_CURRENT_CONTEXT = "guard-approval-context:v1:deadbeefdeadbeef"
+
+
+def _skill_artifact(tmp_path: Path) -> GuardArtifact:
+    skill_md = tmp_path / "workspace" / "skills" / "apple" / "apple-notes" / "SKILL.md"
+    skill_md.parent.mkdir(parents=True, exist_ok=True)
+    skill_md.write_text("# Apple Notes\n\nRead notes.\n", encoding="utf-8")
+    return GuardArtifact(
+        artifact_id="hermes:skill:apple:apple-notes",
+        name="apple-notes",
+        harness="hermes",
+        artifact_type="skill",
+        source_scope="global",
+        config_path=str(skill_md),
+        command=str(skill_md),
+        metadata={"action_class": "skill"},
+    )
+
+
+def _detection(artifact: GuardArtifact) -> HarnessDetection:
+    return HarnessDetection(
+        harness=artifact.harness,
+        installed=True,
+        command_available=True,
+        config_paths=(artifact.config_path,),
+        artifacts=(artifact,),
+    )
+
+
+def test_hashless_harness_allow_skips_context_validation() -> None:
+    assert (
+        _consumer_saved_allow_validation_reason(
+            {"action": "allow", "artifact_hash": None, "scope": "harness"},
+            approval_context_hash=_CURRENT_CONTEXT,
+        )
+        is None
+    )
+
+
+def test_hashless_global_allow_skips_context_validation() -> None:
+    assert (
+        _consumer_saved_allow_validation_reason(
+            {"action": "allow", "artifact_hash": None, "scope": "global"},
+            approval_context_hash=_CURRENT_CONTEXT,
+        )
+        is None
+    )
+
+
+def test_hashless_artifact_allow_still_fails_closed() -> None:
+    assert (
+        _consumer_saved_allow_validation_reason(
+            {"action": "allow", "artifact_hash": None, "scope": "artifact"},
+            approval_context_hash=_CURRENT_CONTEXT,
+        )
+        == "approval_reuse_content_changed"
+    )
+
+
+def test_hashless_workspace_allow_still_fails_closed() -> None:
+    assert (
+        _consumer_saved_allow_validation_reason(
+            {"action": "allow", "artifact_hash": None, "scope": "workspace"},
+            approval_context_hash=_CURRENT_CONTEXT,
+        )
+        == "approval_reuse_content_changed"
+    )
+
+
+def test_consumer_honors_broad_harness_allow_for_hermes_skill(tmp_path: Path) -> None:
+    artifact = _skill_artifact(tmp_path)
+    detection = _detection(artifact)
+    store = GuardStore(tmp_path / "guard-home")
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=tmp_path / "workspace",
+        mode="prompt",
+    )
+    store.upsert_policy(
+        PolicyDecision(
+            harness="hermes",
+            scope="harness",
+            action="allow",
+            artifact_hash=None,
+            reason="broad harness allow",
+            source="approval-gate",
+        ),
+        "2026-07-17T00:00:00Z",
+    )
+
+    item = evaluate_detection(
+        detection,
+        store,
+        config,
+        default_action="review",
+        persist=False,
+    )["artifacts"][0]
+
+    assert item["approval_reuse_status"] == "accepted"
+    assert item["policy_action"] == "allow"
+
+
+def test_consumer_honors_broad_global_allow_for_hermes_skill(tmp_path: Path) -> None:
+    artifact = _skill_artifact(tmp_path)
+    detection = _detection(artifact)
+    store = GuardStore(tmp_path / "guard-home")
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=tmp_path / "workspace",
+        mode="prompt",
+    )
+    store.upsert_policy(
+        PolicyDecision(
+            harness="hermes",
+            scope="global",
+            action="allow",
+            artifact_hash=None,
+            reason="broad global allow",
+            source="approval-gate",
+        ),
+        "2026-07-17T00:00:00Z",
+    )
+
+    item = evaluate_detection(
+        detection,
+        store,
+        config,
+        default_action="review",
+        persist=False,
+    )["artifacts"][0]
+
+    assert item["approval_reuse_status"] == "accepted"
+    assert item["policy_action"] == "allow"
+
+
+def test_consumer_rejects_hashless_artifact_allow_for_hermes_skill(tmp_path: Path) -> None:
+    artifact = _skill_artifact(tmp_path)
+    detection = _detection(artifact)
+    store = GuardStore(tmp_path / "guard-home")
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=tmp_path / "workspace",
+        mode="prompt",
+    )
+    store.upsert_policy(
+        PolicyDecision(
+            harness="hermes",
+            scope="artifact",
+            action="allow",
+            artifact_id=artifact.artifact_id,
+            artifact_hash=None,
+            reason="legacy unbound artifact allow",
+            source="approval-gate",
+        ),
+        "2026-07-17T00:00:00Z",
+    )
+
+    item = evaluate_detection(
+        detection,
+        store,
+        config,
+        default_action="review",
+        persist=False,
+    )["artifacts"][0]
+
+    assert item["approval_reuse_status"] == "rejected"
+    assert item["approval_reuse_reason_code"] == "approval_reuse_content_changed"


### PR DESCRIPTION
## Summary
- Honor saved `allow hermes --scope harness|global` rules for review artifacts such as `hermes:skill:apple:apple-notes`.
- Skip approval-context validation only for hashless harness and global allows. Hashless artifact-scoped allows still fail closed as `approval_reuse_content_changed`.

Fixes #2675

## Testing
- `uv run pytest tests/test_guard_broad_allow_consumer.py tests/test_guard_approval_decisions.py::TestEvaluateDetectionScopePersistence::test_legacy_stored_allow_cannot_lower_current_reapproval tests/test_guard_approval_precedence_consumers.py::test_tool_call_local_saved_allow_without_exact_hash_is_rejected -q`
