### PR TITLE
fix(guard): continue prompt lifecycle hooks when native review cannot run

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
   "maximum_collected_cases": 16698,
-  "maximum_test_source_lines": 362042
+  "maximum_test_source_lines": 362059
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
-  "maximum_collected_cases": 16697,
-  "maximum_test_source_lines": 361973
+  "maximum_collected_cases": 16698,
+  "maximum_test_source_lines": 362014
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
   "maximum_collected_cases": 16698,
-  "maximum_test_source_lines": 362014
+  "maximum_test_source_lines": 362042
 }

--- a/src/codex_plugin_scanner/guard/daemon/hook_availability_policy.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_availability_policy.py
@@ -45,12 +45,15 @@ def _compact_hook_event_name(event_name: str) -> str:
     return event_name.strip().lower().replace("_", "").replace("-", "")
 
 
-_LIFECYCLE_OBSERVE_COMPACT = frozenset(_compact_hook_event_name(name) for name in LIFECYCLE_OBSERVE_EVENTS)
-_LIFECYCLE_CANONICAL_BY_COMPACT = {_compact_hook_event_name(name): name for name in LIFECYCLE_OBSERVE_EVENTS}
+_LIFECYCLE_CANONICAL_BY_COMPACT = {
+    **{_compact_hook_event_name(name): name for name in LIFECYCLE_OBSERVE_EVENTS},
+    "userpromptsubmitted": "UserPromptSubmit",
+    "subagentend": "SubagentStop",
+}
 
 
 def lifecycle_event_is_observe_only(event_name: str) -> bool:
