### PR TITLE
fix(guard): continue Watch hooks and trust same-release daemons

### DIFF
--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
-  "maximum_collected_cases": 16815,
-  "maximum_test_source_lines": 364933
+  "maximum_collected_cases": 16822,
+  "maximum_test_source_lines": 365105
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
-  "maximum_collected_cases": 16823,
-  "maximum_test_source_lines": 365144
+  "maximum_collected_cases": 16825,
+  "maximum_test_source_lines": 365195
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
-  "maximum_collected_cases": 16822,
-  "maximum_test_source_lines": 365105
+  "maximum_collected_cases": 16823,
+  "maximum_test_source_lines": 365144
 }

--- a/ci/test-suite-ratchet-baseline.json
+++ b/ci/test-suite-ratchet-baseline.json
@@ -1,5 +1,5 @@
 {
   "schema_version": 1,
-  "maximum_collected_cases": 16825,
-  "maximum_test_source_lines": 365195
+  "maximum_collected_cases": 16826,
+  "maximum_test_source_lines": 365222
 }

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_tail.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_tail.py
@@ -307,12 +307,19 @@ def _cursor_availability_response(
         }, 2
 
 
+_LAST_HOOK_EVENT_NAME = ""
+
+
 def main() -> int:
     try:
         return _main_inner()
     except Exception:
         if _recording_only_from_guard_home():
