### PR TITLE
fix(guard): continue Watch Grok hooks after Core moves

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
@@ -7,9 +7,6 @@ to an isolated subprocess (~1s) when the daemon is unreachable.
 from __future__ import annotations
 
 import json
-import os
-import stat
-import subprocess
 import sys
 import urllib.error
 import urllib.request
@@ -25,6 +22,12 @@ from ..codex_hook_launch_runtime import (
 )
 from ..daemon.hook_availability_policy import EMERGENCY_SAFE_REASON, hook_action_is_emergency_safe
 from ..private_file_io import read_private_regular_text
+from .desktop_hook_proxy import (
+    _DESKTOP_PROXY_LAUNCH_SCRIPT as _DESKTOP_PROXY_LAUNCH_SCRIPT,
+)
+from .desktop_hook_proxy import (
+    _trusted_desktop_hook_proxy_command,
+)
 
 _MAX_HOOK_INPUT_BYTES = 1_000_000
 _MAX_HOOK_RESPONSE_BYTES = 1_000_000
@@ -33,164 +36,6 @@ _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 _DAEMON_TIMEOUT_BUDGET_SECONDS = 5.0
 _FROZEN_BRIDGE_COMMAND = "__guard-bounded-hook"
 _FROZEN_OPTIONAL_PATH_FLAGS = frozenset({"--home", "--workspace"})
