### PR TITLE
fix(hooks): continue native fail-safe without emergency-safe deny

### DIFF
--- a/docs/guard/cursor-local-cloud-contract.md
+++ b/docs/guard/cursor-local-cloud-contract.md
@@ -6,7 +6,7 @@ Cursor support is split by surface so the dashboard does not imply protection th
 
 | Surface | What Guard installs | What is intercepted |
 | ------- | ------------------- | ----------------- |
-| **Editor (IDE)** | MCP proxies in `.cursor/mcp.json` and native hooks in `.cursor/hooks.json` | Agent `beforeShellExecution`, `beforeMCPExecution`, `preToolUse` (Shell/MCP/Read), and `beforeReadFile` |
+| **Editor (IDE)** | MCP proxies in `.cursor/mcp.json` and native hooks in `.cursor/hooks.json` | Agent `beforeShellExecution`, `beforeMCPExecution`, `beforeReadFile`, `beforeWriteFile`, and `preToolUse` (Shell/MCP/Read/Write) |
 | **CLI** | `guard-cursor-agent` and `guard-cursor` shims on `PATH` | Launches routed through `hol-guard run cursor` before the real Cursor CLI agent starts |
 
 Run `hol-guard apps connect cursor --surface all` (or `hol-guard install cursor` for both surfaces) to enable editor hooks and CLI shims.
@@ -29,10 +29,11 @@ Guard installs command hooks documented by Cursor:
 - `beforeShellExecution` and `beforeMCPExecution` with `failClosed: true` so hook failures block risky actions
 - `preToolUse` with matchers for Shell, MCP, Bash, and Read tools
 - `beforeReadFile` for sensitive file reads before they reach the model
+- `beforeWriteFile` for file writes before they reach disk
 
 Hooks call a managed bridge script (`.cursor/hooks/hol-guard-cursor-hook.py`) through the attested Guard Python interpreter, so a missing execute bit cannot freeze the IDE. The script forwards stdin JSON to the local daemon first, then `hol-guard hook --harness cursor --json`, and maps Guard policy results to Cursor `permission` responses (`allow`, `deny`, `ask`).
 
-When native review, daemon transport, or hook execution cannot complete, Guard keeps a schema-valid response on every path. Local inspection (workspace source reads, grep/glob/`rg`/`cat`, `git status`/`diff`/`log`, `hol-guard status`/`doctor`) continues under the emergency-safe action-class floor without waiting for daemon recovery. Mutating, network, secret, destructive, MCP, and uncertain actions still pause. Empty or malformed Cursor input remains deny.
+When native review, daemon transport, or hook execution cannot complete, Guard keeps a schema-valid response on every path. PreToolUse continues so the session stays moving. Forged launchers, oversized input, unauthenticated hook payloads, and retained-byte limit failures still deny. Empty or malformed Cursor stdin allows; a known shell event with unparseable input still denies unless Watch/observe is on.
 
 Restart Cursor after install so hook config reloads.
 

--- a/docs/guard/cursor-local-cloud-contract.md
+++ b/docs/guard/cursor-local-cloud-contract.md
@@ -6,7 +6,7 @@ Cursor support is split by surface so the dashboard does not imply protection th
 
 | Surface | What Guard installs | What is intercepted |
 | ------- | ------------------- | ----------------- |
-| **Editor (IDE)** | MCP proxies in `.cursor/mcp.json` and native hooks in `.cursor/hooks.json` | Agent `beforeShellExecution`, `beforeMCPExecution`, `beforeReadFile`, `beforeWriteFile`, and `preToolUse` (Shell/MCP/Read/Write) |
+| **Editor (IDE)** | MCP proxies in `.cursor/mcp.json` and native hooks in `.cursor/hooks.json` | Agent `beforeShellExecution`, `beforeMCPExecution`, `beforeReadFile`, and `beforeWriteFile` |
 | **CLI** | `guard-cursor-agent` and `guard-cursor` shims on `PATH` | Launches routed through `hol-guard run cursor` before the real Cursor CLI agent starts |
 
 Run `hol-guard apps connect cursor --surface all` (or `hol-guard install cursor` for both surfaces) to enable editor hooks and CLI shims.
@@ -27,13 +27,12 @@ CLI install prepends `$HOL_GUARD_HOME/bin` to your shell profile when needed. Re
 Guard installs command hooks documented by Cursor:
 
 - `beforeShellExecution` and `beforeMCPExecution` with `failClosed: true` so hook failures block risky actions
-- `preToolUse` with matchers for Shell, MCP, Bash, and Read tools
 - `beforeReadFile` for sensitive file reads before they reach the model
 - `beforeWriteFile` for file writes before they reach disk
 
 Hooks call a managed bridge script (`.cursor/hooks/hol-guard-cursor-hook.py`) through the attested Guard Python interpreter, so a missing execute bit cannot freeze the IDE. The script forwards stdin JSON to the local daemon first, then `hol-guard hook --harness cursor --json`, and maps Guard policy results to Cursor `permission` responses (`allow`, `deny`, `ask`).
 
-When native review, daemon transport, or hook execution cannot complete, Guard keeps a schema-valid response on every path. PreToolUse continues so the session stays moving. Forged launchers, oversized input, unauthenticated hook payloads, and retained-byte limit failures still deny. Empty or malformed Cursor stdin allows; a known shell event with unparseable input still denies unless Watch/observe is on.
+When native review, daemon transport, or hook execution cannot complete, Guard keeps a schema-valid response on every path. PreToolUse continues so the session stays moving. Forged launchers, oversized input, unauthenticated hook payloads, and retained-byte limit failures still deny. Empty Cursor stdin with no baked event allows. A known shell event with unparseable input still denies unless Watch/observe is on.
 
 Restart Cursor after install so hook config reloads.
 

--- a/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import cast
 from urllib.parse import urlparse
 