-            print(json.dumps({"permission": "allow"}))
+            compact = _LAST_HOOK_EVENT_NAME.strip().lower().replace("_", "").replace("-", "")
+            if compact in {"aftershellexecution", "aftermcpexecution"}:
+                print("{}")
+            else:
+                print(json.dumps({"permission": "allow"}))
             return 0
         print(
             json.dumps(
@@ -340,6 +347,8 @@ def _main_inner() -> int:
         return 2
     inferred = _infer_cursor_hook_event_name(payload)
     hook_event_name = str(inferred.get("hook_event_name") or inferred.get("hookEventName") or "preToolUse")
+    global _LAST_HOOK_EVENT_NAME
+    _LAST_HOOK_EVENT_NAME = hook_event_name
     prepared = _prepare_cursor_hook_payload(inferred)
     workspace = _workspace_from_cursor_input(prepared)
     guard_argv = list(GUARD_HOOK_ARGV)

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_tail.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_tail.py
@@ -248,8 +248,14 @@ def _cursor_availability_response(
             payload,
             hook_event_name=hook_event_name,
             workspace=workspace_path,
+            recording_only=_recording_only_from_guard_home(),
         )
     except Exception:
+        if _recording_only_from_guard_home():
+            compact = hook_event_name.strip().lower().replace("_", "").replace("-", "")
+            if compact in {"aftershellexecution", "aftermcpexecution"}:
+                return {}, 0
+            return {"permission": "allow"}, 0
         compact = hook_event_name.strip().lower().replace("_", "").replace("-", "")
         if compact in {"aftershellexecution", "aftermcpexecution"}:
             return {}, 0
@@ -302,6 +308,9 @@ def main() -> int:
     try:
         return _main_inner()
     except Exception:
+        if _recording_only_from_guard_home():
+            print(json.dumps({"permission": "allow"}))
+            return 0
         print(
             json.dumps(
                 {

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_tail.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_tail.py
@@ -2,20 +2,21 @@
 
 from __future__ import annotations
 
-HOOK_SCRIPT_TEMPLATE_TAIL = """def _recording_only_from_guard_home() -> bool:
+HOOK_SCRIPT_TEMPLATE_TAIL = """def _recording_only_from_guard_home(workspace: str | None = None) -> bool:
     try:
         from codex_plugin_scanner.guard.config import load_guard_config
         from codex_plugin_scanner.guard.protection_posture import protection_is_off
 
-        config = load_guard_config(Path(GUARD_HOME))
+        workspace_path = Path(workspace) if workspace else None
+        config = load_guard_config(Path(GUARD_HOME), workspace=workspace_path)
         return protection_is_off(posture=config.protection_posture, mode=config.mode)
     except Exception:
         return False
 
 
-def _cursor_permission(policy_action: str, guard_payload: dict[str, object]) -> str:
+def _cursor_permission(policy_action: str, guard_payload: dict[str, object], workspace: str | None = None) -> str:
     del guard_payload
-    if _recording_only_from_guard_home():
+    if _recording_only_from_guard_home(workspace):
         return "allow"
     if policy_action not in GUARD_ACTIONS:
         return "deny"
@@ -31,8 +32,9 @@ def _emit_cursor_response(
     hook_event_name: str,
     policy_action: str,
     guard_payload: dict[str, object],
+    workspace: str | None = None,
 ) -> tuple[dict[str, object], int]:
-    permission = _cursor_permission(policy_action, guard_payload)
+    permission = _cursor_permission(policy_action, guard_payload, workspace)
     reason = _cursor_reason(guard_payload)
     if hook_event_name.strip().lower() == "beforereadfile":
         read_permission = "deny" if permission in {"deny", "ask"} else "allow"
@@ -248,10 +250,11 @@ def _cursor_availability_response(
             payload,
             hook_event_name=hook_event_name,
             workspace=workspace_path,
-            recording_only=_recording_only_from_guard_home(),
+            guard_home=Path(GUARD_HOME),
+            recording_only=_recording_only_from_guard_home(workspace),
         )
     except Exception:
-        if _recording_only_from_guard_home():
+        if _recording_only_from_guard_home(workspace):
             compact = hook_event_name.strip().lower().replace("_", "").replace("-", "")
             if compact in {"aftershellexecution", "aftermcpexecution"}:
                 return {}, 0
@@ -429,7 +432,7 @@ def _main_inner() -> int:
         return 0
     raw_policy_action = guard_payload.get("policy_action")
     if not isinstance(raw_policy_action, str) or raw_policy_action not in GUARD_ACTIONS:
-        if _recording_only_from_guard_home():
+        if _recording_only_from_guard_home(workspace):
             print(json.dumps({"permission": "allow"}))
             return 0
         response, exit_code = _cursor_availability_response(
@@ -452,6 +455,7 @@ def _main_inner() -> int:
         hook_event_name=hook_event_name,
         policy_action=policy_action,
         guard_payload=guard_payload,
+        workspace=workspace,
     )
     print(json.dumps(response))
     return exit_code

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_tail.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_tail.py
@@ -243,6 +243,7 @@ def _cursor_availability_response(
     workspace: str | None,
 ) -> tuple[dict[str, object], int]:
     workspace_path = Path(workspace) if workspace else None
+    recording_only = _recording_only_from_guard_home(workspace)
     try:
         from codex_plugin_scanner.guard.daemon.hook_availability_policy import cursor_fallback_permission
 
@@ -251,10 +252,10 @@ def _cursor_availability_response(
             hook_event_name=hook_event_name,
             workspace=workspace_path,
             guard_home=Path(GUARD_HOME),
-            recording_only=_recording_only_from_guard_home(workspace),
+            recording_only=recording_only,
         )
     except Exception:
-        if _recording_only_from_guard_home(workspace):
+        if recording_only:
             compact = hook_event_name.strip().lower().replace("_", "").replace("-", "")
             if compact in {"aftershellexecution", "aftermcpexecution"}:
                 return {}, 0

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_native_authority.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_native_authority.py
@@ -72,6 +72,7 @@ def try_native_hook_authority(
             reason="HOL Guard could not complete the native hook decision safely.",
             workspace=workspace,
             home_dir=home_dir,
+            guard_home=guard_home,
         )
     finally:
         if worker is not None:
@@ -133,6 +134,7 @@ def try_native_or_source_ref_hook(
                 reason="HOL Guard could not complete the native hook decision safely.",
                 workspace=runtime_workspace,
                 home_dir=context.home_dir,
+                guard_home=context.guard_home,
             ),
             getattr(args, "json", False),
         )

--- a/src/codex_plugin_scanner/guard/daemon/hook_availability_policy.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_availability_policy.py
@@ -23,7 +23,9 @@ _CURSOR_UNAVAILABLE_DENY: dict[str, object] = {
 
 # Native review covers PreToolUse and PostToolUse. Lifecycle events are inventory
 # only: fail-closing them freezes the conversation without adding an enforcement
-# boundary. PostToolUse and PermissionRequest stay withheld/paused.
+# boundary. Protected/Extra careful keep PostToolUse withheld and high-impact
+# PreToolUse paused when native review cannot complete. Watch records those
+# actions and continues them.
 LIFECYCLE_OBSERVE_EVENTS = frozenset(
     {
         "UserPromptSubmit",
@@ -56,6 +58,60 @@ def lifecycle_event_is_observe_only(event_name: str) -> bool:
     return _compact_hook_event_name(event_name) in _LIFECYCLE_CANONICAL_BY_COMPACT
 
 
+def hook_review_is_recording_only(
+    *,
+    guard_home: Path | None = None,
+    workspace: Path | None = None,
+    recording_only: bool = False,
+) -> bool:
+    """True when Watch/observe must record without stopping the harness."""
+
+    if recording_only:
+        return True
+    if guard_home is None:
+        return False
+    try:
+        from ..config import load_guard_config
+        from ..protection_posture import protection_is_off
+
+        config = load_guard_config(guard_home, workspace=workspace)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return False
+    return protection_is_off(posture=config.protection_posture, mode=config.mode)
+
+
+_DECISION_HOOK_HARNESSES = frozenset({"grok", "hermes", "openclaw", "pi", "omp"})
+
+
+def recording_only_pre_tool_response(
+    harness: str,
+    *,
+    reason_code: str,
+    reason: str,
+) -> dict[str, object]:
+    """Continue a PreToolUse hook in Watch without changing Protected fail-closed JSON."""
+
+    from .hook_worker_responses import harness_json_from_native_pre_tool
+
+    if harness.strip().lower().replace("_", "-") in _DECISION_HOOK_HARNESSES:
+        return {
+            "decision": "allow",
+            "policy_action": "warn",
+            "reason_code": reason_code,
+            "reason": reason,
+        }
+    return harness_json_from_native_pre_tool(
+        harness,
+        {
+            "decision": "allow",
+            "minimum_action": "warn",
+            "policy_action": "warn",
+            "reason_code": reason_code,
+            "reason": reason,
+        },
+    )
+
+
 def availability_harness_response(
     payload: Mapping[str, object],
     *,
@@ -65,6 +121,8 @@ def availability_harness_response(
     reason: str,
     workspace: Path | None = None,
     home_dir: Path | None = None,
+    guard_home: Path | None = None,
+    recording_only: bool = False,
 ) -> dict[str, object]:
     """Render a schema-valid harness result when native review is unavailable."""
 
@@ -80,6 +138,23 @@ def availability_harness_response(
             harness,
             event_name=canonical_lifecycle,
             reason_code=reason_code,
+        )
+    watch_only = hook_review_is_recording_only(
+        guard_home=guard_home,
+        workspace=workspace,
+        recording_only=recording_only,
+    )
+    if watch_only:
+        if event_name != "PreToolUse":
+            return observe_lifecycle_fail_safe_response(
+                harness,
+                event_name=event_name,
+                reason_code=reason_code,
+            )
+        return recording_only_pre_tool_response(
+            harness,
+            reason_code=reason_code,
+            reason=reason,
         )
     if event_name != "PreToolUse":
         return post_tool_fail_safe_response(harness, reason=reason, reason_code=reason_code)
@@ -116,12 +191,20 @@ def cursor_fallback_permission(
     hook_event_name: str,
     workspace: Path | None = None,
     home_dir: Path | None = None,
+    guard_home: Path | None = None,
+    recording_only: bool = False,
 ) -> tuple[dict[str, object], int]:
     """Return Cursor hook stdout when daemon or native review cannot complete."""
 
     compact = hook_event_name.strip().lower().replace("_", "").replace("-", "")
     if compact in {"aftershellexecution", "aftermcpexecution"}:
         return {}, 0
+    if hook_review_is_recording_only(
+        guard_home=guard_home,
+        workspace=workspace,
+        recording_only=recording_only,
+    ):
+        return {"permission": "allow"}, 0
     if compact in {"beforewritefile", "beforemcpexecution"}:
         return dict(_CURSOR_UNAVAILABLE_DENY), 2
     if hook_action_is_emergency_safe(payload, workspace=workspace, home_dir=home_dir):
@@ -142,5 +225,7 @@ __all__ = [
     "availability_harness_response",
     "cursor_fallback_permission",
     "hook_action_is_emergency_safe",
+    "hook_review_is_recording_only",
     "lifecycle_event_is_observe_only",
+    "recording_only_pre_tool_response",
 ]

--- a/src/codex_plugin_scanner/guard/daemon/hook_worker_native.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_worker_native.py
@@ -106,6 +106,17 @@ def _record_unavailable_native(
     )
     route = "native_degraded" if response.get("reason_code") == "native_degraded_emergency_safe" else "native_fail_safe"
     host.metrics.record_route(route)
+    if event_name == "PreToolUse":
+        writer = host.activity_writer
+        submit = getattr(writer, "submit_command_activity", None)
+        if callable(submit):
+            with suppress(Exception):
+                _ = submit(
+                    harness=harness,
+                    event=event_name,
+                    payload=payload,
+                    succeeded=str(response.get("policy_action") or "") != "block",
+                )
     return response
 
 

--- a/src/codex_plugin_scanner/guard/daemon/hook_worker_native.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_worker_native.py
@@ -176,10 +176,16 @@ class HookWorkerNativeMixin:
                     raise HookWorkerUnsupported("native PreToolUse review uses CLI approval coordination")
             return harness_json_from_native_pre_tool(harness, native)
         if recording_only:
-            return recording_only_pre_tool_response(
-                harness,
+            return _record_unavailable_native(
+                self,
+                payload,
+                harness=harness,
+                event_name="PreToolUse",
                 reason_code="watch_recording_only",
-                reason="Watch recorded this action without stopping it.",
+                workspace=workspace,
+                home_dir=home_dir,
+                guard_home=guard_home,
+                recording_only=True,
             )
         status = self._native_runtime_status()
         if status.mode == "off":

--- a/src/codex_plugin_scanner/guard/daemon/hook_worker_native.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_worker_native.py
@@ -8,27 +8,21 @@ from pathlib import Path
 from typing import Protocol
 
 from ..cli.commands_support_command_activity import hook_post_succeeded
-from ..config import load_guard_config
 from ..native_mode import python_oracle_surface_enabled
 from ..native_route_receipt import record_python_semantic_hook_route
 from ..native_runtime import NativeRuntimeStatus
-from ..protection_posture import protection_is_off
 from ..runtime.hook_review_types import HookReviewRequest, HookReviewResponse
-from .hook_availability_policy import availability_harness_response, recording_only_pre_tool_response
+from .hook_availability_policy import (
+    availability_harness_response,
+    hook_review_is_recording_only,
+    recording_only_pre_tool_response,
+)
 from .hook_request_parsing import pre_tool_command
 from .hook_worker_responses import (
     harness_json_from_native_post_tool,
     harness_json_from_native_pre_tool,
     post_tool_fail_safe_response,
 )
-
-
-def _config_is_recording_only(guard_home: Path, workspace: Path | None) -> bool:
-    try:
-        config = load_guard_config(guard_home, workspace=workspace)
-    except (OSError, RuntimeError, TypeError, ValueError):
-        return False
-    return protection_is_off(posture=config.protection_posture, mode=config.mode)
 
 
 def _watch_native_pre_tool_result(native: Mapping[str, object]) -> dict[str, object]:
@@ -163,8 +157,7 @@ class HookWorkerNativeMixin:
         command = pre_tool_command(payload)
         if command is None:
             raise HookWorkerUnsupported("fast path PreToolUse requires a command")
-        config = load_guard_config(guard_home, workspace=workspace)
-        recording_only = protection_is_off(posture=config.protection_posture, mode=config.mode)
+        recording_only = hook_review_is_recording_only(guard_home=guard_home, workspace=workspace)
         native = self._review_pre_tool_native(command, guard_home=guard_home, cwd=workspace, home_dir=home_dir)
         if native is not None:
             if recording_only:
@@ -212,7 +205,7 @@ class HookWorkerNativeMixin:
         deadline: float | None,
     ) -> dict[str, object]:
         policy_snapshot = self._native_policy_snapshot(workspace)
-        recording_only = _config_is_recording_only(guard_home, workspace) or (
+        recording_only = hook_review_is_recording_only(guard_home=guard_home, workspace=workspace) or (
             policy_snapshot is not None and policy_snapshot.get("mode") == "observe"
         )
         edge = self._review_raw_hook_native(

--- a/src/codex_plugin_scanner/guard/daemon/hook_worker_native.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_worker_native.py
@@ -14,13 +14,41 @@ from ..native_route_receipt import record_python_semantic_hook_route
 from ..native_runtime import NativeRuntimeStatus
 from ..protection_posture import protection_is_off
 from ..runtime.hook_review_types import HookReviewRequest, HookReviewResponse
-from .hook_availability_policy import availability_harness_response
+from .hook_availability_policy import availability_harness_response, recording_only_pre_tool_response
 from .hook_request_parsing import pre_tool_command
 from .hook_worker_responses import (
     harness_json_from_native_post_tool,
     harness_json_from_native_pre_tool,
     post_tool_fail_safe_response,
 )
+
+
+def _config_is_recording_only(guard_home: Path, workspace: Path | None) -> bool:
+    try:
+        config = load_guard_config(guard_home, workspace=workspace)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return False
+    return protection_is_off(posture=config.protection_posture, mode=config.mode)
+
+
+def _watch_native_pre_tool_result(native: Mapping[str, object]) -> dict[str, object]:
+    rewritten = dict(native)
+    if str(rewritten.get("minimum_action") or "") == "allow" and rewritten.get("decision") == "allow":
+        return rewritten
+    rewritten["decision"] = "allow"
+    rewritten["minimum_action"] = "warn"
+    rewritten["policy_action"] = "warn"
+    return rewritten
+
+
+def _watch_native_post_tool_result(native: Mapping[str, object]) -> dict[str, object]:
+    rewritten = dict(native)
+    if rewritten.get("decision") == "allow" and rewritten.get("model_output_action") == "allow_original":
+        return rewritten
+    rewritten["decision"] = "allow"
+    rewritten["model_output_action"] = "allow_original"
+    rewritten["policy_action"] = "warn"
+    return rewritten
 
 
 class PythonOracle(Protocol):
@@ -51,6 +79,34 @@ class _HookWorkerNativeHost(Protocol):
     _review_raw_hook_native: Callable[..., dict[str, object] | None]
     _record_post_tool_activity: Callable[..., None]
     _record_native_decision_receipt: Callable[[object], None]
+
+
+def _record_unavailable_native(
+    host: _HookWorkerNativeHost,
+    payload: dict[str, object],
+    *,
+    harness: str,
+    event_name: str,
+    reason_code: str,
+    workspace: Path | None,
+    home_dir: Path,
+    guard_home: Path,
+    recording_only: bool,
+) -> dict[str, object]:
+    response = availability_harness_response(
+        payload,
+        harness=harness,
+        event_name=event_name,
+        reason_code=reason_code,
+        reason="HOL Guard could not complete the native hook decision safely.",
+        workspace=workspace,
+        home_dir=home_dir,
+        guard_home=guard_home,
+        recording_only=recording_only,
+    )
+    route = "native_degraded" if response.get("reason_code") == "native_degraded_emergency_safe" else "native_fail_safe"
+    host.metrics.record_route(route)
+    return response
 
 
 class HookWorkerNativeMixin:
@@ -100,13 +156,27 @@ class HookWorkerNativeMixin:
         recording_only = protection_is_off(posture=config.protection_posture, mode=config.mode)
         native = self._review_pre_tool_native(command, guard_home=guard_home, cwd=workspace, home_dir=home_dir)
         if native is not None:
-            action = str(native.get("minimum_action") or "")
-            if action == "review" or (recording_only and action != "allow"):
-                record_python_semantic_hook_route()
-                raise HookWorkerUnsupported("native PreToolUse review uses CLI approval coordination")
+            if recording_only:
+                action = str(native.get("minimum_action") or "")
+                if action != "allow" or native.get("decision") != "allow":
+                    native = _watch_native_pre_tool_result(native)
+                    return recording_only_pre_tool_response(
+                        harness,
+                        reason_code=str(native.get("reason_code") or "watch_recording_only"),
+                        reason=str(native.get("reason") or "Watch recorded this action without stopping it."),
+                    )
+            else:
+                action = str(native.get("minimum_action") or "")
+                if action == "review":
+                    record_python_semantic_hook_route()
+                    raise HookWorkerUnsupported("native PreToolUse review uses CLI approval coordination")
             return harness_json_from_native_pre_tool(harness, native)
         if recording_only:
-            raise HookWorkerUnsupported("observe PreToolUse uses CLI recording")
+            return recording_only_pre_tool_response(
+                harness,
+                reason_code="watch_recording_only",
+                reason="Watch recorded this action without stopping it.",
+            )
         status = self._native_runtime_status()
         if status.mode == "off":
             raise HookWorkerUnsupported("native PreToolUse runtime is off")
@@ -131,7 +201,9 @@ class HookWorkerNativeMixin:
         deadline: float | None,
     ) -> dict[str, object]:
         policy_snapshot = self._native_policy_snapshot(workspace)
-        recording_only = policy_snapshot is not None and policy_snapshot.get("mode") == "observe"
+        recording_only = _config_is_recording_only(guard_home, workspace) or (
+            policy_snapshot is not None and policy_snapshot.get("mode") == "observe"
+        )
         edge = self._review_raw_hook_native(
             payload=payload,
             harness=harness,
@@ -155,46 +227,47 @@ class HookWorkerNativeMixin:
                 "PostToolUse": "native_post_tool_unavailable",
                 "PreToolUse": "native_pre_tool_unavailable",
             }.get(event_name, "native_hook_event_unavailable")
-            response = availability_harness_response(
+            return _record_unavailable_native(
+                self,
                 payload,
                 harness=harness,
                 event_name=event_name,
                 reason_code=reason_code,
-                reason="HOL Guard could not complete the native hook decision safely.",
                 workspace=workspace,
                 home_dir=home_dir,
+                guard_home=guard_home,
+                recording_only=recording_only,
             )
-            route = (
-                "native_degraded"
-                if response.get("reason_code") == "native_degraded_emergency_safe"
-                else "native_fail_safe"
-            )
-            self.metrics.record_route(route)
-            return response
         native_event = str(edge["event_name"])
         native_harness = str(edge["harness"])
         native_result = edge["result"]
         if not isinstance(native_result, Mapping):
-            response = availability_harness_response(
+            return _record_unavailable_native(
+                self,
                 payload,
                 harness=harness,
                 event_name=event_name,
                 reason_code="native_hook_edge_invalid_response",
-                reason="HOL Guard could not complete the native hook decision safely.",
                 workspace=workspace,
                 home_dir=home_dir,
+                guard_home=guard_home,
+                recording_only=recording_only,
             )
-            route = (
-                "native_degraded"
-                if response.get("reason_code") == "native_degraded_emergency_safe"
-                else "native_fail_safe"
-            )
-            self.metrics.record_route(route)
-            return response
         self._record_native_decision_receipt(edge.get("receipt"))
         self.metrics.record_route("native_resident")
         if native_event == "PreToolUse":
+            if recording_only:
+                action = str(native_result.get("minimum_action") or "")
+                if action != "allow" or native_result.get("decision") != "allow":
+                    native_result = _watch_native_pre_tool_result(native_result)
+                    return recording_only_pre_tool_response(
+                        native_harness,
+                        reason_code=str(native_result.get("reason_code") or "watch_recording_only"),
+                        reason=str(native_result.get("reason") or "Watch recorded this action without stopping it."),
+                    )
             return harness_json_from_native_pre_tool(native_harness, native_result)
+        if recording_only:
+            native_result = _watch_native_post_tool_result(native_result)
         self._record_post_tool_activity(
             harness=native_harness,
             payload=payload,

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -1124,10 +1124,10 @@ def _daemon_healthz_details_match_guard_home(
 
 
 def _daemon_healthz_details_match_current_runtime(payload: dict[str, object]) -> bool:
-    return (
-        payload.get("package_version") == __version__
-        and payload.get("runtime_fingerprint") == _current_guard_daemon_runtime_fingerprint()
-    )
+    fingerprint = payload.get("runtime_fingerprint")
+    current = fingerprint == _current_guard_daemon_runtime_fingerprint()
+    peer = payload.get("package_version") == __version__
+    return isinstance(fingerprint, str) and bool(fingerprint.strip()) and (current or peer)
 
 
 def _guard_daemon_url_port(url: str) -> int | None:
@@ -2598,11 +2598,11 @@ def _running_guard_daemon_processes_for_guard_home(guard_home: Path) -> list[tup
 
 
 def _guard_daemon_state_matches_current_runtime(payload: dict[str, object]) -> bool:
-    compatibility_version = payload.get("compatibility_version")
-    if compatibility_version != GUARD_DAEMON_COMPATIBILITY_VERSION:
-        return False
-    runtime_fingerprint = payload.get("runtime_fingerprint")
-    return isinstance(runtime_fingerprint, str) and runtime_fingerprint == _current_guard_daemon_runtime_fingerprint()
+    fingerprint = payload.get("runtime_fingerprint")
+    compatible = payload.get("compatibility_version") == GUARD_DAEMON_COMPATIBILITY_VERSION
+    current = fingerprint == _current_guard_daemon_runtime_fingerprint()
+    peer = payload.get("package_version") == __version__
+    return compatible and isinstance(fingerprint, str) and bool(fingerprint.strip()) and (current or peer)
 
 
 def _current_guard_daemon_source_root() -> str:

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -1124,10 +1124,10 @@ def _daemon_healthz_details_match_guard_home(
 
 
 def _daemon_healthz_details_match_current_runtime(payload: dict[str, object]) -> bool:
-    fingerprint = payload.get("runtime_fingerprint")
-    current = fingerprint == _current_guard_daemon_runtime_fingerprint()
-    peer = payload.get("package_version") == __version__
-    return isinstance(fingerprint, str) and bool(fingerprint.strip()) and (current or peer)
+    """Match live daemon identity including protocol compatibility."""
+
+    # Same-release peers still require a current compatibility version.
+    return _guard_daemon_state_matches_current_runtime(payload)
 
 
 def _guard_daemon_url_port(url: str) -> int | None:

--- a/src/codex_plugin_scanner/guard/daemon/runtime_repair.py
+++ b/src/codex_plugin_scanner/guard/daemon/runtime_repair.py
@@ -10,7 +10,6 @@ from ...version import __version__
 from .live_identity import verified_live_guard_daemon_identity
 from .manager import (
     clear_guard_daemon_state,
-    current_guard_daemon_runtime_fingerprint,
     ensure_guard_daemon_after_update,
     guard_daemon_retirement_is_complete,
     repair_approval_center_locator,
@@ -51,11 +50,7 @@ def repair_guard_daemon_runtime(
             current_version = Version(__version__)
         except InvalidVersion as error:
             raise RuntimeError("Installed Guard package version is invalid.") from error
-        current_fingerprint = current_guard_daemon_runtime_fingerprint()
-        if verified_runtime is not None and (
-            verified_runtime[0] > current_version
-            or (verified_runtime[0] == current_version and verified_runtime[2] == current_fingerprint)
-        ):
+        if verified_runtime is not None and verified_runtime[0] >= current_version:
             daemon_version, daemon_version_text, _ = verified_runtime
             return {
                 **result,

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -5927,12 +5927,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         harness = (runtime_harness or default_harness).strip().lower().replace("_", "-")
         event = self._optional_string(payload.get("hook_event_name", payload.get("event"))) or "PreToolUse"
         daemon_server = getattr(self, "server", None)
+        workspace_path, home_path = self._validated_fail_safe_hook_paths(params)
+        guard_home = None if daemon_server is None else cast(_GuardDaemonHttpServer, daemon_server).store.guard_home
         try:
-            loaded = (
-                None
-                if daemon_server is None
-                else load_guard_config(cast(_GuardDaemonHttpServer, daemon_server).store.guard_home)
-            )
+            loaded = None if guard_home is None else load_guard_config(guard_home, workspace=workspace_path)
             observe_mode = loaded is not None and protection_is_off(posture=loaded.protection_posture, mode=loaded.mode)
         except (OSError, RuntimeError, TypeError, ValueError):
             observe_mode = False
@@ -5954,7 +5952,6 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
 
         if event == "PreToolUse" or lifecycle_event_is_observe_only(event):
             payload_dict = dict(payload) if isinstance(payload, Mapping) else {}
-            workspace_path, home_path = self._validated_fail_safe_hook_paths(params)
             return availability_harness_response(
                 payload_dict,
                 harness=harness,
@@ -5963,6 +5960,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 reason=reason,
                 workspace=workspace_path,
                 home_dir=home_path,
+                guard_home=guard_home,
+                recording_only=observe_mode,
             )
         if harness in {"pi", "omp"}:
             return {

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -150,6 +150,7 @@ from ..policy_bundle_trusted_keys import (
     validate_synced_policy_bundle,
 )
 from ..policy_bundle_v2 import POLICY_BUNDLE_V2_CONTRACT
+from ..protection_posture import protection_is_off
 from ..receipts.manager import build_receipt
 from ..runtime.approval_attention import ApprovalAttentionCoordinator
 from ..runtime.cloud_review_sync import CloudReviewSyncWorker, start_cloud_sync_sync_worker, stop_cloud_sync_sync_worker
@@ -5927,42 +5928,28 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         event = self._optional_string(payload.get("hook_event_name", payload.get("event"))) or "PreToolUse"
         daemon_server = getattr(self, "server", None)
         try:
-            observe_mode = (
-                daemon_server is not None
-                and load_guard_config(cast(_GuardDaemonHttpServer, daemon_server).store.guard_home).mode == "observe"
+            loaded = (
+                None
+                if daemon_server is None
+                else load_guard_config(cast(_GuardDaemonHttpServer, daemon_server).store.guard_home)
             )
+            observe_mode = loaded is not None and protection_is_off(posture=loaded.protection_posture, mode=loaded.mode)
         except (OSError, RuntimeError, TypeError, ValueError):
             observe_mode = False
         if observe_mode and not native_authoritative:
             if harness in {"pi", "omp"}:
-                return {
-                    "decision": "allow",
-                    "reason_code": reason_code,
-                    "observed_review_failure": True,
-                }
+                return {"decision": "allow", "reason_code": reason_code, "observed_review_failure": True}
             if event == "PermissionRequest":
                 return {
                     "reason_code": reason_code,
-                    "hookSpecificOutput": {
-                        "hookEventName": event,
-                        "decision": {
-                            "behavior": "allow",
-                        },
-                    },
+                    "hookSpecificOutput": {"hookEventName": event, "decision": {"behavior": "allow"}},
                 }
             if event == "PreToolUse":
                 return {
                     "reason_code": reason_code,
-                    "hookSpecificOutput": {
-                        "hookEventName": event,
-                        "permissionDecision": "allow",
-                    },
+                    "hookSpecificOutput": {"hookEventName": event, "permissionDecision": "allow"},
                 }
-            return {
-                "continue": True,
-                "reason_code": reason_code,
-                "observed_review_failure": True,
-            }
+            return {"continue": True, "reason_code": reason_code, "observed_review_failure": True}
         from .hook_availability_policy import availability_harness_response, lifecycle_event_is_observe_only
 
         if event == "PreToolUse" or lifecycle_event_is_observe_only(event):
@@ -5990,18 +5977,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 "reason_code": reason_code,
                 "hookSpecificOutput": {
                     "hookEventName": event,
-                    "decision": {
-                        "behavior": "deny",
-                        "message": reason,
-                    },
+                    "decision": {"behavior": "deny", "message": reason},
                 },
             }
-        return {
-            "continue": False,
-            "stopReason": reason,
-            "systemMessage": reason,
-            "reason_code": reason_code,
-        }
+        return {"continue": False, "stopReason": reason, "systemMessage": reason, "reason_code": reason_code}
 
     def _validated_fail_safe_hook_paths(
         self,

--- a/tests/test_cursor_watch_hook_script.py
+++ b/tests/test_cursor_watch_hook_script.py
@@ -21,6 +21,7 @@ def _cursor_permission(tmp_path: Path, config_text: str) -> Callable[..., Any]:
     )
     source = cursor_hook_script_source(context)
     assert "load_guard_config" in source
+    assert "workspace=workspace_path" in source
     script_globals: dict[str, object] = {"__name__": "cursor_hook"}
     exec(compile(source, "hol-guard-cursor-hook.py", "exec"), script_globals)
     permission = script_globals["_cursor_permission"]

--- a/tests/test_cursor_watch_hook_script.py
+++ b/tests/test_cursor_watch_hook_script.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
+import io
+import json
+import sys
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+
+import pytest
 
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.cursor_hooks import cursor_hook_script_source
 
 
-def _cursor_permission(tmp_path: Path, config_text: str) -> Callable[..., Any]:
+def _cursor_permission(tmp_path: Path, config_text: str) -> Callable[..., object]:
     guard_home = tmp_path / "guard"
     guard_home.mkdir()
     (guard_home / "config.toml").write_text(config_text, encoding="utf-8")
@@ -22,6 +26,7 @@ def _cursor_permission(tmp_path: Path, config_text: str) -> Callable[..., Any]:
     source = cursor_hook_script_source(context)
     assert "load_guard_config" in source
     assert "workspace=workspace_path" in source
+    assert "_LAST_HOOK_EVENT_NAME" in source
     script_globals: dict[str, object] = {"__name__": "cursor_hook"}
     exec(compile(source, "hol-guard-cursor-hook.py", "exec"), script_globals)
     permission = script_globals["_cursor_permission"]
@@ -54,3 +59,37 @@ def test_generated_cursor_hook_ignores_nested_observe_keys(tmp_path: Path) -> No
         'mode = "observe"\nprotection_posture = "watch"\n',
     )
     assert permission("block", {}) == "deny"
+
+
+def test_generated_cursor_watch_after_shell_exception_prints_empty(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    guard_home = tmp_path / "guard"
+    guard_home.mkdir()
+    (guard_home / "config.toml").write_text(
+        'mode = "observe"\nprotection_posture = "watch"\n',
+        encoding="utf-8",
+    )
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        guard_home=guard_home,
+        workspace_dir=tmp_path,
+    )
+    script_globals: dict[str, object] = {"__name__": "cursor_hook"}
+    exec(compile(cursor_hook_script_source(context), "hol-guard-cursor-hook.py", "exec"), script_globals)
+
+    def _raise_daemon_hook(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("daemon hook unavailable")
+
+    script_globals["_daemon_hook_result"] = _raise_daemon_hook
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(json.dumps({"hook_event_name": "afterShellExecution", "command": "true"})),
+    )
+    main = script_globals["main"]
+    assert callable(main)
+    assert main() == 0
+    assert capsys.readouterr().out.strip() == "{}"

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -1794,24 +1794,6 @@ class TestGuardApprovals:
 
         assert daemon_manager_module.load_guard_daemon_url(guard_home) == "http://127.0.0.1:5530"
 
-    def test_load_guard_daemon_url_rejects_different_runtime_fingerprint(self, tmp_path, monkeypatch):
-        guard_home = tmp_path / "guard-home"
-
-        daemon_manager_module.write_guard_daemon_state(
-            guard_home,
-            5530,
-            "token-123",
-            pid=12345,
-        )
-        monkeypatch.setattr(
-            daemon_manager_module,
-            "_current_guard_daemon_runtime_fingerprint",
-            lambda: "stale-runtime-fingerprint",
-        )
-        monkeypatch.setattr(daemon_manager_module, "_guard_daemon_pid_is_running", lambda _pid: True)
-
-        assert daemon_manager_module.load_guard_daemon_url(guard_home) is None
-
     def test_guard_daemon_server_reuses_existing_auth_token(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")
         token_path = store.guard_home / "daemon-auth-token"

--- a/tests/test_guard_daemon_runtime_repair.py
+++ b/tests/test_guard_daemon_runtime_repair.py
@@ -44,7 +44,6 @@ def test_repair_restarts_authenticated_older_runtime(
     monkeypatch.setattr(runtime_repair, "guard_daemon_retirement_is_complete", lambda _home: True)
     monkeypatch.setattr(runtime_repair, "clear_guard_daemon_state", lambda _home: None)
     monkeypatch.setattr(runtime_repair, "__version__", "3.0.34")
-    monkeypatch.setattr(runtime_repair, "current_guard_daemon_runtime_fingerprint", lambda: "current")
     monkeypatch.setattr(
         runtime_repair,
         "ensure_guard_daemon_after_update",
@@ -82,7 +81,6 @@ def test_repair_retains_authenticated_newer_runtime(
         lambda _home: {"repaired": True, "cleared": []},
     )
     monkeypatch.setattr(runtime_repair, "__version__", "3.0.34")
-    monkeypatch.setattr(runtime_repair, "current_guard_daemon_runtime_fingerprint", lambda: "current")
     monkeypatch.setattr(
         runtime_repair,
         "retire_all_guard_daemons_for_home",
@@ -110,7 +108,7 @@ def test_repair_validates_home_before_retiring_runtime(
         runtime_repair.repair_guard_daemon_runtime(tmp_path / "guard-home", home_dir=missing_home)
 
 
-def test_repair_restarts_equal_version_with_stale_fingerprint(
+def test_repair_retains_equal_version_peer_runtime(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -120,27 +118,25 @@ def test_repair_restarts_equal_version_with_stale_fingerprint(
     monkeypatch.setattr(
         runtime_repair,
         "verified_live_guard_daemon_identity",
-        lambda _home: {"package_version": "3.0.34", "runtime_fingerprint": "stale"},
+        lambda _home: {"package_version": "3.0.34", "runtime_fingerprint": "desktop-sidecar"},
     )
     monkeypatch.setattr(runtime_repair, "__version__", "3.0.34")
-    monkeypatch.setattr(runtime_repair, "current_guard_daemon_runtime_fingerprint", lambda: "current")
     monkeypatch.setattr(
         runtime_repair,
         "repair_approval_center_locator",
         lambda _home: {"repaired": True, "cleared": []},
     )
-    monkeypatch.setattr(runtime_repair, "retire_all_guard_daemons_for_home", lambda _home: [321])
-    monkeypatch.setattr(runtime_repair, "guard_daemon_retirement_is_complete", lambda _home: True)
-    monkeypatch.setattr(runtime_repair, "clear_guard_daemon_state", lambda _home: None)
     monkeypatch.setattr(
         runtime_repair,
-        "ensure_guard_daemon_after_update",
-        lambda _home, *, home_dir: "http://127.0.0.1:5474",
+        "retire_all_guard_daemons_for_home",
+        lambda _home: (_ for _ in ()).throw(AssertionError("same-release peer runtime must remain active")),
     )
 
     result = runtime_repair.repair_guard_daemon_runtime(guard_home, home_dir=home_dir)
 
-    assert result["runtime_status"] == "restarted"
+    assert result["runtime_status"] == "current"
+    assert result["daemon_version"] == "3.0.34"
+    assert result["cli_version"] == "3.0.34"
 
 
 def test_repair_restarts_when_authenticated_state_is_absent(
@@ -152,7 +148,6 @@ def test_repair_restarts_when_authenticated_state_is_absent(
     home_dir.mkdir()
     monkeypatch.setattr(runtime_repair, "verified_live_guard_daemon_identity", lambda _home: None)
     monkeypatch.setattr(runtime_repair, "__version__", "3.0.34")
-    monkeypatch.setattr(runtime_repair, "current_guard_daemon_runtime_fingerprint", lambda: "current")
     monkeypatch.setattr(
         runtime_repair,
         "repair_approval_center_locator",

--- a/tests/test_guard_observe_mode_liveness.py
+++ b/tests/test_guard_observe_mode_liveness.py
@@ -56,34 +56,11 @@ def _review_request(
     return payload
 
 
-@pytest.mark.parametrize(
-    ("endpoint", "expected"),
-    (
-        (
-            "pi",
-            {
-                "decision": "allow",
-                "reason_code": _DEADLINE_REASON,
-                "observed_review_failure": True,
-            },
-        ),
-        (
-            "claude-code",
-            {
-                "reason_code": _DEADLINE_REASON,
-                "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
-                    "permissionDecision": "allow",
-                },
-            },
-        ),
-    ),
-)
+@pytest.mark.parametrize("endpoint", ("pi", "claude-code"))
 def test_observe_mode_does_not_block_failed_local_review(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     endpoint: str,
-    expected: dict[str, object],
 ) -> None:
     guard_home = tmp_path / "guard-home"
     workspace = tmp_path / "workspace"
@@ -108,7 +85,13 @@ def test_observe_mode_does_not_block_failed_local_review(
     finally:
         daemon.stop()
 
-    assert payload == expected
+    if endpoint == "pi":
+        assert payload["decision"] == "allow"
+        return
+    hook_output = payload["hookSpecificOutput"]
+    assert isinstance(hook_output, dict)
+    assert hook_output["hookEventName"] == "PreToolUse"
+    assert hook_output["permissionDecision"] == "allow"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_hook_worker_observe_pretool.py
+++ b/tests/test_hook_worker_observe_pretool.py
@@ -1,4 +1,4 @@
-"""Watch/observe preserves native authority and fail-safe behavior."""
+"""Watch/observe records native decisions without stopping the harness."""
 
 from __future__ import annotations
 
@@ -70,7 +70,7 @@ def _write_watch_config(guard_home: Path) -> None:
     )
 
 
-def test_hook_worker_watch_native_block_stays_native_and_denies(
+def test_hook_worker_watch_native_block_records_without_stopping(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -110,10 +110,11 @@ def test_hook_worker_watch_native_block_stays_native_and_denies(
     assert captured["observe_mode"] is True
     hook_output = result["hookSpecificOutput"]
     assert isinstance(hook_output, dict)
-    assert hook_output["permissionDecision"] == "deny"
+    assert hook_output["permissionDecision"] == "allow"
+    assert result["policy_action"] == "warn"
 
 
-def test_hook_worker_watch_native_unavailable_fails_closed_without_cli_escape(
+def test_hook_worker_watch_native_unavailable_continues_without_cli_escape(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -145,11 +146,73 @@ def test_hook_worker_watch_native_unavailable_fails_closed_without_cli_escape(
         guard_home=guard_home,
         workspace=tmp_path / "workspace",
     )
-    assert result["reason_code"] == "native_degraded_emergency_safe"
+    assert result["reason_code"] == "native_pre_tool_unavailable"
     assert result["policy_action"] == "warn"
     hook_output = result["hookSpecificOutput"]
     assert isinstance(hook_output, dict)
     assert hook_output["permissionDecision"] == "allow"
+
+
+def test_hook_worker_watch_native_unavailable_allows_network(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    _write_watch_config(guard_home)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.hook_worker.native_mode",
+        lambda: "auto",
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.hook_worker.review_raw_hook_native",
+        lambda *_args, **_kwargs: None,
+    )
+    worker = HookWorker(store=GuardStore(guard_home))
+    result = worker.review_http_payload(
+        payload={"hook_event_name": "PreToolUse", "tool_input": {"command": "curl https://example.test"}},
+        params={},
+        default_harness="grok",
+        home_dir=tmp_path / "home",
+        guard_home=guard_home,
+        workspace=tmp_path / "workspace",
+    )
+    assert result["decision"] == "allow"
+    assert result["policy_action"] == "warn"
+    assert result["reason_code"] == "native_pre_tool_unavailable"
+
+
+def test_hook_worker_enforce_native_unavailable_still_pauses_network(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir(parents=True, exist_ok=True)
+    (guard_home / "config.toml").write_text(
+        'mode = "enforce"\nprotection_posture = "protected"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.hook_worker.native_mode",
+        lambda: "auto",
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.hook_worker.review_raw_hook_native",
+        lambda *_args, **_kwargs: None,
+    )
+    worker = HookWorker(store=GuardStore(guard_home))
+    result = worker.review_http_payload(
+        payload={"hook_event_name": "PreToolUse", "tool_input": {"command": "curl https://example.test"}},
+        params={},
+        default_harness="grok",
+        home_dir=tmp_path / "home",
+        guard_home=guard_home,
+        workspace=tmp_path / "workspace",
+    )
+    assert result["policy_action"] == "block"
+    assert result["reason_code"] == "native_pre_tool_unavailable"
+    hook_output = result["hookSpecificOutput"]
+    assert isinstance(hook_output, dict)
+    assert hook_output["permissionDecision"] == "deny"
 
 
 def test_hook_worker_watch_native_allow_still_allows(
@@ -185,7 +248,7 @@ def test_hook_worker_watch_native_allow_still_allows(
     assert hook_output["permissionDecision"] == "allow"
 
 
-def test_hook_worker_watch_posttool_native_unavailable_fails_closed(
+def test_hook_worker_watch_posttool_native_unavailable_continues(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -196,7 +259,7 @@ def test_hook_worker_watch_posttool_native_unavailable_fails_closed(
         lambda: "auto",
     )
     monkeypatch.setattr(
-        "codex_plugin_scanner.guard.daemon.hook_worker.review_post_tool_native",
+        "codex_plugin_scanner.guard.daemon.hook_worker.review_raw_hook_native",
         lambda *_args, **_kwargs: None,
     )
     worker = HookWorker(store=GuardStore(guard_home))
@@ -212,5 +275,6 @@ def test_hook_worker_watch_posttool_native_unavailable_fails_closed(
         guard_home=guard_home,
         workspace=tmp_path / "workspace",
     )
-    assert result["policy_action"] == "block"
+    assert result["policy_action"] == "allow"
     assert result["reason_code"] == "native_post_tool_unavailable"
+    assert result.get("continue") is True

--- a/tests/test_watch_continue_same_release_daemon.py
+++ b/tests/test_watch_continue_same_release_daemon.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -12,6 +13,8 @@ from codex_plugin_scanner.guard.daemon.hook_availability_policy import (
     availability_harness_response,
     cursor_fallback_permission,
 )
+from codex_plugin_scanner.guard.daemon.hook_worker import HookWorker
+from codex_plugin_scanner.guard.store import GuardStore
 from codex_plugin_scanner.version import __version__
 
 
@@ -146,3 +149,38 @@ def test_cursor_fallback_watch_allows_shell() -> None:
     )
     assert code == 0
     assert allow["permission"] == "allow"
+
+
+def test_watch_unavailable_pretool_records_command_activity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    (guard_home / "config.toml").write_text(
+        'mode = "observe"\nprotection_posture = "watch"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.hook_worker.native_mode",
+        lambda: "auto",
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.hook_worker.review_raw_hook_native",
+        lambda *_args, **_kwargs: None,
+    )
+    writer = MagicMock()
+    worker = HookWorker(store=GuardStore(guard_home), activity_writer=writer)
+    result = worker.review_http_payload(
+        payload={"hook_event_name": "PreToolUse", "tool_input": {"command": "git status"}},
+        params={},
+        default_harness="grok",
+        home_dir=tmp_path / "home",
+        guard_home=guard_home,
+        workspace=tmp_path / "workspace",
+    )
+    assert result["decision"] == "allow"
+    writer.submit_command_activity.assert_called_once()
+    recorded = writer.submit_command_activity.call_args.kwargs
+    assert recorded["event"] == "PreToolUse"
+    assert recorded["succeeded"] is True

--- a/tests/test_watch_continue_same_release_daemon.py
+++ b/tests/test_watch_continue_same_release_daemon.py
@@ -1,0 +1,148 @@
+"""Watch continues tools; same-release daemons stay current across install paths."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.daemon import manager as daemon_manager_module
+from codex_plugin_scanner.guard.daemon.hook_availability_policy import (
+    availability_harness_response,
+    cursor_fallback_permission,
+)
+from codex_plugin_scanner.version import __version__
+
+
+class _HealthzResponse:
+    status = 200
+
+    def __enter__(self) -> _HealthzResponse:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(
+            {
+                "ok": True,
+                "tables": ["guard_connect_states"],
+                "compatibility_version": daemon_manager_module.GUARD_DAEMON_COMPATIBILITY_VERSION,
+            }
+        ).encode("utf-8")
+
+
+def test_guard_daemon_state_matches_same_release_peer_fingerprint() -> None:
+    payload = {
+        "compatibility_version": daemon_manager_module.GUARD_DAEMON_COMPATIBILITY_VERSION,
+        "package_version": __version__,
+        "source_root": "/desktop/core/sidecar",
+        "runtime_fingerprint": "desktop-sidecar-fingerprint",
+    }
+
+    assert daemon_manager_module._guard_daemon_state_matches_current_runtime(payload)
+
+
+def test_guard_daemon_state_rejects_different_package_version_peer() -> None:
+    payload = {
+        "compatibility_version": daemon_manager_module.GUARD_DAEMON_COMPATIBILITY_VERSION,
+        "package_version": "0.0.1",
+        "source_root": "/desktop/core/sidecar",
+        "runtime_fingerprint": "desktop-sidecar-fingerprint",
+    }
+
+    assert not daemon_manager_module._guard_daemon_state_matches_current_runtime(payload)
+
+
+def test_load_guard_daemon_url_rejects_older_package_version(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    daemon_manager_module.write_guard_daemon_state(
+        guard_home,
+        5530,
+        "token-123",
+        pid=12345,
+    )
+    monkeypatch.setattr(daemon_manager_module, "__version__", "9.9.9")
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "_current_guard_daemon_runtime_fingerprint",
+        lambda: "pipx-runtime-fingerprint",
+    )
+    monkeypatch.setattr(daemon_manager_module, "_guard_daemon_pid_is_running", lambda _pid: True)
+
+    assert daemon_manager_module.load_guard_daemon_url(guard_home) is None
+
+
+def test_load_guard_daemon_url_accepts_same_release_peer_fingerprint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    daemon_manager_module.write_guard_daemon_state(
+        guard_home,
+        5530,
+        "token-123",
+        pid=12345,
+    )
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "_current_guard_daemon_runtime_fingerprint",
+        lambda: "pipx-runtime-fingerprint",
+    )
+    monkeypatch.setattr(daemon_manager_module, "_guard_daemon_pid_is_running", lambda _pid: True)
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "_guard_daemon_pid_matches_command",
+        lambda _pid, expected_guard_home=None: True,
+    )
+    monkeypatch.setattr(
+        daemon_manager_module.urllib.request,
+        "urlopen",
+        lambda request, timeout=1: _HealthzResponse(),
+    )
+
+    assert daemon_manager_module.load_guard_daemon_url(guard_home) == "http://127.0.0.1:5530"
+
+
+def test_availability_watch_config_allows_git_and_network(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    (guard_home / "config.toml").write_text(
+        'mode = "observe"\nprotection_posture = "watch"\n',
+        encoding="utf-8",
+    )
+    git_cmd = availability_harness_response(
+        {"hook_event_name": "PreToolUse", "tool_input": {"command": "git status"}},
+        harness="grok",
+        event_name="PreToolUse",
+        reason_code="native_pre_tool_unavailable",
+        reason="native unavailable",
+        guard_home=guard_home,
+        workspace=tmp_path,
+        home_dir=tmp_path / "home",
+    )
+    assert git_cmd["decision"] == "allow"
+    gh_cmd = availability_harness_response(
+        {"hook_event_name": "PreToolUse", "tool_input": {"command": "gh pr view 1"}},
+        harness="grok",
+        event_name="PreToolUse",
+        reason_code="native_pre_tool_unavailable",
+        reason="native unavailable",
+        guard_home=guard_home,
+    )
+    assert gh_cmd["decision"] == "allow"
+
+
+def test_cursor_fallback_watch_allows_shell() -> None:
+    allow, code = cursor_fallback_permission(
+        {"hook_event_name": "beforeShellExecution", "command": "rm -rf /"},
+        hook_event_name="beforeShellExecution",
+        recording_only=True,
+    )
+    assert code == 0
+    assert allow["permission"] == "allow"

--- a/tests/test_watch_continue_same_release_daemon.py
+++ b/tests/test_watch_continue_same_release_daemon.py
@@ -196,3 +196,30 @@ def test_watch_unavailable_pretool_records_command_activity(
     recorded = writer.submit_command_activity.call_args.kwargs
     assert recorded["event"] == "PreToolUse"
     assert recorded["succeeded"] is True
+
+
+def test_watch_http_pretool_unavailable_records_command_activity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    (guard_home / "config.toml").write_text(
+        'mode = "observe"\nprotection_posture = "watch"\n',
+        encoding="utf-8",
+    )
+    writer = MagicMock()
+    worker = HookWorker(store=GuardStore(guard_home), activity_writer=writer)
+    monkeypatch.setattr(worker, "_review_pre_tool_native", lambda *_args, **_kwargs: None)
+    result = worker._review_pre_tool_http(
+        {"hook_event_name": "PreToolUse", "tool_input": {"command": "git status"}},
+        harness="grok",
+        home_dir=tmp_path / "home",
+        guard_home=guard_home,
+        workspace=tmp_path / "workspace",
+    )
+    assert result["decision"] == "allow"
+    writer.submit_command_activity.assert_called_once()
+    recorded = writer.submit_command_activity.call_args.kwargs
+    assert recorded["event"] == "PreToolUse"
+    assert recorded["succeeded"] is True

--- a/tests/test_watch_continue_same_release_daemon.py
+++ b/tests/test_watch_continue_same_release_daemon.py
@@ -59,6 +59,18 @@ def test_guard_daemon_state_rejects_different_package_version_peer() -> None:
     assert not daemon_manager_module._guard_daemon_state_matches_current_runtime(payload)
 
 
+def test_healthz_details_require_compatible_same_release_peer() -> None:
+    compatible = {
+        "compatibility_version": daemon_manager_module.GUARD_DAEMON_COMPATIBILITY_VERSION,
+        "package_version": __version__,
+        "runtime_fingerprint": "desktop-sidecar-fingerprint",
+    }
+    incompatible = dict(compatible)
+    incompatible["compatibility_version"] = "not-current"
+    assert daemon_manager_module._daemon_healthz_details_match_current_runtime(compatible)
+    assert not daemon_manager_module._daemon_healthz_details_match_current_runtime(incompatible)
+
+
 def test_load_guard_daemon_url_rejects_older_package_version(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Watch and observe record native and unavailable-hook decisions without stopping PreToolUse or withholding PostToolUse.
- Protected and Extra careful still pause high-impact tools on the emergency floor when native review cannot complete.
- CLI and daemon repair treat a live same-version daemon from another install path as current instead of stale.

## Testing
- `uv run pytest tests/test_watch_continue_same_release_daemon.py tests/test_hook_worker_observe_pretool.py tests/test_hook_availability_policy.py tests/test_guard_daemon_runtime_repair.py tests/test_guard_observe_mode_liveness.py tests/test_grok_watch_hooks.py -q`
- `uv run python scripts/ci/code_quality_audit.py --root . --baseline ci/code-quality-baseline.json`
- `uv run python scripts/ci/rust_authority_ownership_gate.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added recording-only (Watch) behavior, allowing supported actions to continue while activity is recorded and warnings are displayed when review is unavailable.
  - Cursor fallback handling now permits actions in recording-only mode.
  - Workspace-level Watch settings are respected in hook and fail-safe responses.

- **Bug Fixes**
  - Same-release daemon runtimes can remain active despite differing runtime fingerprints.
  - Improved fail-safe behavior for pre-action and lifecycle events.
  - Daemon health checks now enforce compatibility-version validation.

- **Tests**
  - Added coverage for Watch mode, unavailable reviews, Cursor fallbacks, and daemon compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->