### PR TITLE
fix(ci): pin native-wheel publish to the release enrollment root

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -116,6 +116,12 @@ jobs:
             --setup-action-ref "$SETUP_UV_ACTION_REF"
       - name: Install dependencies
         run: uv sync --frozen --extra dev --extra publish --extra cisco
+      - name: Verify release approval enrollment root pin
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release/3.0')
+        env:
+          HOL_GUARD_APPROVAL_ENROLLMENT_ROOT_HEX: ${{ vars.HOL_GUARD_APPROVAL_ENROLLMENT_ROOT_HEX }}
+          HOL_GUARD_APPROVAL_ENROLLMENT_ROOT_FINGERPRINT_HEX: ${{ vars.HOL_GUARD_APPROVAL_ENROLLMENT_ROOT_FINGERPRINT_HEX }}
+        run: uv run --no-sync python scripts/ci/native_approval_contract_gate.py --root . --require-release-root
       - name: Compute publish version
         id: version
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -116,12 +116,6 @@ jobs:
             --setup-action-ref "$SETUP_UV_ACTION_REF"
       - name: Install dependencies
         run: uv sync --frozen --extra dev --extra publish --extra cisco
-      - name: Verify release approval enrollment root pin
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release/3.0')
-        env:
-          HOL_GUARD_APPROVAL_ENROLLMENT_ROOT_HEX: ${{ vars.HOL_GUARD_APPROVAL_ENROLLMENT_ROOT_HEX }}
-          HOL_GUARD_APPROVAL_ENROLLMENT_ROOT_FINGERPRINT_HEX: ${{ vars.HOL_GUARD_APPROVAL_ENROLLMENT_ROOT_FINGERPRINT_HEX }}
-        run: uv run --no-sync python scripts/ci/native_approval_contract_gate.py --root . --require-release-root
       - name: Compute publish version
         id: version
         env:

--- a/ci/code-quality-baseline.json
+++ b/ci/code-quality-baseline.json
@@ -431,7 +431,7 @@
   "oversized_files": {
     ".github/workflows/ci.yml": 554,
     ".github/workflows/desktop-core-alpha-feed.yml": 539,
-    ".github/workflows/publish.yml": 1718,
+    ".github/workflows/publish.yml": 1724,
     "dashboard/src/app.tsx": 1051,
     "dashboard/src/approval-center-primitives.tsx": 1049,
     "dashboard/src/approval-center-utils.ts": 748,
@@ -736,7 +736,7 @@
     "tests/test_policy_bundle_v2.py": 537,
     "tests/test_policy_decision_source_context.py": 570,
     "tests/test_policy_document_io.py": 679,
-    "tests/test_release_train_workflow.py": 628,
+    "tests/test_release_train_workflow.py": 636,
     "tests/test_update_desktop_core.py": 644,
     "tests/test_verify_release_registry.py": 567,
     "tests/test_zcode_adapter.py": 685

--- a/ci/code-quality-baseline.json
+++ b/ci/code-quality-baseline.json
@@ -431,7 +431,7 @@
   "oversized_files": {
     ".github/workflows/ci.yml": 554,
     ".github/workflows/desktop-core-alpha-feed.yml": 539,
-    ".github/workflows/publish.yml": 1724,
+    ".github/workflows/publish.yml": 1718,
     "dashboard/src/app.tsx": 1051,
     "dashboard/src/approval-center-primitives.tsx": 1049,
     "dashboard/src/approval-center-utils.ts": 748,
@@ -736,7 +736,7 @@
     "tests/test_policy_bundle_v2.py": 537,
     "tests/test_policy_decision_source_context.py": 570,
     "tests/test_policy_document_io.py": 679,
-    "tests/test_release_train_workflow.py": 636,
+    "tests/test_release_train_workflow.py": 635,
     "tests/test_update_desktop_core.py": 644,
     "tests/test_verify_release_registry.py": 567,
     "tests/test_zcode_adapter.py": 685

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
   "maximum_collected_cases": 16697,
-  "maximum_test_source_lines": 361966
+  "maximum_test_source_lines": 361974
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
   "maximum_collected_cases": 16697,
-  "maximum_test_source_lines": 361974
+  "maximum_test_source_lines": 361973
 }

--- a/docs/guard/native-approval-enrollment.md
+++ b/docs/guard/native-approval-enrollment.md
@@ -15,9 +15,10 @@ values:
   those 32 raw public-key bytes, encoded as 64 lowercase hexadecimal
   characters.
 
-The runtime refuses enrollment when either value is absent or the fingerprint
-does not match. The root private key is never stored in this repository or in
-the Guard state directory. The `[42; 32]` root used by Rust tests is compiled
+Stable and alpha native-wheel jobs compile these values from GitHub repository
+variables of the same names. The runtime refuses enrollment when either value
+is absent or the fingerprint does not match. The root private key is never
+stored in this repository or in the Guard state directory. The `[42; 32]` root used by Rust tests is compiled
 only under `cfg(test)` and is not a production fallback. Release packaging
 must record the root fingerprint and signing provenance in its attestation.
 

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -222,7 +222,7 @@ def test_release_publication_reuses_one_hashed_build_artifact() -> None:
         if step.get("name") == "Verify release approval enrollment root pin"
     )
     assert "--require-release-root" in native_pin["run"]
