### PR TITLE
fix(hermes): qualify local-mode coverage

### DIFF
--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -354,6 +354,8 @@ Hermes gets the normal Guard shim plus a Guard-owned bundle at `<guard-home>/her
 Guard injects the managed overlay paths through `HERMES_GUARD_MCP_OVERLAY_PATH` and `HERMES_GUARD_PRETOOL_PATH` when
 you launch Hermes through Guard.
 
+Hermes local installs only cover launch-time artifacts; runtime shell enforcement requires a Guard Cloud pairing.
+
 OpenClaw gets the normal Guard shim plus a Guard-owned bundle at `<guard-home>/openclaw/` with:
 
 - `overlay.json`

--- a/src/codex_plugin_scanner/guard/adapters/contracts.py
+++ b/src/codex_plugin_scanner/guard/adapters/contracts.py
@@ -297,7 +297,8 @@ HARNESS_CONTRACTS: tuple[HarnessProtectionContract, ...] = (
         browser_fallback=True,
         resume_support=False,
         known_blind_spots=(
-            "Hermes is an early-access harness; some event surface coverage depends on the Hermes version installed."
+            "Hermes local installs only guarantee launch-time artifact review; "
+            "runtime shell enforcement requires a Guard Cloud pairing or a Guard-launched session."
         ),
         smoke_command="hol-guard install hermes --dry-run",
     ),

--- a/src/codex_plugin_scanner/guard/adapters/contracts.py
+++ b/src/codex_plugin_scanner/guard/adapters/contracts.py
@@ -297,8 +297,8 @@ HARNESS_CONTRACTS: tuple[HarnessProtectionContract, ...] = (
         browser_fallback=True,
         resume_support=False,
         known_blind_spots=(
-            "Hermes local installs only guarantee launch-time artifact review; "
-            "runtime shell enforcement requires a Guard Cloud pairing or a Guard-launched session."
+            "Hermes local installs only cover launch-time artifacts; "
+            "runtime shell enforcement requires a Guard Cloud pairing."
         ),
         smoke_command="hol-guard install hermes --dry-run",
     ),

--- a/src/codex_plugin_scanner/guard/adapters/hermes.py
+++ b/src/codex_plugin_scanner/guard/adapters/hermes.py
@@ -22,6 +22,7 @@ from ..skill_directory_identity import (
     inspect_skill_directory,
     skill_directory_identity_metadata,
 )
+from ..store import GuardStore
 from .base import HarnessAdapter, HarnessContext, _command_available, _json_payload, _run_command_probe
 from .bounded_cli_hook_bridge import bounded_cli_hook_command
 from .cloud_identity import cloud_agent_identity_environment, cloud_agent_identity_hints
@@ -62,6 +63,10 @@ _HERMES_MANAGED_APPROVAL_TIER = "native-or-center"
 _HERMES_MANAGED_PROMPT_CHANNEL = "native"
 _HERMES_LOCAL_MODE_NOTE = (
     "Hermes local installs only cover launch-time artifacts; runtime shell enforcement requires a Guard Cloud pairing."
+)
+_HERMES_MANAGED_INSTALL_INCOMPLETE_NOTE = (
+    "Hermes managed installation is incomplete; "
+    "runtime shell enforcement remains unavailable until the bundle is repaired."
 )
 _GUARD_PRETOOL_INTERNAL_TIMEOUT_SECONDS = 3
 _GUARD_PRETOOL_HOST_TIMEOUT_SECONDS = 5
@@ -153,6 +158,10 @@ def _hermes_home_has_artifacts(hermes_home: Path) -> bool:
     return False
 
 
+def _hermes_cloud_identity_configured(context: HarnessContext) -> bool:
+    return GuardStore(context.guard_home).get_cloud_sync_profile() is not None
+
+
 def _manifest_notes(payload: dict[str, object]) -> list[str]:
     notes = payload.get("notes")
     if not isinstance(notes, list):
@@ -195,6 +204,9 @@ class HermesHarnessAdapter(HarnessAdapter):
         )
         overlay_servers = _overlay_servers(context=context, source_configs=source_configs)
         cloud_identity = cloud_agent_identity_hints(context, runtime=self.harness)
+        cloud_configured = _hermes_cloud_identity_configured(context)
+        if not cloud_configured:
+            cloud_identity = None
         overlay_path.write_text(json.dumps(overlay_servers, indent=2) + "\n", encoding="utf-8")
         pretool_path.write_text(
             json.dumps(_pretool_payload(context=context), indent=2) + "\n",
@@ -244,6 +256,7 @@ class HermesHarnessAdapter(HarnessAdapter):
             "notes": [
                 "Guard generated a Hermes MCP overlay and pre-tool hook bundle.",
                 *([_HERMES_LOCAL_MODE_NOTE] if cloud_identity is None else []),
+                *([_HERMES_MANAGED_INSTALL_INCOMPLETE_NOTE] if not cloud_configured else []),
                 "Guard wrote Guard-managed MCP proxy entries into the Hermes config.yaml.",
                 *_manifest_notes(shim_manifest),
             ],
@@ -331,7 +344,7 @@ class HermesHarnessAdapter(HarnessAdapter):
                 and isinstance(pretool_path, str)
                 and Path(pretool_path).exists()
             ),
-            "cloud_agent_identity_configured": bool(cloud_agent_identity_hints(context, runtime=self.harness)),
+            "cloud_agent_identity_configured": _hermes_cloud_identity_configured(context),
         }
 
     def diagnostic_warnings(
@@ -343,10 +356,15 @@ class HermesHarnessAdapter(HarnessAdapter):
         if (
             detection.installed
             and isinstance(runtime_probe, dict)
-            and runtime_probe.get("managed_install_ready") is True
             and runtime_probe.get("cloud_agent_identity_configured") is False
         ):
             warnings.append(_HERMES_LOCAL_MODE_NOTE)
+        if (
+            detection.installed
+            and isinstance(runtime_probe, dict)
+            and runtime_probe.get("managed_install_ready") is False
+        ):
+            warnings.append(_HERMES_MANAGED_INSTALL_INCOMPLETE_NOTE)
         return warnings
 
     def approval_flow(self, *, managed_install: dict[str, object] | None = None) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/adapters/hermes.py
+++ b/src/codex_plugin_scanner/guard/adapters/hermes.py
@@ -60,6 +60,9 @@ _SCANNABLE_NAMES = {".env", "Makefile", "Dockerfile", "Procfile"}
 
 _HERMES_MANAGED_APPROVAL_TIER = "native-or-center"
 _HERMES_MANAGED_PROMPT_CHANNEL = "native"
+_HERMES_LOCAL_MODE_NOTE = (
+    "Hermes local installs only cover launch-time artifacts; runtime shell enforcement requires a Guard Cloud pairing."
+)
 _GUARD_PRETOOL_INTERNAL_TIMEOUT_SECONDS = 3
 _GUARD_PRETOOL_HOST_TIMEOUT_SECONDS = 5
 
@@ -240,6 +243,7 @@ class HermesHarnessAdapter(HarnessAdapter):
             "servers": _manifest_servers(source_configs),
             "notes": [
                 "Guard generated a Hermes MCP overlay and pre-tool hook bundle.",
+                *([_HERMES_LOCAL_MODE_NOTE] if cloud_identity is None else []),
                 "Guard wrote Guard-managed MCP proxy entries into the Hermes config.yaml.",
                 *_manifest_notes(shim_manifest),
             ],
@@ -329,6 +333,21 @@ class HermesHarnessAdapter(HarnessAdapter):
             ),
             "cloud_agent_identity_configured": bool(cloud_agent_identity_hints(context, runtime=self.harness)),
         }
+
+    def diagnostic_warnings(
+        self,
+        detection: HarnessDetection,
+        runtime_probe: dict[str, object] | None,
+    ) -> list[str]:
+        warnings = super().diagnostic_warnings(detection, runtime_probe)
+        if (
+            detection.installed
+            and isinstance(runtime_probe, dict)
+            and runtime_probe.get("managed_install_ready") is True
+            and runtime_probe.get("cloud_agent_identity_configured") is False
+        ):
+            warnings.append(_HERMES_LOCAL_MODE_NOTE)
+        return warnings
 
     def approval_flow(self, *, managed_install: dict[str, object] | None = None) -> dict[str, object]:
         manifest = managed_install.get("manifest") if isinstance(managed_install, dict) else None

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_admin.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_admin.py
@@ -360,14 +360,12 @@ def _run_guard_doctor_command(
     if (
         args.harness == "hermes"
         and isinstance(runtime_probe, dict)
-        and runtime_probe.get("managed_install_ready") is True
         and runtime_probe.get("cloud_agent_identity_configured") is False
     ):
+        from ..adapters.hermes import _HERMES_LOCAL_MODE_NOTE
+
         payload["protection_label"] = "launch-review only"
-        payload["protection_help"] = (
-            "Hermes local installs only cover launch-time artifacts; "
-            "runtime shell enforcement requires a Guard Cloud pairing."
-        )
+        payload["protection_help"] = _HERMES_LOCAL_MODE_NOTE
     _emit("doctor", payload, getattr(args, "json", False))
     return 0
 

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_admin.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_admin.py
@@ -356,6 +356,18 @@ def _run_guard_doctor_command(
     from ..protection_posture import protection_status_fields
 
     payload.update(protection_status_fields(posture=config.protection_posture, mode=config.mode))
+    runtime_probe = payload.get("runtime_probe")
+    if (
+        args.harness == "hermes"
+        and isinstance(runtime_probe, dict)
+        and runtime_probe.get("managed_install_ready") is True
+        and runtime_probe.get("cloud_agent_identity_configured") is False
+    ):
+        payload["protection_label"] = "launch-review only"
+        payload["protection_help"] = (
+            "Hermes local installs only cover launch-time artifacts; "
+            "runtime shell enforcement requires a Guard Cloud pairing."
+        )
     _emit("doctor", payload, getattr(args, "json", False))
     return 0
 

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sqlite3
 import subprocess
 import sys
@@ -29,6 +30,7 @@ from codex_plugin_scanner.guard.adapters import cursor as cursor_adapter_module
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.claude_code import CLAUDE_GUARD_DAEMON_HOOK_MARKER, ClaudeCodeHarnessAdapter
 from codex_plugin_scanner.guard.adapters.cursor_cli import CursorCliLaunchEntry
+from codex_plugin_scanner.guard.adapters.hermes import HermesHarnessAdapter
 from codex_plugin_scanner.guard.adapters.opencode import OpenCodeHarnessAdapter
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
 from codex_plugin_scanner.guard.cli import commands_support_connect as guard_connect_support_module
@@ -4983,6 +4985,41 @@ args = ["-lc", "echo hi"]
         assert rc == 0
         assert output["native_hook_state"]["protection_active"] is False
         assert any("managed Codex hooks are missing" in warning for warning in output["warnings"])
+
+    def test_guard_doctor_labels_hermes_local_only_coverage(self, tmp_path, monkeypatch, capsys):
+        home_dir = tmp_path / "home"
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        hermes = bin_dir / "hermes"
+        hermes.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        hermes.chmod(0o755)
+        monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+        _write_text(
+            home_dir / ".hermes" / "config.yaml",
+            "mcp_servers:\n  github:\n    command: npx\n",
+        )
+
+        context = HarnessContext(home_dir=home_dir, workspace_dir=None, guard_home=home_dir / ".hol-guard")
+        HermesHarnessAdapter().install(context)
+
+        rc = main([
+            "guard",
+            "doctor",
+            "hermes",
+            "--home",
+            str(home_dir),
+            "--guard-home",
+            str(home_dir / ".hol-guard"),
+            "--json",
+        ])
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["protection_label"] == "launch-review only"
+        assert any(
+            "runtime shell enforcement requires a Guard Cloud pairing" in warning
+            for warning in output["warnings"]
+        )
 
     def test_guard_doctor_reports_runtime_detector_registry_state(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -30,7 +30,10 @@ from codex_plugin_scanner.guard.adapters import cursor as cursor_adapter_module
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.claude_code import CLAUDE_GUARD_DAEMON_HOOK_MARKER, ClaudeCodeHarnessAdapter
 from codex_plugin_scanner.guard.adapters.cursor_cli import CursorCliLaunchEntry
-from codex_plugin_scanner.guard.adapters.hermes import HermesHarnessAdapter
+from codex_plugin_scanner.guard.adapters.hermes import (
+    _HERMES_LOCAL_MODE_NOTE,
+    HermesHarnessAdapter,
+)
 from codex_plugin_scanner.guard.adapters.opencode import OpenCodeHarnessAdapter
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
 from codex_plugin_scanner.guard.cli import commands_support_connect as guard_connect_support_module
@@ -5016,6 +5019,7 @@ args = ["-lc", "echo hi"]
 
         assert rc == 0
         assert output["protection_label"] == "launch-review only"
+        assert output["protection_help"] == _HERMES_LOCAL_MODE_NOTE
         assert any(
             "runtime shell enforcement requires a Guard Cloud pairing" in warning
             for warning in output["warnings"]

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -501,6 +502,36 @@ def test_launch_environment_recomputes_cloud_identity_hints(tmp_path: Path):
     env = HermesHarnessAdapter().launch_environment(context)
 
     assert "HERMES_GUARD_CLOUD_WORKSPACE" not in env
+
+
+def test_install_warns_when_local_mode_has_no_cloud_pairing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    hermes = bin_dir / "hermes"
+    hermes.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    hermes.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+    _write(
+        tmp_path / ".hermes" / "config.yaml",
+        "mcp_servers:\n  github:\n    command: npx\n",
+    )
+    context = _ctx(tmp_path)
+    adapter = HermesHarnessAdapter()
+
+    manifest = adapter.install(context)
+    diagnostics = adapter.diagnostics(context)
+
+    assert any(
+        "runtime shell enforcement requires a Guard Cloud pairing" in note
+        for note in manifest["notes"]
+    )
+    assert any(
+        "runtime shell enforcement requires a Guard Cloud pairing" in warning
+        for warning in diagnostics["warnings"]
+    )
 
 
 def test_install_stringifies_typed_env_values_in_managed_manifest(tmp_path: Path):

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -12,10 +12,13 @@ import pytest
 
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.hermes import (
+    _HERMES_LOCAL_MODE_NOTE,
+    _HERMES_MANAGED_INSTALL_INCOMPLETE_NOTE,
     HermesHarnessAdapter,
     _extract_env_mentions,
     _looks_like_secret,
 )
+from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
 from codex_plugin_scanner.guard.inventory_cisco import CiscoInventoryRun
 from codex_plugin_scanner.guard.inventory_contract import serialize_inventory_snapshot
 from codex_plugin_scanner.guard.risk import artifact_risk_signals
@@ -39,6 +42,22 @@ def _write(path: Path, content: str) -> None:
 
 
 def _seed_cloud_profile(context: HarnessContext, runtime: str = "hermes") -> None:
+    dpop_key_material = generate_dpop_key_pair()
+    GuardStore(context.guard_home).set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="oauth_refresh_token_fixture",
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant_123",
+        machine_id="machine_123",
+        workspace_id="workspace_ops",
+        runtime_id="runtime_123",
+        runtime_label="Hermes Telegram agent",
+        access_token="oauth_access_token_fixture",
+        now="2026-05-05T00:00:00.000Z",
+    )
     GuardStore(context.guard_home).set_sync_payload(
         "service_runtime_profile",
         {
@@ -532,6 +551,30 @@ def test_install_warns_when_local_mode_has_no_cloud_pairing(
         "runtime shell enforcement requires a Guard Cloud pairing" in warning
         for warning in diagnostics["warnings"]
     )
+
+
+def test_diagnostic_warns_when_managed_install_is_incomplete(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    hermes = bin_dir / "hermes"
+    hermes.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    hermes.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+    _write(
+        tmp_path / ".hermes" / "config.yaml",
+        "mcp_servers:\n  github:\n    command: npx\n",
+    )
+
+    context = _ctx(tmp_path)
+    adapter = HermesHarnessAdapter()
+    manifest = adapter.install(context)
+    Path(str(manifest["mcp_overlay_path"])).unlink()
+    Path(str(manifest["pretool_hook_path"])).unlink()
+
+    diagnostics = adapter.diagnostics(context)
+
+    assert _HERMES_LOCAL_MODE_NOTE in diagnostics["warnings"]
+    assert _HERMES_MANAGED_INSTALL_INCOMPLETE_NOTE in diagnostics["warnings"]
 
 
 def test_install_stringifies_typed_env_values_in_managed_manifest(tmp_path: Path):


### PR DESCRIPTION
Fixes #2717

Hermes local installs were still presenting `Protected` even when they only had launch-time artifacts and no Guard Cloud pairing was available. This patch qualifies the local-mode posture, adds the missing warning, and keeps the contract/docs aligned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Guard Doctor now clearly labels Hermes protection as “launch-review only” when no Guard Cloud pairing is configured.
  - Hermes diagnostics now distinguish local-mode coverage from incomplete managed installations.
  - Hermes status information now reports whether a Guard Cloud identity is configured.

- **Documentation**
  - Clarified that Hermes local installations cover launch-time artifacts only.
  - Documented that runtime shell enforcement requires a Guard Cloud pairing.

- **Bug Fixes**
  - Improved Hermes warnings and protection details to accurately reflect the active installation and cloud pairing state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->