### PR TITLE
fix(hooks): rebind Cursor launchers off pruneable Core paths

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -9,6 +9,7 @@ from hashlib import sha256
 from pathlib import Path
 
 from ..frozen_runtime_commands import frozen_daemon_recovery_command
+from ..stable_guard_cli import uses_top_level_hook_command as _uses_top_level_hook_command
 from .base import HarnessContext
 from .cursor_hook_config import (
     _MANAGED_HOOK_EVENTS,
@@ -342,15 +343,6 @@ def _resolve_guard_cli_command(context: HarnessContext) -> list[str]:
     """Return only the isolated CLI bound to the running Guard distribution."""
 
     return list(resolve_attested_guard_cli(context).command)
-
-
-def _uses_top_level_hook_command(guard_cli: list[str]) -> bool:
-    if not guard_cli:
-        return False
-    # hol-guard/plugin-guard entrypoints expose `hook` at the top level (combined-mode
-    # hol-guard rewrites `hook` to `guard hook` internally). Only module invocations
-    # need an explicit `guard` prefix.
-    return Path(guard_cli[0]).name in {"hol-guard", "plugin-guard"}
 
 
 def _embedded_guard_hook_argv(context: HarnessContext) -> list[str]:

--- a/src/codex_plugin_scanner/guard/adapters/guard_cli_attestation.py
+++ b/src/codex_plugin_scanner/guard/adapters/guard_cli_attestation.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from ...version import __version__
+from ..stable_guard_cli import resolve_frozen_guard_cli
 from .base import HarnessContext
 from .hook_python import (
     HookPythonAttestation,
@@ -83,17 +84,24 @@ def _file_metadata_payload(value: HookPythonFileMetadata) -> dict[str, int]:
     }
 
 
+def _frozen_guard_cli_attestation() -> GuardCliAttestation:
+    launcher = Path(resolve_frozen_guard_cli()).expanduser().absolute()
+    try:
+        identity = _executable_identity(launcher)
+    except RuntimeError:
+        identity = _executable_identity(Path(sys.executable).expanduser().absolute())
+    return GuardCliAttestation(
+        command=(str(identity.invocation_path),),
+        python=None,
+        frozen_identity=identity,
+    )
+
+
 def resolve_attested_guard_cli(context: HarnessContext) -> GuardCliAttestation:
     """Resolve Guard's CLI without consulting PATH or the caller's import cwd."""
 
     if bool(getattr(sys, "frozen", False)):
-        executable = Path(sys.executable).expanduser().absolute()
-        identity = _executable_identity(executable)
-        return GuardCliAttestation(
-            command=(str(identity.invocation_path),),
-            python=None,
-            frozen_identity=identity,
-        )
+        return _frozen_guard_cli_attestation()
     try:
         python = attest_guard_hook_python(context)
     except RuntimeError as error:

--- a/src/codex_plugin_scanner/guard/adapters/guard_cli_attestation.py
+++ b/src/codex_plugin_scanner/guard/adapters/guard_cli_attestation.py
@@ -86,10 +86,7 @@ def _file_metadata_payload(value: HookPythonFileMetadata) -> dict[str, int]:
 
 def _frozen_guard_cli_attestation() -> GuardCliAttestation:
     launcher = Path(resolve_frozen_guard_cli()).expanduser().absolute()
-    try:
-        identity = _executable_identity(launcher)
-    except RuntimeError:
-        identity = _executable_identity(Path(sys.executable).expanduser().absolute())
+    identity = _executable_identity(launcher)
     return GuardCliAttestation(
         command=(str(identity.invocation_path),),
         python=None,

--- a/src/codex_plugin_scanner/guard/cursor_hook_rebind.py
+++ b/src/codex_plugin_scanner/guard/cursor_hook_rebind.py
@@ -7,9 +7,23 @@ import sys
 from pathlib import Path
 
 from .adapters.base import HarnessContext
-from .adapters.cursor_hook_config import _is_managed_hook_script
-from .adapters.cursor_hooks import cursor_hook_script_path, install_cursor_hooks, managed_hook_script_path
-from .stable_guard_cli import argv0_is_ephemeral_desktop_cli, frozen_launcher_is_prune_safe, resolve_frozen_guard_cli
+from .adapters.cursor_hook_config import _hooks_state_path, _is_managed_hook_script
+from .adapters.cursor_hooks import (
+    cursor_hook_script_path,
+    cursor_hook_script_source,
+    cursor_hooks_path,
+    install_cursor_hooks,
+    managed_hook_script_path,
+)
+from .adapters.guard_cli_attestation import resolve_attested_guard_cli
+from .stable_guard_cli import (
+    argv0_is_ephemeral_desktop_cli,
+    frozen_cli_path_is_runnable,
+    frozen_launcher_is_prune_safe,
+    resolve_frozen_guard_cli,
+)
+
+_READ_ERRORS = (OSError, UnicodeError)
 
 
 def _assignment_argv(source: str, name: str) -> list[str] | None:
@@ -44,7 +58,29 @@ def can_rebind_to_stable_frozen_cli() -> bool:
 
     if not bool(getattr(sys, "frozen", False)):
         return False
-    return frozen_launcher_is_prune_safe(resolve_frozen_guard_cli())
+    launcher = Path(resolve_frozen_guard_cli())
+    return frozen_launcher_is_prune_safe(str(launcher)) and frozen_cli_path_is_runnable(launcher)
+
+
+def _read_hook_script(path: Path) -> tuple[str | None, dict[str, object] | None]:
+    try:
+        return path.read_text(encoding="utf-8"), None
+    except _READ_ERRORS as error:
+        return None, {
+            "rebound": False,
+            "reason": "cursor_hook_script_unreadable",
+            "error": str(error),
+        }
+
+
+def _state_matches_attested_cli(context: HarnessContext) -> bool:
+    state_path = _hooks_state_path(cursor_hooks_path(context), context)
+    try:
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        attested = resolve_attested_guard_cli(context)
+    except (OSError, UnicodeError, json.JSONDecodeError, RuntimeError):
+        return False
+    return isinstance(state, dict) and state.get("guard_cli_identity") == attested.manifest_payload()
 
 
 def rebind_stale_cursor_hooks(guard_home: Path, *, home_dir: Path) -> dict[str, object]:
@@ -53,25 +89,36 @@ def rebind_stale_cursor_hooks(guard_home: Path, *, home_dir: Path) -> dict[str, 
     if not can_rebind_to_stable_frozen_cli():
         return {"rebound": False, "reason": "stable_frozen_cli_unavailable"}
     context = HarnessContext(home_dir=home_dir, guard_home=guard_home, workspace_dir=None)
-    candidates = [
-        path for path in (cursor_hook_script_path(context), managed_hook_script_path(context)) if path.is_file()
-    ]
-    if not candidates:
+    live_path = cursor_hook_script_path(context)
+    if not live_path.is_file():
         return {"rebound": False, "reason": "cursor_hook_script_absent"}
-    needs_rebind = False
-    for path in candidates:
-        try:
-            source = path.read_text(encoding="utf-8")
-        except OSError as error:
-            return {"rebound": False, "reason": "cursor_hook_script_unreadable", "error": str(error)}
-        if cursor_hook_script_bakes_ephemeral_cli(source):
-            needs_rebind = True
-            break
-    if not needs_rebind:
+    live_source, error = _read_hook_script(live_path)
+    if error is not None or live_source is None:
+        return error or {"rebound": False, "reason": "cursor_hook_script_unreadable"}
+    if not _is_managed_hook_script(live_source):
+        return {"rebound": False, "reason": "cursor_hook_script_unmanaged"}
+    managed_path = managed_hook_script_path(context)
+    managed_source: str | None = None
+    if managed_path.is_file():
+        managed_source, error = _read_hook_script(managed_path)
+        if error is not None or managed_source is None:
+            return error or {"rebound": False, "reason": "cursor_hook_script_unreadable"}
+        if not _is_managed_hook_script(managed_source):
+            return {"rebound": False, "reason": "cursor_hook_script_unmanaged"}
+    try:
+        expected_source = cursor_hook_script_source(context)
+    except RuntimeError as error:
+        return {"rebound": False, "reason": "cursor_hook_script_rebind_failed", "error": str(error)}
+    needs_rebind = live_source != expected_source or cursor_hook_script_bakes_ephemeral_cli(live_source)
+    if managed_source is not None:
+        needs_rebind = (
+            needs_rebind or managed_source != expected_source or cursor_hook_script_bakes_ephemeral_cli(managed_source)
+        )
+    if not needs_rebind and _state_matches_attested_cli(context):
         return {"rebound": False, "reason": "cursor_hook_script_current"}
     try:
         install_cursor_hooks(context)
-    except (OSError, RuntimeError) as error:
+    except (OSError, RuntimeError, UnicodeError) as error:
         return {"rebound": False, "reason": "cursor_hook_script_rebind_failed", "error": str(error)}
     return {"rebound": True, "reason": "cursor_hook_script_rebound"}
 

--- a/src/codex_plugin_scanner/guard/cursor_hook_rebind.py
+++ b/src/codex_plugin_scanner/guard/cursor_hook_rebind.py
@@ -1,0 +1,83 @@
+"""Rewrite Guard-managed Cursor hooks that still bake a pruneable Core path."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from .adapters.base import HarnessContext
+from .adapters.cursor_hook_config import _is_managed_hook_script
+from .adapters.cursor_hooks import cursor_hook_script_path, install_cursor_hooks, managed_hook_script_path
+from .stable_guard_cli import argv0_is_ephemeral_desktop_cli, frozen_launcher_is_prune_safe, resolve_frozen_guard_cli
+
+
+def _assignment_argv(source: str, name: str) -> list[str] | None:
+    prefix = f"{name} = "
+    for line in source.splitlines():
+        if not line.startswith(prefix):
+            continue
+        try:
+            payload = json.loads(line[len(prefix) :])
+        except json.JSONDecodeError:
+            return None
+        if isinstance(payload, list) and all(isinstance(item, str) for item in payload):
+            return payload
+        return None
+    return None
+
+
+def cursor_hook_script_bakes_ephemeral_cli(source: str) -> bool:
+    """Return whether a managed Cursor hook script still bakes a versions/ Core path."""
+
+    if not _is_managed_hook_script(source):
+        return False
+    for name in ("GUARD_CLI", "GUARD_RECOVERY_COMMAND"):
+        argv = _assignment_argv(source, name)
+        if argv and argv0_is_ephemeral_desktop_cli(argv[0]):
+            return True
+    return False
+
+
+def can_rebind_to_stable_frozen_cli() -> bool:
+    """Return whether this process would bake a prune-safe frozen launcher."""
+
+    if not bool(getattr(sys, "frozen", False)):
+        return False
+    return frozen_launcher_is_prune_safe(resolve_frozen_guard_cli())
+
+
+def rebind_stale_cursor_hooks(guard_home: Path, *, home_dir: Path) -> dict[str, object]:
+    """Rewrite managed Cursor hook scripts that still bake a versions/ Core path."""
+
+    if not can_rebind_to_stable_frozen_cli():
+        return {"rebound": False, "reason": "stable_frozen_cli_unavailable"}
+    context = HarnessContext(home_dir=home_dir, guard_home=guard_home, workspace_dir=None)
+    candidates = [
+        path for path in (cursor_hook_script_path(context), managed_hook_script_path(context)) if path.is_file()
+    ]
+    if not candidates:
+        return {"rebound": False, "reason": "cursor_hook_script_absent"}
+    needs_rebind = False
+    for path in candidates:
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError as error:
+            return {"rebound": False, "reason": "cursor_hook_script_unreadable", "error": str(error)}
+        if cursor_hook_script_bakes_ephemeral_cli(source):
+            needs_rebind = True
+            break
+    if not needs_rebind:
+        return {"rebound": False, "reason": "cursor_hook_script_current"}
+    try:
+        install_cursor_hooks(context)
+    except (OSError, RuntimeError) as error:
+        return {"rebound": False, "reason": "cursor_hook_script_rebind_failed", "error": str(error)}
+    return {"rebound": True, "reason": "cursor_hook_script_rebound"}
+
+
+__all__ = [
+    "can_rebind_to_stable_frozen_cli",
+    "cursor_hook_script_bakes_ephemeral_cli",
+    "rebind_stale_cursor_hooks",
+]

--- a/src/codex_plugin_scanner/guard/daemon/runtime_repair.py
+++ b/src/codex_plugin_scanner/guard/daemon/runtime_repair.py
@@ -45,7 +45,7 @@ def _retained_runtime_status(daemon_version: Version, current_version: Version) 
 def _rebind_cursor_hooks_best_effort(guard_home: Path, *, home_dir: Path) -> dict[str, object]:
     try:
         return rebind_stale_cursor_hooks(guard_home, home_dir=home_dir)
-    except (OSError, RuntimeError) as error:
+    except (OSError, RuntimeError, UnicodeError) as error:
         return {
             "rebound": False,
             "reason": "cursor_hook_script_rebind_failed",
@@ -110,6 +110,7 @@ def repair_guard_daemon_runtime(
             guard_home,
             home_dir=trusted_home,
         )
+        cursor_rebind = _rebind_cursor_hooks_best_effort(guard_home, home_dir=trusted_home)
     return {
         **result,
         "runtime_status": "restarted",
@@ -117,6 +118,7 @@ def repair_guard_daemon_runtime(
         "cli_version": __version__,
         "daemon_url": daemon_url,
         "retired": retired,
+        "cursor_hook_rebind": cursor_rebind.get("reason"),
     }
 
 

--- a/src/codex_plugin_scanner/guard/daemon/runtime_repair.py
+++ b/src/codex_plugin_scanner/guard/daemon/runtime_repair.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from packaging.version import InvalidVersion, Version
 
 from ...version import __version__
+from ..cursor_hook_rebind import rebind_stale_cursor_hooks
 from .live_identity import verified_live_guard_daemon_identity
 from .manager import (
     clear_guard_daemon_state,
@@ -39,6 +40,17 @@ def _retained_runtime_status(daemon_version: Version, current_version: Version) 
     if daemon_version > current_version:
         return "retained_newer_runtime"
     return "retained_desktop_runtime"
+
+
+def _rebind_cursor_hooks_best_effort(guard_home: Path, *, home_dir: Path) -> dict[str, object]:
+    try:
+        return rebind_stale_cursor_hooks(guard_home, home_dir=home_dir)
+    except (OSError, RuntimeError) as error:
+        return {
+            "rebound": False,
+            "reason": "cursor_hook_script_rebind_failed",
+            "error": str(error),
+        }
 
 
 def _keep_live_runtime_result(
@@ -86,7 +98,8 @@ def repair_guard_daemon_runtime(
             current_version=current_version,
         )
         if kept is not None:
-            return kept
+            cursor_rebind = _rebind_cursor_hooks_best_effort(guard_home, home_dir=trusted_home)
+            return {**kept, "cursor_hook_rebind": cursor_rebind.get("reason")}
 
         daemon_version_text = identity.get("package_version") if identity is not None else None
         retired = retire_all_guard_daemons_for_home(guard_home)

--- a/src/codex_plugin_scanner/guard/frozen_runtime_commands.py
+++ b/src/codex_plugin_scanner/guard/frozen_runtime_commands.py
@@ -6,6 +6,8 @@ import json
 import sys
 from pathlib import Path
 
+from .stable_guard_cli import resolve_frozen_guard_cli
+
 FROZEN_DAEMON_RECOVER_ARG = "--_hol-guard-codex-daemon-recover"
 FROZEN_DAEMON_RECOVERY_WORKER_ARG = "--_hol-guard-codex-daemon-recovery-worker"
 
@@ -14,6 +16,14 @@ def is_frozen_guard_runtime() -> bool:
     """Return whether this process is a PyInstaller-style frozen Guard binary."""
 
     return bool(getattr(sys, "frozen", False)) and Path(sys.executable).is_file()
+
+
+def _recovery_executable(executable: str | None) -> str:
+    if executable is not None:
+        return executable
+    if is_frozen_guard_runtime():
+        return resolve_frozen_guard_cli()
+    return sys.executable
 
 
 def frozen_daemon_recovery_command(
@@ -32,7 +42,7 @@ def frozen_daemon_recovery_command(
         sort_keys=True,
         separators=(",", ":"),
     )
-    return (executable or sys.executable, FROZEN_DAEMON_RECOVER_ARG, payload)
+    return (_recovery_executable(executable), FROZEN_DAEMON_RECOVER_ARG, payload)
 
 
 def frozen_daemon_recovery_worker_command(
@@ -55,7 +65,7 @@ def frozen_daemon_recovery_worker_command(
         sort_keys=True,
         separators=(",", ":"),
     )
-    return (executable or sys.executable, FROZEN_DAEMON_RECOVERY_WORKER_ARG, payload)
+    return (_recovery_executable(executable), FROZEN_DAEMON_RECOVERY_WORKER_ARG, payload)
 
 
 __all__ = [

--- a/src/codex_plugin_scanner/guard/runtime_artifact_reconciliation.py
+++ b/src/codex_plugin_scanner/guard/runtime_artifact_reconciliation.py
@@ -173,7 +173,7 @@ def reconcile_runtime_artifacts(
     )
     try:
         cursor_rebind = rebind_stale_cursor_hooks(store.guard_home, home_dir=context.home_dir)
-    except (OSError, RuntimeError) as error:
+    except (OSError, RuntimeError, UnicodeError) as error:
         cursor_rebind = {
             "rebound": False,
             "reason": "cursor_hook_script_rebind_failed",
@@ -181,7 +181,10 @@ def reconcile_runtime_artifacts(
         }
     if cursor_rebind.get("rebound") is True and "cursor" not in repaired_harnesses:
         repaired_harnesses = (*repaired_harnesses, "cursor")
-    if cursor_rebind.get("reason") == "cursor_hook_script_rebind_failed":
+    if cursor_rebind.get("reason") in {
+        "cursor_hook_script_rebind_failed",
+        "cursor_hook_script_unreadable",
+    }:
         error_text = cursor_rebind.get("error")
         errors.append(f"cursor:rebind:{error_text if isinstance(error_text, str) else 'failed'}")
 

--- a/src/codex_plugin_scanner/guard/runtime_artifact_reconciliation.py
+++ b/src/codex_plugin_scanner/guard/runtime_artifact_reconciliation.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from .adapters.base import HarnessContext
 from .approvals import _live_hook_verification
 from .cli.install_commands import apply_managed_install
+from .cursor_hook_rebind import rebind_stale_cursor_hooks
 from .shim_refresh import refresh_stale_harness_shims
 from .shims import package_shim_dashboard_status, package_shim_status, repair_package_shims
 from .store import GuardStore
@@ -170,6 +171,19 @@ def reconcile_runtime_artifacts(
         store,
         home_dir=context.home_dir,
     )
+    try:
+        cursor_rebind = rebind_stale_cursor_hooks(store.guard_home, home_dir=context.home_dir)
+    except (OSError, RuntimeError) as error:
+        cursor_rebind = {
+            "rebound": False,
+            "reason": "cursor_hook_script_rebind_failed",
+            "error": str(error),
+        }
+    if cursor_rebind.get("rebound") is True and "cursor" not in repaired_harnesses:
+        repaired_harnesses = (*repaired_harnesses, "cursor")
+    if cursor_rebind.get("reason") == "cursor_hook_script_rebind_failed":
+        error_text = cursor_rebind.get("error")
+        errors.append(f"cursor:rebind:{error_text if isinstance(error_text, str) else 'failed'}")
 
     repaired_managers: tuple[str, ...] = ()
     try:

--- a/src/codex_plugin_scanner/guard/stable_guard_cli.py
+++ b/src/codex_plugin_scanner/guard/stable_guard_cli.py
@@ -6,6 +6,7 @@ on update. Hooks and package-manager shims must not bake that ephemeral path.
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -31,6 +32,16 @@ def desktop_core_shim_for_executable(executable: Path) -> Path | None:
     return unix
 
 
+def frozen_cli_path_is_runnable(path: Path) -> bool:
+    """Return whether a frozen launcher can be executed as argv0."""
+
+    if not path.is_file():
+        return False
+    if os.name == "nt":
+        return True
+    return os.access(path, os.X_OK)
+
+
 def resolve_frozen_guard_cli() -> str:
     """Return a prune-safe frozen launcher, then the process executable.
 
@@ -40,10 +51,10 @@ def resolve_frozen_guard_cli() -> str:
 
     executable = Path(sys.executable)
     shim = desktop_core_shim_for_executable(executable)
-    if shim is not None and shim.is_file():
+    if shim is not None and frozen_cli_path_is_runnable(shim):
         return str(shim)
     versioned_desktop = shim is not None
-    if versioned_desktop and sys.platform == "darwin" and MACOS_BUNDLED_HOL_GUARD.is_file():
+    if versioned_desktop and sys.platform == "darwin" and frozen_cli_path_is_runnable(MACOS_BUNDLED_HOL_GUARD):
         return str(MACOS_BUNDLED_HOL_GUARD)
     return sys.executable
 
@@ -117,6 +128,7 @@ __all__ = [
     "MACOS_BUNDLED_HOL_GUARD",
     "argv0_is_ephemeral_desktop_cli",
     "desktop_core_shim_for_executable",
+    "frozen_cli_path_is_runnable",
     "frozen_launcher_is_prune_safe",
     "resolve_frozen_guard_cli",
     "resolve_guard_cli_argv0",

--- a/src/codex_plugin_scanner/guard/stable_guard_cli.py
+++ b/src/codex_plugin_scanner/guard/stable_guard_cli.py
@@ -83,12 +83,44 @@ def trusted_frozen_guard_cli_paths() -> frozenset[str]:
     return frozenset(trusted)
 
 
+def uses_top_level_hook_command(guard_cli: list[str]) -> bool:
+    """Return whether argv0 exposes `hook` without a `guard` prefix."""
+
+    if not guard_cli:
+        return False
+    name = Path(guard_cli[0]).name.lower()
+    return name in {
+        "hol-guard",
+        "hol-guard.exe",
+        "plugin-guard",
+        "plugin-guard.exe",
+        CURRENT_HOL_GUARD_SHIM,
+        f"{CURRENT_HOL_GUARD_SHIM}.cmd",
+        f"{CURRENT_HOL_GUARD_SHIM}.exe",
+    }
+
+
+def argv0_is_ephemeral_desktop_cli(argv0: str) -> bool:
+    """Return whether argv0 lives under a pruneable Desktop `versions/` path."""
+
+    return desktop_core_shim_for_executable(Path(argv0)) is not None
+
+
+def frozen_launcher_is_prune_safe(launcher: str) -> bool:
+    """Return whether a frozen launcher survives Desktop Core prune."""
+
+    return desktop_core_shim_for_executable(Path(launcher)) is None
+
+
 __all__ = [
     "CURRENT_HOL_GUARD_SHIM",
     "MACOS_BUNDLED_HOL_GUARD",
+    "argv0_is_ephemeral_desktop_cli",
     "desktop_core_shim_for_executable",
+    "frozen_launcher_is_prune_safe",
     "resolve_frozen_guard_cli",
     "resolve_guard_cli_argv0",
     "resolved_guard_cli",
     "trusted_frozen_guard_cli_paths",
+    "uses_top_level_hook_command",
 ]

--- a/tests/test_cursor_frozen_hook_command.py
+++ b/tests/test_cursor_frozen_hook_command.py
@@ -52,6 +52,7 @@ def test_frozen_cursor_hook_command_prefers_current_hol_guard_shim(monkeypatch, 
     versioned.write_text("", encoding="utf-8")
     shim = core_dir / "current-hol-guard"
     shim.write_text("", encoding="utf-8")
+    shim.chmod(0o755)
     monkeypatch.setattr("codex_plugin_scanner.guard.adapters.cursor_hook_config.sys.frozen", True, raising=False)
     monkeypatch.setattr("codex_plugin_scanner.guard.adapters.cursor_hook_config.sys.executable", str(versioned))
     script = tmp_path / ".cursor" / "hooks" / HOOK_SCRIPT_NAME
@@ -73,6 +74,7 @@ def test_frozen_cursor_hook_command_prefers_macos_bundle_without_shim(monkeypatc
     bundle = tmp_path / "HOL Guard.app" / "Contents" / "MacOS" / "hol-guard"
     bundle.parent.mkdir(parents=True)
     bundle.write_text("", encoding="utf-8")
+    bundle.chmod(0o755)
     monkeypatch.setattr("codex_plugin_scanner.guard.adapters.cursor_hook_config.sys.frozen", True, raising=False)
     monkeypatch.setattr("codex_plugin_scanner.guard.adapters.cursor_hook_config.sys.executable", str(versioned))
     monkeypatch.setattr(

--- a/tests/test_cursor_hook_guard_cli.py
+++ b/tests/test_cursor_hook_guard_cli.py
@@ -49,6 +49,7 @@ def test_resolve_frozen_cursor_hook_launcher_prefers_shim(monkeypatch: pytest.Mo
     versioned.write_text("", encoding="utf-8")
     shim = core_dir / "current-hol-guard"
     shim.write_text("", encoding="utf-8")
+    shim.chmod(0o755)
     monkeypatch.setattr(
         "codex_plugin_scanner.guard.stable_guard_cli.sys.executable",
         str(versioned),

--- a/tests/test_cursor_hook_rebind.py
+++ b/tests/test_cursor_hook_rebind.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -202,3 +203,117 @@ def test_reconcile_rebinds_ephemeral_cursor_hooks(
     assert result.repaired_harnesses == ("cursor",)
     assert result.changed is True
     assert result.healthy is True
+
+
+def test_rebind_does_not_overwrite_unmanaged_live_script(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    core_dir = tmp_path / "core"
+    versioned = _executable_file(core_dir / "versions" / "3.0.57" / "hol-guard")
+    _executable_file(core_dir / "current-hol-guard", "#!/bin/sh\nexec true\n")
+    home = tmp_path / "home"
+    guard_home = tmp_path / "guard"
+    live = home / ".cursor" / "hooks" / "hol-guard-cursor-hook.py"
+    live.parent.mkdir(parents=True)
+    live.write_text("print('user owned')\n", encoding="utf-8")
+    managed = guard_home / "managed" / "cursor" / "hol-guard-cursor-hook.py"
+    managed.parent.mkdir(parents=True)
+    managed.write_text(_managed_hook_source(argv0=str(versioned)), encoding="utf-8")
+    monkeypatch.setattr("codex_plugin_scanner.guard.cursor_hook_rebind.sys.frozen", True, raising=False)
+    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.guard_cli_attestation.sys.frozen", True, raising=False)
+    monkeypatch.setattr("codex_plugin_scanner.guard.stable_guard_cli.sys.executable", str(versioned))
+    result = rebind_stale_cursor_hooks(guard_home, home_dir=home)
+    assert result["rebound"] is False
+    assert result["reason"] == "cursor_hook_script_unmanaged"
+    assert live.read_text(encoding="utf-8") == "print('user owned')\n"
+    assert "versions/3.0.57" in managed.read_text(encoding="utf-8")
+
+
+def test_rebind_reports_unreadable_non_utf8_script(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    core_dir = tmp_path / "core"
+    versioned = _executable_file(core_dir / "versions" / "3.0.57" / "hol-guard")
+    _executable_file(core_dir / "current-hol-guard", "#!/bin/sh\nexec true\n")
+    home = tmp_path / "home"
+    live = home / ".cursor" / "hooks" / "hol-guard-cursor-hook.py"
+    live.parent.mkdir(parents=True)
+    live.write_bytes(b"\xff\xfe unmanaged-binary")
+    monkeypatch.setattr("codex_plugin_scanner.guard.cursor_hook_rebind.sys.frozen", True, raising=False)
+    monkeypatch.setattr("codex_plugin_scanner.guard.stable_guard_cli.sys.executable", str(versioned))
+    result = rebind_stale_cursor_hooks(tmp_path / "guard", home_dir=home)
+    assert result["rebound"] is False
+    assert result["reason"] == "cursor_hook_script_unreadable"
+
+
+def test_nonexecutable_shim_is_not_a_stable_frozen_launcher(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if os.name == "nt":
+        pytest.skip("POSIX execute bit is not enforced")
+    core_dir = tmp_path / "core"
+    versioned = _executable_file(core_dir / "versions" / "3.0.57" / "hol-guard")
+    shim = core_dir / "current-hol-guard"
+    shim.write_text("#!/bin/sh\n", encoding="utf-8")
+    shim.chmod(0o644)
+    monkeypatch.setattr("codex_plugin_scanner.guard.stable_guard_cli.sys.executable", str(versioned))
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.stable_guard_cli.MACOS_BUNDLED_HOL_GUARD",
+        tmp_path / "missing-bundle",
+    )
+    monkeypatch.setattr("codex_plugin_scanner.guard.frozen_runtime_commands.sys.frozen", True, raising=False)
+    monkeypatch.setattr("codex_plugin_scanner.guard.frozen_runtime_commands.sys.executable", str(versioned))
+    from codex_plugin_scanner.guard.stable_guard_cli import resolve_frozen_guard_cli
+
+    assert resolve_frozen_guard_cli() == str(versioned)
+    command = frozen_daemon_recovery_command(tmp_path / "guard", tmp_path / "home")
+    assert command[0] == str(versioned)
+
+
+def test_reconcile_reports_unreadable_cursor_hooks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codex_plugin_scanner.guard import runtime_artifact_reconciliation as reconciliation
+    from codex_plugin_scanner.guard.shim_refresh import ShimRefreshResult
+
+    store = type(
+        "Store",
+        (),
+        {
+            "guard_home": tmp_path / "guard",
+            "list_managed_installs": staticmethod(lambda: []),
+        },
+    )()
+    monkeypatch.setattr(
+        reconciliation,
+        "refresh_stale_harness_shims",
+        lambda **_kwargs: ShimRefreshResult(refreshed=(), unchanged=(), errors=()),
+    )
+    monkeypatch.setattr(
+        reconciliation,
+        "repair_failing_managed_harness_hooks",
+        lambda *_args, **_kwargs: ((), ()),
+    )
+    monkeypatch.setattr(
+        reconciliation,
+        "package_shim_status",
+        lambda _context: {"installed_managers": []},
+    )
+    monkeypatch.setattr(
+        reconciliation,
+        "rebind_stale_cursor_hooks",
+        lambda *_args, **_kwargs: {
+            "rebound": False,
+            "reason": "cursor_hook_script_unreadable",
+            "error": "utf-8",
+        },
+    )
+
+    result = reconciliation.reconcile_runtime_artifacts(store, home_dir=tmp_path / "home")
+
+    assert result.healthy is False
+    assert result.errors == ("cursor:rebind:utf-8",)

--- a/tests/test_cursor_hook_rebind.py
+++ b/tests/test_cursor_hook_rebind.py
@@ -1,0 +1,204 @@
+"""Cursor hooks must bake a prune-safe launcher and rebind stale versioned paths."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.cursor_hooks import cursor_hook_script_source
+from codex_plugin_scanner.guard.adapters.guard_cli_attestation import resolve_attested_guard_cli
+from codex_plugin_scanner.guard.cursor_hook_rebind import (
+    cursor_hook_script_bakes_ephemeral_cli,
+    rebind_stale_cursor_hooks,
+)
+from codex_plugin_scanner.guard.frozen_runtime_commands import frozen_daemon_recovery_command
+from codex_plugin_scanner.guard.stable_guard_cli import uses_top_level_hook_command
+
+
+def _managed_hook_source(*, argv0: str) -> str:
+    return (
+        "#!/usr/bin/env python3\n"
+        '"""Managed by HOL Guard. Re-run `hol-guard install cursor` after moving Guard home."""\n'
+        "from pathlib import Path\n"
+        f"GUARD_CLI = {json.dumps([argv0])}\n"
+        f"GUARD_RECOVERY_COMMAND = {json.dumps([argv0])}\n"
+        "HOOK_SCRIPT_NAME = 'hol-guard-cursor-hook.py'\n"
+    )
+
+
+def _executable_file(path: Path, body: str = "#!/bin/sh\n") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def test_uses_top_level_hook_command_for_stable_desktop_shim() -> None:
+    assert uses_top_level_hook_command(["/core/current-hol-guard"]) is True
+    assert uses_top_level_hook_command(["/core/current-hol-guard.cmd"]) is True
+    assert uses_top_level_hook_command(["/core/versions/3.0.57/hol-guard"]) is True
+    assert uses_top_level_hook_command(["/usr/bin/python3", "-m", "codex_plugin_scanner.cli"]) is False
+
+
+def test_cursor_hook_script_source_does_not_prefix_guard_for_stable_shim(tmp_path: Path) -> None:
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        guard_home=tmp_path / "guard",
+        workspace_dir=tmp_path / "workspace",
+    )
+    source = cursor_hook_script_source(
+        context,
+        guard_cli=[str(tmp_path / "core" / "current-hol-guard")],
+        recovery_command=["true"],
+    )
+    assert '["guard", "hook"' not in source
+    assert '"hook"' in source
+
+
+def test_cursor_hook_script_bakes_ephemeral_cli_detects_versioned_core(tmp_path: Path) -> None:
+    versioned = str(tmp_path / "core" / "versions" / "3.0.57" / "hol-guard")
+    shim = str(tmp_path / "core" / "current-hol-guard")
+    assert cursor_hook_script_bakes_ephemeral_cli(_managed_hook_source(argv0=versioned)) is True
+    assert cursor_hook_script_bakes_ephemeral_cli(_managed_hook_source(argv0=shim)) is False
+    assert cursor_hook_script_bakes_ephemeral_cli("print('not managed')\n") is False
+
+
+def test_rebind_skips_unfrozen_process_even_when_script_is_ephemeral(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    guard_home = tmp_path / "guard"
+    versioned = tmp_path / "core" / "versions" / "3.0.57" / "hol-guard"
+    script = home / ".cursor" / "hooks" / "hol-guard-cursor-hook.py"
+    script.parent.mkdir(parents=True)
+    script.write_text(_managed_hook_source(argv0=str(versioned)), encoding="utf-8")
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cursor_hook_rebind.sys.frozen",
+        False,
+        raising=False,
+    )
+    result = rebind_stale_cursor_hooks(guard_home, home_dir=home)
+    assert result["rebound"] is False
+    assert result["reason"] == "stable_frozen_cli_unavailable"
+    assert "versions/3.0.57" in script.read_text(encoding="utf-8")
+
+
+def test_rebind_rewrites_versioned_cli_to_current_hol_guard_shim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    core_dir = tmp_path / "core"
+    versioned = _executable_file(core_dir / "versions" / "3.0.57" / "hol-guard")
+    shim = _executable_file(core_dir / "current-hol-guard", "#!/bin/sh\nexec true\n")
+    home = tmp_path / "home"
+    guard_home = tmp_path / "guard"
+    script = home / ".cursor" / "hooks" / "hol-guard-cursor-hook.py"
+    script.parent.mkdir(parents=True)
+    script.write_text(_managed_hook_source(argv0=str(versioned)), encoding="utf-8")
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cursor_hook_rebind.sys.frozen",
+        True,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.adapters.guard_cli_attestation.sys.frozen",
+        True,
+        raising=False,
+    )
+    monkeypatch.setattr("codex_plugin_scanner.guard.stable_guard_cli.sys.executable", str(versioned))
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.adapters.guard_cli_attestation.sys.executable",
+        str(versioned),
+    )
+    monkeypatch.setattr("codex_plugin_scanner.guard.frozen_runtime_commands.sys.frozen", True, raising=False)
+    monkeypatch.setattr("codex_plugin_scanner.guard.frozen_runtime_commands.sys.executable", str(shim))
+
+    result = rebind_stale_cursor_hooks(guard_home, home_dir=home)
+
+    assert result["rebound"] is True
+    rewritten = script.read_text(encoding="utf-8")
+    assert "current-hol-guard" in rewritten
+    assert "versions/3.0.57" not in rewritten
+    assert '["guard", "hook"' not in rewritten
+
+
+def test_resolve_attested_guard_cli_bakes_current_hol_guard_shim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    core_dir = tmp_path / "core"
+    versioned = _executable_file(core_dir / "versions" / "3.0.57" / "hol-guard")
+    shim = _executable_file(core_dir / "current-hol-guard", "#!/bin/sh\nexec true\n")
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.adapters.guard_cli_attestation.sys.frozen",
+        True,
+        raising=False,
+    )
+    monkeypatch.setattr("codex_plugin_scanner.guard.stable_guard_cli.sys.executable", str(versioned))
+    context = HarnessContext(home_dir=tmp_path / "home", guard_home=tmp_path / "guard", workspace_dir=None)
+    attested = resolve_attested_guard_cli(context)
+    assert attested.frozen is True
+    assert Path(attested.command[0]).name == "current-hol-guard"
+    assert attested.command == (str(shim.expanduser().absolute()),)
+
+
+def test_frozen_recovery_command_defaults_to_stable_shim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    core_dir = tmp_path / "core"
+    versioned = _executable_file(core_dir / "versions" / "3.0.57" / "hol-guard")
+    shim = _executable_file(core_dir / "current-hol-guard", "#!/bin/sh\nexec true\n")
+    monkeypatch.setattr("codex_plugin_scanner.guard.frozen_runtime_commands.sys.frozen", True, raising=False)
+    monkeypatch.setattr("codex_plugin_scanner.guard.frozen_runtime_commands.sys.executable", str(versioned))
+    monkeypatch.setattr("codex_plugin_scanner.guard.stable_guard_cli.sys.executable", str(versioned))
+    command = frozen_daemon_recovery_command(tmp_path / "guard", tmp_path / "home")
+    assert Path(command[0]).name == "current-hol-guard"
+    assert command[0] == str(shim)
+
+
+def test_reconcile_rebinds_ephemeral_cursor_hooks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codex_plugin_scanner.guard import runtime_artifact_reconciliation as reconciliation
+    from codex_plugin_scanner.guard.shim_refresh import ShimRefreshResult
+
+    store = type(
+        "Store",
+        (),
+        {
+            "guard_home": tmp_path / "guard",
+            "list_managed_installs": staticmethod(lambda: []),
+        },
+    )()
+    monkeypatch.setattr(
+        reconciliation,
+        "refresh_stale_harness_shims",
+        lambda **_kwargs: ShimRefreshResult(refreshed=(), unchanged=(), errors=()),
+    )
+    monkeypatch.setattr(
+        reconciliation,
+        "repair_failing_managed_harness_hooks",
+        lambda *_args, **_kwargs: ((), ()),
+    )
+    monkeypatch.setattr(
+        reconciliation,
+        "package_shim_status",
+        lambda _context: {"installed_managers": []},
+    )
+    monkeypatch.setattr(
+        reconciliation,
+        "rebind_stale_cursor_hooks",
+        lambda *_args, **_kwargs: {"rebound": True, "reason": "cursor_hook_script_rebound"},
+    )
+
+    result = reconciliation.reconcile_runtime_artifacts(store, home_dir=tmp_path / "home")
+
+    assert result.repaired_harnesses == ("cursor",)
+    assert result.changed is True
+    assert result.healthy is True

--- a/tests/test_guard_daemon_runtime_repair.py
+++ b/tests/test_guard_daemon_runtime_repair.py
@@ -96,6 +96,7 @@ def test_repair_retains_authenticated_newer_runtime(
 
     assert result["runtime_status"] == "retained_newer_runtime"
     assert result["daemon_version"] == "3.0.35"
+    assert result["cursor_hook_rebind"] == "stable_frozen_cli_unavailable"
 
 
 def test_repair_restarts_newer_mismatched_non_desktop_runtime(
@@ -189,6 +190,7 @@ def test_repair_retains_equal_version_peer_runtime(
     assert result["runtime_status"] == "current"
     assert result["daemon_version"] == "3.0.34"
     assert result["cli_version"] == "3.0.34"
+    assert result["cursor_hook_rebind"] == "stable_frozen_cli_unavailable"
 
 
 def test_repair_restarts_older_desktop_core_sidecar(

--- a/tests/test_guard_daemon_runtime_repair.py
+++ b/tests/test_guard_daemon_runtime_repair.py
@@ -58,6 +58,7 @@ def test_repair_restarts_authenticated_older_runtime(
     assert result["retired"] == [321]
     assert retired == [guard_home]
     assert events == ["lock-enter", "ensure", "lock-exit"]
+    assert result["cursor_hook_rebind"] == "stable_frozen_cli_unavailable"
 
 
 def test_repair_retains_authenticated_newer_runtime(

--- a/tests/test_guard_package_shim_frozen.py
+++ b/tests/test_guard_package_shim_frozen.py
@@ -107,6 +107,7 @@ def test_frozen_package_shim_wrapper_uses_current_hol_guard_shim(
     versioned.write_text("", encoding="utf-8")
     shim = core_dir / "current-hol-guard"
     shim.write_text("", encoding="utf-8")
+    shim.chmod(0o755)
     monkeypatch.setattr(guard_shims_module.sys, "frozen", True, raising=False)
     monkeypatch.setattr(guard_shims_module.sys, "executable", str(versioned))
     monkeypatch.setattr(
@@ -202,7 +203,7 @@ def test_package_shim_status_stale_when_wrapper_interpreter_is_untrusted(
     outsider.write_text("", encoding="utf-8")
     outsider.chmod(0o755)
     wrapper_path.write_text(
-        "\n".join(("#!/bin/sh", f"exec {shlex.quote(str(outsider))} {shlex.quote(str(python_path))} \"$@\"", "")),
+        "\n".join(("#!/bin/sh", f'exec {shlex.quote(str(outsider))} {shlex.quote(str(python_path))} "$@"', "")),
         encoding="utf-8",
     )
 
@@ -229,6 +230,7 @@ def test_resolve_frozen_package_shim_path_accepts_stable_launcher_shebang(
     versioned.write_text("", encoding="utf-8")
     shim = tmp_path / "core" / "current-hol-guard"
     shim.write_text("", encoding="utf-8")
+    shim.chmod(0o755)
     monkeypatch.setattr(sys, "frozen", True, raising=False)
     monkeypatch.setattr(sys, "executable", str(versioned))
     shim_dir = tmp_path / "package-shims" / "bin"


### PR DESCRIPTION
## Summary
- Frozen Cursor hooks now persist the stable `current-hol-guard` launcher instead of a pruneable `versions/` Core path.
- Daemon start and daemon repair rewrite Guard-managed Cursor scripts that still bake a `versions/` path.
- Unfrozen installs are left unchanged so a source CLI cannot overwrite a Desktop-managed hook.

## Testing
- `python3 -m pytest tests/test_cursor_hook_rebind.py tests/test_cursor_hook_guard_cli.py tests/test_cursor_frozen_hook_command.py tests/test_guard_daemon_runtime_repair.py tests/test_guard_runtime_artifact_reconciliation.py`
- `python3 -m ruff check` on the changed Guard modules
- `python3 scripts/ci/code_quality_audit.py --root . --baseline ci/code-quality-baseline.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cursor hooks now continue working after Desktop version cleanup by switching stale references to a stable launcher.
  * Frozen runtime recovery and daemon repair now resolve the appropriate stable Guard CLI launcher.
  * Hook command handling is improved for supported launcher formats.
  * Runtime reconciliation reports successful hook repairs and rebind failures.

* **Tests**
  * Added coverage for stale hook detection, rebinding, stable launcher resolution, and unavailable frozen runtimes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->