### PR TITLE
fix(guard): keep leftover hooks and daemon gaps from freezing sessions

### DIFF
--- a/ci/native_runtime/probe_native_default_auto.py
+++ b/ci/native_runtime/probe_native_default_auto.py
@@ -245,7 +245,13 @@ def _exercise_mode_invariants(
             )
             if not isinstance(response, dict):
                 raise RuntimeError(f"native_default_auto_probe_failed: invalid mode response: {response}")
-            _require(response.get("decision") == "block", {"mode": mode, "response": response})
+            _require(
+                response.get("continue") is True
+                and response.get("policy_action") == "allow"
+                and response.get("reason_code")
+                in {"native_hook_disabled", "native_shadow_diagnostic_disabled"},
+                {"mode": mode, "response": response},
+            )
             mode_invariants[mode] = {
                 "decision": response.get("decision"),
                 "reason_code": response.get("reason_code"),

--- a/ci/native_runtime/test_guard_native_runtime_resident.py
+++ b/ci/native_runtime/test_guard_native_runtime_resident.py
@@ -339,7 +339,7 @@ def test_hook_worker_auto_fails_closed_when_native_unavailable(tmp_path: Path, m
         workspace=tmp_path,
     )
     assert python_calls == 0
-    assert result["decision"] == "block"
+    assert result["continue"] is True
     assert result["reason_code"] == "native_post_tool_unavailable"
 
 

--- a/docs/guard/adr/0009-native-and-daemon-critical-failure.md
+++ b/docs/guard/adr/0009-native-and-daemon-critical-failure.md
@@ -21,8 +21,8 @@ A native failure follows a capability-specific bounded sequence while the Python
 
 A Python daemon failure is a critical protection state:
 
-- PostToolUse output remains withheld or blocked.
 - Mutating, network-capable, secret-capable, destructive, package-executing, process-control, policy-tampering, and uncertain PreToolUse actions pause.
+- PostToolUse continues when native review cannot complete. The tool already ran; withholding the turn freezes the session without preventing the action. Native PostToolUse decisions still apply when review succeeds.
 - The ratified emergency-safe inspection profile may continue: workspace source reads, grep/glob, and bounded local git/status inspection. Continuations emit `native_degraded_emergency_safe` and never restore a Python semantic evaluator.
 - Empty or malformed hook responses must never be interpreted as successful tool execution.
 

--- a/docs/guard/contracts/rust-native-fail-safe-matrix.v1.json
+++ b/docs/guard/contracts/rust-native-fail-safe-matrix.v1.json
@@ -13,12 +13,12 @@
     },
     "all_evaluators_overloaded": {
       "pre_tool": "emergency_safe_only_else_pause",
-      "post_tool": "withhold_or_block",
+      "post_tool": "observe_continue",
       "prompt_and_permission": "pause_or_deny"
     },
     "python_daemon_unavailable": {
       "pre_tool": "authenticated_emergency_safe_only_else_pause",
-      "post_tool": "withhold_or_block",
+      "post_tool": "observe_continue",
       "prompt_and_permission": "fail_closed"
     },
     "policy_snapshot_stale_or_invalid": {
@@ -38,8 +38,8 @@
     }
   },
   "invariants": [
-    "No native, daemon, transport, policy, timeout, overload, or parser failure becomes allow.",
-    "PostToolUse output is withheld until an authoritative review completes.",
+    "No native, daemon, transport, policy, timeout, overload, or parser failure becomes a high-impact PreToolUse allow.",
+    "PostToolUse continues when authoritative review cannot complete; native block decisions still withhold output.",
     "One-shot and Python fallbacks are bounded and may not amplify overload into process creation.",
     "After Rust authority cutover, resident Rust then verified one-shot Rust then fail-safe pause is the only supported chain."
   ]

--- a/docs/guard/rust-runtime-hardening-prd.md
+++ b/docs/guard/rust-runtime-hardening-prd.md
@@ -13,8 +13,8 @@ Eligible PostToolUse and supported PreToolUse review use the verified bundled Ru
 ## Security invariants
 
 1. Rust never lowers the canonical action, approval floor, or output restriction.
-2. Unreviewed PostToolUse output never reaches the model.
-3. Unknown parsing, stale policy, exhausted scan budget, overload, or daemon unavailability never becomes an unsafe allow.
+2. When native PostToolUse review completes, blocked output never reaches the model. When that review cannot complete, the turn continues because the tool already ran.
+3. Unknown parsing, stale policy, exhausted scan budget, overload, or daemon unavailability never becomes an unsafe high-impact PreToolUse allow.
 4. Same-user local processes are untrusted until message-level authentication succeeds.
 5. Every connection, frame, allocation, parser, scanner, worker, queue, subprocess, log, restart, and fallback is bounded.
 6. The resident Rust child remains outside the Python process and runs through the existing containment and process-tree cleanup boundary.
@@ -37,7 +37,7 @@ A resident crash must not retire a healthy Python daemon. Restart occurs outside
 
 During Python daemon failure:
 
-- PostToolUse output is withheld or blocked.
+- PostToolUse output is withheld when native review blocks it. When the daemon cannot complete PostToolUse review, the turn continues because the tool already ran.
 - Mutating, network, secret-capable, destructive, package-executing, process-control, policy-tampering, and uncertain PreToolUse operations pause.
 - Only the authenticated exact emergency-safe profile may continue.
 - Empty or malformed responses are never treated as successful execution.

--- a/docs/guard/rust-runtime-hardening-takeaway.md
+++ b/docs/guard/rust-runtime-hardening-takeaway.md
@@ -35,8 +35,8 @@ HOL Guard's product contract:
 - Safe, routine engineering work should proceed autonomously with minimal or no prompts.
 - Catastrophic-capable actions must pause before the side effect occurs.
 - Catastrophic risks include secret exfiltration, prompt injection, broad file deletion or corruption, destructive production database or infrastructure actions, supply-chain compromise, and attempts to disable or overload Guard.
-- PostToolUse output must not reach the model until it has been safely reviewed.
-- A timeout, crash, overload, stale policy, invalid artifact, transport failure, or parser uncertainty must never become an unsafe allow.
+- PostToolUse output is withheld when native review blocks it. If review cannot complete, the turn continues because the tool already ran.
+- A timeout, crash, overload, stale policy, invalid artifact, transport failure, or parser uncertainty must never become an unsafe high-impact PreToolUse allow.
 - If Python and Rust disagree, choose the more restrictive outcome and record only a privacy-safe mismatch category.
 - A Rust crash must not crash the Python daemon.
 - A Python daemon crash or authenticated daemon-unavailable state is a critical failure and must invoke the documented fail-safe hook behavior.
@@ -168,7 +168,7 @@ Crash requirements:
 - Repeated crashes open a circuit and keep Python authoritative.
 - A native crash during a request may use Python only if deadline and capacity remain.
 - A daemon crash must never allow a dangerous, network, secret-capable, destructive, package-executing, process-control, policy-tampering, or uncertain action.
-- PostToolUse output remains blocked while the daemon is unavailable.
+- PostToolUse continues while the daemon is unavailable; native block decisions still withhold output.
 - Only the ratified authenticated emergency-safe read-only profile may continue.
 
 Performance requirements:

--- a/scripts/ci/rust_pretool_no_python_gate.py
+++ b/scripts/ci/rust_pretool_no_python_gate.py
@@ -49,6 +49,20 @@ def function_calls(node: ast.AST) -> set[str]:
     return calls
 
 
+_TYPED_FAIL_SAFE = frozenset(
+    {
+        "post_tool_fail_safe_response",
+        "availability_harness_response",
+        "_native_worker_fail_safe_result",
+        "_runtime_hook_fail_safe_response",
+    }
+)
+
+
+def _has_typed_fail_safe(node: ast.AST) -> bool:
+    return bool(_TYPED_FAIL_SAFE.intersection(function_calls(node)))
+
+
 def function_strings(node: ast.AST) -> set[str]:
     return {child.value for child in ast.walk(node) if isinstance(child, ast.Constant) and isinstance(child.value, str)}
 
@@ -195,7 +209,7 @@ def _resident_graph_failures(root: Path) -> list[str]:
         for child in resident.body
     ):
         failures.append("resident entrypoint can reach Python CLI without a native-mode return guard")
-    elif "post_tool_fail_safe_response" not in function_calls(unsupported):
+    elif not _has_typed_fail_safe(unsupported):
         failures.append("resident HookWorkerUnsupported native branch has no fail-safe response")
     return failures
 
@@ -213,7 +227,7 @@ def _native_cli_graph_failures(root: Path) -> list[str]:
         failures.append("CLI source-ref path is reachable before native authority")
     if "_native_mode_requires_rust" not in function_calls(native_route):
         failures.append("CLI native/source-ref route has no native-mode guard")
-    if "post_tool_fail_safe_response" not in function_calls(native_route):
+    if not _has_typed_fail_safe(native_route):
         failures.append("CLI native/source-ref route has no fail-safe native terminal")
     return failures
 

--- a/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
@@ -16,8 +16,8 @@ from ..codex_hook_launch_runtime import (
     isolated_hook_environment,
     run_isolated_hook_process,
 )
