### PR TITLE
fix(guard): keep native review live after Core moves

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_payload.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_payload.py
@@ -214,7 +214,7 @@ def _cursor_read_file_permission(permission: str) -> str:
 
 
 def _cursor_block_reason(guard_payload: Mapping[str, object]) -> str:
-    for key in ("review_hint", "risk_summary", "why_now", "risk_headline"):
+    for key in ("reason", "stopReason", "systemMessage", "review_hint", "risk_summary", "why_now", "risk_headline"):
         value = guard_payload.get(key)
         if isinstance(value, str) and value.strip():
             return value.strip()

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_head.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_head.py
@@ -473,7 +473,7 @@ def _cursor_read_file_permission(permission: str) -> str:
 def _cursor_reason(guard_payload: dict[str, object]) -> str:
     primary_url = guard_payload.get("primary_approval_url")
     reason: str | None = None
-    for key in ("review_hint", "risk_summary", "why_now", "risk_headline"):
+    for key in ("reason", "stopReason", "systemMessage", "review_hint", "risk_summary", "why_now", "risk_headline"):
         value = guard_payload.get(key)
         if isinstance(value, str) and value.strip():
             reason = value.strip()

--- a/src/codex_plugin_scanner/guard/daemon/hook_process_entrypoint.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_process_entrypoint.py
@@ -265,6 +265,7 @@ def _run_resident_hook_request(
                 home_dir=parsed.home_dir,
                 guard_home=parsed.guard_home,
                 workspace=parsed.workspace,
+                deadline=parsed.deadline,
             )
         except HookWorkerUnsupported:
             if _native_mode_requires_rust() or not python_oracle_surface_enabled():

--- a/src/codex_plugin_scanner/guard/daemon/hook_process_entrypoint.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_process_entrypoint.py
@@ -255,7 +255,7 @@ def _run_resident_hook_request(
     ):
         worker = hook_workers.get(store_key)
         if worker is None:
-            worker = HookWorker(store=store)
+            worker = HookWorker(store=store, wait_for_native_policy=False)
             hook_workers[store_key] = worker
         try:
             worker_payload = worker.review_http_payload(

--- a/src/codex_plugin_scanner/guard/daemon/hook_process_request.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_process_request.py
@@ -27,6 +27,7 @@ def build_hook_process_review_request(
     claimed_saved_allow_hash: str | None,
     claimed_trusted_request_override: bool,
     claimed_approval_request_id: str | None,
+    deadline: float | None = None,
 ) -> dict[str, object]:
     return {
         "payload": dict(payload),
@@ -39,6 +40,7 @@ def build_hook_process_review_request(
         "claimed_saved_allow_hash": claimed_saved_allow_hash,
         "claimed_trusted_request_override": claimed_trusted_request_override,
         "claimed_approval_request_id": claimed_approval_request_id,
+        "deadline": deadline,
     }
 
 
@@ -63,6 +65,7 @@ class ResidentHookRequest:
     claimed_saved_allow_hash: str | None
     claimed_trusted_request_override: bool
     claimed_approval_request_id: str | None
+    deadline: float | None = None
 
 
 def coerce_resident_hook_request(request: dict[str, object]) -> ResidentHookRequest | None:
@@ -75,6 +78,7 @@ def coerce_resident_hook_request(request: dict[str, object]) -> ResidentHookRequ
     claimed_saved_allow_hash = request.get("claimed_saved_allow_hash")
     claimed_trusted_request_override = request.get("claimed_trusted_request_override", False)
     claimed_approval_request_id = request.get("claimed_approval_request_id")
+    raw_deadline = request.get("deadline")
     typed_payload = as_string_object_dict(payload)
     if typed_payload is None or not isinstance(harness, str):
         return None
@@ -98,6 +102,11 @@ def coerce_resident_hook_request(request: dict[str, object]) -> ResidentHookRequ
         claimed_saved_allow_hash=claimed_saved_allow_hash,
         claimed_trusted_request_override=claimed_trusted_request_override,
         claimed_approval_request_id=claimed_approval_request_id,
+        deadline=(
+            float(raw_deadline)
+            if isinstance(raw_deadline, (int, float)) and not isinstance(raw_deadline, bool)
+            else None
+        ),
     )
 
 

--- a/src/codex_plugin_scanner/guard/daemon/hook_process_runner.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_process_runner.py
@@ -217,7 +217,7 @@ class HookProcessRunner(HookProcessRunnerLifecycleMixin):
             claim_saved_approval=claim_saved_approval,
             claimed_saved_allow_hash=claimed_saved_allow_hash,
             claimed_trusted_request_override=claimed_trusted_request_override,
-            claimed_approval_request_id=claimed_approval_request_id,
+            claimed_approval_request_id=claimed_approval_request_id, deadline=review_deadline,
         )
         try:
             if review_deadline <= time.monotonic():

--- a/src/codex_plugin_scanner/guard/daemon/hook_process_runner.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_process_runner.py
@@ -217,7 +217,8 @@ class HookProcessRunner(HookProcessRunnerLifecycleMixin):
             claim_saved_approval=claim_saved_approval,
             claimed_saved_allow_hash=claimed_saved_allow_hash,
             claimed_trusted_request_override=claimed_trusted_request_override,
-            claimed_approval_request_id=claimed_approval_request_id, deadline=review_deadline,
+            claimed_approval_request_id=claimed_approval_request_id,
+            deadline=review_deadline,
         )
         try:
             if review_deadline <= time.monotonic():
@@ -321,8 +322,6 @@ class HookProcessRunner(HookProcessRunnerLifecycleMixin):
         typed_response = as_string_object_dict(response)
         if typed_response is None:
             return HookProcessReview(None, "daemon_hook_process_invalid_json")
-        if time.monotonic() >= review_deadline:
-            return HookProcessReview(None, "daemon_hook_process_deadline_exhausted")
         self._record_response_metrics(typed_response)
         self._record_route_metric(typed_result.get("route"))
         if time.monotonic() >= review_deadline:

--- a/src/codex_plugin_scanner/guard/daemon/hook_worker.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_worker.py
@@ -88,7 +88,13 @@ class HookWorker(HookWorkerNativeMixin):
     # Python semantic reviewer from this worker.
     _test_python_oracle_factory: ClassVar[Callable[[HookWorker], PythonOracle] | None] = None
 
-    def __init__(self, *, store: GuardStore, activity_writer: CommandActivityWriter | None = None):
+    def __init__(
+        self,
+        *,
+        store: GuardStore,
+        activity_writer: CommandActivityWriter | None = None,
+        wait_for_native_policy: bool = True,
+    ):
         self.store = store
         self.guard_home = store.guard_home
         self.activity_writer = activity_writer
@@ -110,6 +116,10 @@ class HookWorker(HookWorkerNativeMixin):
         mode = native_mode()
         if mode in {"auto", "force", "shadow"}:
             self.policy_snapshot_publisher.start()
