### PR TITLE
fix(hooks): recognize Guard Cursor scripts by installer watermark

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_config.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_config.py
@@ -164,16 +164,26 @@ def _is_managed_hook_command(command: object) -> bool:
     return Path(tokens[0]).name.lower().startswith("python") if tokens else False
 
 
+_MANAGED_CURSOR_HOOK_DOCSTRING = (
+    '"""Managed by HOL Guard. Re-run `hol-guard install cursor` after moving Guard home."""'
+)
+
+
 def _is_managed_hook_script(source: str) -> bool:
     """Return whether *source* was written by Guard's Cursor installer.
 
-    Installed scripts watermark the module docstring with
-    ``Managed by HOL Guard``. They do not embed ``HOOK_SCRIPT_NAME``, so
-    requiring that filename would treat every live Guard hook as unmanaged
-    and skip prune-safe rebind.
+    Installed scripts use a Cursor-specific module docstring and bake
+    ``GUARD_CLI``. They do not embed ``HOOK_SCRIPT_NAME``, so requiring that
+    filename would treat every live Guard hook as unmanaged and skip
+    prune-safe rebind. A mention of ``Managed by HOL Guard`` alone is not
+    ownership.
     """
 
-    return "Managed by HOL Guard" in source
+    return (
+        _MANAGED_CURSOR_HOOK_DOCSTRING in source
+        and "\nGUARD_CLI =" in source
+        and "\nGUARD_RECOVERY_COMMAND =" in source
+    )
 
 
 def _managed_hooks_payload(payload: dict[str, object]) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_config.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_config.py
@@ -165,7 +165,15 @@ def _is_managed_hook_command(command: object) -> bool:
 
 
 def _is_managed_hook_script(source: str) -> bool:
-    return "Managed by HOL Guard" in source and HOOK_SCRIPT_NAME in source
+    """Return whether *source* was written by Guard's Cursor installer.
+
+    Installed scripts watermark the module docstring with
+    ``Managed by HOL Guard``. They do not embed ``HOOK_SCRIPT_NAME``, so
+    requiring that filename would treat every live Guard hook as unmanaged
+    and skip prune-safe rebind.
+    """
+
+    return "Managed by HOL Guard" in source
 
 
 def _managed_hooks_payload(payload: dict[str, object]) -> dict[str, object]:

--- a/tests/test_cursor_hook_rebind.py
+++ b/tests/test_cursor_hook_rebind.py
@@ -73,6 +73,14 @@ def test_installed_cursor_hook_template_is_recognized_as_managed(tmp_path: Path)
     assert _is_managed_hook_script(source) is True
     assert "hol-guard-cursor-hook.py" not in source
     assert _is_managed_hook_script("print('user owned')\n") is False
+    assert _is_managed_hook_script("# Managed by HOL Guard\nprint('user owned')\n") is False
+    assert (
+        _is_managed_hook_script(
+            '"""Managed by HOL Guard. Re-run `hol-guard install cursor` after moving Guard home."""\n'
+            "print('user owned')\n"
+        )
+        is False
+    )
 
 
 def test_cursor_hook_script_bakes_ephemeral_cli_detects_versioned_core(tmp_path: Path) -> None:
@@ -244,6 +252,27 @@ def test_rebind_does_not_overwrite_unmanaged_live_script(
     assert result["reason"] == "cursor_hook_script_unmanaged"
     assert live.read_text(encoding="utf-8") == "print('user owned')\n"
     assert "versions/3.0.57" in managed.read_text(encoding="utf-8")
+
+
+def test_rebind_does_not_overwrite_script_that_only_quotes_guard_watermark(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    core_dir = tmp_path / "core"
+    versioned = _executable_file(core_dir / "versions" / "3.0.57" / "hol-guard")
+    _executable_file(core_dir / "current-hol-guard", "#!/bin/sh\nexec true\n")
+    home = tmp_path / "home"
+    live = home / ".cursor" / "hooks" / "hol-guard-cursor-hook.py"
+    live.parent.mkdir(parents=True)
+    source = "# Managed by HOL Guard\nUSER_SENTINEL = True\n"
+    live.write_text(source, encoding="utf-8")
+    monkeypatch.setattr("codex_plugin_scanner.guard.cursor_hook_rebind.sys.frozen", True, raising=False)
+    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.guard_cli_attestation.sys.frozen", True, raising=False)
+    monkeypatch.setattr("codex_plugin_scanner.guard.stable_guard_cli.sys.executable", str(versioned))
+    result = rebind_stale_cursor_hooks(tmp_path / "guard", home_dir=home)
+    assert result["rebound"] is False
+    assert result["reason"] == "cursor_hook_script_unmanaged"
+    assert live.read_text(encoding="utf-8") == source
 
 
 def test_rebind_reports_unreadable_non_utf8_script(

--- a/tests/test_cursor_hook_rebind.py
+++ b/tests/test_cursor_hook_rebind.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.cursor_hook_config import _is_managed_hook_script
 from codex_plugin_scanner.guard.adapters.cursor_hooks import cursor_hook_script_source
 from codex_plugin_scanner.guard.adapters.guard_cli_attestation import resolve_attested_guard_cli
 from codex_plugin_scanner.guard.cursor_hook_rebind import (
@@ -26,7 +27,6 @@ def _managed_hook_source(*, argv0: str) -> str:
         "from pathlib import Path\n"
         f"GUARD_CLI = {json.dumps([argv0])}\n"
         f"GUARD_RECOVERY_COMMAND = {json.dumps([argv0])}\n"
-        "HOOK_SCRIPT_NAME = 'hol-guard-cursor-hook.py'\n"
     )
 
 
@@ -57,6 +57,22 @@ def test_cursor_hook_script_source_does_not_prefix_guard_for_stable_shim(tmp_pat
     )
     assert '["guard", "hook"' not in source
     assert '"hook"' in source
+
+
+def test_installed_cursor_hook_template_is_recognized_as_managed(tmp_path: Path) -> None:
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        guard_home=tmp_path / "guard",
+        workspace_dir=tmp_path / "workspace",
+    )
+    source = cursor_hook_script_source(
+        context,
+        guard_cli=[str(tmp_path / "core" / "current-hol-guard")],
+        recovery_command=["true"],
+    )
+    assert _is_managed_hook_script(source) is True
+    assert "hol-guard-cursor-hook.py" not in source
+    assert _is_managed_hook_script("print('user owned')\n") is False
 
 
 def test_cursor_hook_script_bakes_ephemeral_cli_detects_versioned_core(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Treat Cursor hook scripts as Guard-managed when they carry the installer watermark, without requiring the hook filename inside the file.
- Frozen Core can rebind those scripts onto the stable launcher instead of skipping them as unmanaged.

## Testing
- `python3 -m pytest tests/test_cursor_hook_rebind.py tests/test_cursor_hook_guard_cli.py tests/test_cursor_frozen_hook_command.py --tb=short -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/adapters/cursor_hook_config.py tests/test_cursor_hook_rebind.py`
- `python3 scripts/ci/code_quality_audit.py --root . --baseline ci/code-quality-baseline.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recognition of Guard-managed Cursor hooks using distinctive installer markers.
  - Prevented user-owned scripts that merely mention Guard from being treated as Guard-managed during hook rebinding.
  - Preserved user-owned scripts during prune-safe rebind operations.

- **Tests**
  - Added coverage for generated managed hook detection.
  - Added safeguards verifying that user scripts containing Guard references remain untouched.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->