-from ..daemon.hook_availability_policy import EMERGENCY_SAFE_REASON, hook_action_is_emergency_safe
 from ..private_file_io import read_private_regular_text
+from .bounded_cli_hook_failure import failure_payload as _failure_payload
 from .desktop_hook_proxy import (
     _DESKTOP_PROXY_LAUNCH_SCRIPT as _DESKTOP_PROXY_LAUNCH_SCRIPT,
 )
@@ -251,83 +251,6 @@ def _guard_home_is_recording_only(guard_home: Path) -> bool:
     return protection_is_off(posture=config.protection_posture, mode=config.mode)
 
 
-def _watch_continue_payload(harness: str, event_name: str) -> dict[str, object]:
-    if harness == "copilot":
-        return {"permissionDecision": "allow"}
-    if harness in {"grok", "hermes", "openclaw"}:
-        return {"decision": "allow"}
-    return {
-        "hookSpecificOutput": {
-            "hookEventName": event_name,
-            "permissionDecision": "allow",
-        }
-    }
-
-
-def _failure_payload(
-    *,
-    harness: str,
-    event_name: str,
-    reason: str,
-    input_text: str = "",
-    guard_home: Path | None = None,
-) -> tuple[dict[str, object], int]:
-    if guard_home is not None and _guard_home_is_recording_only(guard_home):
-        return _watch_continue_payload(harness, event_name), 0
-    payload = _json_object(input_text or "{}")
-    if event_name == "PreToolUse" and isinstance(payload, dict) and hook_action_is_emergency_safe(payload):
-        if harness == "copilot":
-            return {
-                "permissionDecision": "allow",
-                "permissionDecisionReason": EMERGENCY_SAFE_REASON,
-            }, 0
-        if harness in {"grok", "hermes", "openclaw"}:
-            return {"decision": "allow", "reason": EMERGENCY_SAFE_REASON}, 0
-        return {
-            "hookSpecificOutput": {
-                "hookEventName": event_name,
-                "permissionDecision": "allow",
-                "permissionDecisionReason": EMERGENCY_SAFE_REASON,
-            }
-        }, 0
-    if harness == "copilot":
-        if event_name == "PermissionRequest":
-            return {
-                "behavior": "deny",
-                "message": reason,
-                "interrupt": True,
-            }, 0
-        return {
-            "permissionDecision": "deny",
-            "permissionDecisionReason": reason,
-        }, 0
-    if harness in {"grok", "hermes", "openclaw"}:
-        decision = "block" if harness == "hermes" else "deny"
-        return {"decision": decision, "reason": reason}, (2 if harness == "hermes" else 0)
-    if event_name == "UserPromptSubmit":
-        return {
-            "decision": "block",
-            "reason": reason,
-            "hookSpecificOutput": {
-                "hookEventName": event_name,
-                "additionalContext": reason,
-            },
-        }, 2
-    if event_name == "PreToolUse":
-        return {
-            "hookSpecificOutput": {
-                "hookEventName": event_name,
-                "permissionDecision": "deny",
-                "permissionDecisionReason": reason,
-            }
-        }, 2
-    return {
-        "continue": False,
-        "stopReason": reason,
-        "systemMessage": reason,
-    }, 0
-
-
 def _emit_failure(
     *,
     harness: str,
@@ -339,8 +262,8 @@ def _emit_failure(
         harness=harness,
         event_name=_event_name(input_text),
         reason=reason,
-        input_text=input_text,
-        guard_home=guard_home,
+        payload=_json_object(input_text or "{}"),
+        recording_only=guard_home is not None and _guard_home_is_recording_only(guard_home),
     )
     _ = sys.stdout.write(json.dumps(payload, ensure_ascii=True, separators=(",", ":")) + "\n")
     return returncode

--- a/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_failure.py
+++ b/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_failure.py
@@ -1,0 +1,106 @@
+"""Fail-safe payloads for bounded CLI harness hooks when review cannot finish."""
+
+from __future__ import annotations
+
+from ..daemon.hook_availability_policy import (
+    EMERGENCY_SAFE_REASON,
+    hook_action_is_emergency_safe,
+    hook_event_pauses_when_unavailable,
+)
+
+_DECISION_HOOK_HARNESSES = frozenset({"grok", "hermes", "openclaw"})
+
+
+def watch_continue_payload(harness: str, event_name: str) -> dict[str, object]:
+    if harness == "copilot":
+        return {"permissionDecision": "allow"}
+    if harness in _DECISION_HOOK_HARNESSES:
+        return {"decision": "allow"}
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": event_name,
+            "permissionDecision": "allow",
+        }
+    }
+
+
+def _emergency_safe_payload(harness: str, event_name: str) -> dict[str, object]:
+    if harness == "copilot":
+        return {
+            "permissionDecision": "allow",
+            "permissionDecisionReason": EMERGENCY_SAFE_REASON,
+        }
+    if harness in _DECISION_HOOK_HARNESSES:
+        return {"decision": "allow", "reason": EMERGENCY_SAFE_REASON}
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": event_name,
+            "permissionDecision": "allow",
+            "permissionDecisionReason": EMERGENCY_SAFE_REASON,
+        }
+    }
+
+
+def _observe_payload(harness: str, event_name: str, reason: str) -> dict[str, object]:
+    if harness == "copilot":
+        return {"permissionDecision": "allow"}
+    if harness in _DECISION_HOOK_HARNESSES:
+        return {"decision": "allow", "reason": reason}
+    return {
+        "continue": True,
+        "systemMessage": reason,
+        "hookSpecificOutput": {"hookEventName": event_name},
+    }
+
+
+def _pause_payload(harness: str, event_name: str, reason: str) -> tuple[dict[str, object], int]:
+    if harness == "copilot":
+        if event_name == "PermissionRequest":
+            return {
+                "behavior": "deny",
+                "message": reason,
+                "interrupt": True,
+            }, 0
+        return {
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }, 0
+    if harness in _DECISION_HOOK_HARNESSES:
+        decision = "block" if harness == "hermes" else "deny"
+        return {"decision": decision, "reason": reason}, (2 if harness == "hermes" else 0)
+    if event_name == "PermissionRequest":
+        return {
+            "continue": False,
+            "stopReason": reason,
+            "systemMessage": reason,
+        }, 0
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": event_name,
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }, 2
+
+
+def failure_payload(
+    *,
+    harness: str,
+    event_name: str,
+    reason: str,
+    payload: dict[str, object] | None,
+    recording_only: bool,
+) -> tuple[dict[str, object], int]:
+    if recording_only:
+        return watch_continue_payload(harness, event_name), 0
+    pauses = hook_event_pauses_when_unavailable(event_name)
+    if (
+        pauses
+        and event_name != "PermissionRequest"
+        and isinstance(payload, dict)
+        and hook_action_is_emergency_safe(payload)
+    ):
+        return _emergency_safe_payload(harness, event_name), 0
+    if not pauses:
+        return _observe_payload(harness, event_name, reason), 0
+    return _pause_payload(harness, event_name, reason)

--- a/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
@@ -337,7 +337,7 @@ def _authenticated_control_plane_failure(reason: str, data: str) -> str:
             },
             separators=(",", ":"),
         )
-    return json.dumps({"continue": False, "stopReason": message}, separators=(",", ":"))
+    return json.dumps({"continue": True, "stopReason": message}, separators=(",", ":"))
 
 
 def _should_suppress_output(data: str, response_body: str) -> bool:

--- a/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
@@ -325,12 +325,12 @@ def _degraded(reason: str, data: str) -> str:
 
 def _authenticated_control_plane_failure(reason: str, data: str) -> str:
     message = f"HOL Guard denied the action because daemon authentication failed: {reason}"