+        if wait_for_native_policy and mode in {"auto", "force"}:
+            wait_until_ready = getattr(self.policy_snapshot_publisher, "wait_until_ready", None)
+            if callable(wait_until_ready):
+                _ = wait_until_ready(time.monotonic() + _NATIVE_POLICY_READY_TIMEOUT_SECONDS)
 
     @property
     def test_oracle(self) -> PythonOracle | None:

--- a/src/codex_plugin_scanner/guard/daemon/hook_worker.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_worker.py
@@ -36,6 +36,7 @@ from ..config import load_guard_config
 from ..native_hook_edge import review_raw_hook_native
 from ..native_mode import python_oracle_enabled, python_oracle_surface_enabled
 from ..native_policy_snapshot import get_native_policy_snapshot_publisher
+from ..native_policy_snapshot_constants import _PUBLISH_TIMEOUT_SECONDS
 from ..native_pretool import review_pre_tool_native
 from ..native_route_receipt import record_python_semantic_hook_route
 from ..native_runtime import NativeRuntimeStatus, native_mode, native_runtime_status, review_post_tool_native
@@ -75,7 +76,7 @@ class CommandActivityWriter(Protocol):
     ) -> bool: ...
 
 
-_NATIVE_POLICY_READY_TIMEOUT_SECONDS = 0.25
+_NATIVE_POLICY_READY_TIMEOUT_SECONDS = _PUBLISH_TIMEOUT_SECONDS
 
 
 @final
@@ -112,7 +113,7 @@ class HookWorker(HookWorkerNativeMixin):
         if mode in {"auto", "force"}:
             wait_until_ready = getattr(self.policy_snapshot_publisher, "wait_until_ready", None)
             if callable(wait_until_ready):
-                _ = wait_until_ready(time.monotonic() + 0.25)
+                _ = wait_until_ready(time.monotonic() + _NATIVE_POLICY_READY_TIMEOUT_SECONDS)
 
     @property
     def test_oracle(self) -> PythonOracle | None:

--- a/src/codex_plugin_scanner/guard/daemon/hook_worker.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_worker.py
@@ -110,10 +110,6 @@ class HookWorker(HookWorkerNativeMixin):
         mode = native_mode()
         if mode in {"auto", "force", "shadow"}:
             self.policy_snapshot_publisher.start()
-        if mode in {"auto", "force"}:
-            wait_until_ready = getattr(self.policy_snapshot_publisher, "wait_until_ready", None)
-            if callable(wait_until_ready):
-                _ = wait_until_ready(time.monotonic() + _NATIVE_POLICY_READY_TIMEOUT_SECONDS)
 
     @property
     def test_oracle(self) -> PythonOracle | None:

--- a/src/codex_plugin_scanner/guard/daemon/hook_worker.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_worker.py
@@ -198,7 +198,8 @@ class HookWorker(HookWorkerNativeMixin):
         self.policy_snapshot_publisher.start()
         if native_mode() in {"auto", "force"}:
             wait_until_ready = getattr(self.policy_snapshot_publisher, "wait_until_ready", None)
-            if callable(wait_until_ready):
+            last_error = getattr(self.policy_snapshot_publisher, "last_error", None)
+            if callable(wait_until_ready) and not (isinstance(last_error, str) and last_error.strip()):
                 readiness_deadline = time.monotonic() + _NATIVE_POLICY_READY_TIMEOUT_SECONDS
                 if deadline is not None:
                     readiness_deadline = min(readiness_deadline, deadline)
@@ -211,10 +212,15 @@ class HookWorker(HookWorkerNativeMixin):
         snapshot = self.policy_snapshot_publisher.current_snapshot()
         return snapshot if isinstance(snapshot, dict) else None
 
-    def _native_policy_snapshot(self, workspace: Path | None = None) -> dict[str, object] | None:
+    def _native_policy_snapshot(
+        self,
+        workspace: Path | None = None,
+        *,
+        deadline: float | None = None,
+    ) -> dict[str, object] | None:
         """Return only the last resident-ACKed snapshot for native hooks."""
 
-        return self.prepare_workspace_policy(workspace)
+        return self.prepare_workspace_policy(workspace, deadline=deadline)
 
     def review_http_payload(
         self,
@@ -298,7 +304,7 @@ class HookWorker(HookWorkerNativeMixin):
         mode = native_mode()
         native_required = mode in {"auto", "force"}
         if native_required:
-            policy_snapshot = self._native_policy_snapshot(workspace)
+            policy_snapshot = self._native_policy_snapshot(workspace, deadline=deadline)
             recording_only = policy_snapshot is not None and policy_snapshot.get("mode") == "observe"
             response = review_post_tool_native(
                 request,
@@ -336,7 +342,7 @@ class HookWorker(HookWorkerNativeMixin):
                     _ = review_post_tool_native(
                         request,
                         observe_mode=response.observe_mode,
-                        policy_snapshot=self._native_policy_snapshot(workspace),
+                        policy_snapshot=self._native_policy_snapshot(workspace, deadline=deadline),
                     )
         elif python_oracle_enabled() and python_oracle_surface_enabled(mode):
             raise HookWorkerUnsupported("explicit test oracle is not installed in this process")

--- a/src/codex_plugin_scanner/guard/daemon/hook_worker_native.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_worker_native.py
@@ -67,7 +67,7 @@ class _HookWorkerNativeHost(Protocol):
     def activity_writer(self) -> object | None: ...
 
     _last_native_decision_receipt: dict[str, object] | None
-    _native_policy_snapshot: Callable[[Path | None], dict[str, object] | None]
+    _native_policy_snapshot: Callable[..., dict[str, object] | None]
     _review_pre_tool_native: Callable[..., dict[str, object] | None]
     _native_runtime_status: Callable[[], NativeRuntimeStatus]
     _review_raw_hook_native: Callable[..., dict[str, object] | None]
@@ -210,7 +210,7 @@ class HookWorkerNativeMixin:
         workspace: Path | None,
         deadline: float | None,
     ) -> dict[str, object]:
-        policy_snapshot = self._native_policy_snapshot(workspace)
+        policy_snapshot = self._native_policy_snapshot(workspace, deadline=deadline)
         recording_only = hook_review_is_recording_only(guard_home=guard_home, workspace=workspace) or (
             policy_snapshot is not None and policy_snapshot.get("mode") == "observe"
         )

--- a/src/codex_plugin_scanner/guard/daemon/hook_worker_responses.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_worker_responses.py
@@ -35,12 +35,21 @@ def prepare_native_hook_policy(
             payload,
             params,
             default_harness=default_harness,
-            reason="HOL Guard could not prepare the native policy safely.",
+            reason=_native_policy_not_ready_reason(daemon_server),
             reason_code="native_policy_not_ready",
             native_authoritative=True,
         )
     )
     return False