-    assert "canary" in str(native_pin.get("if", ""))
+    assert "needs.build.outputs.channel != 'canary'" in str(native_pin.get("if", ""))
     alpha_needs = ["build", "reserve-alpha-tag", "assemble-native-guard-distributions"]
     assert jobs["publish-alpha-testpypi"]["needs"] == alpha_needs
     assert jobs["publish-alpha-pypi"]["needs"] == alpha_needs

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -216,6 +216,14 @@ def test_release_publication_reuses_one_hashed_build_artifact() -> None:
     assert "distribution-sha256" in {
         step.get("with", {}).get("name") for step in jobs["build"]["steps"] if isinstance(step, dict)
     }
+    build_pin = next(
+        step
+        for step in jobs["build"]["steps"]
+        if step.get("name") == "Verify release approval enrollment root pin"
+    )
+    assert "--require-release-root" in build_pin["run"]
+    assert "refs/heads/main" in str(build_pin.get("if", ""))
+    assert "refs/heads/release/3.0" in str(build_pin.get("if", ""))
     alpha_needs = ["build", "reserve-alpha-tag", "assemble-native-guard-distributions"]
     assert jobs["publish-alpha-testpypi"]["needs"] == alpha_needs
     assert jobs["publish-alpha-pypi"]["needs"] == alpha_needs

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -216,14 +216,13 @@ def test_release_publication_reuses_one_hashed_build_artifact() -> None:
     assert "distribution-sha256" in {
         step.get("with", {}).get("name") for step in jobs["build"]["steps"] if isinstance(step, dict)
     }
-    build_pin = next(
+    native_pin = next(
         step
-        for step in jobs["build"]["steps"]
+        for step in jobs["build-native-guard-wheels"]["steps"]
         if step.get("name") == "Verify release approval enrollment root pin"
     )
-    assert "--require-release-root" in build_pin["run"]
-    assert "refs/heads/main" in str(build_pin.get("if", ""))
-    assert "refs/heads/release/3.0" in str(build_pin.get("if", ""))
+    assert "--require-release-root" in native_pin["run"]
+    assert "canary" in str(native_pin.get("if", ""))
     alpha_needs = ["build", "reserve-alpha-tag", "assemble-native-guard-distributions"]
     assert jobs["publish-alpha-testpypi"]["needs"] == alpha_needs
     assert jobs["publish-alpha-pypi"]["needs"] == alpha_needs


### PR DESCRIPTION
## Summary
- Keep native-wheel publication gated on the public enrollment-root pin.
- Document that stable and alpha native-wheel jobs compile that pin from repository variables of the same names.

## Testing
- `uv run --no-sync pytest tests/test_release_train_workflow.py -k test_release_publication_reuses_one_hashed_build_artifact`
- `uv run --no-sync python scripts/ci/code_quality_audit.py --root . --baseline ci/code-quality-baseline.json --write-baseline`
- `uv run --no-sync python scripts/ci/test_inventory.py --output test-inventory.json`
- `uv run --no-sync python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory test-inventory.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how stable and alpha native packages obtain release enrollment trust-root values.
  * Documented that packages refuse enrollment when required values are missing or fingerprints do not match.

* **Tests**
  * Updated release workflow validation to reflect the current approval-enrollment verification step and canary release conditions.
  * Refreshed quality and test-size baselines to match the latest project state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->