-    return _compact_hook_event_name(event_name) in _LIFECYCLE_OBSERVE_COMPACT
+    return _compact_hook_event_name(event_name) in _LIFECYCLE_CANONICAL_BY_COMPACT
 
 
 def availability_harness_response(

--- a/src/codex_plugin_scanner/guard/daemon/hook_availability_policy.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_availability_policy.py
@@ -21,6 +21,29 @@ _CURSOR_UNAVAILABLE_DENY: dict[str, object] = {
     "agent_message": _CURSOR_UNAVAILABLE_MESSAGE,
 }
 
+# Native review covers PreToolUse and PostToolUse. Lifecycle events are inventory
+# only: fail-closing them freezes the conversation without adding an enforcement
+# boundary. PostToolUse and PermissionRequest stay withheld/paused.
+LIFECYCLE_OBSERVE_EVENTS = frozenset(
+    {
+        "UserPromptSubmit",
+        "SessionStart",
+        "SessionEnd",
+        "SubagentStart",
+        "SubagentStop",
+        "Stop",
+        "Notification",
+        "TaskStart",
+        "TaskError",
+        "SessionShutdown",
+        "PermissionDenied",
+    }
+)
+
+
+def lifecycle_event_is_observe_only(event_name: str) -> bool:
+    return event_name.strip() in LIFECYCLE_OBSERVE_EVENTS
+
 
 def availability_harness_response(
     payload: Mapping[str, object],
@@ -34,8 +57,18 @@ def availability_harness_response(
 ) -> dict[str, object]:
     """Render a schema-valid harness result when native review is unavailable."""
 
-    from .hook_worker_responses import harness_json_from_native_pre_tool, post_tool_fail_safe_response
+    from .hook_worker_responses import (
+        harness_json_from_native_pre_tool,
+        observe_lifecycle_fail_safe_response,
+        post_tool_fail_safe_response,
+    )
 
+    if lifecycle_event_is_observe_only(event_name):
+        return observe_lifecycle_fail_safe_response(
+            harness,
+            event_name=event_name,
+            reason_code=reason_code,
+        )
     if event_name != "PreToolUse":
         return post_tool_fail_safe_response(harness, reason=reason, reason_code=reason_code)
     if not hook_action_is_emergency_safe(
@@ -93,7 +126,9 @@ def cursor_fallback_permission(
 __all__ = [
     "EMERGENCY_SAFE_REASON",
     "EMERGENCY_SAFE_REASON_CODE",
+    "LIFECYCLE_OBSERVE_EVENTS",
     "availability_harness_response",
     "cursor_fallback_permission",
     "hook_action_is_emergency_safe",
+    "lifecycle_event_is_observe_only",
 ]

--- a/src/codex_plugin_scanner/guard/daemon/hook_availability_policy.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_availability_policy.py
@@ -41,8 +41,16 @@ LIFECYCLE_OBSERVE_EVENTS = frozenset(
 )
 
 
+def _compact_hook_event_name(event_name: str) -> str:
+    return event_name.strip().lower().replace("_", "").replace("-", "")
+
+
+_LIFECYCLE_OBSERVE_COMPACT = frozenset(_compact_hook_event_name(name) for name in LIFECYCLE_OBSERVE_EVENTS)
+_LIFECYCLE_CANONICAL_BY_COMPACT = {_compact_hook_event_name(name): name for name in LIFECYCLE_OBSERVE_EVENTS}
+
+
 def lifecycle_event_is_observe_only(event_name: str) -> bool:
-    return event_name.strip() in LIFECYCLE_OBSERVE_EVENTS
+    return _compact_hook_event_name(event_name) in _LIFECYCLE_OBSERVE_COMPACT
 
 
 def availability_harness_response(
@@ -63,10 +71,11 @@ def availability_harness_response(
         post_tool_fail_safe_response,
     )
 
-    if lifecycle_event_is_observe_only(event_name):
+    canonical_lifecycle = _LIFECYCLE_CANONICAL_BY_COMPACT.get(_compact_hook_event_name(event_name))
+    if canonical_lifecycle is not None:
         return observe_lifecycle_fail_safe_response(
             harness,
-            event_name=event_name,
+            event_name=canonical_lifecycle,
             reason_code=reason_code,
         )
     if event_name != "PreToolUse":

--- a/src/codex_plugin_scanner/guard/daemon/hook_worker_native.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_worker_native.py
@@ -68,10 +68,12 @@ class HookWorkerNativeMixin:
         if event_name not in {"PreToolUse", "PostToolUse"}:
             if oracle_surface:
                 raise HookWorkerUnsupported(f"fast path supports PreToolUse and PostToolUse, got event={event_name}")
-            return post_tool_fail_safe_response(
-                harness,
-                reason="HOL Guard could not classify this hook event safely.",
+            return availability_harness_response(
+                {},
+                harness=harness,
+                event_name=event_name,
                 reason_code="native_hook_event_unavailable",
+                reason="HOL Guard could not classify this hook event safely.",
             )
         reason_code = {"off": "native_hook_disabled", "shadow": "native_shadow_diagnostic_disabled"}.get(mode)
         if reason_code is None or oracle_surface:

--- a/src/codex_plugin_scanner/guard/daemon/hook_worker_responses.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_worker_responses.py
@@ -157,6 +157,29 @@ def post_tool_fail_safe_response(
     return post_tool_native_block_response(reason=reason, reason_code=reason_code)
 
 
+def observe_lifecycle_fail_safe_response(
+    harness: str,
+    *,
+    event_name: str,
+    reason_code: str,
+) -> dict[str, object]:
+    """Continue prompt/session inventory hooks when native review cannot run."""
+
+    canonical = _canonical_hook_harness(harness)
+    if canonical in {"grok", "hermes", "openclaw", "pi", "omp"}:
+        return {
+            "decision": "allow",
+            "policy_action": "allow",
+            "reason_code": reason_code,
+        }
+    return {
+        "continue": True,
+        "policy_action": "allow",
+        "reason_code": reason_code,
+        "hookSpecificOutput": {"hookEventName": event_name},
+    }
+
+
 def harness_json_from_review_response(
     harness: str,
     event_name: str,
@@ -186,6 +209,7 @@ __all__ = [
     "harness_json_from_native_post_tool",
     "harness_json_from_native_pre_tool",
     "harness_json_from_review_response",
+    "observe_lifecycle_fail_safe_response",
     "post_tool_fail_safe_response",
     "post_tool_native_block_response",
 ]

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -5963,15 +5963,15 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 "reason_code": reason_code,
                 "observed_review_failure": True,
             }
-        if event == "PreToolUse":
-            from .hook_availability_policy import availability_harness_response
+        from .hook_availability_policy import LIFECYCLE_OBSERVE_EVENTS, availability_harness_response
 
+        if event == "PreToolUse" or event in LIFECYCLE_OBSERVE_EVENTS:
             payload_dict = dict(payload) if isinstance(payload, Mapping) else {}
             workspace_path, home_path = self._validated_fail_safe_hook_paths(params)
             return availability_harness_response(
                 payload_dict,
                 harness=harness,
-                event_name="PreToolUse",
+                event_name=event,
                 reason_code=reason_code,
                 reason=reason,
                 workspace=workspace_path,

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -5963,9 +5963,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 "reason_code": reason_code,
                 "observed_review_failure": True,
             }
-        from .hook_availability_policy import LIFECYCLE_OBSERVE_EVENTS, availability_harness_response
+        from .hook_availability_policy import availability_harness_response, lifecycle_event_is_observe_only
 
-        if event == "PreToolUse" or event in LIFECYCLE_OBSERVE_EVENTS:
+        if event == "PreToolUse" or lifecycle_event_is_observe_only(event):
             payload_dict = dict(payload) if isinstance(payload, Mapping) else {}
             workspace_path, home_path = self._validated_fail_safe_hook_paths(params)
             return availability_harness_response(

--- a/tests/test_hook_availability_policy.py
+++ b/tests/test_hook_availability_policy.py
@@ -369,3 +369,44 @@ def test_macos_private_prefix_stays_workspace_local() -> None:
         "tool_input": {"file_path": "/private/tmp/guard-project/src/app.ts"},
     }
     assert hook_action_is_emergency_safe(payload, workspace=workspace) is True
+
+
+def test_availability_continues_prompt_lifecycle_and_still_pauses_tools(tmp_path: Path) -> None:
+    prompt = availability_harness_response(
+        {"hook_event_name": "UserPromptSubmit", "prompt": "hello"},
+        harness="grok",
+        event_name="UserPromptSubmit",
+        reason_code="native_hook_event_unavailable",
+        reason="native unavailable",
+        workspace=tmp_path,
+        home_dir=tmp_path / "home",
+    )
+    assert prompt["decision"] == "allow"
+    assert prompt["policy_action"] == "allow"
+    session = availability_harness_response(
+        {"hook_event_name": "SessionStart"},
+        harness="grok",
+        event_name="SessionStart",
+        reason_code="native_hook_event_unavailable",
+        reason="native unavailable",
+    )
+    assert session["decision"] == "allow"
+    withheld = availability_harness_response(
+        {"hook_event_name": "PostToolUse", "tool_name": "Read"},
+        harness="cursor",
+        event_name="PostToolUse",
+        reason_code="native_post_tool_unavailable",
+        reason="native unavailable",
+    )
+    assert withheld["continue"] is False
+    assert withheld["policy_action"] == "block"
+    curl = availability_harness_response(
+        {"hook_event_name": "PreToolUse", "tool_input": {"command": "curl https://example.test"}},
+        harness="grok",
+        event_name="PreToolUse",
+        reason_code="native_pre_tool_unavailable",
+        reason="native unavailable",
+        workspace=tmp_path,
+        home_dir=tmp_path / "home",
+    )
+    assert curl["policy_action"] == "block"

--- a/tests/test_hook_availability_policy.py
+++ b/tests/test_hook_availability_policy.py
@@ -408,6 +408,23 @@ def test_availability_continues_prompt_lifecycle_and_still_pauses_tools(tmp_path
         reason="native unavailable",
     )
     assert subagent["decision"] == "allow"
+    submitted = availability_harness_response(
+        {"hook_event_name": "UserPromptSubmitted"},
+        harness="grok",
+        event_name="UserPromptSubmitted",
+        reason_code="native_hook_event_unavailable",
+        reason="native unavailable",
+    )
+    assert submitted["decision"] == "allow"
+    assert submitted["policy_action"] == "allow"
+    compact = availability_harness_response(
+        {"hook_event_name": " userpromptsubmit "},
+        harness="grok",
+        event_name=" userpromptsubmit ",
+        reason_code="native_hook_event_unavailable",
+        reason="native unavailable",
+    )
+    assert compact["decision"] == "allow"
     withheld = availability_harness_response(
         {"hook_event_name": "PostToolUse", "tool_name": "Read"},
         harness="cursor",

--- a/tests/test_hook_availability_policy.py
+++ b/tests/test_hook_availability_policy.py
@@ -391,6 +391,23 @@ def test_availability_continues_prompt_lifecycle_and_still_pauses_tools(tmp_path
         reason="native unavailable",
     )
     assert session["decision"] == "allow"
+    aliased = availability_harness_response(
+        {"hookEventName": "session_start"},
+        harness="grok",
+        event_name="session_start",
+        reason_code="native_hook_event_unavailable",
+        reason="native unavailable",
+    )
+    assert aliased["decision"] == "allow"
+    assert aliased["policy_action"] == "allow"
+    subagent = availability_harness_response(
+        {"hook_event_name": "subagent_start"},
+        harness="grok",
+        event_name="subagent_start",
+        reason_code="native_hook_event_unavailable",
+        reason="native unavailable",
+    )
+    assert subagent["decision"] == "allow"
     withheld = availability_harness_response(
         {"hook_event_name": "PostToolUse", "tool_name": "Read"},
         harness="cursor",

--- a/tests/test_rust_pretool_authority_worker.py
+++ b/tests/test_rust_pretool_authority_worker.py
@@ -366,3 +366,14 @@ def test_hook_worker_routes_out_of_scope_events_to_native_fail_safe(
     )
     assert result["reason_code"] == "native_hook_event_unavailable"
     assert result["continue"] is False
+    grok_session = worker.review_http_payload(
+        payload={"hookEventName": "session_start"},
+        params={},
+        default_harness="grok",
+        home_dir=tmp_path / "home",
+        guard_home=tmp_path / "guard-home",
+        workspace=tmp_path / "workspace",
+    )
+    assert grok_session["decision"] == "allow"
+    assert grok_session["policy_action"] == "allow"
+    assert grok_session["reason_code"] == "native_hook_event_unavailable"


### PR DESCRIPTION
## Summary

- Continue prompt and session inventory hooks when native review cannot complete.
- Keep PreToolUse mutating, network, and MCP actions paused, and keep PostToolUse withheld.
- Native review still covers only PreToolUse and PostToolUse; lifecycle events are observe-only and must not freeze the conversation.

## Testing

- `uv run --no-sync python -m pytest tests/test_hook_availability_policy.py tests/test_bounded_cli_hook_bridge.py tests/test_rust_pretool_authority_worker.py tests/test_grok_adapter.py -q`
- `uv run --no-sync python scripts/ci/code_quality_audit.py --root . --baseline ci/code-quality-baseline.json`
- `uv run --no-sync python scripts/ci/test_inventory.py --output test-inventory.json`
- `uv run --no-sync python scripts/ci/test_suite_ratchet.py --baseline ci/test-suite-ratchet-baseline.json --inventory test-inventory.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved emergency-safe handling for prompt and session lifecycle events.
  * Lifecycle events now continue in observe-only mode when native review is unavailable, while tool-related actions remain protected.
  * Added harness-specific fail-safe responses to preserve expected behavior across supported integrations.
  * Improved recognition of lifecycle event name variations.

* **Tests**
  * Added coverage confirming lifecycle events continue while tool actions are still paused when required.
  * Verified consistent behavior across supported integrations and event formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->