+
+
+def _native_policy_not_ready_reason(daemon_server: Any) -> str:
+    reason = "HOL Guard could not prepare the native policy safely."
+    publisher = getattr(getattr(daemon_server, "hook_worker", None), "policy_snapshot_publisher", None)
+    last_error = getattr(publisher, "last_error", None)
+    if isinstance(last_error, str) and last_error.strip():
+        return f"{reason} {last_error.strip()}."
+    return reason
 
 
 def _canonical_hook_harness(harness: str) -> str:

--- a/src/codex_plugin_scanner/guard/daemon/runtime_peer.py
+++ b/src/codex_plugin_scanner/guard/daemon/runtime_peer.py
@@ -43,7 +43,11 @@ def _package_version_is_current_or_newer(package_version: object, current_versio
         return False
 
 
-def daemon_state_matches_current_runtime(payload: dict[str, object]) -> bool:
+def daemon_state_matches_current_runtime(
+    payload: dict[str, object],
+    *,
+    current_version: str | None = None,
+) -> bool:
     """Accept the live current-protocol daemon when identity or a current Desktop Core matches."""
 
     from .manager import (
@@ -52,6 +56,7 @@ def daemon_state_matches_current_runtime(payload: dict[str, object]) -> bool:
         _current_guard_daemon_runtime_fingerprint,
     )
 
+    installed_version = current_version if current_version is not None else __version__
     fingerprint = payload.get("runtime_fingerprint")
     if payload.get("compatibility_version") != GUARD_DAEMON_COMPATIBILITY_VERSION:
         return False
@@ -59,8 +64,8 @@ def daemon_state_matches_current_runtime(payload: dict[str, object]) -> bool:
         return False
     if fingerprint == _current_guard_daemon_runtime_fingerprint():
         return True
-    if payload.get("package_version") == __version__:
+    if payload.get("package_version") == installed_version:
         return True
     if not daemon_desktop_core_source_available(payload.get("source_root")):
         return False
-    return _package_version_is_current_or_newer(payload.get("package_version"), __version__)
+    return _package_version_is_current_or_newer(payload.get("package_version"), installed_version)

--- a/src/codex_plugin_scanner/guard/daemon/runtime_peer.py
+++ b/src/codex_plugin_scanner/guard/daemon/runtime_peer.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from packaging.version import InvalidVersion, Version
+
 _DESKTOP_CORE_PARTS = ("org.hol.guard.desktop", "core", "versions")
 
 
@@ -36,8 +38,6 @@ def _package_version_is_current_or_newer(package_version: object, current_versio
     if not isinstance(package_version, str) or not package_version.strip():
         return False
     try:
-        from packaging.version import InvalidVersion, Version
-
         return Version(package_version) >= Version(current_version)
     except InvalidVersion:
         return False

--- a/src/codex_plugin_scanner/guard/daemon/runtime_peer.py
+++ b/src/codex_plugin_scanner/guard/daemon/runtime_peer.py
@@ -32,8 +32,19 @@ def daemon_desktop_core_source_available(source_root: object) -> bool:
     return path.exists()
 
 
+def _package_version_is_current_or_newer(package_version: object, current_version: str) -> bool:
+    if not isinstance(package_version, str) or not package_version.strip():
+        return False
+    try:
+        from packaging.version import InvalidVersion, Version
+
+        return Version(package_version) >= Version(current_version)
+    except InvalidVersion:
+        return False
+
+
 def daemon_state_matches_current_runtime(payload: dict[str, object]) -> bool:
-    """Accept the live current-protocol daemon when identity or Desktop Core matches."""
+    """Accept the live current-protocol daemon when identity or a current Desktop Core matches."""
 
     from .manager import (
         GUARD_DAEMON_COMPATIBILITY_VERSION,
@@ -50,4 +61,6 @@ def daemon_state_matches_current_runtime(payload: dict[str, object]) -> bool:
         return True
     if payload.get("package_version") == __version__:
         return True
-    return daemon_desktop_core_source_available(payload.get("source_root"))
+    if not daemon_desktop_core_source_available(payload.get("source_root")):
+        return False
+    return _package_version_is_current_or_newer(payload.get("package_version"), __version__)

--- a/src/codex_plugin_scanner/guard/daemon/runtime_repair.py
+++ b/src/codex_plugin_scanner/guard/daemon/runtime_repair.py
@@ -15,7 +15,7 @@ from .manager import (
     repair_approval_center_locator,
     retire_all_guard_daemons_for_home,
 )
-from .runtime_peer import daemon_desktop_core_source_available, daemon_source_is_desktop_core
+from .runtime_peer import daemon_state_matches_current_runtime
 from .start_lock import guard_daemon_start_lock as _guard_daemon_start_lock
 
 
@@ -48,14 +48,11 @@ def _keep_live_runtime_result(
     verified_runtime: tuple[Version, str, str] | None,
     current_version: Version,
 ) -> dict[str, object] | None:
-    if verified_runtime is None:
+    if verified_runtime is None or identity is None:
+        return None
+    if not daemon_state_matches_current_runtime(identity, current_version=str(current_version)):
         return None
     daemon_version, daemon_version_text, _ = verified_runtime
-    if daemon_version < current_version:
-        return None
-    source_root = None if identity is None else identity.get("source_root")
-    if daemon_source_is_desktop_core(source_root) and not daemon_desktop_core_source_available(source_root):
-        return None
     return {
         **result,
         "runtime_status": _retained_runtime_status(daemon_version, current_version),

--- a/src/codex_plugin_scanner/guard/daemon/runtime_repair.py
+++ b/src/codex_plugin_scanner/guard/daemon/runtime_repair.py
@@ -15,7 +15,7 @@ from .manager import (
     repair_approval_center_locator,
     retire_all_guard_daemons_for_home,
 )
-from .runtime_peer import daemon_desktop_core_source_available
+from .runtime_peer import daemon_desktop_core_source_available, daemon_source_is_desktop_core
 from .start_lock import guard_daemon_start_lock as _guard_daemon_start_lock
 
 
@@ -48,22 +48,18 @@ def _keep_live_runtime_result(
     verified_runtime: tuple[Version, str, str] | None,
     current_version: Version,
 ) -> dict[str, object] | None:
-    desktop_sidecar = identity is not None and daemon_desktop_core_source_available(identity.get("source_root"))
-    if verified_runtime is not None and (verified_runtime[0] >= current_version or desktop_sidecar):
-        daemon_version, daemon_version_text, _ = verified_runtime
-        return {
-            **result,
-            "runtime_status": _retained_runtime_status(daemon_version, current_version),
-            "daemon_version": daemon_version_text,
-            "cli_version": __version__,
-        }
-    if not desktop_sidecar:
+    if verified_runtime is None:
         return None
-    raw_version = identity.get("package_version") if identity is not None else None
+    daemon_version, daemon_version_text, _ = verified_runtime
+    if daemon_version < current_version:
+        return None
+    source_root = None if identity is None else identity.get("source_root")
+    if daemon_source_is_desktop_core(source_root) and not daemon_desktop_core_source_available(source_root):
+        return None
     return {
         **result,
-        "runtime_status": "retained_desktop_runtime",
-        "daemon_version": raw_version if isinstance(raw_version, str) else "unknown",
+        "runtime_status": _retained_runtime_status(daemon_version, current_version),
+        "daemon_version": daemon_version_text,
         "cli_version": __version__,
     }
 

--- a/src/codex_plugin_scanner/guard/native_policy_snapshot_publisher.py
+++ b/src/codex_plugin_scanner/guard/native_policy_snapshot_publisher.py
@@ -146,7 +146,7 @@ class NativePolicySnapshotPublisher(NativePolicySnapshotPublisherInputs):
 
         if workspace is None:
             return False
-        candidate = workspace.expanduser()
+        candidate = self._resolved_workspace(workspace)
         with self._condition:
             if candidate in self._workspace_paths:
                 return False
@@ -330,8 +330,6 @@ class NativePolicySnapshotPublisher(NativePolicySnapshotPublisherInputs):
                 if self._acked and self._renewal_due_monotonic is not None and now >= self._renewal_due_monotonic:
                     snapshot = self._snapshot
                     generation = snapshot.get("generation") if snapshot is not None else None
-                    self._acked = False
-                    self._last_error = None
                     self._renewal_due_monotonic = None
                     self._renewal_after_generation = (
                         generation if isinstance(generation, int) and generation > 0 else None
@@ -340,7 +338,7 @@ class NativePolicySnapshotPublisher(NativePolicySnapshotPublisherInputs):
                     self._failure_count = 0
                 should_publish = (
                     not self._closed
-                    and not self._acked
+                    and (not self._acked or self._renewal_after_generation is not None)
                     and (self._retry_not_before_monotonic is None or now >= self._retry_not_before_monotonic)
                 )
                 renewal_after_generation = self._renewal_after_generation
@@ -353,7 +351,9 @@ class NativePolicySnapshotPublisher(NativePolicySnapshotPublisherInputs):
             safe = "native_policy_snapshot_publish_failed"
         with self._condition:
             self._last_error = safe
-            self._acked = False
+            expires = self._snapshot.get("expires_at_ms") if self._snapshot else None
+            if not (self._acked and isinstance(expires, int) and expires > int(self._wall_clock() * 1_000)):
+                self._acked = False
             self._failure_count += 1
             delay = min(
                 _PUBLISH_RETRY_MAX_SECONDS,

--- a/src/codex_plugin_scanner/guard/native_policy_snapshot_publisher_inputs.py
+++ b/src/codex_plugin_scanner/guard/native_policy_snapshot_publisher_inputs.py
@@ -232,7 +232,4 @@ class NativePolicySnapshotPublisherInputs:
 
     @staticmethod
     def _resolved_workspace(workspace: Path) -> Path:
-        try:
-            return workspace.expanduser().resolve()
-        except (OSError, RuntimeError):
-            return workspace.expanduser()
+        return workspace.expanduser().absolute()

--- a/src/codex_plugin_scanner/guard/native_policy_snapshot_publisher_inputs.py
+++ b/src/codex_plugin_scanner/guard/native_policy_snapshot_publisher_inputs.py
@@ -229,3 +229,10 @@ class NativePolicySnapshotPublisherInputs:
         except (OSError, NativePolicySnapshotError, TypeError, ValueError, RuntimeError):
             return True
         return self._published_policy_fingerprint != current_fingerprint
+
+    @staticmethod
+    def _resolved_workspace(workspace: Path) -> Path:
+        try:
+            return workspace.expanduser().resolve()
+        except (OSError, RuntimeError):
+            return workspace.expanduser()

--- a/tests/test_cursor_hook_block_reason.py
+++ b/tests/test_cursor_hook_block_reason.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from codex_plugin_scanner.guard.adapters.cursor_hook_payload import cursor_hook_response_from_guard
+from codex_plugin_scanner.guard.daemon.hook_worker_responses import _native_policy_not_ready_reason
+
+
+def test_cursor_hook_response_surfaces_native_policy_reason() -> None:
+    reason = "HOL Guard could not prepare the native policy safely. native_policy_snapshot_runtime_unavailable."
+    response = cursor_hook_response_from_guard(
+        policy_action="block",
+        guard_payload={"reason": reason},
+        hook_event_name="beforeShellExecution",
+    )
+    assert response["permission"] == "deny"
+    assert response["user_message"] == reason
+    assert response["agent_message"] == reason
+
+
+def test_cursor_read_deny_surfaces_native_policy_reason() -> None:
+    reason = "HOL Guard could not prepare the native policy safely."
+    response = cursor_hook_response_from_guard(
+        policy_action="block",
+        guard_payload={"reason": reason},
+        hook_event_name="beforeReadFile",
+    )
+    assert response["permission"] == "deny"
+    assert response["user_message"] == reason
+    assert "agent_message" not in response
+
+
+def test_native_policy_not_ready_reason_includes_publisher_error() -> None:
+    daemon = SimpleNamespace(
+        hook_worker=SimpleNamespace(
+            policy_snapshot_publisher=SimpleNamespace(last_error="native_policy_snapshot_runtime_unavailable")
+        )
+    )
+    assert _native_policy_not_ready_reason(daemon) == (
+        "HOL Guard could not prepare the native policy safely. "
+        "native_policy_snapshot_runtime_unavailable."
+    )

--- a/tests/test_guard_daemon_runtime_repair.py
+++ b/tests/test_guard_daemon_runtime_repair.py
@@ -68,7 +68,12 @@ def test_repair_retains_authenticated_newer_runtime(
     monkeypatch.setattr(
         runtime_repair,
         "verified_live_guard_daemon_identity",
-        lambda _home: {"package_version": "3.0.35", "runtime_fingerprint": "newer"},
+        lambda _home: {
+            "package_version": "3.0.35",
+            "runtime_fingerprint": "newer",
+            "compatibility_version": manager.GUARD_DAEMON_COMPATIBILITY_VERSION,
+            "source_root": "Library/Application Support/org.hol.guard.desktop/core/versions/3.0.35/hol-guard",
+        },
     )
     monkeypatch.setattr(
         runtime_repair,
@@ -90,6 +95,49 @@ def test_repair_retains_authenticated_newer_runtime(
     result = runtime_repair.repair_guard_daemon_runtime(guard_home)
 
     assert result["runtime_status"] == "retained_newer_runtime"
+    assert result["daemon_version"] == "3.0.35"
+
+
+def test_repair_restarts_newer_mismatched_non_desktop_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    monkeypatch.setattr(
+        runtime_repair,
+        "verified_live_guard_daemon_identity",
+        lambda _home: {
+            "package_version": "3.0.35",
+            "runtime_fingerprint": "foreign-runtime",
+            "compatibility_version": manager.GUARD_DAEMON_COMPATIBILITY_VERSION,
+            "source_root": "/opt/hol-guard/lib/python",
+        },
+    )
+    monkeypatch.setattr(
+        runtime_repair,
+        "_verified_live_runtime",
+        lambda _state: (runtime_repair.Version("3.0.35"), "3.0.35", "foreign-runtime"),
+    )
+    monkeypatch.setattr(runtime_repair, "__version__", "3.0.34")
+    monkeypatch.setattr(
+        runtime_repair,
+        "repair_approval_center_locator",
+        lambda _home: {"repaired": True, "cleared": []},
+    )
+    monkeypatch.setattr(runtime_repair, "retire_all_guard_daemons_for_home", lambda _home: [321])
+    monkeypatch.setattr(runtime_repair, "guard_daemon_retirement_is_complete", lambda _home: True)
+    monkeypatch.setattr(runtime_repair, "clear_guard_daemon_state", lambda _home: None)
+    monkeypatch.setattr(
+        runtime_repair,
+        "ensure_guard_daemon_after_update",
+        lambda _home, *, home_dir: "http://127.0.0.1:5474",
+    )
+
+    result = runtime_repair.repair_guard_daemon_runtime(guard_home, home_dir=home_dir)
+
+    assert result["runtime_status"] == "restarted"
     assert result["daemon_version"] == "3.0.35"
 
 
@@ -118,7 +166,11 @@ def test_repair_retains_equal_version_peer_runtime(
     monkeypatch.setattr(
         runtime_repair,
         "verified_live_guard_daemon_identity",
-        lambda _home: {"package_version": "3.0.34", "runtime_fingerprint": "desktop-sidecar"},
+        lambda _home: {
+            "package_version": "3.0.34",
+            "runtime_fingerprint": "desktop-sidecar",
+            "compatibility_version": manager.GUARD_DAEMON_COMPATIBILITY_VERSION,
+        },
     )
     monkeypatch.setattr(runtime_repair, "__version__", "3.0.34")
     monkeypatch.setattr(

--- a/tests/test_guard_daemon_runtime_repair.py
+++ b/tests/test_guard_daemon_runtime_repair.py
@@ -139,7 +139,7 @@ def test_repair_retains_equal_version_peer_runtime(
     assert result["cli_version"] == "3.0.34"
 
 
-def test_repair_retains_older_desktop_core_sidecar(
+def test_repair_restarts_older_desktop_core_sidecar(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -156,26 +156,34 @@ def test_repair_retains_older_desktop_core_sidecar(
             "source_root": source_root,
         },
     )
+    monkeypatch.setattr(
+        runtime_repair,
+        "_verified_live_runtime",
+        lambda _state: (runtime_repair.Version("3.0.45"), "3.0.45", "desktop-sidecar"),
+    )
     monkeypatch.setattr(runtime_repair, "__version__", "3.0.46")
     monkeypatch.setattr(
         runtime_repair,
         "repair_approval_center_locator",
         lambda _home: {"repaired": True, "cleared": []},
     )
+    monkeypatch.setattr(runtime_repair, "retire_all_guard_daemons_for_home", lambda _home: [321])
+    monkeypatch.setattr(runtime_repair, "guard_daemon_retirement_is_complete", lambda _home: True)
+    monkeypatch.setattr(runtime_repair, "clear_guard_daemon_state", lambda _home: None)
     monkeypatch.setattr(
         runtime_repair,
-        "retire_all_guard_daemons_for_home",
-        lambda _home: (_ for _ in ()).throw(AssertionError("desktop sidecar must remain active")),
+        "ensure_guard_daemon_after_update",
+        lambda _home, *, home_dir: "http://127.0.0.1:5474",
     )
 
     result = runtime_repair.repair_guard_daemon_runtime(guard_home, home_dir=home_dir)
 
-    assert result["runtime_status"] == "retained_desktop_runtime"
+    assert result["runtime_status"] == "restarted"
     assert result["daemon_version"] == "3.0.45"
     assert result["cli_version"] == "3.0.46"
 
 
-def test_repair_retains_desktop_sidecar_with_invalid_package_version(
+def test_repair_restarts_desktop_sidecar_with_invalid_package_version(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -198,15 +206,18 @@ def test_repair_retains_desktop_sidecar_with_invalid_package_version(
         "repair_approval_center_locator",
         lambda _home: {"repaired": True, "cleared": []},
     )
+    monkeypatch.setattr(runtime_repair, "retire_all_guard_daemons_for_home", lambda _home: [321])
+    monkeypatch.setattr(runtime_repair, "guard_daemon_retirement_is_complete", lambda _home: True)
+    monkeypatch.setattr(runtime_repair, "clear_guard_daemon_state", lambda _home: None)
     monkeypatch.setattr(
         runtime_repair,
-        "retire_all_guard_daemons_for_home",
-        lambda _home: (_ for _ in ()).throw(AssertionError("desktop sidecar must remain active")),
+        "ensure_guard_daemon_after_update",
+        lambda _home, *, home_dir: "http://127.0.0.1:5474",
     )
 
     result = runtime_repair.repair_guard_daemon_runtime(guard_home, home_dir=home_dir)
 
-    assert result["runtime_status"] == "retained_desktop_runtime"
+    assert result["runtime_status"] == "restarted"
     assert result["daemon_version"] == "not-a-version"
     assert result["cli_version"] == "3.0.46"
 

--- a/tests/test_guard_daemon_stress_script.py
+++ b/tests/test_guard_daemon_stress_script.py
@@ -125,7 +125,7 @@ def test_daemon_stress_gate_keeps_fresh_process_alive_with_populated_store() -> 
         check=False,
         capture_output=True,
         text=True,
-        timeout=30,
+        timeout=45,
     )
     loaded = cast(object, json.loads(completed.stdout))
     assert isinstance(loaded, dict)
@@ -190,7 +190,7 @@ def test_enforced_soak_rejects_a_short_run_instead_of_claiming_proof() -> None:
         check=False,
         capture_output=True,
         text=True,
-        timeout=30,
+        timeout=45,
     )
     assert completed.returncode == 2
     assert "requires at least 100000 requests and 250000 receipts" in completed.stderr

--- a/tests/test_hook_worker_observe_pretool.py
+++ b/tests/test_hook_worker_observe_pretool.py
@@ -95,7 +95,7 @@ def test_hook_worker_watch_native_block_records_without_stopping(
         native_block_edge,
     )
     worker = HookWorker(store=GuardStore(guard_home))
-    monkeypatch.setattr(worker, "_native_policy_snapshot", lambda _workspace: {"mode": "observe"})
+    monkeypatch.setattr(worker, "_native_policy_snapshot", lambda _workspace, **_kwargs: {"mode": "observe"})
     try:
         result = worker.review_http_payload(
             payload={"hook_event_name": "PreToolUse", "tool_input": {"command": "rm -rf /"}},

--- a/tests/test_native_policy_snapshot_persistence.py
+++ b/tests/test_native_policy_snapshot_persistence.py
@@ -347,7 +347,7 @@ def test_renewal_failure_keeps_barrier_closed_at_expiry(
         first = publisher.current_snapshot()
         assert first is not None
         publisher._publish_once(renew_after_generation=first["generation"])
-        assert not publisher.is_ready()
+        assert publisher.is_ready()
         clock.wall = first["expires_at_ms"] / 1_000
         assert not publisher.is_ready()
     finally:

--- a/tests/test_native_policy_snapshot_publisher.py
+++ b/tests/test_native_policy_snapshot_publisher.py
@@ -387,6 +387,46 @@ def test_prepare_workspace_policy_waits_publish_budget_without_caller_deadline(
     assert wait_deadlines[-1] <= started_at + budget + 0.05
 
 
+def test_prepare_workspace_policy_skips_wait_after_publisher_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codex_plugin_scanner.guard.daemon.hook_worker as hook_worker_module
+
+    wait_deadlines: list[float] = []
+
+    class _Publisher:
+        last_error = "native_policy_snapshot_runtime_unavailable"
+
+        def start(self) -> None:
+            return
+
+        def register_workspace(self, workspace: Path | None) -> bool:
+            del workspace
+            return False
+
+        def wait_until_ready(self, deadline_monotonic: float) -> bool:
+            wait_deadlines.append(deadline_monotonic)
+            return False
+
+        def current_snapshot_binding(self) -> dict[str, object] | None:
+            return None
+
+        def close(self) -> None:
+            return
+
+    monkeypatch.setattr(hook_worker_module, "native_mode", lambda: "auto")
+    monkeypatch.setattr(hook_worker_module, "get_native_policy_snapshot_publisher", lambda _store: _Publisher())
+
+    worker = hook_worker_module.HookWorker(store=GuardStore(tmp_path / "guard-home"))
+    constructor_waits = len(wait_deadlines)
+    binding = worker.prepare_workspace_policy(tmp_path / "workspace")
+
+    assert binding is None
+    assert constructor_waits >= 1
+    assert len(wait_deadlines) == constructor_waits
+
+
 def test_same_generation_retries_reuse_exact_signed_snapshot_bytes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_native_policy_snapshot_publisher.py
+++ b/tests/test_native_policy_snapshot_publisher.py
@@ -292,7 +292,7 @@ def test_auto_hook_uses_barrier_without_loading_config_per_request(
         workspace=tmp_path / "workspace",
     )
     assert result["reason_code"] == "native_pre_tool_unavailable"
-    assert len(wait_deadlines) == 2
+    assert len(wait_deadlines) == 1
     assert 0 < wait_deadlines[0] - started_at <= hook_worker_module._NATIVE_POLICY_READY_TIMEOUT_SECONDS + 0.05
 
 
@@ -338,7 +338,7 @@ def test_prepare_workspace_policy_uses_bounded_first_workspace_handshake(
 
     assert binding is not None
     assert registered == [workspace]
-    assert len(wait_deadlines) == 2
+    assert len(wait_deadlines) == 1
     assert wait_deadlines[-1] <= started_at + 0.25
 
 
@@ -379,12 +379,13 @@ def test_prepare_workspace_policy_waits_publish_budget_without_caller_deadline(
     worker = hook_worker_module.HookWorker(store=GuardStore(tmp_path / "guard-home"))
     started_at = time.monotonic()
     binding = worker.prepare_workspace_policy(tmp_path / "workspace")
+    finished_at = time.monotonic()
 
     assert binding is not None
-    assert len(wait_deadlines) == 2
+    assert len(wait_deadlines) == 1
     budget = hook_worker_module._NATIVE_POLICY_READY_TIMEOUT_SECONDS
     assert wait_deadlines[-1] >= started_at + budget - 0.05
-    assert wait_deadlines[-1] <= started_at + budget + 0.05
+    assert wait_deadlines[-1] <= finished_at + budget + 0.05
 
 
 def test_prepare_workspace_policy_skips_wait_after_publisher_error(
@@ -419,12 +420,10 @@ def test_prepare_workspace_policy_skips_wait_after_publisher_error(
     monkeypatch.setattr(hook_worker_module, "get_native_policy_snapshot_publisher", lambda _store: _Publisher())
 
     worker = hook_worker_module.HookWorker(store=GuardStore(tmp_path / "guard-home"))
-    constructor_waits = len(wait_deadlines)
     binding = worker.prepare_workspace_policy(tmp_path / "workspace")
 
     assert binding is None
-    assert constructor_waits >= 1
-    assert len(wait_deadlines) == constructor_waits
+    assert wait_deadlines == []
 
 
 def test_same_generation_retries_reuse_exact_signed_snapshot_bytes(

--- a/tests/test_native_policy_snapshot_publisher.py
+++ b/tests/test_native_policy_snapshot_publisher.py
@@ -293,7 +293,7 @@ def test_auto_hook_uses_barrier_without_loading_config_per_request(
     )
     assert result["reason_code"] == "native_pre_tool_unavailable"
     assert len(wait_deadlines) == 2
-    assert 0 < wait_deadlines[0] - started_at <= 1.0
+    assert 0 < wait_deadlines[0] - started_at <= hook_worker_module._NATIVE_POLICY_READY_TIMEOUT_SECONDS + 0.05
 
 
 def test_prepare_workspace_policy_uses_bounded_first_workspace_handshake(
@@ -340,6 +340,51 @@ def test_prepare_workspace_policy_uses_bounded_first_workspace_handshake(
     assert registered == [workspace]
     assert len(wait_deadlines) == 2
     assert wait_deadlines[-1] <= started_at + 0.25
+
+
+def test_prepare_workspace_policy_waits_publish_budget_without_caller_deadline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import codex_plugin_scanner.guard.daemon.hook_worker as hook_worker_module
+
+    wait_deadlines: list[float] = []
+
+    class _Publisher:
+        def start(self) -> None:
+            return
+
+        def register_workspace(self, workspace: Path | None) -> bool:
+            del workspace
+            return False
+
+        def wait_until_ready(self, deadline_monotonic: float) -> bool:
+            wait_deadlines.append(deadline_monotonic)
+            return True
+
+        def current_snapshot_binding(self) -> dict[str, object]:
+            return {
+                "generation": 1,
+                "policy_digest": "a" * 64,
+                "runtime_identity": "b" * 64,
+                "mode": "enforce",
+            }
+
+        def close(self) -> None:
+            return
+
+    monkeypatch.setattr(hook_worker_module, "native_mode", lambda: "auto")
+    monkeypatch.setattr(hook_worker_module, "get_native_policy_snapshot_publisher", lambda _store: _Publisher())
+
+    worker = hook_worker_module.HookWorker(store=GuardStore(tmp_path / "guard-home"))
+    started_at = time.monotonic()
+    binding = worker.prepare_workspace_policy(tmp_path / "workspace")
+
+    assert binding is not None
+    assert len(wait_deadlines) == 2
+    budget = hook_worker_module._NATIVE_POLICY_READY_TIMEOUT_SECONDS
+    assert wait_deadlines[-1] >= started_at + budget - 0.05
+    assert wait_deadlines[-1] <= started_at + budget + 0.05
 
 
 def test_same_generation_retries_reuse_exact_signed_snapshot_bytes(

--- a/tests/test_native_policy_snapshot_publisher.py
+++ b/tests/test_native_policy_snapshot_publisher.py
@@ -292,7 +292,7 @@ def test_auto_hook_uses_barrier_without_loading_config_per_request(
         workspace=tmp_path / "workspace",
     )
     assert result["reason_code"] == "native_pre_tool_unavailable"
-    assert len(wait_deadlines) == 1
+    assert len(wait_deadlines) == 2
     assert 0 < wait_deadlines[0] - started_at <= hook_worker_module._NATIVE_POLICY_READY_TIMEOUT_SECONDS + 0.05
 
 
@@ -338,7 +338,7 @@ def test_prepare_workspace_policy_uses_bounded_first_workspace_handshake(
 
     assert binding is not None
     assert registered == [workspace]
-    assert len(wait_deadlines) == 1
+    assert len(wait_deadlines) == 2
     assert wait_deadlines[-1] <= started_at + 0.25
 
 
@@ -382,7 +382,7 @@ def test_prepare_workspace_policy_waits_publish_budget_without_caller_deadline(
     finished_at = time.monotonic()
 
     assert binding is not None
-    assert len(wait_deadlines) == 1
+    assert len(wait_deadlines) == 2
     budget = hook_worker_module._NATIVE_POLICY_READY_TIMEOUT_SECONDS
     assert wait_deadlines[-1] >= started_at + budget - 0.05
     assert wait_deadlines[-1] <= finished_at + budget + 0.05
@@ -420,10 +420,12 @@ def test_prepare_workspace_policy_skips_wait_after_publisher_error(
     monkeypatch.setattr(hook_worker_module, "get_native_policy_snapshot_publisher", lambda _store: _Publisher())
 
     worker = hook_worker_module.HookWorker(store=GuardStore(tmp_path / "guard-home"))
+    constructor_waits = len(wait_deadlines)
     binding = worker.prepare_workspace_policy(tmp_path / "workspace")
 
     assert binding is None
-    assert wait_deadlines == []
+    assert constructor_waits == 1
+    assert len(wait_deadlines) == 1
 
 
 def test_same_generation_retries_reuse_exact_signed_snapshot_bytes(

--- a/tests/test_native_policy_snapshot_v3_publisher.py
+++ b/tests/test_native_policy_snapshot_v3_publisher.py
@@ -49,6 +49,9 @@ test_auto_hook_uses_barrier_without_loading_config_per_request = (
 test_prepare_workspace_policy_uses_bounded_first_workspace_handshake = (
     _publisher_tests.test_prepare_workspace_policy_uses_bounded_first_workspace_handshake
 )
+test_prepare_workspace_policy_skips_wait_after_publisher_error = (
+    _publisher_tests.test_prepare_workspace_policy_skips_wait_after_publisher_error
+)
 test_prepare_workspace_policy_waits_publish_budget_without_caller_deadline = (
     _publisher_tests.test_prepare_workspace_policy_waits_publish_budget_without_caller_deadline
 )
@@ -129,6 +132,7 @@ __all__ = [
     "test_floor_recovery_requires_exact_typed_ack",
     "test_lost_ack_retries_identical_payload",
     "test_policy_merge_never_downgrades_enforcing_posture_to_watch",
+    "test_prepare_workspace_policy_skips_wait_after_publisher_error",
     "test_prepare_workspace_policy_uses_bounded_first_workspace_handshake",
     "test_prepare_workspace_policy_waits_publish_budget_without_caller_deadline",
     "test_publisher_does_not_ack_snapshot_after_concurrent_mutation",

--- a/tests/test_native_policy_snapshot_v3_publisher.py
+++ b/tests/test_native_policy_snapshot_v3_publisher.py
@@ -49,6 +49,9 @@ test_auto_hook_uses_barrier_without_loading_config_per_request = (
 test_prepare_workspace_policy_uses_bounded_first_workspace_handshake = (
     _publisher_tests.test_prepare_workspace_policy_uses_bounded_first_workspace_handshake
 )
+test_prepare_workspace_policy_waits_publish_budget_without_caller_deadline = (
+    _publisher_tests.test_prepare_workspace_policy_waits_publish_budget_without_caller_deadline
+)
 test_publisher_does_not_ack_snapshot_after_concurrent_mutation = (
     _publisher_tests.test_publisher_does_not_ack_snapshot_after_concurrent_mutation
 )
@@ -127,6 +130,7 @@ __all__ = [
     "test_lost_ack_retries_identical_payload",
     "test_policy_merge_never_downgrades_enforcing_posture_to_watch",
     "test_prepare_workspace_policy_uses_bounded_first_workspace_handshake",
+    "test_prepare_workspace_policy_waits_publish_budget_without_caller_deadline",
     "test_publisher_does_not_ack_snapshot_after_concurrent_mutation",
     "test_publisher_does_not_republish_for_generation_created_by_own_ack",
     "test_publisher_process_restart_reuses_cached_payload",

--- a/tests/test_native_pretool_generic.py
+++ b/tests/test_native_pretool_generic.py
@@ -235,8 +235,9 @@ def test_resident_entrypoint_sends_both_tool_events_to_hook_worker(
     calls: list[str] = []
 
     class FakeWorker:
-        def __init__(self, *, store: object) -> None:
+        def __init__(self, *, store: object, **_kwargs: object) -> None:
             del store
+            del _kwargs
 
         def review_http_payload(self, *, payload: dict[str, object], **_kwargs: object) -> dict[str, object]:
             calls.append(str(payload.get("hook_event_name")))
@@ -272,8 +273,9 @@ def test_resident_entrypoint_routes_unknown_event_to_native_in_auto(
     calls: list[str] = []
 
     class FakeWorker:
-        def __init__(self, *, store: object) -> None:
+        def __init__(self, *, store: object, **_kwargs: object) -> None:
             del store
+            del _kwargs
 
         def review_http_payload(self, *, payload: dict[str, object], **_kwargs: object) -> dict[str, object]:
             calls.append(str(payload.get("hook_event_name")))
@@ -348,8 +350,9 @@ def test_supported_cli_pretool_worker_exception_is_fail_safe(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class BrokenWorker:
-        def __init__(self, *, store: object) -> None:
+        def __init__(self, *, store: object, **_kwargs: object) -> None:
             del store
+            del _kwargs
 
         def review_http_payload(self, **_kwargs: object) -> dict[str, object]:
             raise RuntimeError("worker fixture failure")

--- a/tests/test_native_pretool_receipts.py
+++ b/tests/test_native_pretool_receipts.py
@@ -47,3 +47,41 @@ def test_resident_entrypoint_returns_worker_receipt_to_daemon_owner(
         "route": "native_resident",
         "receipt": receipt,
     }
+
+
+def test_resident_entrypoint_forwards_parent_deadline_to_hook_worker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeWorker:
+        last_native_decision_receipt = None
+
+        def __init__(self, *, store: object, **_kwargs: object) -> None:
+            del store
+            del _kwargs
+
+        def review_http_payload(self, **kwargs: object) -> dict[str, object]:
+            captured.update(kwargs)
+            return {"policy_action": "allow"}
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.daemon.hook_worker.HookWorker", FakeWorker)
+    monkeypatch.setattr(hook_process_entrypoint, "_current_decision_route", lambda: "native_resident")
+    guard_home = tmp_path / "guard-home"
+    result = hook_process_entrypoint._run_resident_hook_request(
+        {
+            "payload": {"hook_event_name": "PreToolUse", "tool_input": {"command": "pwd"}},
+            "harness": "codex",
+            "home_dir": str(tmp_path / "home"),
+            "guard_home": str(guard_home),
+            "workspace": str(tmp_path / "workspace"),
+            "deadline": 12.5,
+        },
+        stores={},
+        hook_workers={},
+        configured_guard_home=str(guard_home),
+    )
+
+    assert result["reason_code"] is None
+    assert captured["deadline"] == 12.5

--- a/tests/test_native_pretool_receipts.py
+++ b/tests/test_native_pretool_receipts.py
@@ -18,8 +18,9 @@ def test_resident_entrypoint_returns_worker_receipt_to_daemon_owner(
     class FakeWorker:
         last_native_decision_receipt = receipt
 
-        def __init__(self, *, store: object) -> None:
+        def __init__(self, *, store: object, **_kwargs: object) -> None:
             del store
+            del _kwargs
 
         def review_http_payload(self, **_kwargs: object) -> dict[str, object]:
             return {"policy_action": "allow"}

--- a/tests/test_watch_continue_same_release_daemon.py
+++ b/tests/test_watch_continue_same_release_daemon.py
@@ -59,7 +59,7 @@ def test_guard_daemon_state_rejects_different_package_version_peer() -> None:
     assert not daemon_manager_module._guard_daemon_state_matches_current_runtime(payload)
 
 
-def test_guard_daemon_state_matches_older_desktop_core_sidecar() -> None:
+def test_guard_daemon_state_rejects_older_desktop_core_sidecar() -> None:
     payload = {
         "compatibility_version": daemon_manager_module.GUARD_DAEMON_COMPATIBILITY_VERSION,
         "package_version": "0.0.1",
@@ -67,14 +67,14 @@ def test_guard_daemon_state_matches_older_desktop_core_sidecar() -> None:
         "runtime_fingerprint": "desktop-sidecar-fingerprint",
     }
 
-    assert daemon_manager_module._guard_daemon_state_matches_current_runtime(payload)
+    assert not daemon_manager_module._guard_daemon_state_matches_current_runtime(payload)
 
 
-def test_guard_daemon_state_matches_windows_desktop_core_sidecar() -> None:
+def test_guard_daemon_state_matches_newer_windows_desktop_core_sidecar() -> None:
     payload = {
         "compatibility_version": daemon_manager_module.GUARD_DAEMON_COMPATIBILITY_VERSION,
-        "package_version": "0.0.1",
-        "source_root": r"AppData\Roaming\org.hol.guard.desktop\core\versions\0.0.1\hol-guard",
+        "package_version": "99.0.0",
+        "source_root": r"AppData\Roaming\org.hol.guard.desktop\core\versions\99.0.0\hol-guard",
         "runtime_fingerprint": "desktop-sidecar-fingerprint",
     }
 
@@ -148,13 +148,13 @@ def test_guard_daemon_state_rejects_missing_absolute_desktop_core_tree(tmp_path:
     assert not daemon_manager_module._guard_daemon_state_matches_current_runtime(payload)
 
 
-def test_guard_daemon_state_matches_existing_absolute_desktop_core_tree(tmp_path: Path) -> None:
-    sidecar = tmp_path / "org.hol.guard.desktop" / "core" / "versions" / "0.0.1" / "hol-guard"
+def test_guard_daemon_state_matches_existing_absolute_newer_desktop_core_tree(tmp_path: Path) -> None:
+    sidecar = tmp_path / "org.hol.guard.desktop" / "core" / "versions" / "99.0.0" / "hol-guard"
     sidecar.parent.mkdir(parents=True)
     sidecar.write_text("placeholder", encoding="utf-8")
     payload = {
         "compatibility_version": daemon_manager_module.GUARD_DAEMON_COMPATIBILITY_VERSION,
-        "package_version": "0.0.1",
+        "package_version": "99.0.0",
         "source_root": str(sidecar),
         "runtime_fingerprint": "desktop-sidecar-fingerprint",
     }
@@ -196,7 +196,7 @@ def test_load_guard_daemon_url_rejects_older_package_version(
     assert daemon_manager_module.load_guard_daemon_url(guard_home) is None
 
 
-def test_load_guard_daemon_url_accepts_older_desktop_core_sidecar(
+def test_load_guard_daemon_url_rejects_older_desktop_core_sidecar(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -231,7 +231,7 @@ def test_load_guard_daemon_url_accepts_older_desktop_core_sidecar(
         lambda request, timeout=1: _HealthzResponse(),
     )
 
-    assert daemon_manager_module.load_guard_daemon_url(guard_home) == "http://127.0.0.1:5530"
+    assert daemon_manager_module.load_guard_daemon_url(guard_home) is None
 
 
 def test_load_guard_daemon_url_accepts_same_release_peer_fingerprint(


### PR DESCRIPTION
## Summary
- Restart older Desktop Core sidecars when the installed CLI is newer so native review uses a matching runtime.
- Keep a still-valid native snapshot across publisher retries, wait the full publish budget before fail-closed, and surface native-policy not-ready reasons in Cursor denies.

## Testing
- `PYTHONPATH=src python -m pytest -q tests/test_guard_daemon_runtime_repair.py tests/test_native_policy_snapshot_persistence.py tests/test_native_policy_snapshot_publisher.py tests/test_native_policy_snapshot_v3_publisher.py tests/test_cursor_hook_block_reason.py tests/test_hook_availability_policy.py tests/test_watch_continue_same_release_daemon.py`
- `python scripts/ci/code_quality_audit.py --baseline ci/code-quality-baseline.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Hook-blocking messages now provide clearer reasons, including policy and system-provided details.
  * Policy readiness failures include more useful error information when available.
  * Policy readiness remains available during recoverable renewal failures until the current snapshot expires.
  * Workspace handling is more consistent across equivalent path formats.
  * Readiness checks respect request deadlines and avoid unnecessary waits after publisher errors.
  * Resident hook requests no longer wait unnecessarily for native policy readiness.
  * Readiness timing now follows the configured policy publishing budget.

* **Bug Fixes**
  * Older, invalid, or unavailable Desktop Core runtimes are no longer accepted and are restarted when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->