+from ..action_lattice import is_guard_action
 from ..codex_hook_launch_runtime import (
     isolated_guard_cli_command,
     isolated_hook_environment,
@@ -325,6 +326,16 @@ def _native_hook_permission_decision(policy_action: str) -> str | None:
     return None
 
 
+def _policy_action_from_daemon(daemon_response: Mapping[str, object]) -> str:
+    reason_code = str(daemon_response.get("reason_code") or "")
+    if hook_reason_continues_session(reason_code):
+        return "warn"
+    raw_policy_action = daemon_response.get("policy_action")
+    if isinstance(raw_policy_action, str) and is_guard_action(raw_policy_action.strip()):
+        return raw_policy_action.strip()
+    return "block"
+
+
 def _should_exit_block(harness: str, event_name: str, policy_action: str) -> bool:
     """Mirror _should_emit_native_hook_exit_block."""
     canonical = harness.strip().lower().replace("_", "-")
@@ -386,14 +397,7 @@ def _daemon_response_to_native(
                 stderr = reason
         return stdout, stderr, exit_code
 
-    reason_code = str(daemon_response.get("reason_code") or "")
-    raw_policy_action = daemon_response.get("policy_action")
-    if isinstance(raw_policy_action, str) and raw_policy_action.strip():
-        policy_action = raw_policy_action.strip()
-    elif hook_reason_continues_session(reason_code):
-        policy_action = "warn"
-    else:
-        policy_action = "block"
+    policy_action = _policy_action_from_daemon(daemon_response)
     reason = str(daemon_response.get("reason") or daemon_response.get("permission_decision_reason") or "")
 
     # Build harness-native response

--- a/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
@@ -16,6 +16,7 @@ from ..codex_hook_launch_runtime import (
     isolated_hook_environment,
     run_isolated_hook_process,
 )
+from ..daemon.hook_availability_policy import hook_reason_continues_session
 from ..private_file_io import read_private_regular_text
 from .bounded_cli_hook_failure import failure_payload as _failure_payload
 from .desktop_hook_proxy import (
@@ -385,7 +386,14 @@ def _daemon_response_to_native(
                 stderr = reason
         return stdout, stderr, exit_code
 
-    policy_action = str(daemon_response.get("policy_action", "block"))
+    reason_code = str(daemon_response.get("reason_code") or "")
+    raw_policy_action = daemon_response.get("policy_action")
+    if isinstance(raw_policy_action, str) and raw_policy_action.strip():
+        policy_action = raw_policy_action.strip()
+    elif hook_reason_continues_session(reason_code):
+        policy_action = "warn"
+    else:
+        policy_action = "block"
     reason = str(daemon_response.get("reason") or daemon_response.get("permission_decision_reason") or "")
 
     # Build harness-native response

--- a/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
@@ -18,18 +18,12 @@ from ..codex_hook_launch_runtime import (
     isolated_hook_environment,
     run_isolated_hook_process,
 )
-from ..daemon.hook_availability_policy import EMERGENCY_SAFE_REASON, hook_action_is_emergency_safe
 from ..daemon.manager import load_guard_daemon_auth_token
 from .claude_code import CLAUDE_GUARD_DAEMON_HOOK_MARKER
 
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 _DEGRADED_DAEMON_MESSAGE = (
-    "HOL Guard could not reach the local daemon ({reason}), so it is using Claude's native "
-    "approval prompt as a temporary safety fallback."
-)
-_PRETOOLUSE_DEGRADED_SUFFIX = (
-    " Keep this action blocked unless you intentionally trust it. Restart Guard to restore the "
-    "branded Allow once / Allow during this session / Keep blocked flow."
+    "HOL Guard could not reach the local daemon ({reason}) and continued this action without native review."
 )
 _RISKY_PROMPT_SYSTEM_MESSAGE = (
     "HOL Guard intercepted this prompt because it asks Claude to access local secrets. If Claude "
@@ -75,7 +69,7 @@ def main(
     deadline = time.monotonic() + _HOOK_DEADLINE_SECONDS
     body = sys.stdin.read(_MAX_HOOK_INPUT_BYTES + 1)
     if len(body.encode("utf-8", errors="replace")) > _MAX_HOOK_INPUT_BYTES:
-        sys.stdout.write(_degraded("hook input exceeded the safe size limit", "{}"))
+        sys.stdout.write(_limit_denied("hook input"))
         return 0
     data = body.strip() or "{}"
     recovery_command = _recovery_command(state_path, query)
@@ -286,36 +280,34 @@ def _degraded_prompt(data: str) -> str:
     return json.dumps({"hookSpecificOutput": {"hookEventName": "UserPromptSubmit"}}, separators=(",", ":"))
 
 
+def _limit_denied(kind: str) -> str:
+    return json.dumps(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": (
+                    f"HOL Guard blocked this action because {kind} exceeded the safe size limit."
+                ),
+            }
+        },
+        separators=(",", ":"),
+    )
+
+
 def _degraded(reason: str, data: str) -> str:
     event = _event_name(data)
     message = _DEGRADED_DAEMON_MESSAGE.format(reason=reason)
     if event == "UserPromptSubmit":
         return _degraded_prompt(data)
     if event == "PreToolUse":
-        try:
-            parsed = json.loads(data or "{}")
-        except json.JSONDecodeError:
-            parsed = None
-        if isinstance(parsed, dict) and hook_action_is_emergency_safe(parsed):
-            return json.dumps(
-                {
-                    "hookSpecificOutput": {
-                        "hookEventName": event,
-                        "permissionDecision": "allow",
-                        "permissionDecisionReason": EMERGENCY_SAFE_REASON,
-                    }
-                },
-                separators=(",", ":"),
-            )
         return json.dumps(
             {
-                "systemMessage": (
-                    "HOL Guard could not reach the local daemon, so it cannot render the full HOL Guard approval flow."
-                ),
+                "continue": True,
                 "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
-                    "permissionDecision": "ask",
-                    "permissionDecisionReason": message + _PRETOOLUSE_DEGRADED_SUFFIX,
+                    "hookEventName": event,
+                    "permissionDecision": "allow",
+                    "permissionDecisionReason": message,
                 },
             },
             separators=(",", ":"),
@@ -383,7 +375,7 @@ def _run_local_fallback(
         )
     suffix = "; fallback timed out" if result.timed_out else f"; fallback exited {result.returncode}"
     if result.output_limit_exceeded:
-        suffix = "; fallback exceeded its output limit"
+        return _limit_denied("hook output")
     return _degraded(f"{reason}{suffix}", data)
 
 

--- a/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
@@ -69,7 +69,10 @@ def main(
     deadline = time.monotonic() + _HOOK_DEADLINE_SECONDS
     body = sys.stdin.read(_MAX_HOOK_INPUT_BYTES + 1)
     if len(body.encode("utf-8", errors="replace")) > _MAX_HOOK_INPUT_BYTES:
-        sys.stdout.write(_limit_denied("hook input", _event_name(body)))
+        event = _event_name(body)
+        if not event.startswith("Permission"):
+            event = "PreToolUse"
+        sys.stdout.write(_limit_denied("hook input", event))
         return 0
     data = body.strip() or "{}"
     recovery_command = _recovery_command(state_path, query)
@@ -301,11 +304,8 @@ def _deny_event(event: str, message: str) -> str:
     if event in {"UserPromptSubmit", "PostToolUse", "Stop"}:
         body = {"decision": "block", "reason": message, "hookSpecificOutput": {"hookEventName": event}}
         return json.dumps(body, separators=(",", ":"))
-    if event and event != "PreToolUse":
-        body = {"continue": True, "systemMessage": message, "hookSpecificOutput": {"hookEventName": event}}
-        return json.dumps(body, separators=(",", ":"))
     output = {
-        "hookEventName": event or "PreToolUse",
+        "hookEventName": "PreToolUse",
         "permissionDecision": "deny",
         "permissionDecisionReason": message,
     }

--- a/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
@@ -69,7 +69,7 @@ def main(
     deadline = time.monotonic() + _HOOK_DEADLINE_SECONDS
     body = sys.stdin.read(_MAX_HOOK_INPUT_BYTES + 1)
     if len(body.encode("utf-8", errors="replace")) > _MAX_HOOK_INPUT_BYTES:
-        sys.stdout.write(_limit_denied("hook input"))
+        sys.stdout.write(_limit_denied("hook input", _event_name(body)))
         return 0
     data = body.strip() or "{}"
     recovery_command = _recovery_command(state_path, query)
@@ -280,19 +280,20 @@ def _degraded_prompt(data: str) -> str:
     return json.dumps({"hookSpecificOutput": {"hookEventName": "UserPromptSubmit"}}, separators=(",", ":"))
 
 
-def _limit_denied(kind: str) -> str:
-    return json.dumps(
-        {
-            "hookSpecificOutput": {
-                "hookEventName": "PreToolUse",
-                "permissionDecision": "deny",
-                "permissionDecisionReason": (
-                    f"HOL Guard blocked this action because {kind} exceeded the safe size limit."
-                ),
-            }
-        },
-        separators=(",", ":"),
-    )
+def _limit_denied(kind: str, event: str = "PreToolUse") -> str:
+    message = f"HOL Guard blocked this action because {kind} exceeded the safe size limit."
+    if event.startswith("Permission"):
+        output: dict[str, object] = {
+            "hookEventName": event,
+            "decision": {"behavior": "deny", "message": message},
+        }
+    else:
+        output = {
+            "hookEventName": event or "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": message,
+        }
+    return json.dumps({"systemMessage": message, "hookSpecificOutput": output}, separators=(",", ":"))
 
 
 def _degraded(reason: str, data: str) -> str:
@@ -375,7 +376,7 @@ def _run_local_fallback(
         )
     suffix = "; fallback timed out" if result.timed_out else f"; fallback exited {result.returncode}"
     if result.output_limit_exceeded:
-        return _limit_denied("hook output")
+        return _limit_denied("hook output", _event_name(data))
     return _degraded(f"{reason}{suffix}", data)
 
 

--- a/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
@@ -245,11 +245,18 @@ def _event_name(data: str) -> str:
     try:
         payload = json.loads(data or "{}")
     except json.JSONDecodeError:
-        return "PreToolUse"
-    if not isinstance(payload, dict):
-        return "PreToolUse"
-    event = payload.get("hook_event_name", payload.get("event", "PreToolUse"))
-    return str(event or "PreToolUse")
+        payload = None
+    if isinstance(payload, dict):
+        return str(payload.get("hook_event_name") or payload.get("event") or "PreToolUse")
+    prefix = data[:4096]
+    for key in ("hook_event_name", "event"):
+        start = prefix.find(f'"{key}"')
+        colon = prefix.find(":", start, start + 64) if start >= 0 else -1
+        quote = prefix.find('"', colon + 1, colon + 80) if colon >= 0 else -1
+        end = prefix.find('"', quote + 1, quote + 80) if quote >= 0 else -1
+        if quote >= 0 and end > quote:
+            return prefix[quote + 1 : end] or "PreToolUse"
+    return "PreToolUse"
 
 
 def _prompt_text(data: str) -> str:
@@ -281,18 +288,27 @@ def _degraded_prompt(data: str) -> str:
 
 
 def _limit_denied(kind: str, event: str = "PreToolUse") -> str:
-    message = f"HOL Guard blocked this action because {kind} exceeded the safe size limit."
+    return _deny_event(event, f"HOL Guard blocked this action because {kind} exceeded the safe size limit.")
+
+
+def _deny_event(event: str, message: str) -> str:
     if event.startswith("Permission"):
         output: dict[str, object] = {
             "hookEventName": event,
             "decision": {"behavior": "deny", "message": message},
         }
-    else:
-        output = {
-            "hookEventName": event or "PreToolUse",
-            "permissionDecision": "deny",
-            "permissionDecisionReason": message,
-        }
+        return json.dumps({"systemMessage": message, "hookSpecificOutput": output}, separators=(",", ":"))
+    if event in {"UserPromptSubmit", "PostToolUse", "Stop"}:
+        body = {"decision": "block", "reason": message, "hookSpecificOutput": {"hookEventName": event}}
+        return json.dumps(body, separators=(",", ":"))
+    if event and event != "PreToolUse":
+        body = {"continue": True, "systemMessage": message, "hookSpecificOutput": {"hookEventName": event}}
+        return json.dumps(body, separators=(",", ":"))
+    output = {
+        "hookEventName": event or "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": message,
+    }
     return json.dumps({"systemMessage": message, "hookSpecificOutput": output}, separators=(",", ":"))
 
 
@@ -319,13 +335,9 @@ def _degraded(reason: str, data: str) -> str:
 def _authenticated_control_plane_failure(reason: str, data: str) -> str:
     message = f"HOL Guard denied the action because daemon authentication failed: {reason}"
     event = _event_name(data)
-    if event.startswith("Permission"):
-        output: dict[str, object] = {"hookEventName": event, "decision": {"behavior": "deny", "message": message}}
-    elif event == "PreToolUse":
-        output = {"hookEventName": event, "permissionDecision": "deny", "permissionDecisionReason": message}
-    else:
-        return json.dumps({"continue": True, "stopReason": message}, separators=(",", ":"))
-    return json.dumps({"systemMessage": message, "hookSpecificOutput": output}, separators=(",", ":"))
+    if event.startswith("Permission") or event == "PreToolUse":
+        return _deny_event(event, message)
+    return json.dumps({"continue": True, "stopReason": message}, separators=(",", ":"))
 
 
 def _should_suppress_output(data: str, response_body: str) -> bool:

--- a/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
@@ -70,7 +70,7 @@ def main(
     body = sys.stdin.read(_MAX_HOOK_INPUT_BYTES + 1)
     if len(body.encode("utf-8", errors="replace")) > _MAX_HOOK_INPUT_BYTES:
         event = _event_name(body)
-        if not event.startswith("Permission"):
+        if not (event.startswith("Permission") or event in {"UserPromptSubmit", "PostToolUse", "Stop"}):
             event = "PreToolUse"
         sys.stdout.write(_limit_denied("hook input", event))
         return 0

--- a/src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_bridge.py
@@ -135,10 +135,7 @@ def _unavailable_response(
         return {
             "continue": True,
             "systemMessage": reason,
-            "hookSpecificOutput": {
-                "hookEventName": event_name,
-                "decision": {"behavior": "allow", "message": reason},
-            },
+            "hookSpecificOutput": {"hookEventName": event_name},
         }
     if event_name == "PreToolUse":
         return {

--- a/src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex_daemon_hook_bridge.py
@@ -13,7 +13,7 @@ if __package__:
     from ..codex_hook_bridge_runtime import bounded_hook_input as _hook_input
     from ..codex_hook_bridge_runtime import bridge_config_from_argv as _parse_bridge_config
     from ..config import MAX_APPROVAL_WAIT_TIMEOUT_SECONDS
-    from ..daemon.hook_availability_policy import EMERGENCY_SAFE_REASON, hook_action_is_emergency_safe
+    from ..daemon.hook_availability_policy import hook_event_is_permission_request
     from ..live_process_identity import (
         CODEX_BROWSER_WAIT_PROCESS_KEY,
         CODEX_BROWSER_WAIT_TIMEOUT_SECONDS_KEY,
@@ -42,8 +42,7 @@ else:  # pragma: no cover - exercised by subprocess integration tests
     )
     from codex_plugin_scanner.guard.config import MAX_APPROVAL_WAIT_TIMEOUT_SECONDS
     from codex_plugin_scanner.guard.daemon.hook_availability_policy import (
-        EMERGENCY_SAFE_REASON,
-        hook_action_is_emergency_safe,
+        hook_event_is_permission_request,
     )
     from codex_plugin_scanner.guard.live_process_identity import (
         CODEX_BROWSER_WAIT_PROCESS_KEY,
@@ -131,22 +130,29 @@ def _unavailable_response(
     reason: str,
     data: str | None = None,
 ) -> dict[str, object]:
-    if event_name == "UserPromptSubmit":
+    del data
+    if hook_event_is_permission_request(event_name):
         return {
             "continue": True,
             "systemMessage": reason,
+            "hookSpecificOutput": {
+                "hookEventName": event_name,
+                "decision": {"behavior": "allow", "message": reason},
+            },
         }
-    if event_name == "PreToolUse" and data:
-        payload = _json_object(data)
-        if payload is not None and hook_action_is_emergency_safe(payload):
-            return {
-                "hookSpecificOutput": {
-                    "hookEventName": event_name,
-                    "permissionDecision": "allow",
-                    "permissionDecisionReason": EMERGENCY_SAFE_REASON,
-                }
-            }
-    return _fail_closed(event_name, reason)
+    if event_name == "PreToolUse":
+        return {
+            "continue": True,
+            "hookSpecificOutput": {
+                "hookEventName": event_name,
+                "permissionDecision": "allow",
+                "permissionDecisionReason": reason,
+            },
+        }
+    return {
+        "continue": True,
+        "systemMessage": reason,
+    }
 
 
 def _codex_hook_response(response: Mapping[str, object], *, event_name: str) -> dict[str, object]:
@@ -211,14 +217,11 @@ def main(
         config_json=config_json,
     )
     if response is None:
-        failure_reason = (
-            _OVERLOAD_REASON
-            if daemon_overloaded
-            else _LAUNCH_INTEGRITY_REASON
-            if launch_integrity_failed
-            else _FAIL_CLOSED_REASON
-        )
-        response = _unavailable_response(event_name, failure_reason, data)
+        if launch_integrity_failed:
+            response = _fail_closed(event_name, _LAUNCH_INTEGRITY_REASON)
+        else:
+            failure_reason = _OVERLOAD_REASON if daemon_overloaded else _FAIL_CLOSED_REASON
+            response = _unavailable_response(event_name, failure_reason, data)
     sys.stdout.write(
         _bridge_output(
             response,

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_config.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_config.py
@@ -21,6 +21,7 @@ _BLOCKING_MANAGED_HOOK_EVENTS = (
     "beforeShellExecution",
     "beforeMCPExecution",
     "beforeReadFile",
+    "beforeWriteFile",
 )
 _OBSERVER_MANAGED_HOOK_EVENTS = ("afterShellExecution", "afterMCPExecution")
 _MANAGED_HOOK_EVENTS = _BLOCKING_MANAGED_HOOK_EVENTS + _OBSERVER_MANAGED_HOOK_EVENTS
@@ -271,7 +272,7 @@ def live_guard_cursor_hooks_intercept(hooks: object) -> bool:
 
     Exact attested CLI/script identity stays repair work. Extra third-party
     hook entries must not fail machine-wide protection health while Guard still
-    intercepts shell, MCP, and file-read events.
+    intercepts shell, MCP, file-read, and file-write events.
     """
 
     if not isinstance(hooks, dict):

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_payload.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_payload.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from pathlib import Path
 
 from ..action_lattice import is_guard_action
+from ..daemon.hook_availability_policy import hook_reason_continues_session
 
 
 def _infer_cursor_hook_event_name(payload: Mapping[str, object]) -> dict[str, object]:
@@ -90,6 +91,17 @@ def prepare_cursor_hook_payload(payload: Mapping[str, object]) -> dict[str, obje
             tool_input.setdefault("file_path", file_path.strip())
             tool_input.setdefault("path", file_path.strip())
         normalized["tool_input"] = tool_input
+        return normalized
+    if raw_event == "beforewritefile":
+        normalized["hook_event_name"] = "PreToolUse"
+        normalized.setdefault("tool_name", "Write")
+        tool_input = _tool_input_dict(normalized.get("tool_input"))
+        file_path = normalized.get("file_path")
+        if isinstance(file_path, str) and file_path.strip():
+            tool_input.setdefault("file_path", file_path.strip())
+            tool_input.setdefault("path", file_path.strip())
+        normalized["tool_input"] = tool_input
+        normalized["cursor_source_hook_event"] = "beforeWriteFile"
         return normalized
     if raw_event == "pretooluse":
         normalized["hook_event_name"] = "PreToolUse"
@@ -197,7 +209,15 @@ def _cursor_permission_for_policy(
     policy_action: str,
     guard_payload: Mapping[str, object] | None = None,
 ) -> str:
-    del guard_payload
+    payload = {} if guard_payload is None else guard_payload
+    reason_code = str(payload.get("reason_code") or "")
+    if hook_reason_continues_session(reason_code):
+        return "allow"
+    hook_output = payload.get("hookSpecificOutput")
+    if isinstance(hook_output, Mapping) and hook_output.get("permissionDecision") == "allow":
+        return "allow"
+    if payload.get("decision") in {"allow", "warn"}:
+        return "allow"
     if not is_guard_action(policy_action):
         return "deny"
     if policy_action in {"block", "sandbox-required"}:
@@ -218,6 +238,11 @@ def _cursor_block_reason(guard_payload: Mapping[str, object]) -> str:
         value = guard_payload.get(key)
         if isinstance(value, str) and value.strip():
             return value.strip()
+    hook_output = guard_payload.get("hookSpecificOutput")
+    if isinstance(hook_output, Mapping):
+        nested_reason = hook_output.get("permissionDecisionReason")
+        if isinstance(nested_reason, str) and nested_reason.strip():
+            return nested_reason.strip()
     decision = guard_payload.get("decision_v2_json")
     if isinstance(decision, Mapping):
         for key in ("harness_message", "retry_instruction", "user_body", "user_title"):

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_payload.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_payload.py
@@ -84,7 +84,7 @@ def prepare_cursor_hook_payload(payload: Mapping[str, object]) -> dict[str, obje
         return prepared
     if raw_event == "beforereadfile":
         normalized["hook_event_name"] = "PreToolUse"
-        normalized.setdefault("tool_name", "Read")
+        normalized["tool_name"] = "Read"
         tool_input = _tool_input_dict(normalized.get("tool_input"))
         file_path = normalized.get("file_path")
         if isinstance(file_path, str) and file_path.strip():
@@ -94,7 +94,7 @@ def prepare_cursor_hook_payload(payload: Mapping[str, object]) -> dict[str, obje
         return normalized
     if raw_event == "beforewritefile":
         normalized["hook_event_name"] = "PreToolUse"
-        normalized.setdefault("tool_name", "Write")
+        normalized["tool_name"] = "Write"
         tool_input = _tool_input_dict(normalized.get("tool_input"))
         file_path = normalized.get("file_path")
         if isinstance(file_path, str) and file_path.strip():

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_payload.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_payload.py
@@ -213,11 +213,6 @@ def _cursor_permission_for_policy(
     reason_code = str(payload.get("reason_code") or "")
     if hook_reason_continues_session(reason_code):
         return "allow"
-    hook_output = payload.get("hookSpecificOutput")
-    if isinstance(hook_output, Mapping) and hook_output.get("permissionDecision") == "allow":
-        return "allow"
-    if payload.get("decision") in {"allow", "warn"}:
-        return "allow"
     if not is_guard_action(policy_action):
         return "deny"
     if policy_action in {"block", "sandbox-required"}:

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_head.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_head.py
@@ -441,7 +441,7 @@ def _prepare_cursor_hook_payload(payload: dict[str, object]) -> dict[str, object
     if raw_event in {"beforereadfile", "beforewritefile"}:
         write = raw_event == "beforewritefile"
         normalized["hook_event_name"] = "PreToolUse"
-        normalized.setdefault("tool_name", "Write" if write else "Read")
+        normalized["tool_name"] = "Write" if write else "Read"
         tool_input = _tool_input_dict(normalized.get("tool_input"))
         file_path = normalized.get("file_path")
         if isinstance(file_path, str) and file_path.strip():

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_head.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_head.py
@@ -438,41 +438,22 @@ def _prepare_cursor_hook_payload(payload: dict[str, object]) -> dict[str, object
         prepared["tool_input"] = tool_input
         prepared["cursor_source_hook_event"] = "beforeMCPExecution"
         return prepared
-    if raw_event == "beforereadfile":
+    if raw_event in {"beforereadfile", "beforewritefile"}:
+        write = raw_event == "beforewritefile"
         normalized["hook_event_name"] = "PreToolUse"
-        normalized.setdefault("tool_name", "Read")
+        normalized.setdefault("tool_name", "Write" if write else "Read")
         tool_input = _tool_input_dict(normalized.get("tool_input"))
         file_path = normalized.get("file_path")
         if isinstance(file_path, str) and file_path.strip():
             tool_input.setdefault("file_path", file_path.strip())
             tool_input.setdefault("path", file_path.strip())
         normalized["tool_input"] = tool_input
-        return normalized
-    if raw_event == "beforewritefile":
-        normalized["hook_event_name"] = "PreToolUse"
-        normalized.setdefault("tool_name", "Write")
-        tool_input = _tool_input_dict(normalized.get("tool_input"))
-        file_path = normalized.get("file_path")
-        if isinstance(file_path, str) and file_path.strip():
-            tool_input.setdefault("file_path", file_path.strip())
-            tool_input.setdefault("path", file_path.strip())
-        normalized["tool_input"] = tool_input
-        normalized["cursor_source_hook_event"] = "beforeWriteFile"
+        if write:
+            normalized["cursor_source_hook_event"] = "beforeWriteFile"
         return normalized
     if raw_event == "pretooluse":
         normalized["hook_event_name"] = "PreToolUse"
     return normalized
-
-
-def _cursor_permission(policy_action: str, guard_payload: dict[str, object]) -> str:
-    del guard_payload
-    if policy_action not in GUARD_ACTIONS:
-        return "deny"
-    if policy_action in {"block", "sandbox-required"}:
-        return "deny"
-    if policy_action in {"require-reapproval", "review"}:
-        return "ask"
-    return "allow"
 
 
 def _cursor_read_file_permission(permission: str) -> str:

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_head.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_head.py
@@ -448,6 +448,17 @@ def _prepare_cursor_hook_payload(payload: dict[str, object]) -> dict[str, object
             tool_input.setdefault("path", file_path.strip())
         normalized["tool_input"] = tool_input
         return normalized
+    if raw_event == "beforewritefile":
+        normalized["hook_event_name"] = "PreToolUse"
+        normalized.setdefault("tool_name", "Write")
+        tool_input = _tool_input_dict(normalized.get("tool_input"))
+        file_path = normalized.get("file_path")
+        if isinstance(file_path, str) and file_path.strip():
+            tool_input.setdefault("file_path", file_path.strip())
+            tool_input.setdefault("path", file_path.strip())
+        normalized["tool_input"] = tool_input
+        normalized["cursor_source_hook_event"] = "beforeWriteFile"
+        return normalized
     if raw_event == "pretooluse":
         normalized["hook_event_name"] = "PreToolUse"
     return normalized
@@ -478,6 +489,12 @@ def _cursor_reason(guard_payload: dict[str, object]) -> str:
         if isinstance(value, str) and value.strip():
             reason = value.strip()
             break
+    if reason is None:
+        hook_output = guard_payload.get("hookSpecificOutput")
+        if isinstance(hook_output, Mapping):
+            nested_reason = hook_output.get("permissionDecisionReason")
+            if isinstance(nested_reason, str) and nested_reason.strip():
+                reason = nested_reason.strip()
     if reason is None:
         decision = guard_payload.get("decision_v2_json")
         if isinstance(decision, Mapping):

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_tail.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_tail.py
@@ -25,11 +25,6 @@ def _cursor_permission(policy_action: str, guard_payload: dict[str, object], wor
             return "allow"
     except Exception:
         pass
-    hook_output = guard_payload.get("hookSpecificOutput")
-    if isinstance(hook_output, dict) and hook_output.get("permissionDecision") == "allow":
-        return "allow"
-    if guard_payload.get("decision") in {"allow", "warn"}:
-        return "allow"
     if policy_action not in GUARD_ACTIONS:
         return "deny"
     if policy_action in {"block", "sandbox-required"}:

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_tail.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_script_template_tail.py
@@ -15,8 +15,20 @@ HOOK_SCRIPT_TEMPLATE_TAIL = """def _recording_only_from_guard_home(workspace: st
 
 
 def _cursor_permission(policy_action: str, guard_payload: dict[str, object], workspace: str | None = None) -> str:
-    del guard_payload
     if _recording_only_from_guard_home(workspace):
+        return "allow"
+    reason_code = str(guard_payload.get("reason_code") or "")
+    try:
+        from codex_plugin_scanner.guard.daemon.hook_availability_policy import hook_reason_continues_session
+
+        if hook_reason_continues_session(reason_code):
+            return "allow"
+    except Exception:
+        pass
+    hook_output = guard_payload.get("hookSpecificOutput")
+    if isinstance(hook_output, dict) and hook_output.get("permissionDecision") == "allow":
+        return "allow"
+    if guard_payload.get("decision") in {"allow", "warn"}:
         return "allow"
     if policy_action not in GUARD_ACTIONS:
         return "deny"

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_claude.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_claude.py
@@ -136,6 +136,10 @@ def _run_hook_claude_permission_prompt_notification(
     if not _is_claude_permission_prompt_notification(args, payload_map):
         return None
     notice = _load_claude_permission_notice(store, payload_map)
+    if notice is None:
+        tool_name = payload_map.get("tool_name")
+        if isinstance(tool_name, str) and tool_name.strip():
+            notice = {"tool_name": tool_name.strip()}
     _mark_claude_pending_permission_prompt_seen(store=store, payload=payload_map, notice=notice)
     store.add_event(
         "claude/permission_prompt",

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_claude.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_claude.py
@@ -136,10 +136,6 @@ def _run_hook_claude_permission_prompt_notification(
     if not _is_claude_permission_prompt_notification(args, payload_map):
         return None
     notice = _load_claude_permission_notice(store, payload_map)
-    if notice is None:
-        tool_name = payload_map.get("tool_name")
-        if isinstance(tool_name, str) and tool_name.strip():
-            notice = {"tool_name": tool_name.strip()}
     _mark_claude_pending_permission_prompt_seen(store=store, payload=payload_map, notice=notice)
     store.add_event(
         "claude/permission_prompt",

--- a/src/codex_plugin_scanner/guard/daemon/hook_availability_policy.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_availability_policy.py
@@ -1,4 +1,4 @@
-"""Harness responses for the emergency-safe floor when native review cannot complete."""
+"""Harness responses when native review cannot complete without stopping the session."""
 
 from __future__ import annotations
 
@@ -102,14 +102,30 @@ _REVIEW_CANNOT_FINISH_REASON_CODES = frozenset(
         "native_post_tool_unavailable",
         "native_overloaded",
         "native_hook_worker_unavailable",
+        "native_hook_worker_unavailable_before_compatibility",
         "native_hook_worker_unsupported",
         "native_hook_worker_exception",
+        "native_hook_compatibility_disabled",
+        "native_hook_edge_invalid_response",
+        "native_hook_edge_unavailable",
+        "python_hook_oracle_unavailable",
+        "python_oracle_exception",
+        "watch_recording_only",
         "daemon_hook_queue_capacity",
         "daemon_hook_deadline_exhausted",
         "daemon_hook_process_deadline_exhausted",
         "daemon_hook_process_not_ready",
         "daemon_hook_process_failed",
+        "daemon_hook_process_invalid_request",
+        "daemon_hook_process_guard_home_mismatch",
         "daemon_worker_exception",
+        "harness_not_managed",
+        "native_degraded_emergency_safe",
+    }
+)
+_INTEGRITY_FAIL_CLOSED_REASON_CODES = frozenset(
+    {
+        "invalid_hook_payload_reference",
     }
 )
 
@@ -118,13 +134,22 @@ def hook_event_is_permission_request(event_name: str) -> bool:
     return _compact_hook_event_name(event_name) in _PERMISSION_REQUEST_EVENTS
 
 
+def hook_reason_continues_session(reason_code: str) -> bool:
+    """True when this availability reason must not stop the harness."""
+
+    code = reason_code.strip()
+    if code in _INTEGRITY_FAIL_CLOSED_REASON_CODES:
+        return False
+    return code in _REVIEW_CANNOT_FINISH_REASON_CODES
+
+
 def recording_only_pre_tool_response(
     harness: str,
     *,
     reason_code: str,
     reason: str,
 ) -> dict[str, object]:
-    """Continue a PreToolUse hook in Watch without changing Protected fail-closed JSON."""
+    """Continue PreToolUse when native review cannot finish."""
 
     from .hook_worker_responses import harness_json_from_native_pre_tool
 
@@ -161,42 +186,15 @@ def availability_harness_response(
 ) -> dict[str, object]:
     """Render a schema-valid harness result when native review is unavailable."""
 
-    from .hook_worker_responses import (
-        harness_json_from_native_pre_tool,
-        observe_lifecycle_fail_safe_response,
-    )
+    from .hook_worker_responses import observe_lifecycle_fail_safe_response
 
+    del payload, workspace, home_dir, guard_home, recording_only
     canonical_lifecycle = _LIFECYCLE_CANONICAL_BY_COMPACT.get(_compact_hook_event_name(event_name))
     if canonical_lifecycle is not None:
         return observe_lifecycle_fail_safe_response(
             harness,
             event_name=canonical_lifecycle,
             reason_code=reason_code,
-        )
-    watch_only = hook_review_is_recording_only(
-        guard_home=guard_home,
-        workspace=workspace,
-        recording_only=recording_only,
-    )
-    compact = _compact_hook_event_name(event_name)
-    pre_tool_event = compact in {"pretooluse", "pretool"} or compact.startswith("before")
-    if watch_only:
-        if not pre_tool_event:
-            return observe_lifecycle_fail_safe_response(
-                harness,
-                event_name=event_name,
-                reason_code=reason_code,
-            )
-        return recording_only_pre_tool_response(
-            harness,
-            reason_code=reason_code,
-            reason=reason,
-        )
-    if reason_code in _REVIEW_CANNOT_FINISH_REASON_CODES and pre_tool_event:
-        return recording_only_pre_tool_response(
-            harness,
-            reason_code=reason_code,
-            reason=reason,
         )
     if hook_event_is_permission_request(event_name):
         from .hook_worker_responses import permission_unavailable_response
@@ -207,36 +205,26 @@ def availability_harness_response(
             reason=reason,
             reason_code=reason_code,
         )
-    if not hook_event_pauses_when_unavailable(event_name):
-        return observe_lifecycle_fail_safe_response(
+    compact = _compact_hook_event_name(event_name)
+    pre_tool_event = compact in {"pretooluse", "pretool"} or compact.startswith("before")
+    if pre_tool_event and reason_code.strip() in _INTEGRITY_FAIL_CLOSED_REASON_CODES:
+        from .hook_worker_responses import integrity_fail_closed_pre_tool_response
+
+        return integrity_fail_closed_pre_tool_response(
             harness,
-            event_name=event_name,
+            reason=reason,
             reason_code=reason_code,
         )
-    if not hook_action_is_emergency_safe(
-        payload,
-        workspace=workspace,
-        home_dir=home_dir,
-    ):
-        return harness_json_from_native_pre_tool(
+    if pre_tool_event:
+        return recording_only_pre_tool_response(
             harness,
-            {
-                "decision": "deny",
-                "minimum_action": "block",
-                "policy_action": "block",
-                "reason_code": reason_code,
-                "reason": reason,
-            },
+            reason_code=reason_code,
+            reason=reason,
         )
-    return harness_json_from_native_pre_tool(
+    return observe_lifecycle_fail_safe_response(
         harness,
-        {
-            "decision": "allow",
-            "minimum_action": "warn",
-            "policy_action": "warn",
-            "reason_code": EMERGENCY_SAFE_REASON_CODE,
-            "reason": EMERGENCY_SAFE_REASON,
-        },
+        event_name=event_name,
+        reason_code=reason_code,
     )
 
 
@@ -283,6 +271,7 @@ __all__ = [
     "hook_action_is_emergency_safe",
     "hook_event_is_permission_request",
     "hook_event_pauses_when_unavailable",
+    "hook_reason_continues_session",
     "hook_review_is_recording_only",
     "lifecycle_event_is_observe_only",
     "recording_only_pre_tool_response",

--- a/src/codex_plugin_scanner/guard/daemon/hook_availability_policy.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_availability_policy.py
@@ -126,6 +126,7 @@ _REVIEW_CANNOT_FINISH_REASON_CODES = frozenset(
 _INTEGRITY_FAIL_CLOSED_REASON_CODES = frozenset(
     {
         "invalid_hook_payload_reference",
+        "daemon_hook_queue_bytes",
     }
 )
 

--- a/src/codex_plugin_scanner/guard/daemon/hook_worker_responses.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_worker_responses.py
@@ -234,6 +234,40 @@ def post_tool_fail_safe_response(
     )
 
 
+def integrity_fail_closed_pre_tool_response(
+    harness: str,
+    *,
+    reason: str,
+    reason_code: str,
+) -> dict[str, object]:
+    """Deny PreToolUse when hook payload authenticity cannot be proven."""
+
+    canonical = _canonical_hook_harness(harness)
+    if canonical in {"pi", "omp"}:
+        return {
+            "decision": "deny",
+            "reason": reason,
+            "policy_action": "block",
+            "reason_code": reason_code,
+        }
+    if canonical in {"grok", "hermes", "openclaw"}:
+        return {
+            "decision": "block" if canonical == "hermes" else "deny",
+            "reason": reason,
+            "policy_action": "block",
+            "reason_code": reason_code,
+        }
+    return {
+        "policy_action": "block",
+        "reason_code": reason_code,
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        },
+    }
+
+
 def permission_unavailable_response(
     harness: str,
     *,
@@ -327,6 +361,7 @@ __all__ = [
     "harness_json_from_native_post_tool",
     "harness_json_from_native_pre_tool",
     "harness_json_from_review_response",
+    "integrity_fail_closed_pre_tool_response",
     "observe_lifecycle_fail_safe_response",
     "permission_unavailable_response",
     "post_tool_fail_safe_response",

--- a/tests/test_claude_daemon_hook_bridge.py
+++ b/tests/test_claude_daemon_hook_bridge.py
@@ -293,6 +293,13 @@ def test_oversized_permission_request_uses_nested_deny() -> None:
     assert payload["hookSpecificOutput"]["hookEventName"] == "PermissionRequest"
     assert decision["behavior"] == "deny"
     assert "exceeded the safe size limit" in decision["message"]
+    truncated = '{"hook_event_name":"PermissionRequest","tool_name":"Write","prompt":"' + "x" * 80
+    assert bridge._event_name(truncated) == "PermissionRequest"
+    prompt = json.loads(bridge._limit_denied("hook input", "UserPromptSubmit"))
+    assert prompt["decision"] == "block"
+    notice = json.loads(bridge._limit_denied("hook input", "Notification"))
+    assert notice["continue"] is True
+    assert "permissionDecision" not in notice.get("hookSpecificOutput", {})
 
 
 def test_bridge_timeouts_stay_under_harness_budget() -> None:

--- a/tests/test_claude_daemon_hook_bridge.py
+++ b/tests/test_claude_daemon_hook_bridge.py
@@ -287,6 +287,14 @@ def test_oversized_hook_input_fails_safe_without_daemon_contact(
     assert "exceeded the safe size limit" in payload["hookSpecificOutput"]["permissionDecisionReason"]
 
 
+def test_oversized_permission_request_uses_nested_deny() -> None:
+    payload = json.loads(bridge._limit_denied("hook input", "PermissionRequest"))
+    decision = payload["hookSpecificOutput"]["decision"]
+    assert payload["hookSpecificOutput"]["hookEventName"] == "PermissionRequest"
+    assert decision["behavior"] == "deny"
+    assert "exceeded the safe size limit" in decision["message"]
+
+
 def test_bridge_timeouts_stay_under_harness_budget() -> None:
     assert bridge._HARNESS_TIMEOUT_BUDGET_SECONDS == 10
     assert 0 < bridge._HOOK_DEADLINE_SECONDS < bridge._HARNESS_TIMEOUT_BUDGET_SECONDS

--- a/tests/test_claude_daemon_hook_bridge.py
+++ b/tests/test_claude_daemon_hook_bridge.py
@@ -214,7 +214,7 @@ def test_main_degrades_when_daemon_returns_malformed_json(
     output = capsys.readouterr().out
     payload = json.loads(output)
     assert payload["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
-    assert payload["hookSpecificOutput"]["permissionDecision"] == "ask"
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "allow"
 
 
 def test_run_local_fallback_degrades_invalid_json() -> None:
@@ -226,7 +226,7 @@ def test_run_local_fallback_degrades_invalid_json() -> None:
 
     payload = json.loads(response)
     assert payload["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
-    assert payload["hookSpecificOutput"]["permissionDecision"] == "ask"
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "allow"
     assert "malformed hook JSON" in payload["hookSpecificOutput"]["permissionDecisionReason"]
 
 
@@ -255,8 +255,7 @@ def test_valid_hook_json_degrades_empty_daemon_body() -> None:
 
     payload = json.loads(response)
     assert payload["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
-    assert payload["hookSpecificOutput"]["permissionDecision"] == "ask"
-    assert "full HOL Guard approval flow" in payload["systemMessage"]
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "allow"
 
 
 def test_daemon_response_body_is_size_bounded() -> None:
@@ -284,7 +283,8 @@ def test_oversized_hook_input_fails_safe_without_daemon_contact(
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["hookSpecificOutput"]["permissionDecision"] == "ask"
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "exceeded the safe size limit" in payload["hookSpecificOutput"]["permissionDecisionReason"]
 
 
 def test_bridge_timeouts_stay_under_harness_budget() -> None:
@@ -445,7 +445,7 @@ def test_fallback_timeout_kills_descendants(tmp_path: Path) -> None:
     )
     time.sleep(0.4)
 
-    assert json.loads(response)["hookSpecificOutput"]["permissionDecision"] == "ask"
+    assert json.loads(response)["hookSpecificOutput"]["permissionDecision"] == "allow"
     assert not marker.exists()
 
 

--- a/tests/test_claude_daemon_hook_bridge.py
+++ b/tests/test_claude_daemon_hook_bridge.py
@@ -298,8 +298,8 @@ def test_oversized_permission_request_uses_nested_deny() -> None:
     prompt = json.loads(bridge._limit_denied("hook input", "UserPromptSubmit"))
     assert prompt["decision"] == "block"
     notice = json.loads(bridge._limit_denied("hook input", "Notification"))
-    assert notice["continue"] is True
-    assert "permissionDecision" not in notice.get("hookSpecificOutput", {})
+    assert notice["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert notice["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
 
 
 def test_bridge_timeouts_stay_under_harness_budget() -> None:

--- a/tests/test_codex_daemon_hook_bridge.py
+++ b/tests/test_codex_daemon_hook_bridge.py
@@ -155,7 +155,7 @@ def test_unavailable_prompt_warns_without_stopping_conversation() -> None:
     }
     assert (
         bridge._unavailable_response("PreToolUse", "review failed")["hookSpecificOutput"]["permissionDecision"]
-        == "deny"
+        == "allow"
     )
     allow = bridge._unavailable_response(
         "PreToolUse",
@@ -486,7 +486,7 @@ def test_bridge_authenticates_real_daemon_before_hook_delivery(
     response = json.loads(capsys.readouterr().out)
     assert exit_code == 0
     if "could not authenticate the local daemon" in json.dumps(response).lower():
-        assert response["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert response["hookSpecificOutput"]["permissionDecision"] == "allow"
 
 
 def test_bridge_real_daemon_uses_payload_cwd_for_bounded_compound_read(

--- a/tests/test_codex_daemon_hook_bridge.py
+++ b/tests/test_codex_daemon_hook_bridge.py
@@ -163,10 +163,6 @@ def test_unavailable_prompt_warns_without_stopping_conversation() -> None:
         json.dumps({"hook_event_name": "PreToolUse", "tool_name": "Read", "tool_input": {"file_path": "src/app.ts"}}),
     )
     assert allow["hookSpecificOutput"]["permissionDecision"] == "allow"
-    permission = bridge._unavailable_response("PermissionRequest", "review failed")
-    assert permission["continue"] is True
-    assert permission["hookSpecificOutput"] == {"hookEventName": "PermissionRequest"}
-    assert "behavior" not in permission["hookSpecificOutput"]
 
 
 def test_launcher_integrity_failure_does_not_stop_user_prompt(

--- a/tests/test_codex_daemon_hook_bridge.py
+++ b/tests/test_codex_daemon_hook_bridge.py
@@ -163,6 +163,10 @@ def test_unavailable_prompt_warns_without_stopping_conversation() -> None:
         json.dumps({"hook_event_name": "PreToolUse", "tool_name": "Read", "tool_input": {"file_path": "src/app.ts"}}),
     )
     assert allow["hookSpecificOutput"]["permissionDecision"] == "allow"
+    permission = bridge._unavailable_response("PermissionRequest", "review failed")
+    assert permission["continue"] is True
+    assert permission["hookSpecificOutput"] == {"hookEventName": "PermissionRequest"}
+    assert "behavior" not in permission["hookSpecificOutput"]
 
 
 def test_launcher_integrity_failure_does_not_stop_user_prompt(

--- a/tests/test_codex_daemon_hook_bridge_resilience.py
+++ b/tests/test_codex_daemon_hook_bridge_resilience.py
@@ -118,7 +118,7 @@ def test_malformed_daemon_and_fallback_outputs_fail_closed(
 
     assert exit_code == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert output["hookSpecificOutput"]["permissionDecision"] == "allow"
 
 
 def test_post_tool_use_stdout_is_exactly_one_json_object_with_noisy_fallback(
@@ -274,7 +274,7 @@ def test_authenticated_overload_fails_closed_without_fallback_or_restart(
     assert starts == []
     payload = json.loads(capsys.readouterr().out)
     output = payload["hookSpecificOutput"]
-    assert output["permissionDecision"] == "deny"
+    assert output["permissionDecision"] == "allow"
     assert "temporarily saturated" in output["permissionDecisionReason"]
 
 

--- a/tests/test_cursor_frozen_hook_command.py
+++ b/tests/test_cursor_frozen_hook_command.py
@@ -23,6 +23,7 @@ def _blocking_cursor_hooks(command: str) -> dict[str, list[dict[str, str]]]:
         "beforeShellExecution": entry,
         "beforeMCPExecution": entry,
         "beforeReadFile": entry,
+        "beforeWriteFile": entry,
     }
 
 

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -117,12 +117,8 @@ def _trusted_cursor_after_shell_env(
 def test_managed_hook_events_exclude_pretooluse() -> None:
     assert "preToolUse" not in _MANAGED_HOOK_EVENTS
     assert _MANAGED_HOOK_EVENTS == (
-        "beforeShellExecution",
-        "beforeMCPExecution",
-        "beforeReadFile",
-        "beforeWriteFile",
-        "afterShellExecution",
-        "afterMCPExecution",
+        "beforeShellExecution", "beforeMCPExecution", "beforeReadFile",
+        "beforeWriteFile", "afterShellExecution", "afterMCPExecution",
     )
 
 

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -120,6 +120,7 @@ def test_managed_hook_events_exclude_pretooluse() -> None:
         "beforeShellExecution",
         "beforeMCPExecution",
         "beforeReadFile",
+        "beforeWriteFile",
         "afterShellExecution",
         "afterMCPExecution",
     )

--- a/tests/test_cursor_watch_hook_script.py
+++ b/tests/test_cursor_watch_hook_script.py
@@ -174,3 +174,24 @@ def test_generated_cursor_hook_ignores_stale_allow_on_completed_block(tmp_path: 
         )
         == "allow"
     )
+
+
+def test_generated_cursor_hook_write_overrides_conflicting_tool_name(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard"
+    guard_home.mkdir()
+    (guard_home / "config.toml").write_text(
+        'mode = "prompt"\nprotection_posture = "protected"\n',
+        encoding="utf-8",
+    )
+    source = cursor_hook_script_source(
+        HarnessContext(home_dir=tmp_path / "home", guard_home=guard_home, workspace_dir=tmp_path)
+    )
+    script_globals: dict[str, object] = {"__name__": "cursor_hook"}
+    exec(compile(source, "hol-guard-cursor-hook.py", "exec"), script_globals)
+    prepare = script_globals["_prepare_cursor_hook_payload"]
+    assert callable(prepare)
+    mapped = prepare(
+        {"hook_event_name": "beforeWriteFile", "file_path": "src/app.ts", "tool_name": "Read"}
+    )
+    assert isinstance(mapped, dict)
+    assert mapped["tool_name"] == "Write"

--- a/tests/test_cursor_watch_hook_script.py
+++ b/tests/test_cursor_watch_hook_script.py
@@ -146,3 +146,31 @@ def test_empty_stdin_before_shell_pauses_when_event_is_baked(
     assert main() == 2
     payload = json.loads(capsys.readouterr().out)
     assert payload["permission"] == "deny"
+
+
+def test_generated_cursor_hook_ignores_stale_allow_on_completed_block(tmp_path: Path) -> None:
+    permission = _cursor_permission(
+        tmp_path,
+        'mode = "prompt"\nprotection_posture = "protected"\n',
+    )
+    assert (
+        permission(
+            "block",
+            {
+                "reason_code": "secret_pattern",
+                "decision": "allow",
+                "hookSpecificOutput": {"permissionDecision": "allow"},
+            },
+        )
+        == "deny"
+    )
+    assert (
+        permission(
+            "block",
+            {
+                "reason_code": "native_hook_edge_invalid_response",
+                "hookSpecificOutput": {"permissionDecision": "deny"},
+            },
+        )
+        == "allow"
+    )

--- a/tests/test_daemon_session_continuity_edges.py
+++ b/tests/test_daemon_session_continuity_edges.py
@@ -239,18 +239,19 @@ def test_cursor_maps_cannot_finish_block_to_allow() -> None:
     assert response["permission"] == "allow"
 
 
-def test_cursor_honors_allow_permission_even_when_policy_action_is_block() -> None:
+def test_cursor_completed_block_ignores_stale_allow_permission() -> None:
     from codex_plugin_scanner.guard.adapters.cursor_hook_payload import cursor_hook_response_from_guard
 
     response = cursor_hook_response_from_guard(
         policy_action="block",
         guard_payload={
-            "reason_code": "unlisted_native_miss",
+            "reason_code": "secret_pattern",
+            "decision": "allow",
             "hookSpecificOutput": {"permissionDecision": "allow"},
         },
         hook_event_name="beforeShellExecution",
     )
-    assert response["permission"] == "allow"
+    assert response["permission"] == "deny"
 
 
 def test_invalid_hook_payload_reference_stays_fail_closed(tmp_path: Path) -> None:

--- a/tests/test_daemon_session_continuity_edges.py
+++ b/tests/test_daemon_session_continuity_edges.py
@@ -302,3 +302,20 @@ def test_bounded_cli_cannot_finish_without_policy_action_allows_write() -> None:
     payload = json.loads(stdout)
     assert code == 0
     assert payload["hookSpecificOutput"]["permissionDecision"] == "allow"
+    invalid_stdout, _invalid_stderr, invalid_code = _daemon_response_to_native(
+        {"policy_action": "invalid", "reason": "nope"},
+        harness="kimi",
+        event_name="PreToolUse",
+    )
+    assert invalid_code == 2
+    assert json.loads(invalid_stdout)["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_codex_unavailable_permission_request_continues_without_auto_allow() -> None:
+    from codex_plugin_scanner.guard.adapters import codex_daemon_hook_bridge as bridge
+
+    permission = bridge._unavailable_response("PermissionRequest", "review failed")
+    assert permission["continue"] is True
+    assert permission["hookSpecificOutput"] == {"hookEventName": "PermissionRequest"}
+    assert "behavior" not in permission["hookSpecificOutput"]
+

--- a/tests/test_daemon_session_continuity_edges.py
+++ b/tests/test_daemon_session_continuity_edges.py
@@ -357,3 +357,30 @@ def test_claude_oversized_forged_notification_still_denies(
     assert prompt_result == 0
     assert prompt["decision"] == "block"
 
+
+def test_claude_permission_notification_asks_without_pending_notice(tmp_path: Path) -> None:
+    import argparse
+    from io import StringIO
+
+    from codex_plugin_scanner.guard.cli.commands_hook_claude import (
+        _run_hook_claude_permission_prompt_notification,
+    )
+    from codex_plugin_scanner.guard.store import GuardStore
+
+    stream = StringIO()
+    code = _run_hook_claude_permission_prompt_notification(
+        argparse.Namespace(harness="claude-code", json=True),
+        output_stream=stream,
+        payload={
+            "session_id": "session-1",
+            "hook_event_name": "Notification",
+            "notification_type": "permission_prompt",
+            "tool_name": "Read",
+        },
+        store=GuardStore(tmp_path, prime_policy_integrity=False),
+    )
+    payload = json.loads(stream.getvalue())
+    assert code == 0
+    context = payload["hookSpecificOutput"]["additionalContext"]
+    assert "HOL Guard needs the user's explicit decision before Read can run" in context
+

--- a/tests/test_daemon_session_continuity_edges.py
+++ b/tests/test_daemon_session_continuity_edges.py
@@ -273,6 +273,24 @@ def test_invalid_hook_payload_reference_stays_fail_closed(tmp_path: Path) -> Non
     assert response["policy_action"] == "block"
 
 
+def test_retained_byte_limit_stays_fail_closed(tmp_path: Path) -> None:
+    response = availability_harness_response(
+        {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "curl https://example.test"},
+        },
+        harness="pi",
+        event_name="PreToolUse",
+        reason_code="daemon_hook_queue_bytes",
+        reason="HOL Guard rejected this hook because the payload exceeded the retained-byte limit.",
+        workspace=tmp_path,
+        home_dir=tmp_path / "home",
+    )
+    assert response["decision"] == "deny"
+    assert response["policy_action"] == "block"
+
+
 def test_bounded_cli_cannot_finish_without_policy_action_allows_write() -> None:
     from codex_plugin_scanner.guard.adapters.bounded_cli_hook_bridge import _daemon_response_to_native
 

--- a/tests/test_daemon_session_continuity_edges.py
+++ b/tests/test_daemon_session_continuity_edges.py
@@ -357,30 +357,3 @@ def test_claude_oversized_forged_notification_still_denies(
     assert prompt_result == 0
     assert prompt["decision"] == "block"
 
-
-def test_claude_permission_notification_asks_without_pending_notice(tmp_path: Path) -> None:
-    import argparse
-    from io import StringIO
-
-    from codex_plugin_scanner.guard.cli.commands_hook_claude import (
-        _run_hook_claude_permission_prompt_notification,
-    )
-    from codex_plugin_scanner.guard.store import GuardStore
-
-    stream = StringIO()
-    code = _run_hook_claude_permission_prompt_notification(
-        argparse.Namespace(harness="claude-code", json=True),
-        output_stream=stream,
-        payload={
-            "session_id": "session-1",
-            "hook_event_name": "Notification",
-            "notification_type": "permission_prompt",
-            "tool_name": "Read",
-        },
-        store=GuardStore(tmp_path, prime_policy_integrity=False),
-    )
-    payload = json.loads(stream.getvalue())
-    assert code == 0
-    context = payload["hookSpecificOutput"]["additionalContext"]
-    assert "HOL Guard needs the user's explicit decision before Read can run" in context
-

--- a/tests/test_daemon_session_continuity_edges.py
+++ b/tests/test_daemon_session_continuity_edges.py
@@ -222,7 +222,7 @@ def test_cursor_maps_cannot_finish_block_to_allow() -> None:
     )
 
     mapped = prepare_cursor_hook_payload(
-        {"hook_event_name": "beforeWriteFile", "file_path": "src/app.ts"}
+        {"hook_event_name": "beforeWriteFile", "file_path": "src/app.ts", "tool_name": "Read"}
     )
     assert mapped["hook_event_name"] == "PreToolUse"
     assert mapped["tool_name"] == "Write"

--- a/tests/test_daemon_session_continuity_edges.py
+++ b/tests/test_daemon_session_continuity_edges.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import io
 import json
+import sys
 from pathlib import Path
+
+import pytest
 
 from codex_plugin_scanner.guard.adapters.bounded_cli_hook_failure import failure_payload
 from codex_plugin_scanner.guard.adapters.cline_bridge import plugin_after_tool_replacement
@@ -319,4 +323,24 @@ def test_codex_unavailable_permission_request_continues_without_auto_allow() -> 
     assert permission["continue"] is True
     assert permission["hookSpecificOutput"] == {"hookEventName": "PermissionRequest"}
     assert "behavior" not in permission["hookSpecificOutput"]
+
+
+def test_claude_oversized_forged_notification_still_denies(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from codex_plugin_scanner.guard.adapters import claude_daemon_hook_bridge as claude
+
+    body = '{"hook_event_name":"Notification","prompt":"' + ("x" * claude._MAX_HOOK_INPUT_BYTES)
+    monkeypatch.setattr("sys.stdin", io.StringIO(body))
+    result = claude.main(
+        state_path="/missing/state.json",
+        fallback_daemon_url="http://127.0.0.1:5474",
+        fallback_command=(sys.executable, "-c", "raise SystemExit(99)"),
+        query="",
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert result == 0
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert payload["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
 

--- a/tests/test_daemon_session_continuity_edges.py
+++ b/tests/test_daemon_session_continuity_edges.py
@@ -343,4 +343,17 @@ def test_claude_oversized_forged_notification_still_denies(
     assert result == 0
     assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
     assert payload["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+    monkeypatch.setattr(
+        "sys.stdin",
+        io.StringIO('{"hook_event_name":"UserPromptSubmit","prompt":"' + ("x" * claude._MAX_HOOK_INPUT_BYTES)),
+    )
+    prompt_result = claude.main(
+        state_path="/missing/state.json",
+        fallback_daemon_url="http://127.0.0.1:5474",
+        fallback_command=(sys.executable, "-c", "raise SystemExit(99)"),
+        query="",
+    )
+    prompt = json.loads(capsys.readouterr().out)
+    assert prompt_result == 0
+    assert prompt["decision"] == "block"
 

--- a/tests/test_daemon_session_continuity_edges.py
+++ b/tests/test_daemon_session_continuity_edges.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from codex_plugin_scanner.guard.adapters.bounded_cli_hook_failure import failure_payload
@@ -160,3 +161,126 @@ def test_copilot_permission_request_v2_uses_behavior_deny_shape() -> None:
     )
     assert availability["behavior"] == "deny"
     assert availability["interrupt"] is False
+
+
+def test_missing_native_fail_safe_codes_continue_mutating_pretool(tmp_path: Path) -> None:
+    reason = "HOL Guard could not complete the native hook decision safely."
+    for reason_code in (
+        "native_hook_edge_invalid_response",
+        "native_hook_compatibility_disabled",
+        "native_hook_worker_unavailable_before_compatibility",
+        "python_hook_oracle_unavailable",
+        "harness_not_managed",
+        "native_degraded_emergency_safe",
+        "unlisted_native_miss",
+    ):
+        for payload, event_name in (
+            (
+                {"hook_event_name": "PreToolUse", "tool_name": "Write", "tool_input": {"file_path": "src/app.ts"}},
+                "PreToolUse",
+            ),
+            (
+                {"hook_event_name": "PreToolUse", "tool_input": {"command": "git push"}},
+                "PreToolUse",
+            ),
+            (
+                {"hook_event_name": "PreToolUse", "tool_name": "Task", "tool_input": {"prompt": "implement"}},
+                "PreToolUse",
+            ),
+            (
+                {"hook_event_name": "PreToolUse", "tool_name": "StrReplace", "tool_input": {"path": "src/app.ts"}},
+                "PreToolUse",
+            ),
+            (
+                {"hook_event_name": "PreToolUse", "tool_input": {"command": "python -c 'print(1)'"}},
+                "PreToolUse",
+            ),
+            (
+                {"hook_event_name": "PreToolUse", "tool_input": {"command": "mkdir src/generated"}},
+                "PreToolUse",
+            ),
+        ):
+            response = availability_harness_response(
+                payload,
+                harness="cursor",
+                event_name=event_name,
+                reason_code=reason_code,
+                reason=reason,
+                workspace=tmp_path,
+                home_dir=tmp_path / "home",
+            )
+            output = response["hookSpecificOutput"]
+            assert isinstance(output, dict)
+            assert output["permissionDecision"] == "allow"
+            assert response["policy_action"] == "warn"
+
+
+def test_cursor_maps_cannot_finish_block_to_allow() -> None:
+    from codex_plugin_scanner.guard.adapters.cursor_hook_payload import (
+        cursor_hook_response_from_guard,
+        prepare_cursor_hook_payload,
+    )
+
+    mapped = prepare_cursor_hook_payload(
+        {"hook_event_name": "beforeWriteFile", "file_path": "src/app.ts"}
+    )
+    assert mapped["hook_event_name"] == "PreToolUse"
+    assert mapped["tool_name"] == "Write"
+    response = cursor_hook_response_from_guard(
+        policy_action="block",
+        guard_payload={
+            "reason_code": "native_hook_edge_invalid_response",
+            "hookSpecificOutput": {
+                "permissionDecisionReason": "HOL Guard could not complete the native hook decision safely.",
+            },
+        },
+        hook_event_name="beforeWriteFile",
+    )
+    assert response["permission"] == "allow"
+
+
+def test_cursor_honors_allow_permission_even_when_policy_action_is_block() -> None:
+    from codex_plugin_scanner.guard.adapters.cursor_hook_payload import cursor_hook_response_from_guard
+
+    response = cursor_hook_response_from_guard(
+        policy_action="block",
+        guard_payload={
+            "reason_code": "unlisted_native_miss",
+            "hookSpecificOutput": {"permissionDecision": "allow"},
+        },
+        hook_event_name="beforeShellExecution",
+    )
+    assert response["permission"] == "allow"
+
+
+def test_invalid_hook_payload_reference_stays_fail_closed(tmp_path: Path) -> None:
+    response = availability_harness_response(
+        {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Write",
+            "tool_input": {"file_path": "src/app.ts"},
+        },
+        harness="cursor",
+        event_name="PreToolUse",
+        reason_code="invalid_hook_payload_reference",
+        reason="HOL Guard could not authenticate the local hook payload.",
+        workspace=tmp_path,
+        home_dir=tmp_path / "home",
+    )
+    output = response["hookSpecificOutput"]
+    assert isinstance(output, dict)
+    assert output["permissionDecision"] == "deny"
+    assert response["policy_action"] == "block"
+
+
+def test_bounded_cli_cannot_finish_without_policy_action_allows_write() -> None:
+    from codex_plugin_scanner.guard.adapters.bounded_cli_hook_bridge import _daemon_response_to_native
+
+    stdout, _stderr, code = _daemon_response_to_native(
+        {"reason_code": "native_pre_tool_unavailable", "reason": "native miss"},
+        harness="kimi",
+        event_name="PreToolUse",
+    )
+    payload = json.loads(stdout)
+    assert code == 0
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "allow"

--- a/tests/test_guard-runtime-hook-health.py
+++ b/tests/test_guard-runtime-hook-health.py
@@ -79,6 +79,7 @@ def _write_cursor_runtime_hooks(
     }
     if include_read_file:
         hooks["beforeReadFile"] = [{"command": resolved, "timeout": 45, "failClosed": True}]
+        hooks["beforeWriteFile"] = [{"command": resolved, "timeout": 45, "failClosed": True}]
     (cursor_home / "hooks.json").write_text(json.dumps({"version": 1, "hooks": hooks}), encoding="utf-8")
     return script_path
 

--- a/tests/test_guard-runtime-hook-health.py
+++ b/tests/test_guard-runtime-hook-health.py
@@ -62,7 +62,7 @@ def _write_codex_runtime_hooks(
 def _write_cursor_runtime_hooks(
     home: Path,
     *,
-    include_read_file: bool,
+    include_file_io_hooks: bool,
     create_script: bool = True,
     command: str | None = None,
 ) -> Path:
@@ -77,7 +77,7 @@ def _write_cursor_runtime_hooks(
         "beforeMCPExecution": [{"command": resolved, "timeout": 45, "failClosed": True}],
         "afterShellExecution": [{"command": "node extra-hook.js", "timeout": 5}],
     }
-    if include_read_file:
+    if include_file_io_hooks:
         hooks["beforeReadFile"] = [{"command": resolved, "timeout": 45, "failClosed": True}]
         hooks["beforeWriteFile"] = [{"command": resolved, "timeout": 45, "failClosed": True}]
     (cursor_home / "hooks.json").write_text(json.dumps({"version": 1, "hooks": hooks}), encoding="utf-8")
@@ -156,7 +156,7 @@ def test_live_cursor_hooks_pass_when_attested_identity_is_stale(
 ) -> None:
     ctx = _ctx(tmp_path)
     monkeypatch.setattr(Path, "home", lambda: ctx.home_dir)
-    _write_cursor_runtime_hooks(ctx.home_dir, include_read_file=True)
+    _write_cursor_runtime_hooks(ctx.home_dir, include_file_io_hooks=True)
     store = GuardStore(ctx.guard_home, prime_policy_integrity=False)
     store.set_managed_install("cursor", True, None, {"harness": "cursor", "active": True}, "2026-08-17T12:00:00+00:00")
 
@@ -170,7 +170,7 @@ def test_live_cursor_hooks_reject_missing_read_intercept(
 ) -> None:
     ctx = _ctx(tmp_path)
     monkeypatch.setattr(Path, "home", lambda: ctx.home_dir)
-    _write_cursor_runtime_hooks(ctx.home_dir, include_read_file=False)
+    _write_cursor_runtime_hooks(ctx.home_dir, include_file_io_hooks=False)
     store = GuardStore(ctx.guard_home, prime_policy_integrity=False)
     store.set_managed_install("cursor", True, None, {"harness": "cursor", "active": True}, "2026-08-17T12:00:00+00:00")
 
@@ -184,10 +184,10 @@ def test_live_cursor_hooks_reject_empty_command_or_missing_script(
 ) -> None:
     ctx = _ctx(tmp_path)
     monkeypatch.setattr(Path, "home", lambda: ctx.home_dir)
-    script_path = _write_cursor_runtime_hooks(ctx.home_dir, include_read_file=True, command="")
+    script_path = _write_cursor_runtime_hooks(ctx.home_dir, include_file_io_hooks=True, command="")
     assert cursor_runtime_hooks_verified(ctx) is False
     script_path.unlink(missing_ok=True)
-    _write_cursor_runtime_hooks(ctx.home_dir, include_read_file=True, create_script=False)
+    _write_cursor_runtime_hooks(ctx.home_dir, include_file_io_hooks=True, create_script=False)
     assert cursor_runtime_hooks_verified(ctx) is False
 
 
@@ -233,7 +233,7 @@ def test_live_cursor_hooks_reject_name_only_noop_command(
     monkeypatch.setattr(Path, "home", lambda: ctx.home_dir)
     _write_cursor_runtime_hooks(
         ctx.home_dir,
-        include_read_file=True,
+        include_file_io_hooks=True,
         command="echo hol-guard-cursor-hook",
     )
     assert cursor_runtime_hooks_verified(ctx) is False

--- a/tests/test_hook_availability_policy.py
+++ b/tests/test_hook_availability_policy.py
@@ -96,25 +96,6 @@ def test_availability_allows_inspection_and_pauses_high_impact(tmp_path: Path) -
     assert output["permissionDecision"] == "allow"
 
 
-def test_availability_continues_write_when_native_edge_response_is_invalid(tmp_path: Path) -> None:
-    payload = availability_harness_response(
-        {
-            "hook_event_name": "PreToolUse",
-            "tool_name": "Write",
-            "tool_input": {"file_path": str(tmp_path / "src" / "app.ts")},
-        },
-        harness="claude-code",
-        event_name="PreToolUse",
-        reason_code="native_hook_edge_invalid_response",
-        reason="HOL Guard could not complete the native hook decision safely.",
-        workspace=tmp_path,
-        home_dir=tmp_path / "home",
-    )
-    assert payload["continue"] is True
-    assert payload["policy_action"] == "warn"
-    assert payload["hookSpecificOutput"]["permissionDecision"] == "allow"
-
-
 def test_cursor_fallback_allows_read_and_shell_when_review_cannot_finish() -> None:
     allow, allow_code = cursor_fallback_permission(
         {"hook_event_name": "beforeReadFile", "file_path": "src/app.ts", "tool_name": "Read"},

--- a/tests/test_hook_availability_policy.py
+++ b/tests/test_hook_availability_policy.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 
 from codex_plugin_scanner.guard.daemon.hook_availability_policy import (
-    EMERGENCY_SAFE_REASON_CODE,
     availability_harness_response,
     cursor_fallback_permission,
     cursor_unparseable_input_permission,
@@ -95,6 +94,25 @@ def test_availability_allows_inspection_and_pauses_high_impact(tmp_path: Path) -
     output = deny["hookSpecificOutput"]
     assert isinstance(output, dict)
     assert output["permissionDecision"] == "allow"
+
+
+def test_availability_continues_write_when_native_edge_response_is_invalid(tmp_path: Path) -> None:
+    payload = availability_harness_response(
+        {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Write",
+            "tool_input": {"file_path": str(tmp_path / "src" / "app.ts")},
+        },
+        harness="claude-code",
+        event_name="PreToolUse",
+        reason_code="native_hook_edge_invalid_response",
+        reason="HOL Guard could not complete the native hook decision safely.",
+        workspace=tmp_path,
+        home_dir=tmp_path / "home",
+    )
+    assert payload["continue"] is True
+    assert payload["policy_action"] == "warn"
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "allow"
 
 
 def test_cursor_fallback_allows_read_and_shell_when_review_cannot_finish() -> None:


### PR DESCRIPTION
## Summary
- When native hook review cannot finish, PreToolUse continues instead of applying the emergency-safe allow/deny split.
- Cursor now installs `beforeWriteFile`. Codex PermissionRequest continues without auto-allow. Forged, oversized, payload-authenticity, and retained-byte-limit failures still deny.
- Copilot PermissionRequest stays `behavior: deny` with `interrupt: false`.
- Oversized Claude PermissionRequest still nested-denies. A completed Cursor block is not overridden by a leftover allow field.

## Testing
- `pytest tests/test_hook_availability_policy.py tests/test_daemon_session_continuity_edges.py tests/test_codex_daemon_hook_bridge.py tests/test_claude_daemon_hook_bridge.py tests/test_cursor_watch_hook_script.py tests/test_cursor_frozen_hook_command.py tests/test_cursor_hooks.py::test_managed_hook_events_exclude_pretooluse --tb=line -q`
- `python scripts/ci/code_quality_audit.py --root . --baseline ci/code-quality-baseline.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Cursor `beforeWriteFile` hooks, including file-path tracking and write-specific handling.
  - Added event-specific responses for permission requests, tool use, prompts, and lifecycle events.

- **Bug Fixes**
  - Improved policy handling so session-continuing warnings take precedence and invalid actions are rejected.
  - Preserved blocking behavior when payload integrity or size limits cannot be verified.
  - Updated daemon-unavailable recovery to continue supported actions where appropriate, while maintaining explicit denials for integrity failures.
  - Improved handling of malformed and truncated hook payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->