-_DESKTOP_PROXY_ENV = "HOL_GUARD_DESKTOP_HOOK_PROXY"
-
-
-def _codesign_team(path: Path) -> str | None:
-    """Return a verified Apple TeamIdentifier without importing the Desktop runtime."""
-
-    verify = subprocess.run(
-        ["/usr/bin/codesign", "--verify", "--strict", "--verbose=2", str(path)],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if verify.returncode != 0:
-        return None
-    display = subprocess.run(
-        ["/usr/bin/codesign", "--display", "--verbose=4", str(path)],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if display.returncode != 0:
-        return None
-    for line in display.stderr.splitlines():
-        team = line.strip().removeprefix("TeamIdentifier=")
-        if team != line.strip() and team and team != "not set":
-            return team
-    return None
-
-
-_DESKTOP_PROXY_LAUNCH_SCRIPT = r"""
-set -u
-proxy=$1
-expected_team=$2
-bundle=$3
-config=$4
-fallback=$5
-fallback_bridge() {
-  exec "$fallback" __guard-bounded-hook "$config"
-}
-verify_team() {
-  candidate=$1
-  /usr/bin/codesign --verify --strict --verbose=2 "$candidate" >/dev/null 2>&1 || return 1
-  actual_team=$(
-    /usr/bin/codesign --display --verbose=4 "$candidate" 2>&1 \
-      | /usr/bin/sed -n 's/^TeamIdentifier=//p' \
-      | /usr/bin/head -n 1
-  ) || return 1
-  [ -n "$actual_team" ] || return 1
-  [ "$actual_team" != "not set" ] || return 1
-  [ "$actual_team" = "$expected_team" ]
-}
-[ -x "$proxy" ] && [ ! -L "$proxy" ] || fallback_bridge
-[ -x "$fallback" ] && [ ! -L "$fallback" ] || fallback_bridge
-[ -d "$bundle" ] && [ ! -L "$bundle" ] || fallback_bridge
-proxy_before=$(/usr/bin/stat -f '%d:%i:%u:%p' "$proxy" 2>/dev/null) || fallback_bridge
-fallback_before=$(/usr/bin/stat -f '%d:%i:%u:%p' "$fallback" 2>/dev/null) || fallback_bridge
-verify_team "$bundle" || fallback_bridge
-verify_team "$proxy" || fallback_bridge
-verify_team "$fallback" || fallback_bridge
-proxy_after=$(/usr/bin/stat -f '%d:%i:%u:%p' "$proxy" 2>/dev/null) || fallback_bridge
-fallback_after=$(/usr/bin/stat -f '%d:%i:%u:%p' "$fallback" 2>/dev/null) || fallback_bridge
-[ "$proxy_before" = "$proxy_after" ] || fallback_bridge
-[ "$fallback_before" = "$fallback_after" ] || fallback_bridge
-"$proxy" __guard-hook-proxy "$config"
-status=$?
-if [ "$status" -eq 125 ] || [ "$status" -eq 126 ] || [ "$status" -eq 127 ]; then
-  fallback_bridge
-fi
-exit "$status"
-""".strip()
-
-
-def _bundle_for_executable(path: Path) -> Path | None:
-    for ancestor in path.parents:
-        if ancestor.suffix == ".app":
-            return ancestor
-    return None
-
-
-def _trusted_desktop_path(path: Path) -> bool:
-    """Require a regular private executable under a non-symlinked app bundle."""
-
-    try:
-        raw_metadata = path.lstat()
-        resolved = path.resolve(strict=True)
-        metadata = resolved.stat()
-    except OSError:
-        return False
-    if stat.S_ISLNK(raw_metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
-        return False
-    if not os.access(resolved, os.X_OK):
-        return False
-    if metadata.st_uid not in {os.getuid(), 0} or stat.S_IMODE(metadata.st_mode) & 0o022:
-        return False
-    bundle = _bundle_for_executable(resolved)
-    if bundle is None:
-        return False
-    for directory in (bundle, bundle / "Contents", bundle / "Contents" / "MacOS"):
-        try:
-            raw = directory.lstat()
-            current = directory.stat()
-        except OSError:
-            return False
-        if stat.S_ISLNK(raw.st_mode) or not stat.S_ISDIR(current.st_mode):
-            return False
-        if current.st_uid not in {os.getuid(), 0} or stat.S_IMODE(current.st_mode) & 0o022:
-            return False
-    return True
-
-
-def _trusted_desktop_hook_proxy_command(
-    python_executable: str,
-    config_json: str,
-) -> tuple[str, ...] | None:
-    """Return a runtime-verified signed macOS proxy command or retain Core."""
-
-    if (
-        sys.platform != "darwin"
-        or not bool(getattr(sys, "frozen", False))
-        or os.environ.get("HOL_GUARD_DESKTOP") != "1"
-    ):
-        return None
-    raw = os.environ.get(_DESKTOP_PROXY_ENV)
-    if not raw:
-        return None
-    candidate = Path(raw)
-    core_candidate = Path(python_executable)
-    if not candidate.is_absolute() or not core_candidate.is_absolute():
-        return None
-    if not _trusted_desktop_path(candidate) or not _trusted_desktop_path(core_candidate):
-        return None
-    try:
-        proxy = candidate.resolve(strict=True)
-        core = core_candidate.resolve(strict=True)
-    except OSError:
-        return None
-    proxy_bundle = _bundle_for_executable(proxy)
-    core_bundle = _bundle_for_executable(core)
-    if proxy_bundle is None or proxy_bundle != core_bundle or proxy.parent != core.parent:
-        return None
-
-    proxy_team = _codesign_team(proxy)
-    core_team = _codesign_team(core)
-    bundle_team = _codesign_team(proxy_bundle)
-    if proxy_team is None or proxy_team == "not set" or proxy_team != core_team or proxy_team != bundle_team:
-        return None
-
-    return (
-        "/bin/sh",
-        "-c",
-        _DESKTOP_PROXY_LAUNCH_SCRIPT,
-        "hol-guard-desktop-proxy",
-        str(proxy),
-        proxy_team,
-        str(proxy_bundle),
-        config_json,
-        str(core),
-    )
 
 
 def _assert_loopback_http_url(url: str) -> None:
@@ -372,10 +217,10 @@ def _cli_args_with_json(cli_args: Sequence[str]) -> list[str]:
 
 def _guard_home_is_recording_only(guard_home: Path) -> bool:
     try:
-        from ..config import load_guard_config
+        from ..config import maybe_auto_revert_watch
         from ..protection_posture import protection_is_off
 
-        config = load_guard_config(guard_home)
+        config = maybe_auto_revert_watch(guard_home)
     except (OSError, RuntimeError, ValueError):
         return False
     return protection_is_off(posture=config.protection_posture, mode=config.mode)

--- a/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
@@ -629,10 +629,13 @@ def main_from_argv(argv: Sequence[str]) -> int:
     harness = configured_harness if isinstance(configured_harness, str) else "unknown"
     input_text = _bounded_stdin()
     if input_text is None:
+        guard_home_value = config.get("guard_home") if config is not None else None
+        guard_home = Path(guard_home_value) if isinstance(guard_home_value, str) else None
         return _emit_failure(
             harness=harness,
             input_text="{}",
             reason="HOL Guard blocked this action because hook input exceeded the safe size limit.",
+            guard_home=guard_home,
         )
     if config is None:
         return _emit_failure(harness=harness, input_text=input_text)

--- a/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
@@ -296,8 +296,7 @@ def _validated_frozen_cli_args(
     if tuple(cli_args[4:6]) != ("--harness", harness):
         return None
     tail = cli_args[6:]
-    json_output = bool(tail and tail[-1] == "--json")
-    if json_output:
+    if tail and tail[-1] == "--json":
         tail = tail[:-1]
     if len(tail) % 2 != 0:
         return None
@@ -309,17 +308,15 @@ def _validated_frozen_cli_args(
         if not Path(value).is_absolute():
             return None
         seen_flags.add(flag)
-    command: tuple[str, ...] = (
+    return (
         "hook",
         "--guard-home",
         str(expected_guard_home),
         "--harness",
         harness,
         *tail,
+        "--json",
     )
-    if json_output:
-        command = (*command, "--json")
-    return command
 
 
 def _json_object(text: str) -> dict[str, object] | None:
@@ -357,11 +354,44 @@ def _event_name(input_text: str) -> str:
 
 
 def _has_json_object_line(output: str) -> bool:
+    stripped = output.strip()
+    if stripped and _json_object(stripped) is not None:
+        return True
     for line in reversed(output.splitlines()):
         if not line.strip():
             continue
         return _json_object(line.strip()) is not None
     return False
+
+
+def _cli_args_with_json(cli_args: Sequence[str]) -> list[str]:
+    if cli_args and cli_args[-1] == "--json":
+        return list(cli_args)
+    return [*cli_args, "--json"]
+
+
+def _guard_home_is_recording_only(guard_home: Path) -> bool:
+    try:
+        from ..config import load_guard_config
+        from ..protection_posture import protection_is_off
+
+        config = load_guard_config(guard_home)
+    except (OSError, RuntimeError, ValueError):
+        return False
+    return protection_is_off(posture=config.protection_posture, mode=config.mode)
+
+
+def _watch_continue_payload(harness: str, event_name: str) -> dict[str, object]:
+    if harness == "copilot":
+        return {"permissionDecision": "allow"}
+    if harness in {"grok", "hermes", "openclaw"}:
+        return {"decision": "allow"}
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": event_name,
+            "permissionDecision": "allow",
+        }
+    }
 
 
 def _failure_payload(
@@ -370,7 +400,10 @@ def _failure_payload(
     event_name: str,
     reason: str,
     input_text: str = "",
+    guard_home: Path | None = None,
 ) -> tuple[dict[str, object], int]:
+    if event_name == "PreToolUse" and guard_home is not None and _guard_home_is_recording_only(guard_home):
+        return _watch_continue_payload(harness, event_name), 0
     payload = _json_object(input_text or "{}")
     if event_name == "PreToolUse" and isinstance(payload, dict) and hook_action_is_emergency_safe(payload):
         if harness == "copilot":
@@ -424,12 +457,19 @@ def _failure_payload(
     }, 0
 
 
-def _emit_failure(*, harness: str, input_text: str, reason: str = _FAILURE_REASON) -> int:
+def _emit_failure(
+    *,
+    harness: str,
+    input_text: str,
+    reason: str = _FAILURE_REASON,
+    guard_home: Path | None = None,
+) -> int:
     payload, returncode = _failure_payload(
         harness=harness,
         event_name=_event_name(input_text),
         reason=reason,
         input_text=input_text,
+        guard_home=guard_home,
     )
     _ = sys.stdout.write(json.dumps(payload, ensure_ascii=True, separators=(",", ":")) + "\n")
     return returncode
@@ -685,15 +725,15 @@ def run_bounded_cli_hook(config: Mapping[str, object], *, input_text: str) -> in
             harness=harness,
         )
         if direct_cli_args is None:
-            return _emit_failure(harness=harness, input_text=input_text)
+            return _emit_failure(harness=harness, input_text=input_text, guard_home=guard_home)
         command = (sys.executable, *direct_cli_args)
     elif frozen_launcher:
-        return _emit_failure(harness=harness, input_text=input_text)
+        return _emit_failure(harness=harness, input_text=input_text, guard_home=guard_home)
     else:
         command = isolated_guard_cli_command(
             python_executable,
             package_root,
-            cli_args,
+            _cli_args_with_json(cli_args),
         )
     daemon_result = _try_daemon_hook(
         guard_home=guard_home,
@@ -716,18 +756,22 @@ def run_bounded_cli_hook(config: Mapping[str, object], *, input_text: str) -> in
         timeout_seconds=float(timeout_seconds),
     )
     if result.timed_out:
-        return _emit_failure(harness=harness, input_text=input_text)
+        return _emit_failure(harness=harness, input_text=input_text, guard_home=guard_home)
     if result.output_limit_exceeded:
         return _emit_failure(
             harness=harness,
             input_text=input_text,
             reason="HOL Guard blocked this action because hook output exceeded the safe size limit.",
+            guard_home=guard_home,
         )
     if result.returncode is None:
-        return _emit_failure(harness=harness, input_text=input_text)
-    if not _has_json_object_line(result.stdout):
-        return _emit_failure(harness=harness, input_text=input_text)
-    if result.stdout:
+        return _emit_failure(harness=harness, input_text=input_text, guard_home=guard_home)
+    compact_payload = _json_object(result.stdout.strip())
+    if compact_payload is None and not _has_json_object_line(result.stdout):
+        return _emit_failure(harness=harness, input_text=input_text, guard_home=guard_home)
+    if compact_payload is not None:
+        _ = sys.stdout.write(json.dumps(compact_payload, ensure_ascii=True, separators=(",", ":")) + "\n")
+    elif result.stdout:
         _ = sys.stdout.write(result.stdout)
     return result.returncode
 

--- a/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
@@ -113,11 +113,29 @@ def bounded_cli_hook_command(
     )
 
 
-def _bounded_stdin() -> str | None:
+_EVENT_ALIASES = {
+    "permissionrequest": "PermissionRequest",
+    "pretooluse": "PreToolUse",
+    "userpromptsubmit": "UserPromptSubmit",
+    "posttooluse": "PostToolUse",
+    "sessionstart": "SessionStart",
+    "notification": "Notification",
+    "stop": "Stop",
+}
+_EVENT_NAME_KEYS = ("hook_event_name", "hookEventName", "event", "eventName", "hook_name", "hookName")
+
+
+def _read_bounded_stdin() -> tuple[str | None, str]:
     raw = sys.stdin.buffer.read(_MAX_HOOK_INPUT_BYTES + 1)
+    prefix = raw[:_MAX_HOOK_INPUT_BYTES].decode("utf-8", errors="replace")
     if len(raw) > _MAX_HOOK_INPUT_BYTES:
-        return None
-    return raw.decode("utf-8", errors="replace")
+        return None, prefix
+    return prefix, prefix
+
+
+def _bounded_stdin() -> str | None:
+    text, _prefix = _read_bounded_stdin()
+    return text
 
 
 def _validated_frozen_cli_args(
@@ -178,23 +196,33 @@ def _json_object(text: str) -> dict[str, object] | None:
     return payload
 
 
+def _canonical_event_token(value: str) -> str | None:
+    stripped = value.strip()
+    if not stripped:
+        return None
+    normalized = stripped.replace("_", "").replace("-", "").lower()
+    return _EVENT_ALIASES.get(normalized, stripped)
+
+
 def _event_name(input_text: str) -> str:
     payload = _json_object(input_text or "{}")
-    if payload is None:
-        return "PreToolUse"
-    for key in ("hook_event_name", "hookEventName", "event", "eventName", "hook_name", "hookName"):
-        value = payload.get(key)
-        if isinstance(value, str) and value.strip():
-            normalized = value.replace("_", "").replace("-", "").lower()
-            return {
-                "permissionrequest": "PermissionRequest",
-                "pretooluse": "PreToolUse",
-                "userpromptsubmit": "UserPromptSubmit",
-                "posttooluse": "PostToolUse",
-                "sessionstart": "SessionStart",
-                "notification": "Notification",
-                "stop": "Stop",
-            }.get(normalized, value.strip())
+    if payload is not None:
+        for key in _EVENT_NAME_KEYS:
+            value = payload.get(key)
+            if isinstance(value, str):
+                named = _canonical_event_token(value)
+                if named is not None:
+                    return named
+    for key in _EVENT_NAME_KEYS:
+        token = f'"{key}"'
+        start = input_text.find(token)
+        colon = input_text.find(":", start + len(token)) if start >= 0 else -1
+        quote = input_text.find('"', colon + 1) if colon >= 0 else -1
+        end = input_text.find('"', quote + 1) if quote >= 0 else -1
+        if 0 <= quote < end:
+            named = _canonical_event_token(input_text[quote + 1 : end])
+            if named is not None:
+                return named
     return "PreToolUse"
 
 
@@ -247,7 +275,7 @@ def _failure_payload(
     input_text: str = "",
     guard_home: Path | None = None,
 ) -> tuple[dict[str, object], int]:
-    if event_name == "PreToolUse" and guard_home is not None and _guard_home_is_recording_only(guard_home):
+    if guard_home is not None and _guard_home_is_recording_only(guard_home):
         return _watch_continue_payload(harness, event_name), 0
     payload = _json_object(input_text or "{}")
     if event_name == "PreToolUse" and isinstance(payload, dict) and hook_action_is_emergency_safe(payload):
@@ -627,13 +655,13 @@ def main_from_argv(argv: Sequence[str]) -> int:
     config = _json_object(argv[0]) if len(argv) == 1 else None
     configured_harness = config.get("harness") if config is not None else None
     harness = configured_harness if isinstance(configured_harness, str) else "unknown"
-    input_text = _bounded_stdin()
+    input_text, stdin_prefix = _read_bounded_stdin()
     if input_text is None:
         guard_home_value = config.get("guard_home") if config is not None else None
         guard_home = Path(guard_home_value) if isinstance(guard_home_value, str) else None
         return _emit_failure(
             harness=harness,
-            input_text="{}",
+            input_text=stdin_prefix or "{}",
             reason="HOL Guard blocked this action because hook input exceeded the safe size limit.",
             guard_home=guard_home,
         )

--- a/src/codex_plugin_scanner/guard/adapters/desktop_hook_proxy.py
+++ b/src/codex_plugin_scanner/guard/adapters/desktop_hook_proxy.py
@@ -1,0 +1,168 @@
+"""Signed macOS Desktop proxy launcher for frozen bounded hooks."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+_DESKTOP_PROXY_ENV = "HOL_GUARD_DESKTOP_HOOK_PROXY"
+
+
+def _codesign_team(path: Path) -> str | None:
+    """Return a verified Apple TeamIdentifier without importing the Desktop runtime."""
+
+    verify = subprocess.run(
+        ["/usr/bin/codesign", "--verify", "--strict", "--verbose=2", str(path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if verify.returncode != 0:
+        return None
+    display = subprocess.run(
+        ["/usr/bin/codesign", "--display", "--verbose=4", str(path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if display.returncode != 0:
+        return None
+    for line in display.stderr.splitlines():
+        team = line.strip().removeprefix("TeamIdentifier=")
+        if team != line.strip() and team and team != "not set":
+            return team
+    return None
+
+
+_DESKTOP_PROXY_LAUNCH_SCRIPT = r"""
+set -u
+proxy=$1
+expected_team=$2
+bundle=$3
+config=$4
+fallback=$5
+fallback_bridge() {
+  exec "$fallback" __guard-bounded-hook "$config"
+}
+verify_team() {
+  candidate=$1
+  /usr/bin/codesign --verify --strict --verbose=2 "$candidate" >/dev/null 2>&1 || return 1
+  actual_team=$(
+    /usr/bin/codesign --display --verbose=4 "$candidate" 2>&1 \
+      | /usr/bin/sed -n 's/^TeamIdentifier=//p' \
+      | /usr/bin/head -n 1
+  ) || return 1
+  [ -n "$actual_team" ] || return 1
+  [ "$actual_team" != "not set" ] || return 1
+  [ "$actual_team" = "$expected_team" ]
+}
+[ -x "$proxy" ] && [ ! -L "$proxy" ] || fallback_bridge
+[ -x "$fallback" ] && [ ! -L "$fallback" ] || fallback_bridge
+[ -d "$bundle" ] && [ ! -L "$bundle" ] || fallback_bridge
+proxy_before=$(/usr/bin/stat -f '%d:%i:%u:%p' "$proxy" 2>/dev/null) || fallback_bridge
+fallback_before=$(/usr/bin/stat -f '%d:%i:%u:%p' "$fallback" 2>/dev/null) || fallback_bridge
+verify_team "$bundle" || fallback_bridge
+verify_team "$proxy" || fallback_bridge
+verify_team "$fallback" || fallback_bridge
+proxy_after=$(/usr/bin/stat -f '%d:%i:%u:%p' "$proxy" 2>/dev/null) || fallback_bridge
+fallback_after=$(/usr/bin/stat -f '%d:%i:%u:%p' "$fallback" 2>/dev/null) || fallback_bridge
+[ "$proxy_before" = "$proxy_after" ] || fallback_bridge
+[ "$fallback_before" = "$fallback_after" ] || fallback_bridge
+"$proxy" __guard-hook-proxy "$config"
+status=$?
+if [ "$status" -eq 125 ] || [ "$status" -eq 126 ] || [ "$status" -eq 127 ]; then
+  fallback_bridge
+fi
+exit "$status"
+""".strip()
+
+
+def _bundle_for_executable(path: Path) -> Path | None:
+    for ancestor in path.parents:
+        if ancestor.suffix == ".app":
+            return ancestor
+    return None
+
+
+def _trusted_desktop_path(path: Path) -> bool:
+    """Require a regular private executable under a non-symlinked app bundle."""
+
+    try:
+        raw_metadata = path.lstat()
+        resolved = path.resolve(strict=True)
+        metadata = resolved.stat()
+    except OSError:
+        return False
+    if stat.S_ISLNK(raw_metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        return False
+    if not os.access(resolved, os.X_OK):
+        return False
+    if metadata.st_uid not in {os.getuid(), 0} or stat.S_IMODE(metadata.st_mode) & 0o022:
+        return False
+    bundle = _bundle_for_executable(resolved)
+    if bundle is None:
+        return False
+    for directory in (bundle, bundle / "Contents", bundle / "Contents" / "MacOS"):
+        try:
+            raw = directory.lstat()
+            current = directory.stat()
+        except OSError:
+            return False
+        if stat.S_ISLNK(raw.st_mode) or not stat.S_ISDIR(current.st_mode):
+            return False
+        if current.st_uid not in {os.getuid(), 0} or stat.S_IMODE(current.st_mode) & 0o022:
+            return False
+    return True
+
+
+def _trusted_desktop_hook_proxy_command(
+    python_executable: str,
+    config_json: str,
+) -> tuple[str, ...] | None:
+    """Return a runtime-verified signed macOS proxy command or retain Core."""
+
+    if (
+        sys.platform != "darwin"
+        or not bool(getattr(sys, "frozen", False))
+        or os.environ.get("HOL_GUARD_DESKTOP") != "1"
+    ):
+        return None
+    raw = os.environ.get(_DESKTOP_PROXY_ENV)
+    if not raw:
+        return None
+    candidate = Path(raw)
+    core_candidate = Path(python_executable)
+    if not candidate.is_absolute() or not core_candidate.is_absolute():
+        return None
+    if not _trusted_desktop_path(candidate) or not _trusted_desktop_path(core_candidate):
+        return None
+    try:
+        proxy = candidate.resolve(strict=True)
+        core = core_candidate.resolve(strict=True)
+    except OSError:
+        return None
+    proxy_bundle = _bundle_for_executable(proxy)
+    core_bundle = _bundle_for_executable(core)
+    if proxy_bundle is None or proxy_bundle != core_bundle or proxy.parent != core.parent:
+        return None
+
+    proxy_team = _codesign_team(proxy)
+    core_team = _codesign_team(core)
+    bundle_team = _codesign_team(proxy_bundle)
+    if proxy_team is None or proxy_team == "not set" or proxy_team != core_team or proxy_team != bundle_team:
+        return None
+
+    return (
+        "/bin/sh",
+        "-c",
+        _DESKTOP_PROXY_LAUNCH_SCRIPT,
+        "hol-guard-desktop-proxy",
+        str(proxy),
+        proxy_team,
+        str(proxy_bundle),
+        config_json,
+        str(core),
+    )

--- a/src/codex_plugin_scanner/guard/adapters/grok.py
+++ b/src/codex_plugin_scanner/guard/adapters/grok.py
@@ -350,6 +350,7 @@ class GrokHarnessAdapter(HarnessAdapter):
             guard_args.extend(["--home", str(context.home_dir)])
         if context.workspace_dir is not None:
             guard_args.extend(["--workspace", str(context.workspace_dir)])
+        guard_args.append("--json")
         return bounded_cli_hook_command(
             python_executable=sys.executable,
             package_root=Path(__file__).resolve().parents[3],

--- a/src/codex_plugin_scanner/guard/cli/update_grok_repair.py
+++ b/src/codex_plugin_scanner/guard/cli/update_grok_repair.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import shlex
 import sqlite3
 import sys
+from collections.abc import Sequence
 from pathlib import Path
 
 from ..adapters.base import HarnessContext
@@ -87,15 +89,54 @@ def _grok_hooks_are_current(context: HarnessContext) -> bool:
 
 
 def _hook_config_from_command(command: str) -> dict[str, object] | None:
-    start = command.find("{")
-    end = command.rfind("}")
-    if start < 0 or end <= start:
-        return None
+    for posix in (True, False):
+        parsed = _hook_config_from_argv(_split_hook_command(command, posix=posix))
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _split_hook_command(command: str, *, posix: bool) -> list[str]:
     try:
-        parsed = json.loads(command[start : end + 1])
+        return shlex.split(command, posix=posix)
+    except ValueError:
+        return []
+
+
+def _hook_config_from_argv(argv: Sequence[str]) -> dict[str, object] | None:
+    for index, argument in enumerate(argv):
+        if argument == "__guard-bounded-hook" and index + 1 < len(argv):
+            parsed = _hook_config_payload(argv[index + 1])
+            if parsed is not None:
+                return parsed
+        parsed = _hook_config_payload(argument)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _hook_config_payload(raw: str) -> dict[str, object] | None:
+    for candidate in (raw, raw.replace('\\"', '"')):
+        parsed = _parse_grok_hook_config(candidate)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _parse_grok_hook_config(raw: str) -> dict[str, object] | None:
+    try:
+        parsed = json.loads(raw)
     except json.JSONDecodeError:
         return None
-    return parsed if isinstance(parsed, dict) else None
+    if not isinstance(parsed, dict):
+        return None
+    if parsed.get("harness") != "grok":
+        return None
+    if not isinstance(parsed.get("python_executable"), str):
+        return None
+    if not isinstance(parsed.get("cli_args"), list):
+        return None
+    return parsed
 
 
 def _pretool_timeout(payload: object) -> int | None:

--- a/src/codex_plugin_scanner/guard/cli/update_grok_repair.py
+++ b/src/codex_plugin_scanner/guard/cli/update_grok_repair.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import sys
+from pathlib import Path
 
 from ..adapters.base import HarnessContext
 from ..adapters.grok import GrokHarnessAdapter
@@ -24,7 +26,7 @@ def repair_grok_install(
     workspace: str | None,
     now: str,
 ) -> tuple[dict[str, object] | None, str | None]:
-    """Rewrite Grok PreToolUse hooks when the baked timeout is stale."""
+    """Rewrite Grok PreToolUse hooks when the baked launcher is stale."""
 
     try:
         managed_install = store.get_managed_install("grok")
@@ -64,7 +66,36 @@ def _grok_hooks_are_current(context: HarnessContext) -> bool:
     timeout = _pretool_timeout(payload)
     command = _pretool_command(payload)
     marker = f'"timeout_seconds":{GROK_HOOK_INTERNAL_TIMEOUT_SECONDS}'
-    return timeout == GROK_PRETOOL_HOOK_TIMEOUT_SECONDS and marker in command.replace(" ", "")
+    if timeout != GROK_PRETOOL_HOOK_TIMEOUT_SECONDS or marker not in command.replace(" ", ""):
+        return False
+    hook_config = _hook_config_from_command(command)
+    if hook_config is None:
+        return False
+    executable = hook_config.get("python_executable")
+    cli_args = hook_config.get("cli_args")
+    if not isinstance(executable, str) or not executable.strip():
+        return False
+    executable_path = Path(executable)
+    if not executable_path.exists():
+        return False
+    try:
+        if executable_path.resolve() != Path(sys.executable).resolve():
+            return False
+    except OSError:
+        return False
+    return isinstance(cli_args, list) and "--json" in cli_args
+
+
+def _hook_config_from_command(command: str) -> dict[str, object] | None:
+    start = command.find("{")
+    end = command.rfind("}")
+    if start < 0 or end <= start:
+        return None
+    try:
+        parsed = json.loads(command[start : end + 1])
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
 
 
 def _pretool_timeout(payload: object) -> int | None:

--- a/src/codex_plugin_scanner/guard/daemon/runtime_peer.py
+++ b/src/codex_plugin_scanner/guard/daemon/runtime_peer.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 _DESKTOP_CORE_PARTS = ("org.hol.guard.desktop", "core", "versions")
 
 
@@ -13,6 +15,21 @@ def daemon_source_is_desktop_core(source_root: object) -> bool:
     parts = tuple(part.lower() for part in source_root.replace("\\", "/").split("/") if part)
     marker_len = len(_DESKTOP_CORE_PARTS)
     return any(parts[index : index + marker_len] == _DESKTOP_CORE_PARTS for index in range(len(parts) - marker_len))
+
+
+def daemon_desktop_core_source_available(source_root: object) -> bool:
+    """Return True when a Desktop Core sidecar path still exists on disk.
+
+    Relative fixture paths keep matching by shape. Absolute trees that were
+    deleted after a Core move are not peers and must be recycled.
+    """
+
+    if not daemon_source_is_desktop_core(source_root):
+        return False
+    path = Path(str(source_root).replace("\\", "/"))
+    if not path.is_absolute():
+        return True
+    return path.exists()
 
 
 def daemon_state_matches_current_runtime(payload: dict[str, object]) -> bool:
@@ -33,4 +50,4 @@ def daemon_state_matches_current_runtime(payload: dict[str, object]) -> bool:
         return True
     if payload.get("package_version") == __version__:
         return True
-    return daemon_source_is_desktop_core(payload.get("source_root"))
+    return daemon_desktop_core_source_available(payload.get("source_root"))

--- a/src/codex_plugin_scanner/guard/daemon/runtime_repair.py
+++ b/src/codex_plugin_scanner/guard/daemon/runtime_repair.py
@@ -15,7 +15,7 @@ from .manager import (
     repair_approval_center_locator,
     retire_all_guard_daemons_for_home,
 )
-from .runtime_peer import daemon_source_is_desktop_core
+from .runtime_peer import daemon_desktop_core_source_available
 from .start_lock import guard_daemon_start_lock as _guard_daemon_start_lock
 
 
@@ -48,7 +48,7 @@ def _keep_live_runtime_result(
     verified_runtime: tuple[Version, str, str] | None,
     current_version: Version,
 ) -> dict[str, object] | None:
-    desktop_sidecar = identity is not None and daemon_source_is_desktop_core(identity.get("source_root"))
+    desktop_sidecar = identity is not None and daemon_desktop_core_source_available(identity.get("source_root"))
     if verified_runtime is not None and (verified_runtime[0] >= current_version or desktop_sidecar):
         daemon_version, daemon_version_text, _ = verified_runtime
         return {

--- a/tests/test_bounded_cli_hook_bridge.py
+++ b/tests/test_bounded_cli_hook_bridge.py
@@ -565,7 +565,7 @@ def test_oversized_input_uses_configured_harness_native_deny(
     tmp_path: Path,
 ) -> None:
     config = _config(tmp_path, harness="copilot")
-    monkeypatch.setattr(bounded_cli_hook_bridge, "_bounded_stdin", lambda: None)
+    monkeypatch.setattr(bounded_cli_hook_bridge, "_read_bounded_stdin", lambda: (None, "{}"))
     output = io.StringIO()
 
     with redirect_stdout(output):

--- a/tests/test_bounded_cli_hook_bridge.py
+++ b/tests/test_bounded_cli_hook_bridge.py
@@ -9,7 +9,7 @@ from typing import cast
 
 import pytest
 
-from codex_plugin_scanner.guard.adapters import bounded_cli_hook_bridge
+from codex_plugin_scanner.guard.adapters import bounded_cli_hook_bridge, desktop_hook_proxy
 from codex_plugin_scanner.guard.codex_hook_launch_runtime import BoundedHookProcessResult
 
 
@@ -117,61 +117,6 @@ def test_timeout_allows_emergency_safe_read(
     assert hook_output["permissionDecision"] == "allow"
 
 
-def test_timeout_allows_grok_when_watch(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    monkeypatch.setattr(
-        bounded_cli_hook_bridge,
-        "run_isolated_hook_process",
-        _runner_result(BoundedHookProcessResult(None, "", False, True)),
-    )
-    config = _config(tmp_path, harness="grok")
-    guard_home = Path(str(config["guard_home"]))
-    (guard_home / "config.toml").write_text(
-        'protection_posture = "watch"\nmode = "observe"\n',
-        encoding="utf-8",
-    )
-    output = io.StringIO()
-    with redirect_stdout(output):
-        returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(
-            config,
-            input_text=json.dumps(
-                {
-                    "hook_event_name": "PreToolUse",
-                    "tool_name": "Write",
-                    "tool_input": {"path": "foo.txt", "contents": "x"},
-                }
-            ),
-        )
-
-    payload = _json_object(output.getvalue())
-    assert returncode == 0
-    assert payload == {"decision": "allow"}
-
-
-def test_pretty_printed_hook_json_is_accepted(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    pretty = json.dumps({"decision": "allow", "policy_action": "warn"}, indent=2) + "\n"
-    monkeypatch.setattr(
-        bounded_cli_hook_bridge,
-        "run_isolated_hook_process",
-        _runner_result(BoundedHookProcessResult(0, pretty, False, False)),
-    )
-    output = io.StringIO()
-    with redirect_stdout(output):
-        returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(
-            _config(tmp_path, harness="grok"),
-            input_text=json.dumps({"hook_event_name": "PreToolUse"}),
-        )
-
-    payload = _json_object(output.getvalue())
-    assert returncode == 0
-    assert payload == {"decision": "allow", "policy_action": "warn"}
-
-
 @pytest.mark.parametrize("harness", ["kimi", "zcode"])
 def test_claude_shaped_timeout_emits_deny_and_block_exit(
     monkeypatch: pytest.MonkeyPatch,
@@ -238,7 +183,7 @@ def test_frozen_hook_command_prefers_runtime_verified_signed_macos_proxy(
     monkeypatch.setattr(bounded_cli_hook_bridge.sys, "platform", "darwin")
     monkeypatch.setenv("HOL_GUARD_DESKTOP", "1")
     monkeypatch.setenv("HOL_GUARD_DESKTOP_HOOK_PROXY", str(proxy))
-    monkeypatch.setattr(bounded_cli_hook_bridge, "_codesign_team", lambda path: "TEAMID")
+    monkeypatch.setattr(desktop_hook_proxy, "_codesign_team", lambda path: "TEAMID")
 
     command = bounded_cli_hook_bridge.bounded_cli_hook_command(
         python_executable=str(core),
@@ -327,7 +272,7 @@ def test_desktop_proxy_requires_one_real_team_and_same_bundle(
         {proxy: "not set", core: "not set", proxy.parents[2]: "not set"},
         {proxy: "TEAM-A", core: "TEAM-B", proxy.parents[2]: "TEAM-A"},
     ):
-        monkeypatch.setattr(bounded_cli_hook_bridge, "_codesign_team", teams.get)
+        monkeypatch.setattr(desktop_hook_proxy, "_codesign_team", teams.get)
         assert bounded_cli_hook_bridge._trusted_desktop_hook_proxy_command(str(core), "{}") is None
 
 
@@ -341,7 +286,7 @@ def test_desktop_proxy_rejects_writable_or_cross_bundle_paths(
     monkeypatch.setattr(bounded_cli_hook_bridge.sys, "frozen", True, raising=False)
     monkeypatch.setattr(bounded_cli_hook_bridge.sys, "platform", "darwin")
     monkeypatch.setenv("HOL_GUARD_DESKTOP", "1")
-    monkeypatch.setattr(bounded_cli_hook_bridge, "_codesign_team", lambda path: "TEAMID")
+    monkeypatch.setattr(desktop_hook_proxy, "_codesign_team", lambda path: "TEAMID")
 
     monkeypatch.setenv("HOL_GUARD_DESKTOP_HOOK_PROXY", str(other_proxy))
     assert bounded_cli_hook_bridge._trusted_desktop_hook_proxy_command(str(core), "{}") is None
@@ -412,8 +357,7 @@ def test_frozen_fallback_runs_supported_cli_subcommand_without_python_flags(
         "--guard-home",
         str(tmp_path / "guard-home"),
         "--harness",
-        "grok",
-        "--json",
+        "grok", "--json",
     ]
 
 
@@ -467,8 +411,7 @@ def test_live_frozen_runtime_ignores_forged_config_mode_and_executable(
         "--guard-home",
         str((tmp_path / "guard-home").resolve()),
         "--harness",
-        "grok",
-        "--json",
+        "grok", "--json",
     ]
 
 
@@ -521,8 +464,7 @@ def test_frozen_fallback_accepts_equivalent_noncanonical_guard_home(
         "--guard-home",
         str((tmp_path / "guard-home").resolve()),
         "--harness",
-        "grok",
-        "--json",
+        "grok", "--json",
     ]
 
 
@@ -554,8 +496,7 @@ def test_frozen_fallback_accepts_normalized_json_hook_contract(
         "--guard-home",
         str(tmp_path / "guard-home"),
         "--harness",
-        harness,
-        "--json",
+        harness, "--json",
     ]
 
 

--- a/tests/test_bounded_cli_hook_bridge.py
+++ b/tests/test_bounded_cli_hook_bridge.py
@@ -117,6 +117,61 @@ def test_timeout_allows_emergency_safe_read(
     assert hook_output["permissionDecision"] == "allow"
 
 
+def test_timeout_allows_grok_when_watch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        bounded_cli_hook_bridge,
+        "run_isolated_hook_process",
+        _runner_result(BoundedHookProcessResult(None, "", False, True)),
+    )
+    config = _config(tmp_path, harness="grok")
+    guard_home = Path(str(config["guard_home"]))
+    (guard_home / "config.toml").write_text(
+        'protection_posture = "watch"\nmode = "observe"\n',
+        encoding="utf-8",
+    )
+    output = io.StringIO()
+    with redirect_stdout(output):
+        returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(
+            config,
+            input_text=json.dumps(
+                {
+                    "hook_event_name": "PreToolUse",
+                    "tool_name": "Write",
+                    "tool_input": {"path": "foo.txt", "contents": "x"},
+                }
+            ),
+        )
+
+    payload = _json_object(output.getvalue())
+    assert returncode == 0
+    assert payload == {"decision": "allow"}
+
+
+def test_pretty_printed_hook_json_is_accepted(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    pretty = json.dumps({"decision": "allow", "policy_action": "warn"}, indent=2) + "\n"
+    monkeypatch.setattr(
+        bounded_cli_hook_bridge,
+        "run_isolated_hook_process",
+        _runner_result(BoundedHookProcessResult(0, pretty, False, False)),
+    )
+    output = io.StringIO()
+    with redirect_stdout(output):
+        returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(
+            _config(tmp_path, harness="grok"),
+            input_text=json.dumps({"hook_event_name": "PreToolUse"}),
+        )
+
+    payload = _json_object(output.getvalue())
+    assert returncode == 0
+    assert payload == {"decision": "allow", "policy_action": "warn"}
+
+
 @pytest.mark.parametrize("harness", ["kimi", "zcode"])
 def test_claude_shaped_timeout_emits_deny_and_block_exit(
     monkeypatch: pytest.MonkeyPatch,
@@ -358,6 +413,7 @@ def test_frozen_fallback_runs_supported_cli_subcommand_without_python_flags(
         str(tmp_path / "guard-home"),
         "--harness",
         "grok",
+        "--json",
     ]
 
 
@@ -412,6 +468,7 @@ def test_live_frozen_runtime_ignores_forged_config_mode_and_executable(
         str((tmp_path / "guard-home").resolve()),
         "--harness",
         "grok",
+        "--json",
     ]
 
 
@@ -465,6 +522,7 @@ def test_frozen_fallback_accepts_equivalent_noncanonical_guard_home(
         str((tmp_path / "guard-home").resolve()),
         "--harness",
         "grok",
+        "--json",
     ]
 
 

--- a/tests/test_bounded_cli_hook_watch_continue.py
+++ b/tests/test_bounded_cli_hook_watch_continue.py
@@ -144,3 +144,23 @@ def test_timeout_denies_grok_when_watch_has_expired(
     payload = _json_object(output.getvalue())
     assert returncode == 0
     assert payload["decision"] == "deny"
+
+
+def test_oversized_input_allows_grok_when_watch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config = _config(tmp_path, harness="grok")
+    guard_home = Path(str(config["guard_home"]))
+    (guard_home / "config.toml").write_text(
+        'protection_posture = "watch"\nmode = "observe"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(bounded_cli_hook_bridge, "_bounded_stdin", lambda: None)
+    output = io.StringIO()
+    with redirect_stdout(output):
+        returncode = bounded_cli_hook_bridge.main_from_argv([json.dumps(config)])
+
+    payload = _json_object(output.getvalue())
+    assert returncode == 0
+    assert payload == {"decision": "allow"}

--- a/tests/test_bounded_cli_hook_watch_continue.py
+++ b/tests/test_bounded_cli_hook_watch_continue.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import io
+import json
+from collections.abc import Callable, Mapping, Sequence
+from contextlib import redirect_stdout
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters import bounded_cli_hook_bridge
+from codex_plugin_scanner.guard.codex_hook_launch_runtime import BoundedHookProcessResult
+
+
+def _runner_result(result: BoundedHookProcessResult) -> Callable[..., BoundedHookProcessResult]:
+    def run(
+        command: Sequence[str],
+        *,
+        input_text: str,
+        cwd: Path,
+        environment: Mapping[str, str],
+        timeout_seconds: float,
+        output_limit: int = 1_000_000,
+    ) -> BoundedHookProcessResult:
+        del command, input_text, cwd, environment, timeout_seconds, output_limit
+        return result
+
+    return run
+
+
+def _json_object(text: str) -> dict[str, object]:
+    payload = cast(object, json.loads(text))
+    assert isinstance(payload, dict)
+    return {str(key): value for key, value in cast(dict[object, object], payload).items()}
+
+
+def _config(tmp_path: Path, *, harness: str) -> dict[str, object]:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    return {
+        "python_executable": "python",
+        "package_root": str(tmp_path),
+        "guard_home": str(guard_home),
+        "cli_args": [
+            "guard",
+            "hook",
+            "--guard-home",
+            str(guard_home),
+            "--harness",
+            harness,
+        ],
+        "harness": harness,
+        "timeout_seconds": 3,
+    }
+
+
+def test_timeout_allows_grok_when_watch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        bounded_cli_hook_bridge,
+        "run_isolated_hook_process",
+        _runner_result(BoundedHookProcessResult(None, "", False, True)),
+    )
+    config = _config(tmp_path, harness="grok")
+    guard_home = Path(str(config["guard_home"]))
+    (guard_home / "config.toml").write_text(
+        'protection_posture = "watch"\nmode = "observe"\n',
+        encoding="utf-8",
+    )
+    output = io.StringIO()
+    with redirect_stdout(output):
+        returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(
+            config,
+            input_text=json.dumps(
+                {
+                    "hook_event_name": "PreToolUse",
+                    "tool_name": "Write",
+                    "tool_input": {"path": "foo.txt", "contents": "x"},
+                }
+            ),
+        )
+
+    payload = _json_object(output.getvalue())
+    assert returncode == 0
+    assert payload == {"decision": "allow"}
+
+
+def test_pretty_printed_hook_json_is_accepted(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    pretty = json.dumps({"decision": "allow", "policy_action": "warn"}, indent=2) + "\n"
+    monkeypatch.setattr(
+        bounded_cli_hook_bridge,
+        "run_isolated_hook_process",
+        _runner_result(BoundedHookProcessResult(0, pretty, False, False)),
+    )
+    output = io.StringIO()
+    with redirect_stdout(output):
+        returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(
+            _config(tmp_path, harness="grok"),
+            input_text=json.dumps({"hook_event_name": "PreToolUse"}),
+        )
+
+    payload = _json_object(output.getvalue())
+    assert returncode == 0
+    assert payload == {"decision": "allow", "policy_action": "warn"}
+
+
+def test_timeout_denies_grok_when_watch_has_expired(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        bounded_cli_hook_bridge,
+        "run_isolated_hook_process",
+        _runner_result(BoundedHookProcessResult(None, "", False, True)),
+    )
+    config = _config(tmp_path, harness="grok")
+    guard_home = Path(str(config["guard_home"]))
+    (guard_home / "config.toml").write_text(
+        'protection_posture = "watch"\n'
+        'mode = "observe"\n'
+        "watch_auto_revert_hours = 24\n"
+        'watch_entered_at = "2020-01-01T00:00:00+00:00"\n',
+        encoding="utf-8",
+    )
+    output = io.StringIO()
+    with redirect_stdout(output):
+        returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(
+            config,
+            input_text=json.dumps(
+                {
+                    "hook_event_name": "PreToolUse",
+                    "tool_name": "Write",
+                    "tool_input": {"path": "foo.txt", "contents": "x"},
+                }
+            ),
+        )
+
+    payload = _json_object(output.getvalue())
+    assert returncode == 0
+    assert payload["decision"] == "deny"

--- a/tests/test_bounded_cli_hook_watch_continue.py
+++ b/tests/test_bounded_cli_hook_watch_continue.py
@@ -156,7 +156,7 @@ def test_oversized_input_allows_grok_when_watch(
         'protection_posture = "watch"\nmode = "observe"\n',
         encoding="utf-8",
     )
-    monkeypatch.setattr(bounded_cli_hook_bridge, "_bounded_stdin", lambda: None)
+    monkeypatch.setattr(bounded_cli_hook_bridge, "_read_bounded_stdin", lambda: (None, "{}"))
     output = io.StringIO()
     with redirect_stdout(output):
         returncode = bounded_cli_hook_bridge.main_from_argv([json.dumps(config)])
@@ -164,3 +164,30 @@ def test_oversized_input_allows_grok_when_watch(
     payload = _json_object(output.getvalue())
     assert returncode == 0
     assert payload == {"decision": "allow"}
+
+
+def test_oversized_input_preserves_kimi_event_when_watch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config = _config(tmp_path, harness="kimi")
+    guard_home = Path(str(config["guard_home"]))
+    (guard_home / "config.toml").write_text(
+        'protection_posture = "watch"\nmode = "observe"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        bounded_cli_hook_bridge,
+        "_read_bounded_stdin",
+        lambda: (None, '{"hook_event_name":"UserPromptSubmit"'),
+    )
+    output = io.StringIO()
+    with redirect_stdout(output):
+        returncode = bounded_cli_hook_bridge.main_from_argv([json.dumps(config)])
+
+    payload = _json_object(output.getvalue())
+    assert returncode == 0
+    hook_output = payload["hookSpecificOutput"]
+    assert isinstance(hook_output, dict)
+    assert hook_output["hookEventName"] == "UserPromptSubmit"
+    assert hook_output["permissionDecision"] == "allow"

--- a/tests/test_grok_adapter.py
+++ b/tests/test_grok_adapter.py
@@ -115,10 +115,8 @@ class TestGrokInstallUninstall:
         managed_text = managed_config.read_text(encoding="utf-8")
         assert "Read(**/.grok/auth/**)" in managed_text
         assert "Read(~/" not in managed_text
-        assert "[[hooks.PreToolUse]]" in managed_text
-        assert "[[hooks.SessionStart]]" in managed_text
-        pretool_command = pretool_entries[0]["hooks"][0]["command"]
-        assert '"--json"' in pretool_command.replace(" ", "")
+        assert "[[hooks.PreToolUse]]" in managed_text and "[[hooks.SessionStart]]" in managed_text
+        assert '"--json"' in pretool_entries[0]["hooks"][0]["command"].replace(" ", "")
 
     def test_repeated_install_is_idempotent(self, tmp_path: Path, monkeypatch) -> None:
         ctx = _ctx(tmp_path)

--- a/tests/test_grok_adapter.py
+++ b/tests/test_grok_adapter.py
@@ -117,6 +117,8 @@ class TestGrokInstallUninstall:
         assert "Read(~/" not in managed_text
         assert "[[hooks.PreToolUse]]" in managed_text
         assert "[[hooks.SessionStart]]" in managed_text
+        pretool_command = pretool_entries[0]["hooks"][0]["command"]
+        assert '"--json"' in pretool_command.replace(" ", "")
 
     def test_repeated_install_is_idempotent(self, tmp_path: Path, monkeypatch) -> None:
         ctx = _ctx(tmp_path)
@@ -670,7 +672,7 @@ class TestGrokInventoryAndResponses:
         grok_root = ctx.home_dir / ".grok"
         (grok_root / "workflows").mkdir(parents=True)
         (grok_root / "agents").mkdir(parents=True)
-        (grok_root / "sandbox.toml").write_text("[profiles.project]\nextends = \"workspace\"\n", encoding="utf-8")
+        (grok_root / "sandbox.toml").write_text('[profiles.project]\nextends = "workspace"\n', encoding="utf-8")
         result = GrokHarnessAdapter().detect(ctx)
         assert any(path.endswith(".grok/workflows") for path in result.config_paths)
         assert any(path.endswith(".grok/agents") for path in result.config_paths)

--- a/tests/test_guard_daemon_runtime_repair.py
+++ b/tests/test_guard_daemon_runtime_repair.py
@@ -211,6 +211,44 @@ def test_repair_retains_desktop_sidecar_with_invalid_package_version(
     assert result["cli_version"] == "3.0.46"
 
 
+def test_repair_recycles_missing_absolute_desktop_core_tree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    missing = tmp_path / "org.hol.guard.desktop" / "core" / "versions" / "3.0.45" / "hol-guard"
+    monkeypatch.setattr(
+        runtime_repair,
+        "verified_live_guard_daemon_identity",
+        lambda _home: {
+            "package_version": "3.0.45",
+            "runtime_fingerprint": "desktop-sidecar",
+            "source_root": str(missing),
+        },
+    )
+    monkeypatch.setattr(runtime_repair, "__version__", "3.0.46")
+    monkeypatch.setattr(
+        runtime_repair,
+        "repair_approval_center_locator",
+        lambda _home: {"repaired": True, "cleared": []},
+    )
+    monkeypatch.setattr(runtime_repair, "retire_all_guard_daemons_for_home", lambda _home: [321])
+    monkeypatch.setattr(runtime_repair, "guard_daemon_retirement_is_complete", lambda _home: True)
+    monkeypatch.setattr(runtime_repair, "clear_guard_daemon_state", lambda _home: None)
+    monkeypatch.setattr(
+        runtime_repair,
+        "ensure_guard_daemon_after_update",
+        lambda _home, *, home_dir: "http://127.0.0.1:5474",
+    )
+
+    result = runtime_repair.repair_guard_daemon_runtime(guard_home, home_dir=home_dir)
+
+    assert result["runtime_status"] == "restarted"
+    assert result["daemon_version"] == "3.0.45"
+
+
 def test_repair_restarts_when_authenticated_state_is_absent(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_python_capability_cleanup_gate.py
+++ b/tests/test_python_capability_cleanup_gate.py
@@ -20,7 +20,7 @@ def test_cleanup_contract_covers_every_scoped_hook_capability() -> None:
 
     assert payload["schema"] == "hol-guard.python-capability-cleanup.v1"
     assert payload["status"] == "passed"
-    assert payload["scope_files"] == 85
+    assert payload["scope_files"] == 86
     assert payload["capabilities"]["legacy_python_resident_transport"] == 1
     assert payload["candidate_evidence"] == [
         {

--- a/tests/test_update_grok_repair.py
+++ b/tests/test_update_grok_repair.py
@@ -169,3 +169,60 @@ def test_grok_repair_rewrites_hooks_without_json_flag(tmp_path: Path) -> None:
     assert isinstance(repaired, dict)
     command = json.loads(hook_path.read_text(encoding="utf-8"))["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
     assert '"--json"' in command.replace(" ", "")
+
+
+def _sample_hook_config(tmp_path: Path) -> dict[str, object]:
+    return {
+        "python_executable": str(tmp_path / "o'brien" / "python"),
+        "package_root": str(tmp_path),
+        "guard_home": str(tmp_path / "guard-home"),
+        "cli_args": ["guard", "hook", "--harness", "grok", "--json"],
+        "harness": "grok",
+        "timeout_seconds": 25,
+        "frozen_launcher": True,
+    }
+
+
+def test_hook_config_from_desktop_proxy_command_ignores_script_braces(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.adapters.base import _shell_command
+    from codex_plugin_scanner.guard.adapters.desktop_hook_proxy import _DESKTOP_PROXY_LAUNCH_SCRIPT
+    from codex_plugin_scanner.guard.cli.update_grok_repair import _hook_config_from_command
+
+    config = _sample_hook_config(tmp_path)
+    command = _shell_command(
+        (
+            "/bin/sh",
+            "-c",
+            _DESKTOP_PROXY_LAUNCH_SCRIPT,
+            "hol-guard-desktop-proxy",
+            str(tmp_path / "proxy"),
+            "TEAMID",
+            str(tmp_path / "HOL Guard.app"),
+            json.dumps(config, separators=(",", ":")),
+            str(tmp_path / "core"),
+        ),
+        windows=False,
+    )
+    parsed = _hook_config_from_command(command)
+    assert parsed is not None
+    assert parsed["python_executable"] == config["python_executable"]
+    assert parsed["cli_args"] == config["cli_args"]
+
+
+def test_hook_config_from_windows_shell_escaped_json(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.adapters.base import _shell_command
+    from codex_plugin_scanner.guard.cli.update_grok_repair import _hook_config_from_command
+
+    config = _sample_hook_config(tmp_path)
+    command = _shell_command(
+        (
+            str(tmp_path / "python.exe"),
+            "__guard-bounded-hook",
+            json.dumps(config, separators=(",", ":")),
+        ),
+        windows=True,
+    )
+    parsed = _hook_config_from_command(command)
+    assert parsed is not None
+    assert parsed["python_executable"] == config["python_executable"]
+    assert "--json" in parsed["cli_args"]

--- a/tests/test_update_grok_repair.py
+++ b/tests/test_update_grok_repair.py
@@ -110,3 +110,62 @@ def test_update_repair_rewrites_stale_grok_hooks(tmp_path: Path) -> None:
     assert any(item.get("harness") == "grok" for item in repaired)
     payload = json.loads(hook_path.read_text(encoding="utf-8"))
     assert payload["hooks"]["PreToolUse"][0]["hooks"][0]["timeout"] == GROK_PRETOOL_HOOK_TIMEOUT_SECONDS
+
+
+def _replace_hook_config(hook_path: Path, **updates: object) -> None:
+    payload = json.loads(hook_path.read_text(encoding="utf-8"))
+    command = payload["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+    start = command.find("{")
+    end = command.rfind("}")
+    config = json.loads(command[start : end + 1])
+    config.update(updates)
+    payload["hooks"]["PreToolUse"][0]["hooks"][0]["command"] = (
+        command[:start] + json.dumps(config, separators=(",", ":")) + command[end + 1 :]
+    )
+    hook_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def test_grok_repair_rewrites_missing_hook_executable(tmp_path: Path) -> None:
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    now = "2026-08-17T00:00:00+00:00"
+    hook_path = _seed_grok_install(context, store, now)
+    _replace_hook_config(hook_path, python_executable=str(tmp_path / "missing-hol-guard"))
+
+    repaired, warning = repair_grok_install(
+        context=context,
+        store=store,
+        workspace=None,
+        now=now,
+    )
+
+    assert warning is None
+    assert isinstance(repaired, dict)
+    command = json.loads(hook_path.read_text(encoding="utf-8"))["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+    assert "missing-hol-guard" not in command
+
+
+def test_grok_repair_rewrites_hooks_without_json_flag(tmp_path: Path) -> None:
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    now = "2026-08-17T00:00:00+00:00"
+    hook_path = _seed_grok_install(context, store, now)
+    payload = json.loads(hook_path.read_text(encoding="utf-8"))
+    command = payload["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+    start = command.find("{")
+    end = command.rfind("}")
+    config = json.loads(command[start : end + 1])
+    config["cli_args"] = [item for item in config["cli_args"] if item != "--json"]
+    _replace_hook_config(hook_path, cli_args=config["cli_args"])
+
+    repaired, warning = repair_grok_install(
+        context=context,
+        store=store,
+        workspace=None,
+        now=now,
+    )
+
+    assert warning is None
+    assert isinstance(repaired, dict)
+    command = json.loads(hook_path.read_text(encoding="utf-8"))["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+    assert '"--json"' in command.replace(" ", "")

--- a/tests/test_watch_continue_same_release_daemon.py
+++ b/tests/test_watch_continue_same_release_daemon.py
@@ -136,6 +136,32 @@ def test_guard_daemon_state_rejects_desktop_marker_without_version_child() -> No
     assert not daemon_manager_module._guard_daemon_state_matches_current_runtime(payload)
 
 
+def test_guard_daemon_state_rejects_missing_absolute_desktop_core_tree(tmp_path: Path) -> None:
+    missing = tmp_path / "org.hol.guard.desktop" / "core" / "versions" / "0.0.1" / "hol-guard"
+    payload = {
+        "compatibility_version": daemon_manager_module.GUARD_DAEMON_COMPATIBILITY_VERSION,
+        "package_version": "0.0.1",
+        "source_root": str(missing),
+        "runtime_fingerprint": "desktop-sidecar-fingerprint",
+    }
+
+    assert not daemon_manager_module._guard_daemon_state_matches_current_runtime(payload)
+
+
+def test_guard_daemon_state_matches_existing_absolute_desktop_core_tree(tmp_path: Path) -> None:
+    sidecar = tmp_path / "org.hol.guard.desktop" / "core" / "versions" / "0.0.1" / "hol-guard"
+    sidecar.parent.mkdir(parents=True)
+    sidecar.write_text("placeholder", encoding="utf-8")
+    payload = {
+        "compatibility_version": daemon_manager_module.GUARD_DAEMON_COMPATIBILITY_VERSION,
+        "package_version": "0.0.1",
+        "source_root": str(sidecar),
+        "runtime_fingerprint": "desktop-sidecar-fingerprint",
+    }
+
+    assert daemon_manager_module._guard_daemon_state_matches_current_runtime(payload)
+
+
 def test_healthz_details_require_compatible_same_release_peer() -> None:
     compatible = {
         "compatibility_version": daemon_manager_module.GUARD_DAEMON_COMPATIBILITY_VERSION,


### PR DESCRIPTION
## Summary
- Watch Grok PreToolUse continues when isolated hook JSON is pretty-printed or native review misses the deadline.
- Grok hook install and update repair now require a live launcher, `--json` output, and the current runtime executable.
- Daemon repair recycles a Desktop Core sidecar when that Core tree no longer exists on disk.

## Testing
- `python3 -m pytest tests/test_bounded_cli_hook_bridge.py tests/test_update_grok_repair.py tests/test_watch_continue_same_release_daemon.py tests/test_guard_daemon_runtime_repair.py tests/test_grok_watch_hooks.py tests/test_grok_adapter.py::TestGrokInstallUninstall::test_install_writes_managed_hooks_and_config -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Hook commands now consistently produce compact, single-line JSON output.
  - Added recording-only watch behavior that allows operations to continue when protection is turned off.
  - Added secure macOS Desktop proxy verification with fallback handling.

- **Bug Fixes**
  - Grok hooks are refreshed when launcher settings, interpreters, or JSON output options are outdated.
  - Stale desktop-sidecar runtimes are detected and restarted when their files are missing.
  - Improved hook configuration detection across POSIX and Windows command formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->