-    if _event_name(data) == "PreToolUse":
+    if (event := _event_name(data)) == "PreToolUse" or event.startswith("Permission"):
         return json.dumps(
             {
                 "systemMessage": message,
                 "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
+                    "hookEventName": event,
                     "permissionDecision": "deny",
                     "permissionDecisionReason": message,
                 },

--- a/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
@@ -325,19 +325,14 @@ def _degraded(reason: str, data: str) -> str:
 
 def _authenticated_control_plane_failure(reason: str, data: str) -> str:
     message = f"HOL Guard denied the action because daemon authentication failed: {reason}"
-    if (event := _event_name(data)) == "PreToolUse" or event.startswith("Permission"):
-        return json.dumps(
-            {
-                "systemMessage": message,
-                "hookSpecificOutput": {
-                    "hookEventName": event,
-                    "permissionDecision": "deny",
-                    "permissionDecisionReason": message,
-                },
-            },
-            separators=(",", ":"),
-        )
-    return json.dumps({"continue": True, "stopReason": message}, separators=(",", ":"))
+    event = _event_name(data)
+    if event.startswith("Permission"):
+        output: dict[str, object] = {"hookEventName": event, "decision": {"behavior": "deny", "message": message}}
+    elif event == "PreToolUse":
+        output = {"hookEventName": event, "permissionDecision": "deny", "permissionDecisionReason": message}
+    else:
+        return json.dumps({"continue": True, "stopReason": message}, separators=(",", ":"))
+    return json.dumps({"systemMessage": message, "hookSpecificOutput": output}, separators=(",", ":"))
 
 
 def _should_suppress_output(data: str, response_body: str) -> bool:

--- a/src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_bridge.py
@@ -196,7 +196,7 @@ def main(
 
     hook_input = _bound_hook_input(hook_timeouts)
     if hook_input is None:
-        sys.stdout.write(json.dumps(_fail_closed("Unknown"), separators=(",", ":")))
+        sys.stdout.write(json.dumps(_fail_closed("PreToolUse"), separators=(",", ":")))
         return 0
     event_name, data, timeout_seconds = hook_input
     deadline = time.monotonic() + timeout_seconds

--- a/src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_bridge.py
@@ -120,15 +120,8 @@ def _fail_closed(event_name: str, reason: str = _FAIL_CLOSED_REASON) -> dict[str
                 "permissionDecisionReason": reason,
             }
         }
-    if event_name == "PostToolUse":
-        return {
-            "continue": False,
-            "stopReason": reason,
-            "systemMessage": reason,
-        }
     return {
-        "continue": False,
-        "stopReason": reason,
+        "continue": True,
         "systemMessage": reason,
     }
 

--- a/src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_bridge.py
@@ -196,7 +196,7 @@ def main(
 
     hook_input = _bound_hook_input(hook_timeouts)
     if hook_input is None:
-        sys.stdout.write(json.dumps(_fail_closed("PreToolUse"), separators=(",", ":")))
+        sys.stdout.write(json.dumps(_fail_closed("Unknown"), separators=(",", ":")))
         return 0
     event_name, data, timeout_seconds = hook_input
     deadline = time.monotonic() + timeout_seconds

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_config.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_config.py
@@ -26,13 +26,19 @@ _MANAGED_HOOK_EVENTS = _BLOCKING_MANAGED_HOOK_EVENTS + _OBSERVER_MANAGED_HOOK_EV
 _MANAGED_HOOK_TIMEOUT_SECONDS = 45
 
 
-def _managed_hook_command(*, python_executable: Path | None, script_path: Path) -> str:
+def _managed_hook_command(
+    *,
+    python_executable: Path | None,
+    script_path: Path,
+    event_name: str,
+) -> str:
     script = str(script_path.resolve())
+    event_args = ["--cursor-hook-event", event_name]
     if python_executable is not None:
-        return shlex.join([str(python_executable), script])
+        return shlex.join([str(python_executable), script, *event_args])
     if bool(getattr(sys, "frozen", False)):
-        return shlex.join([sys.executable, FROZEN_CURSOR_HOOK_COMMAND, script])
-    return shlex.join([sys.executable, script])
+        return shlex.join([sys.executable, FROZEN_CURSOR_HOOK_COMMAND, script, *event_args])
+    return shlex.join([sys.executable, script, *event_args])
 
 
 def _is_managed_cursor_hook_script(path: Path) -> bool:
@@ -67,7 +73,7 @@ def _cursor_hook_path_contains_symlink(path: Path) -> bool:
 def run_frozen_cursor_hook(argv: Sequence[str]) -> int:
     """Execute the installed Cursor hook script from a frozen Guard binary."""
 
-    if len(argv) != 1:
+    if not argv:
         return 2
     script = Path(argv[0])
     if not _is_managed_cursor_hook_script(script) or not script.is_file() or _cursor_hook_path_contains_symlink(script):
@@ -95,7 +101,11 @@ def _managed_hook_entry(
 ) -> dict[str, object]:
     del context
     entry: dict[str, object] = {
-        "command": _managed_hook_command(python_executable=python_executable, script_path=script_path),
+        "command": _managed_hook_command(
+            python_executable=python_executable,
+            script_path=script_path,
+            event_name=event_name,
+        ),
         "timeout": _MANAGED_HOOK_TIMEOUT_SECONDS,
         "failClosed": event_name in _BLOCKING_MANAGED_HOOK_EVENTS,
     }

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_tail.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_tail.py
@@ -311,44 +311,64 @@ def _cursor_availability_response(
 _LAST_HOOK_EVENT_NAME = ""
 
 
+def _cursor_hook_event_from_argv() -> str:
+    args = sys.argv
+    try:
+        index = args.index("--cursor-hook-event")
+    except ValueError:
+        return ""
+    if index + 1 >= len(args):
+        return ""
+    value = str(args[index + 1]).strip()
+    return value
+
+
+def _exit_unparseable_cursor_input() -> int:
+    event_name = _cursor_hook_event_from_argv() or _LAST_HOOK_EVENT_NAME
+    try:
+        from codex_plugin_scanner.guard.daemon.hook_availability_policy import (
+            cursor_unparseable_input_permission,
+        )
+
+        response, code = cursor_unparseable_input_permission(
+            event_name,
+            recording_only=_recording_only_from_guard_home(),
+        )
+    except Exception:
+        compact = event_name.strip().lower().replace("_", "").replace("-", "")
+        if compact in {"aftershellexecution", "aftermcpexecution"}:
+            print("{}")
+            return 0
+        allow = _recording_only_from_guard_home() or compact in {"beforereadfile", ""}
+        print(json.dumps({"permission": "allow" if allow else "deny"}))
+        return 0 if allow else 2
+    print("{}" if not response else json.dumps(response))
+    return code
+
+
 def main() -> int:
     try:
         return _main_inner()
     except Exception:
-        if _recording_only_from_guard_home():
-            compact = _LAST_HOOK_EVENT_NAME.strip().lower().replace("_", "").replace("-", "")
-            if compact in {"aftershellexecution", "aftermcpexecution"}:
-                print("{}")
-            else:
-                print(json.dumps({"permission": "allow"}))
-            return 0
-        print(
-            json.dumps(
-                {
-                    "permission": "deny",
-                    "user_message": "HOL Guard could not complete this Cursor hook safely.",
-                }
-            )
-        )
-        return 2
+        return _exit_unparseable_cursor_input()
 
 
 def _main_inner() -> int:
+    global _LAST_HOOK_EVENT_NAME
+    argv_event = _cursor_hook_event_from_argv()
+    if argv_event:
+        _LAST_HOOK_EVENT_NAME = argv_event
     raw = sys.stdin.read()
     if not raw.strip():
-        print(json.dumps({"permission": "deny", "user_message": "HOL Guard received empty Cursor hook input."}))
-        return 2
+        return _exit_unparseable_cursor_input()
     try:
         payload = json.loads(raw)
     except json.JSONDecodeError:
-        print(json.dumps({"permission": "deny", "user_message": "HOL Guard could not parse Cursor hook input."}))
-        return 2
+        return _exit_unparseable_cursor_input()
     if not isinstance(payload, dict):
-        print(json.dumps({"permission": "deny", "user_message": "HOL Guard received invalid Cursor hook input."}))
-        return 2
+        return _exit_unparseable_cursor_input()
     inferred = _infer_cursor_hook_event_name(payload)
     hook_event_name = str(inferred.get("hook_event_name") or inferred.get("hookEventName") or "preToolUse")
-    global _LAST_HOOK_EVENT_NAME
     _LAST_HOOK_EVENT_NAME = hook_event_name
     prepared = _prepare_cursor_hook_payload(inferred)
     workspace = _workspace_from_cursor_input(prepared)
@@ -383,20 +403,23 @@ def _main_inner() -> int:
             hook_event_name=hook_event_name,
             workspace=workspace,
         )
+        recover_kind = "overload" if daemon_failure_kind == "overload" else (
+            daemon_failure_kind or "transport-failure"
+        )
         if availability_code == 0 and availability.get("permission") == "allow":
-            if daemon_failure_kind not in {None, "overload"}:
+            if recover_kind != "overload":
                 threading.Thread(
                     target=_run_guard_recovery,
-                    args=(daemon_failure_kind,),
+                    args=(recover_kind,),
                     kwargs={"guard_env": guard_env, "deadline_monotonic": deadline_monotonic},
                     daemon=True,
                     name="hol-guard-cursor-recovery",
                 ).start()
             print(json.dumps(availability))
             return availability_code
-        if daemon_failure_kind not in {None, "overload"}:
+        if recover_kind != "overload":
             _run_guard_recovery(
-                daemon_failure_kind,
+                recover_kind,
                 guard_env=guard_env,
                 deadline_monotonic=deadline_monotonic,
             )

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_tail.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_tail.py
@@ -403,9 +403,7 @@ def _main_inner() -> int:
             hook_event_name=hook_event_name,
             workspace=workspace,
         )
-        recover_kind = "overload" if daemon_failure_kind == "overload" else (
-            daemon_failure_kind or "transport-failure"
-        )
+        recover_kind = daemon_failure_kind or "transport-failure"
         if availability_code == 0 and availability.get("permission") == "allow":
             if recover_kind != "overload":
                 threading.Thread(

--- a/src/codex_plugin_scanner/guard/cli/commands_hook.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ..daemon.hook_worker_responses import post_tool_fail_safe_response
+from ..daemon.hook_availability_policy import availability_harness_response
+from ..daemon.hook_request_parsing import runtime_hook_event_name
 from ..runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
 from ..runtime.extension_control_runtime import (
     ExtensionControlRuntimeSnapshot,
@@ -97,10 +98,7 @@ def _run_guard_hook_command(
         harness=args.harness,
         normalize=False,
     )
-    # Auto/force sends the bounded, authenticated raw payload to Rust before
-    # any harness adapter or generic semantic normalization can project it.
-    # Explicit off/shadow returns here and continues through the compatibility
-    # normalizers below.
+    # Raw payload goes to native first. Off/shadow continues into compatibility.
     raw_routed = try_native_or_source_ref_hook(
         args,
         config=config,
@@ -112,15 +110,14 @@ def _run_guard_hook_command(
     )
     if raw_routed is not None:
         return raw_routed
-    # Explicit off/shadow compatibility reaches this point after native has
-    # declined authority.  Auto/force already returned a typed fail-safe
-    # result above, so no hook request loads config here.
     compatibility_surface = load_hook_compatibility_surface()
     if compatibility_surface is None:
         _emit(
             "hook",
-            post_tool_fail_safe_response(
-                args.harness,
+            availability_harness_response(
+                payload,
+                harness=args.harness,
+                event_name=runtime_hook_event_name(payload),
                 reason="HOL Guard could not enter the explicit Python hook oracle safely.",
                 reason_code="python_hook_oracle_unavailable",
             ),

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_native_authority.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_native_authority.py
@@ -11,7 +11,6 @@ from ..config import GuardConfig
 from ..daemon.hook_availability_policy import availability_harness_response
 from ..daemon.hook_request_parsing import runtime_hook_event_name
 from ..daemon.hook_worker import HookWorker, HookWorkerUnsupported
-from ..daemon.hook_worker_responses import post_tool_fail_safe_response
 from ..daemon.runtime_hook_evidence_writer import RuntimeHookEvidenceWriter
 from ..native_mode import (
     native_mode_is_fail_safe_disabled,
@@ -148,10 +147,15 @@ def try_native_or_source_ref_hook(
         )
         _emit(
             "hook",
-            post_tool_fail_safe_response(
-                args.harness,
+            availability_harness_response(
+                payload,
+                harness=args.harness,
+                event_name=runtime_hook_event_name(payload),
                 reason="HOL Guard could not complete the native hook decision safely.",
                 reason_code=reason_code,
+                workspace=runtime_workspace,
+                home_dir=context.home_dir,
+                guard_home=context.guard_home,
             ),
             getattr(args, "json", False),
         )

--- a/src/codex_plugin_scanner/guard/daemon/hook_availability_policy.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_availability_policy.py
@@ -59,6 +59,17 @@ def lifecycle_event_is_observe_only(event_name: str) -> bool:
     return _compact_hook_event_name(event_name) in _LIFECYCLE_CANONICAL_BY_COMPACT
 
 
+def hook_event_pauses_when_unavailable(event_name: str) -> bool:
+    """True when native miss must pause the harness instead of continuing the turn."""
+
+    compact = _compact_hook_event_name(event_name)
+    if compact in _LIFECYCLE_CANONICAL_BY_COMPACT:
+        return False
+    if compact in {"posttooluse", "posttool"} or compact.startswith("after"):
+        return False
+    return compact in {"permissionrequest", "pretooluse", "pretool"} or compact.startswith("before")
+
+
 def hook_review_is_recording_only(
     *,
     guard_home: Path | None = None,
@@ -144,8 +155,10 @@ def availability_harness_response(
         workspace=workspace,
         recording_only=recording_only,
     )
+    compact = _compact_hook_event_name(event_name)
+    pre_tool_event = compact in {"pretooluse", "pretool"} or compact.startswith("before")
     if watch_only:
-        if event_name != "PreToolUse":
+        if not pre_tool_event:
             return observe_lifecycle_fail_safe_response(
                 harness,
                 event_name=event_name,
@@ -156,7 +169,11 @@ def availability_harness_response(
             reason_code=reason_code,
             reason=reason,
         )
-    if event_name != "PreToolUse":
+    if compact == "permissionrequest":
+        from .hook_worker_responses import post_tool_fail_safe_response
+
+        return post_tool_fail_safe_response(harness, reason=reason, reason_code=reason_code)
+    if not hook_event_pauses_when_unavailable(event_name):
         return observe_lifecycle_fail_safe_response(
             harness,
             event_name=event_name,
@@ -232,7 +249,7 @@ def cursor_unparseable_input_permission(
     compact = hook_event_name.strip().lower().replace("_", "").replace("-", "")
     if compact in {"aftershellexecution", "aftermcpexecution"}:
         return {}, 0
-    if recording_only or compact in {"beforereadfile", ""}:
+    if recording_only or compact == "beforereadfile":
         return {"permission": "allow"}, 0
     return dict(_CURSOR_UNAVAILABLE_DENY), 2
 
@@ -245,6 +262,7 @@ __all__ = [
     "cursor_fallback_permission",
     "cursor_unparseable_input_permission",
     "hook_action_is_emergency_safe",
+    "hook_event_pauses_when_unavailable",
     "hook_review_is_recording_only",
     "lifecycle_event_is_observe_only",
     "recording_only_pre_tool_response",

--- a/src/codex_plugin_scanner/guard/daemon/hook_availability_policy.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_availability_policy.py
@@ -23,9 +23,10 @@ _CURSOR_UNAVAILABLE_DENY: dict[str, object] = {
 
 # Native review covers PreToolUse and PostToolUse. Lifecycle events are inventory
 # only: fail-closing them freezes the conversation without adding an enforcement
-# boundary. Protected/Extra careful keep PostToolUse withheld and high-impact
-# PreToolUse paused when native review cannot complete. Watch records those
-# actions and continues them.
+# boundary. When native review cannot complete, PostToolUse continues because the
+# tool already ran and withholding the turn is not a security boundary.
+# Protected/Extra careful still pause high-impact PreToolUse. Watch records
+# those actions and continues them.
 LIFECYCLE_OBSERVE_EVENTS = frozenset(
     {
         "UserPromptSubmit",
@@ -129,7 +130,6 @@ def availability_harness_response(
     from .hook_worker_responses import (
         harness_json_from_native_pre_tool,
         observe_lifecycle_fail_safe_response,
-        post_tool_fail_safe_response,
     )
 
     canonical_lifecycle = _LIFECYCLE_CANONICAL_BY_COMPACT.get(_compact_hook_event_name(event_name))
@@ -157,7 +157,11 @@ def availability_harness_response(
             reason=reason,
         )
     if event_name != "PreToolUse":
-        return post_tool_fail_safe_response(harness, reason=reason, reason_code=reason_code)
+        return observe_lifecycle_fail_safe_response(
+            harness,
+            event_name=event_name,
+            reason_code=reason_code,
+        )
     if not hook_action_is_emergency_safe(
         payload,
         workspace=workspace,
@@ -218,12 +222,28 @@ def cursor_fallback_permission(
     return response, 2
 
 
+def cursor_unparseable_input_permission(
+    hook_event_name: str,
+    *,
+    recording_only: bool = False,
+) -> tuple[dict[str, object], int]:
+    """Keep Cursor moving when stdin is empty or invalid but the event is known."""
+
+    compact = hook_event_name.strip().lower().replace("_", "").replace("-", "")
+    if compact in {"aftershellexecution", "aftermcpexecution"}:
+        return {}, 0
+    if recording_only or compact in {"beforereadfile", ""}:
+        return {"permission": "allow"}, 0
+    return dict(_CURSOR_UNAVAILABLE_DENY), 2
+
+
 __all__ = [
     "EMERGENCY_SAFE_REASON",
     "EMERGENCY_SAFE_REASON_CODE",
     "LIFECYCLE_OBSERVE_EVENTS",
     "availability_harness_response",
     "cursor_fallback_permission",
+    "cursor_unparseable_input_permission",
     "hook_action_is_emergency_safe",
     "hook_review_is_recording_only",
     "lifecycle_event_is_observe_only",

--- a/src/codex_plugin_scanner/guard/daemon/hook_availability_policy.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_availability_policy.py
@@ -67,7 +67,7 @@ def hook_event_pauses_when_unavailable(event_name: str) -> bool:
         return False
     if compact in {"posttooluse", "posttool"} or compact.startswith("after"):
         return False
-    return compact in {"permissionrequest", "pretooluse", "pretool"} or compact.startswith("before")
+    return compact not in {"posttooluse", "posttool"} and not compact.startswith("after")
 
 
 def hook_review_is_recording_only(
@@ -169,7 +169,7 @@ def availability_harness_response(
             reason_code=reason_code,
             reason=reason,
         )
-    if compact == "permissionrequest":
+    if compact.startswith("permission"):
         from .hook_worker_responses import post_tool_fail_safe_response
 
         return post_tool_fail_safe_response(harness, reason=reason, reason_code=reason_code)

--- a/src/codex_plugin_scanner/guard/daemon/hook_process_entrypoint.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_process_entrypoint.py
@@ -227,6 +227,31 @@ def _hook_evaluator_loop(
             return
 
 
+def _native_worker_fail_safe_result(
+    parsed: ResidentHookRequest,
+    *,
+    event_name: str,
+    reason_code: str,
+) -> dict[str, object]:
+    from .hook_availability_policy import availability_harness_response
+
+    record_native_hook_route("native_fail_safe")
+    return {
+        "payload": availability_harness_response(
+            parsed.payload,
+            harness=parsed.harness,
+            event_name=event_name,
+            reason_code=reason_code,
+            reason="HOL Guard could not complete the native hook decision safely.",
+            workspace=parsed.workspace,
+            home_dir=parsed.home_dir,
+            guard_home=parsed.guard_home,
+        ),
+        "reason_code": reason_code,
+        "route": "native_fail_safe",
+    }
+
+
 def _run_resident_hook_request(
     request: dict[str, object],
     *,
@@ -237,7 +262,7 @@ def _run_resident_hook_request(
     from ..cli.commands_hook import _run_guard_hook_command
     from ..cli.commands_support_connect import _synced_policy_payload
     from ..config import load_guard_config, overlay_synced_guard_policy
-    from .hook_worker import HookWorker, HookWorkerUnsupported, post_tool_fail_safe_response, runtime_hook_event_name
+    from .hook_worker import HookWorker, HookWorkerUnsupported, runtime_hook_event_name
 
     parsed = coerce_resident_hook_request(request)
     if parsed is None:
@@ -269,28 +294,18 @@ def _run_resident_hook_request(
             )
         except HookWorkerUnsupported:
             if _native_mode_requires_rust() or not python_oracle_surface_enabled():
-                record_native_hook_route("native_fail_safe")
-                return {
-                    "payload": post_tool_fail_safe_response(
-                        parsed.harness,
-                        reason="HOL Guard could not complete the native hook decision safely.",
-                        reason_code="native_hook_worker_unsupported",
-                    ),
-                    "reason_code": "native_hook_worker_unsupported",
-                    "route": "native_fail_safe",
-                }
+                return _native_worker_fail_safe_result(
+                    parsed,
+                    event_name=event_name,
+                    reason_code="native_hook_worker_unsupported",
+                )
         except Exception:
             if _native_mode_requires_rust() or not python_oracle_surface_enabled():
-                record_native_hook_route("native_fail_safe")
-                return {
-                    "payload": post_tool_fail_safe_response(
-                        parsed.harness,
-                        reason="HOL Guard could not complete the native hook decision safely.",
-                        reason_code="native_hook_worker_exception",
-                    ),
-                    "reason_code": "native_hook_worker_exception",
-                    "route": "native_fail_safe",
-                }
+                return _native_worker_fail_safe_result(
+                    parsed,
+                    event_name=event_name,
+                    reason_code="native_hook_worker_exception",
+                )
             raise
         else:
             response: dict[str, object] = {

--- a/src/codex_plugin_scanner/guard/daemon/hook_worker.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_worker.py
@@ -287,7 +287,15 @@ class HookWorker(HookWorkerNativeMixin):
                 workspace=workspace,
                 deadline=deadline,
             )
-        mode_response = self._mode_surface_response(harness, event_name, mode)
+        mode_response = self._mode_surface_response(
+            harness,
+            event_name,
+            mode,
+            payload=payload,
+            workspace=workspace,
+            home_dir=home_dir,
+            guard_home=guard_home,
+        )
         if mode_response is not None:
             return mode_response
         if event_name == "PreToolUse":

--- a/src/codex_plugin_scanner/guard/daemon/hook_worker.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_worker.py
@@ -242,10 +242,11 @@ class HookWorker(HookWorkerNativeMixin):
         """Review a hook HTTP payload and return harness JSON.
 
         ``auto`` and ``force`` require the native runtime. When native is
-        unavailable or returns no result, PostToolUse and high-impact
-        PreToolUse fail closed. Emergency-safe local inspection continues
-        with an explicit degraded reason code. ``off`` and ``shadow`` can use
-        only an explicit test oracle; production requests remain fail-safe.
+        unavailable or returns no result, high-impact PreToolUse pauses.
+        PostToolUse continues so the turn does not freeze. Emergency-safe
+        local inspection continues with an explicit degraded reason code.
+        ``off`` and ``shadow`` can use only an explicit test oracle;
+        production requests remain fail-safe.
         """
         self._last_native_decision_receipt = None
         harness = self._runtime_harness(params) or default_harness

--- a/src/codex_plugin_scanner/guard/daemon/hook_worker.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_worker.py
@@ -9,9 +9,10 @@ Security:
 - Never falls back to legacy CLI after a worker exception for a
   request that supplied only ``guard_source_ref`` without full output.
 - Never calls ``run_guard_command()``.
-- Native PostToolUse is decided by Rust for ``auto``/``force``. Native failure
-  fails closed instead of spilling into Python review. Explicit ``off`` is a
-  fail-safe disablement in production; only a test-injected oracle may run.
+- Native PostToolUse is decided by Rust for ``auto``/``force``. When review
+  cannot complete, PostToolUse continues; PreToolUse uses the emergency-safe
+  floor. Explicit ``off`` is a fail-safe disablement in production; only a
+  test-injected oracle may run.
 - Supported generic PreToolUse is decided by Rust. Native failure uses the
   mechanical emergency-safe action-class floor: local inspection may continue,
   while mutating, network, secret, destructive, and uncertain actions pause.
@@ -47,6 +48,7 @@ from ..runtime.hook_review_types import (
     HookReviewResponse,
     HookSourceFileRef,
 )
+from .hook_availability_policy import availability_harness_response
 from .hook_request_parsing import (
     build_hook_review_request,
     parse_output_summary,
@@ -57,8 +59,6 @@ from .hook_request_parsing import (
 from .hook_worker_native import HookWorkerNativeMixin, HookWorkerUnsupported, PythonOracle
 from .hook_worker_responses import (
     harness_json_from_review_response,
-    post_tool_fail_safe_response,
-    post_tool_native_block_response,
 )
 
 if TYPE_CHECKING:
@@ -77,6 +77,27 @@ class CommandActivityWriter(Protocol):
 
 
 _NATIVE_POLICY_READY_TIMEOUT_SECONDS = _PUBLISH_TIMEOUT_SECONDS
+
+
+def _post_tool_unavailable_response(
+    payload: dict[str, object],
+    *,
+    harness: str,
+    reason_code: str,
+    workspace: Path | None,
+    home_dir: Path,
+    guard_home: Path,
+) -> dict[str, object]:
+    return availability_harness_response(
+        payload,
+        harness=harness,
+        event_name="PostToolUse",
+        reason_code=reason_code,
+        reason="HOL Guard could not complete the native local hook review safely.",
+        workspace=workspace,
+        home_dir=home_dir,
+        guard_home=guard_home,
+    )
 
 
 @final
@@ -324,10 +345,13 @@ class HookWorker(HookWorkerNativeMixin):
                     payload=payload,
                     succeeded=hook_post_succeeded(event_name, payload),
                 )
-                return post_tool_fail_safe_response(
-                    harness,
-                    reason="HOL Guard could not complete the native local hook review safely.",
+                return _post_tool_unavailable_response(
+                    payload,
+                    harness=harness,
                     reason_code="native_post_tool_unavailable",
+                    workspace=workspace,
+                    home_dir=home_dir,
+                    guard_home=guard_home,
                 )
         elif self._python_oracle is not None and python_oracle_surface_enabled(mode):
             record_python_semantic_hook_route()
@@ -339,10 +363,13 @@ class HookWorker(HookWorkerNativeMixin):
                     payload=payload,
                     succeeded=hook_post_succeeded(event_name, payload),
                 )
-                return post_tool_fail_safe_response(
-                    harness,
-                    reason="HOL Guard could not complete the explicit differential oracle safely.",
+                return _post_tool_unavailable_response(
+                    payload,
+                    harness=harness,
                     reason_code="python_oracle_exception",
+                    workspace=workspace,
+                    home_dir=home_dir,
+                    guard_home=guard_home,
                 )
             if mode == "shadow":
                 with suppress(Exception):
@@ -360,10 +387,13 @@ class HookWorker(HookWorkerNativeMixin):
                 succeeded=hook_post_succeeded(event_name, payload),
             )
             reason_code = "native_hook_disabled" if mode == "off" else "native_shadow_diagnostic_disabled"
-            return post_tool_fail_safe_response(
-                harness,
-                reason="HOL Guard could not complete the native local hook review safely.",
+            return _post_tool_unavailable_response(
+                payload,
+                harness=harness,
                 reason_code=reason_code,
+                workspace=workspace,
+                home_dir=home_dir,
+                guard_home=guard_home,
             )
 
         self._record_post_tool_activity(
@@ -440,6 +470,4 @@ class HookWorker(HookWorkerNativeMixin):
 __all__ = [
     "HookWorker",
     "HookWorkerUnsupported",
-    "post_tool_fail_safe_response",
-    "post_tool_native_block_response",
 ]

--- a/src/codex_plugin_scanner/guard/daemon/hook_worker_native.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_worker_native.py
@@ -21,7 +21,6 @@ from .hook_request_parsing import pre_tool_command
 from .hook_worker_responses import (
     harness_json_from_native_post_tool,
     harness_json_from_native_pre_tool,
-    post_tool_fail_safe_response,
 )
 
 
@@ -143,7 +142,13 @@ class HookWorkerNativeMixin:
             "off": "HOL Guard native hook review is explicitly disabled; the action is blocked safely.",
             "shadow": "HOL Guard shadow comparison is unavailable outside its diagnostic surface.",
         }[mode]
-        return post_tool_fail_safe_response(harness, reason=reason, reason_code=reason_code)
+        return availability_harness_response(
+            {},
+            harness=harness,
+            event_name=event_name,
+            reason_code=reason_code,
+            reason=reason,
+        )
 
     def _review_pre_tool_http(
         self: _HookWorkerNativeHost,
@@ -192,10 +197,15 @@ class HookWorkerNativeMixin:
             raise HookWorkerUnsupported("native PreToolUse runtime is off")
         if status.mode == "shadow":
             raise HookWorkerUnsupported("native PreToolUse runtime is unavailable")
-        return post_tool_fail_safe_response(
-            harness,
-            reason="HOL Guard could not complete the native PreToolUse decision safely.",
+        return availability_harness_response(
+            payload,
+            harness=harness,
+            event_name="PreToolUse",
             reason_code="native_pre_tool_unavailable",
+            reason="HOL Guard could not complete the native PreToolUse decision safely.",
+            workspace=workspace,
+            home_dir=home_dir,
+            guard_home=guard_home,
         )
 
     def _review_native_edge(

--- a/src/codex_plugin_scanner/guard/daemon/hook_worker_native.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_worker_native.py
@@ -123,17 +123,25 @@ class HookWorkerNativeMixin:
         harness: str,
         event_name: str,
         mode: str,
+        *,
+        payload: dict[str, object],
+        workspace: Path | None,
+        home_dir: Path,
+        guard_home: Path,
     ) -> dict[str, object] | None:
         oracle_surface = python_oracle_surface_enabled(mode)
         if event_name not in {"PreToolUse", "PostToolUse"}:
             if oracle_surface:
                 raise HookWorkerUnsupported(f"fast path supports PreToolUse and PostToolUse, got event={event_name}")
             return availability_harness_response(
-                {},
+                payload,
                 harness=harness,
                 event_name=event_name,
                 reason_code="native_hook_event_unavailable",
                 reason="HOL Guard could not classify this hook event safely.",
+                workspace=workspace,
+                home_dir=home_dir,
+                guard_home=guard_home,
             )
         reason_code = {"off": "native_hook_disabled", "shadow": "native_shadow_diagnostic_disabled"}.get(mode)
         if reason_code is None or oracle_surface:
@@ -143,11 +151,14 @@ class HookWorkerNativeMixin:
             "shadow": "HOL Guard shadow comparison is unavailable outside its diagnostic surface.",
         }[mode]
         return availability_harness_response(
-            {},
+            payload,
             harness=harness,
             event_name=event_name,
             reason_code=reason_code,
             reason=reason,
+            workspace=workspace,
+            home_dir=home_dir,
+            guard_home=guard_home,
         )
 
     def _review_pre_tool_http(

--- a/src/codex_plugin_scanner/guard/daemon/hook_worker_responses.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_worker_responses.py
@@ -21,7 +21,7 @@ def prepare_native_hook_policy(
     """Apply the production native-policy barrier before hook admission."""
 
     harness = _canonical_managed_harness(default_harness)
-    if _hook_harness_is_explicitly_inactive(daemon_server, harness):
+    if _hook_harness_is_unmanaged(daemon_server, harness):
         _write_unmanaged_harness_passthrough(handler, payload, harness)
         return False
     workspace_path = Path(workspace) if workspace is not None else None
@@ -56,18 +56,37 @@ def _canonical_managed_harness(harness: str) -> str:
         return _canonical_hook_harness(harness)
 
 
-def _hook_harness_is_explicitly_inactive(daemon_server: Any, harness: str) -> bool:
-    """True only when Guard recorded this app as disconnected."""
+def _hook_harness_is_unmanaged(daemon_server: Any, harness: str) -> bool:
+    """True when leftover hooks belong to an app Guard is not currently protecting."""
 
     store = getattr(daemon_server, "store", None)
     getter = getattr(store, "get_managed_install", None)
     if not callable(getter):
         return False
+    canonical = _canonical_managed_harness(harness)
     try:
-        managed = getter(_canonical_managed_harness(harness))
+        managed = getter(canonical)
     except Exception:
         return False
-    return isinstance(managed, dict) and managed.get("active") is False
+    if isinstance(managed, dict) and managed.get("active") is False:
+        return True
+    if managed is not None:
+        return False
+    lister = getattr(store, "list_managed_installs", None)
+    if not callable(lister):
+        return False
+    try:
+        installs = lister()
+    except Exception:
+        return False
+    if not isinstance(installs, list):
+        return False
+    return any(
+        isinstance(item, dict)
+        and item.get("active") is True
+        and _canonical_managed_harness(str(item.get("harness") or "")) != canonical
+        for item in installs
+    )
 
 
 def _write_unmanaged_harness_passthrough(

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -5972,9 +5972,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     "hookSpecificOutput": {"hookEventName": event, "permissionDecision": "allow"},
                 }
             return {"continue": True, "reason_code": reason_code, "observed_review_failure": True}
-        from .hook_availability_policy import availability_harness_response, lifecycle_event_is_observe_only
+        from .hook_availability_policy import availability_harness_response
 
-        if event == "PreToolUse" or lifecycle_event_is_observe_only(event):
+        if event != "PermissionRequest":
             payload_dict = dict(payload) if isinstance(payload, Mapping) else {}
             return availability_harness_response(
                 payload_dict,

--- a/tests/test_bounded_cli_hook_watch_continue.py
+++ b/tests/test_bounded_cli_hook_watch_continue.py
@@ -191,3 +191,24 @@ def test_oversized_input_preserves_kimi_event_when_watch(
     assert isinstance(hook_output, dict)
     assert hook_output["hookEventName"] == "UserPromptSubmit"
     assert hook_output["permissionDecision"] == "allow"
+
+
+def test_timeout_continues_post_tool_for_grok(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        bounded_cli_hook_bridge,
+        "run_isolated_hook_process",
+        _runner_result(BoundedHookProcessResult(None, "", False, True)),
+    )
+    output = io.StringIO()
+    with redirect_stdout(output):
+        returncode = bounded_cli_hook_bridge.run_bounded_cli_hook(
+            _config(tmp_path, harness="grok"),
+            input_text=json.dumps({"hook_event_name": "PostToolUse"}),
+        )
+
+    payload = _json_object(output.getvalue())
+    assert returncode == 0
+    assert payload["decision"] == "allow"

--- a/tests/test_claude_daemon_hook_bridge.py
+++ b/tests/test_claude_daemon_hook_bridge.py
@@ -388,6 +388,24 @@ def test_authenticated_daemon_failure_denies_without_local_fallback(
     assert "authentication failed" in payload["hookSpecificOutput"]["permissionDecisionReason"]
 
 
+def test_authenticated_failure_denies_permission_request_behavior() -> None:
+    payload = json.loads(
+        bridge._authenticated_control_plane_failure(
+            "invalid daemon token",
+            json.dumps({"hook_event_name": "PermissionRequest"}),
+        )
+    )
+    assert payload["hookSpecificOutput"]["decision"]["behavior"] == "deny"
+    v2 = json.loads(
+        bridge._authenticated_control_plane_failure(
+            "invalid daemon token",
+            json.dumps({"hook_event_name": "PermissionRequestV2"}),
+        )
+    )
+    assert v2["hookSpecificOutput"]["decision"]["behavior"] == "deny"
+
+
+
 def test_recovery_only_restarts_for_transport_and_server_failures() -> None:
     assert not bridge._daemon_failure_is_recoverable(ValueError("invalid loopback URL"))
     assert not bridge._daemon_failure_is_recoverable(

--- a/tests/test_codex_daemon_hook_bridge.py
+++ b/tests/test_codex_daemon_hook_bridge.py
@@ -121,8 +121,8 @@ def test_fail_closed_uses_supported_codex_deny_shapes() -> None:
 
     assert pretool["hookSpecificOutput"]["permissionDecision"] == "deny"
     assert permission["hookSpecificOutput"]["decision"]["behavior"] == "deny"
-    assert posttool["continue"] is False
-    assert prompt["continue"] is False
+    assert posttool["continue"] is True
+    assert prompt["continue"] is True
 
 
 def test_bridge_keeps_inline_browser_wait_within_consumer_limit(
@@ -564,7 +564,7 @@ def test_bridge_real_daemon_emits_schema_exact_post_tool_response(
     if "hookSpecificOutput" in response:
         assert response == {"hookSpecificOutput": {"hookEventName": "PostToolUse"}}
     else:
-        assert response["continue"] is False
+        assert response["continue"] is True
 
 
 def test_bridge_real_daemon_prefers_payload_cwd_for_verified_git_fetch(

--- a/tests/test_codex_daemon_hook_bridge_resilience.py
+++ b/tests/test_codex_daemon_hook_bridge_resilience.py
@@ -141,7 +141,7 @@ def test_post_tool_use_stdout_is_exactly_one_json_object_with_noisy_fallback(
     captured = capsys.readouterr()
     output = json.loads(captured.out)
     assert exit_code == 0
-    assert output["continue"] is False
+    assert output["continue"] is True
     assert captured.out == json.dumps(output, separators=(",", ":"))
     assert captured.err == ""
 

--- a/tests/test_cursor_frozen_hook_command.py
+++ b/tests/test_cursor_frozen_hook_command.py
@@ -33,18 +33,27 @@ def test_frozen_cursor_hook_command_uses_supported_launcher(monkeypatch, tmp_pat
         "/Applications/HOL Guard.app/Contents/MacOS/hol-guard",
     )
     script = tmp_path / ".cursor" / "hooks" / HOOK_SCRIPT_NAME
-    command = _managed_hook_command(python_executable=None, script_path=script)
+    command = _managed_hook_command(
+        python_executable=None,
+        script_path=script,
+        event_name="beforeReadFile",
+    )
     tokens = shlex.split(command)
     assert tokens[0] == "/Applications/HOL Guard.app/Contents/MacOS/hol-guard"
     assert tokens[1] == FROZEN_CURSOR_HOOK_COMMAND
     assert tokens[2].endswith(HOOK_SCRIPT_NAME)
+    assert tokens[-2:] == ["--cursor-hook-event", "beforeReadFile"]
 
 
 def test_unfrozen_cursor_hook_command_uses_current_interpreter(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr("codex_plugin_scanner.guard.adapters.cursor_hook_config.sys.frozen", False, raising=False)
     monkeypatch.setattr("codex_plugin_scanner.guard.adapters.cursor_hook_config.sys.executable", "/usr/bin/python3")
     script = tmp_path / ".cursor" / "hooks" / HOOK_SCRIPT_NAME
-    command = _managed_hook_command(python_executable=None, script_path=script)
+    command = _managed_hook_command(
+        python_executable=None,
+        script_path=script,
+        event_name="beforeReadFile",
+    )
     assert FROZEN_CURSOR_HOOK_COMMAND not in command
     assert command.startswith("/usr/bin/python3")
 
@@ -58,6 +67,7 @@ def test_run_frozen_cursor_hook_executes_managed_script(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     assert run_frozen_cursor_hook([str(script)]) == 0
+    assert run_frozen_cursor_hook([str(script), "--cursor-hook-event", "beforeReadFile"]) == 0
     assert marker.read_text(encoding="utf-8") == "ok"
 
 
@@ -80,9 +90,8 @@ def test_run_frozen_cursor_hook_rejects_symlink(tmp_path: Path) -> None:
     assert run_frozen_cursor_hook([str(script)]) == 3
 
 
-def test_run_frozen_cursor_hook_rejects_wrong_argc() -> None:
+def test_run_frozen_cursor_hook_rejects_empty_argv() -> None:
     assert run_frozen_cursor_hook([]) == 2
-    assert run_frozen_cursor_hook(["a", "b"]) == 2
 
 
 def test_live_cursor_hook_script_path_rejects_symlink(tmp_path: Path) -> None:

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -249,7 +249,7 @@ def test_cursor_hook_script_uses_one_deadline_and_isolated_process_tree(tmp_path
     assert "run_isolated_hook_process(" in source
     assert "allow_windows_breakaway=True" in source
     assert "_FALLBACK_LOCK.acquire(blocking=False)" in source
-    assert 'daemon_failure_kind not in {None, "overload"}' in source
+    assert 'recover_kind != "overload"' in source
     assert "[*GUARD_RECOVERY_COMMAND, failure_kind]" in source
 
 
@@ -1104,7 +1104,7 @@ def test_install_cursor_hooks_preserves_top_level_event_entries(
     for event_name in _MANAGED_HOOK_EVENTS:
         entries = installed["hooks"][event_name]
         assert entries[0] == existing_entries[event_name][0]
-        assert entries[-1]["command"].endswith(HOOK_SCRIPT_NAME)
+        assert HOOK_SCRIPT_NAME in entries[-1]["command"]
 
 
 def test_prepare_cursor_hook_payload_maps_before_mcp_execution() -> None:

--- a/tests/test_cursor_watch_hook_script.py
+++ b/tests/test_cursor_watch_hook_script.py
@@ -93,3 +93,56 @@ def test_generated_cursor_watch_after_shell_exception_prints_empty(
     assert callable(main)
     assert main() == 0
     assert capsys.readouterr().out.strip() == "{}"
+
+
+def test_empty_stdin_before_read_allows_when_event_is_baked(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    guard_home = tmp_path / "guard"
+    guard_home.mkdir()
+    (guard_home / "config.toml").write_text(
+        'mode = "prompt"\nprotection_posture = "protected"\n',
+        encoding="utf-8",
+    )
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        guard_home=guard_home,
+        workspace_dir=tmp_path,
+    )
+    script_globals: dict[str, object] = {"__name__": "cursor_hook"}
+    exec(compile(cursor_hook_script_source(context), "hol-guard-cursor-hook.py", "exec"), script_globals)
+    monkeypatch.setattr(sys, "argv", ["hol-guard-cursor-hook.py", "--cursor-hook-event", "beforeReadFile"])
+    monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+    main = script_globals["main"]
+    assert callable(main)
+    assert main() == 0
+    assert json.loads(capsys.readouterr().out) == {"permission": "allow"}
+
+
+def test_empty_stdin_before_shell_pauses_when_event_is_baked(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    guard_home = tmp_path / "guard"
+    guard_home.mkdir()
+    (guard_home / "config.toml").write_text(
+        'mode = "prompt"\nprotection_posture = "protected"\n',
+        encoding="utf-8",
+    )
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        guard_home=guard_home,
+        workspace_dir=tmp_path,
+    )
+    script_globals: dict[str, object] = {"__name__": "cursor_hook"}
+    exec(compile(cursor_hook_script_source(context), "hol-guard-cursor-hook.py", "exec"), script_globals)
+    monkeypatch.setattr(sys, "argv", ["hol-guard-cursor-hook.py", "--cursor-hook-event", "beforeShellExecution"])
+    monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+    main = script_globals["main"]
+    assert callable(main)
+    assert main() == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["permission"] == "deny"

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -1933,7 +1933,7 @@ class TestGuardSurfaceServer:
                     }
                 },
             ),
-            ("cursor", "PostToolUse", {"continue": False}),
+            ("cursor", "PostToolUse", {"continue": True}),
         ],
     )
     def test_guard_daemon_hook_capacity_uses_native_fail_safe_response(

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -4538,8 +4538,8 @@ class TestGuardDaemonFastHookPath:
             daemon.stop()
             monkeypatch.delenv("HOL_GUARD_HOOK_FAST_PATH", raising=False)
 
-        assert result["decision"] == "deny"
-        assert result["model_output_action"] == "block"
+        assert result["decision"] == "allow"
+        assert result["policy_action"] == "allow"
         assert result["reason_code"] == "daemon_worker_exception"
 
     def test_fast_path_secret_source_file_is_denied(self, tmp_path, monkeypatch) -> None:

--- a/tests/test_hook_availability_policy.py
+++ b/tests/test_hook_availability_policy.py
@@ -8,6 +8,7 @@ from codex_plugin_scanner.guard.daemon.hook_availability_policy import (
     EMERGENCY_SAFE_REASON_CODE,
     availability_harness_response,
     cursor_fallback_permission,
+    cursor_unparseable_input_permission,
     hook_action_is_emergency_safe,
 )
 
@@ -432,8 +433,9 @@ def test_availability_continues_prompt_lifecycle_and_still_pauses_tools(tmp_path
         reason_code="native_post_tool_unavailable",
         reason="native unavailable",
     )
-    assert withheld["continue"] is False
-    assert withheld["policy_action"] == "block"
+    assert withheld["continue"] is True
+    assert withheld["policy_action"] == "allow"
+    assert withheld["reason_code"] == "native_post_tool_unavailable"
     curl = availability_harness_response(
         {"hook_event_name": "PreToolUse", "tool_input": {"command": "curl https://example.test"}},
         harness="grok",
@@ -444,3 +446,21 @@ def test_availability_continues_prompt_lifecycle_and_still_pauses_tools(tmp_path
         home_dir=tmp_path / "home",
     )
     assert curl["policy_action"] == "block"
+
+
+def test_cursor_unparseable_input_allows_read_and_pauses_shell() -> None:
+    allow, allow_code = cursor_unparseable_input_permission("beforeReadFile")
+    assert allow_code == 0
+    assert allow == {"permission": "allow"}
+    deny, deny_code = cursor_unparseable_input_permission("beforeShellExecution")
+    assert deny_code == 2
+    assert deny["permission"] == "deny"
+    after, after_code = cursor_unparseable_input_permission("afterShellExecution")
+    assert after_code == 0
+    assert after == {}
+    watch, watch_code = cursor_unparseable_input_permission(
+        "beforeShellExecution",
+        recording_only=True,
+    )
+    assert watch_code == 0
+    assert watch == {"permission": "allow"}

--- a/tests/test_hook_availability_policy.py
+++ b/tests/test_hook_availability_policy.py
@@ -454,6 +454,14 @@ def test_availability_continues_prompt_lifecycle_and_still_pauses_tools(tmp_path
         reason="native unavailable",
     )
     assert permission["continue"] is False
+    permission_v2 = availability_harness_response(
+        {"hook_event_name": "PermissionRequestV2", "tool_input": {"command": "pwd"}},
+        harness="claude-code",
+        event_name="PermissionRequestV2",
+        reason_code="native_hook_event_unavailable",
+        reason="native unavailable",
+    )
+    assert permission_v2["continue"] is False
     alias = availability_harness_response(
         {"hook_event_name": "beforeShellExecution", "command": "curl https://example.test"},
         harness="cursor",

--- a/tests/test_hook_availability_policy.py
+++ b/tests/test_hook_availability_policy.py
@@ -446,6 +446,24 @@ def test_availability_continues_prompt_lifecycle_and_still_pauses_tools(tmp_path
         home_dir=tmp_path / "home",
     )
     assert curl["policy_action"] == "block"
+    permission = availability_harness_response(
+        {"hook_event_name": "PermissionRequest", "tool_input": {"command": "pwd"}},
+        harness="claude-code",
+        event_name="PermissionRequest",
+        reason_code="native_hook_event_unavailable",
+        reason="native unavailable",
+    )
+    assert permission["continue"] is False
+    alias = availability_harness_response(
+        {"hook_event_name": "beforeShellExecution", "command": "curl https://example.test"},
+        harness="cursor",
+        event_name="beforeShellExecution",
+        reason_code="native_pre_tool_unavailable",
+        reason="native unavailable",
+        workspace=tmp_path,
+        home_dir=tmp_path / "home",
+    )
+    assert alias["hookSpecificOutput"]["permissionDecision"] == "deny"
 
 
 def test_cursor_unparseable_input_allows_read_and_pauses_shell() -> None:
@@ -464,3 +482,6 @@ def test_cursor_unparseable_input_allows_read_and_pauses_shell() -> None:
     )
     assert watch_code == 0
     assert watch == {"permission": "allow"}
+    empty, empty_code = cursor_unparseable_input_permission("")
+    assert empty_code == 2
+    assert empty["permission"] == "deny"

--- a/tests/test_hook_worker_observe_pretool.py
+++ b/tests/test_hook_worker_observe_pretool.py
@@ -277,4 +277,32 @@ def test_hook_worker_watch_posttool_native_unavailable_continues(
     )
     assert result["policy_action"] == "allow"
     assert result["reason_code"] == "native_post_tool_unavailable"
+
+
+def test_hook_worker_watch_native_off_pretool_continues(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    _write_watch_config(guard_home)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.hook_worker.native_mode",
+        lambda: "off",
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.hook_worker_native.python_oracle_surface_enabled",
+        lambda _mode=None: False,
+    )
+    worker = HookWorker(store=GuardStore(guard_home))
+    result = worker.review_http_payload(
+        payload={"hook_event_name": "PreToolUse", "tool_input": {"command": "pwd"}},
+        params={},
+        default_harness="codex",
+        home_dir=tmp_path / "home",
+        guard_home=guard_home,
+        workspace=tmp_path / "workspace",
+    )
+    assert result["continue"] is True
+    assert result["reason_code"] == "native_hook_disabled"
+
     assert result.get("continue") is True

--- a/tests/test_inactive_harness_hook_passthrough.py
+++ b/tests/test_inactive_harness_hook_passthrough.py
@@ -30,9 +30,25 @@ class _Handler:
         }
 
 
-def _daemon(*, managed: dict[str, object] | None, prepared: object = None) -> SimpleNamespace:
+def _daemon(
+    *,
+    managed: dict[str, object] | None,
+    prepared: object = None,
+    other_active: str | None = None,
+) -> SimpleNamespace:
+    def getter(_harness: str) -> dict[str, object] | None:
+        return managed
+
+    def lister() -> list[dict[str, object]]:
+        installs: list[dict[str, object]] = []
+        if isinstance(managed, dict):
+            installs.append(managed)
+        if other_active:
+            installs.append({"harness": other_active, "active": True})
+        return installs
+
     return SimpleNamespace(
-        store=SimpleNamespace(get_managed_install=lambda _harness: managed),
+        store=SimpleNamespace(get_managed_install=getter, list_managed_installs=lister),
         hook_worker=SimpleNamespace(
             prepare_workspace_policy=lambda *_args, **_kwargs: prepared,
             metrics=SimpleNamespace(record_route=lambda *_args, **_kwargs: None),
@@ -89,6 +105,23 @@ def test_never_installed_codex_hook_still_fail_closes_when_native_policy_is_not_
     assert admitted is False
     assert handler.payload is not None
     assert handler.payload.get("reason_code") == "native_policy_not_ready"
+
+
+def test_never_installed_codex_hook_passthrough_when_another_app_is_active() -> None:
+    handler = _Handler()
+    admitted = prepare_native_hook_policy(
+        handler,
+        _daemon(managed=None, other_active="cursor"),
+        dict(_PRE_TOOL_PAYLOAD),
+        {},
+        "codex",
+        None,
+        0.0,
+    )
+
+    assert admitted is False
+    assert handler.payload is not None
+    assert handler.payload.get("reason_code") == "harness_not_managed"
 
 
 def test_runtime_harness_query_cannot_bypass_active_cursor_native_barrier() -> None:

--- a/tests/test_python_capability_cleanup_gate.py
+++ b/tests/test_python_capability_cleanup_gate.py
@@ -20,7 +20,7 @@ def test_cleanup_contract_covers_every_scoped_hook_capability() -> None:
 
     assert payload["schema"] == "hol-guard.python-capability-cleanup.v1"
     assert payload["status"] == "passed"
-    assert payload["scope_files"] == 89
+    assert payload["scope_files"] == 90
     assert payload["capabilities"]["legacy_python_resident_transport"] == 2
     assert payload["candidate_evidence"] == [
         {

--- a/tests/test_python_hook_semantic_callgraph_gate.py
+++ b/tests/test_python_hook_semantic_callgraph_gate.py
@@ -94,7 +94,7 @@ def test_production_off_returns_fail_safe_without_constructing_oracle(
         workspace=tmp_path,
     )
 
-    assert result["decision"] == "block"
+    assert result["continue"] is True
     assert result["reason_code"] == "native_hook_disabled"
     assert worker.test_oracle is None
 

--- a/tests/test_rust_hardening_contracts.py
+++ b/tests/test_rust_hardening_contracts.py
@@ -77,6 +77,7 @@ def test_fail_safe_matrix_never_allows_unreviewed_output() -> None:
             "python_reference_withhold_until_complete",
             "python_reference_within_deadline",
             "withhold_or_block",
+            "observe_continue",
             "not_valid_for_allow",
             "more_restrictive_output_action",
             "python_reference_or_block",

--- a/tests/test_rust_posttool_authority.py
+++ b/tests/test_rust_posttool_authority.py
@@ -50,7 +50,7 @@ def test_hook_worker_fails_closed_when_forced_posttool_native_is_missing(
         guard_home=tmp_path / "guard-home",
         workspace=tmp_path / "workspace",
     )
-    assert result["decision"] == "deny"
+    assert result["decision"] == "allow"
     assert result["reason_code"] == "native_post_tool_unavailable"
 
 
@@ -88,7 +88,7 @@ def test_hook_worker_fails_closed_when_available_native_posttool_returns_none(
         guard_home=tmp_path / "guard-home",
         workspace=tmp_path / "workspace",
     )
-    assert result["decision"] == "deny"
+    assert result["decision"] == "allow"
     assert result["reason_code"] == "native_post_tool_unavailable"
 
 
@@ -129,7 +129,7 @@ def test_hook_worker_fails_closed_when_auto_native_is_unavailable(
         workspace=tmp_path / "workspace",
     )
     assert called["native"] == 1
-    assert result["decision"] == "deny"
+    assert result["decision"] == "allow"
     assert result["reason_code"] == "native_post_tool_unavailable"
 
 


### PR DESCRIPTION
## Summary
- Continue PostToolUse and conversation inventory when native review cannot finish, so a daemon or native gap does not freeze the turn after a tool already ran.
- Pause PermissionRequest and PreTool aliases when native review is unavailable; leftover hooks for apps that are not the active managed install still pass through.
- Classify empty or invalid Cursor hook stdin from the installed event name, deny unknown empty input, and start daemon recovery whenever the daemon is unreachable.
- Keep bounded CLI, Claude auth-failure, and Codex empty-input paths from blocking PostToolUse or prompt inventory.

## Testing
- `pytest tests/test_hook_availability_policy.py tests/test_inactive_harness_hook_passthrough.py tests/test_cursor_watch_hook_script.py tests/test_cursor_frozen_hook_command.py tests/test_rust_posttool_authority.py tests/test_hook_worker_observe_pretool.py`
- `pytest tests/test_codex_daemon_hook_bridge.py tests/test_codex_daemon_hook_bridge_resilience.py tests/test_rust_pretool_authority.py tests/test_rust_pretool_authority_worker.py tests/test_bounded_cli_hook_watch_continue.py tests/test_hook_data_plane_ownership_gate.py`

## Notes
- High-impact PreToolUse still pauses when native review cannot complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Post-tool actions now continue when native review or the daemon is unavailable, preventing completed operations from freezing the turn.
  * Confirmed native block decisions still withhold post-tool output.
  * High-impact pre-tool actions and permission requests remain paused or denied when safety review cannot complete.
  * Cursor hooks now correctly identify events, including empty or invalid input, with event-specific decisions.
  * Unmanaged harnesses pass through in recording-only mode when another harness is active.
  * Authentication failures now apply appropriate permission denials while allowing non-permission hook processing to continue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->