### PR TITLE
chore(guard): remove stray review scratch file

### DIFF
--- a/review-body.md
+++ b/review-body.md
@@ -1,8 +1,0 @@
-All previously flagged probes now reach review with attribution to `command.repo2nb.reverse-force` / `command.repo2nb.sync`:
-
-- Indirect launchers: `python`/`python3`/`py -m repo2nb`, `exec`, `xargs` including `-n 1` forms.
-- Abbreviated force flags: every unambiguous argparse prefix of `--force` (`--f` through `--force`).
-- Unresolved shell expansions: `$VAR`, `${VAR}`, `$(...)`, and backtick tokens in a `reverse` invocation cannot prove `--force` absent, so a conservative matcher overlay routes them to review; safe variants still clone pure literal-flag matchers.
-- `sync --dry-run` remains a safe variant while unknown options fail secure.
-
-Regression cases cover direct and wrapper forms; plain `repo2nb reverse` and dry-run sync stay unreviewed. The extension-control catalog baseline, policy-bundle projection vector, permission-catalog digest, and decision-diff report are regenerated to match the updated catalog. CI and Desktop contract CI pass on the final head (plus Security Gates, CodeQL, Fuzzing, Semgrep, Gitleaks); the Native wheel soak failure reproduces on `main` and unrelated PRs and is unrelated to this diff.


### PR DESCRIPTION
## Summary
- Remove a stray top-level `review-body.md` scratch file that was committed by accident and currently ships in the source distribution without being referenced anywhere.

## Testing
- `git grep review-body` after removal returns no references
- `uv run --no-progress python scripts/ci/code_quality_audit.py --root . --baseline ci/code-quality-baseline.json --json-output /tmp/quality.json`
