### PR TITLE
fix(release): stage every wheel force-include before PyInstaller freezes

### DIFF
--- a/scripts/release/stage_guard_cloud_review_artifacts.py
+++ b/scripts/release/stage_guard_cloud_review_artifacts.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 import argparse
 import shutil
-import tomllib
 from pathlib import Path
 from typing import Any
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10 uses the declared tomli dependency.
+    import tomli as tomllib
 
 _FORCE_INCLUDE_KEYS = ("tool", "hatch", "build", "targets", "wheel", "force-include")
 

--- a/scripts/release/stage_guard_cloud_review_artifacts.py
+++ b/scripts/release/stage_guard_cloud_review_artifacts.py
@@ -1,30 +1,50 @@
-"""Stage Guard Cloud Review artifacts for editable PyInstaller builds."""
+"""Stage wheel force-include artifacts for editable PyInstaller builds."""
 
 from __future__ import annotations
 
 import argparse
 import shutil
+import tomllib
 from pathlib import Path
+from typing import Any
 
-_ARTIFACTS = {
-    "contracts/guard-cloud-review/v2/contract.json": "v2/contract.json",
-    "contracts/guard-cloud-review/v2/command-result.json": "v2/command-result.json",
-    "contracts/guard-cloud-review/v2/fixtures.json": "v2/fixtures.json",
-    "docs/guard/contracts/guard-cloud-review.md": "guard-cloud-review.md",
-}
+_FORCE_INCLUDE_KEYS = ("tool", "hatch", "build", "targets", "wheel", "force-include")
+
+
+def _force_includes(pyproject: Path) -> dict[str, str]:
+    with pyproject.open("rb") as handle:
+        node: Any = tomllib.load(handle)
+    for key in _FORCE_INCLUDE_KEYS:
+        if not isinstance(node, dict) or key not in node:
+            table = ".".join(_FORCE_INCLUDE_KEYS)
+            raise ValueError(f"pyproject.toml is missing [{table}] mappings")
+        node = node[key]
+    if not isinstance(node, dict) or not node:
+        raise ValueError("wheel force-include mappings must be a non-empty table")
+    for source_name, destination_name in node.items():
+        if not isinstance(source_name, str) or not isinstance(destination_name, str):
+            raise ValueError("wheel force-include mappings must be string-to-string")
+    return dict(node)
 
 
 def stage_artifacts(source_root: Path) -> tuple[Path, ...]:
-    """Copy canonical artifacts into package data and return staged paths."""
+    """Copy every wheel force-include mapping into the source package tree.
+
+    PyInstaller freezes build from the git source tree, where hatch's wheel
+    force-include data (extension trust-class map, Guard Cloud Review
+    contracts) has not been materialized yet. Without this staging, packaged
+    resource lookups fail inside the frozen binary and fall back to
+    repository-relative paths that do not exist on a build runner.
+    """
 
     source_root = source_root.resolve()
-    data_root = source_root / "src/codex_plugin_scanner/guard/contracts/data/guard-cloud-review"
+    mappings = _force_includes(source_root / "pyproject.toml")
     staged: list[Path] = []
-    for source_name, destination_name in _ARTIFACTS.items():
+    for source_name, destination_name in mappings.items():
         source = source_root / source_name
         if not source.is_file():
-            raise FileNotFoundError(f"required Guard Cloud Review artifact is missing: {source_name}")
-        destination = data_root / destination_name
+            raise FileNotFoundError(f"required wheel artifact is missing: {source_name}")
+        destination = source_root / "src" / destination_name
         destination.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(source, destination)
         staged.append(destination)

--- a/tests/test_stage_guard_cloud_review_artifacts.py
+++ b/tests/test_stage_guard_cloud_review_artifacts.py
@@ -11,28 +11,61 @@ assert SPEC is not None and SPEC.loader is not None
 MODULE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(MODULE)
 
+_MAPPINGS = {
+    "contracts/guard-cloud-review/v2/contract.json": "codex_plugin_scanner/guard/contracts/data/guard-cloud-review/v2/contract.json",
+    "contracts/extensions/trust-class-map.v1.json": "codex_plugin_scanner/guard/contracts/data/extensions/trust-class-map.v1.json",
+}
 
-def _write_artifacts(root: Path) -> None:
-    for source_name in MODULE._ARTIFACTS:
+
+def _write_source_tree(root: Path) -> None:
+    (root / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[tool.hatch.build.targets.wheel.force-include]",
+                *(f'"{source}" = "{destination}"' for source, destination in _MAPPINGS.items()),
+            ]
+        ),
+        encoding="utf-8",
+    )
+    for source_name in _MAPPINGS:
         source = root / source_name
         source.parent.mkdir(parents=True, exist_ok=True)
         source.write_text(source_name, encoding="utf-8")
 
 
-def test_stage_artifacts_copies_every_canonical_artifact(tmp_path: Path) -> None:
-    _write_artifacts(tmp_path)
+def test_stage_artifacts_copies_every_force_include_mapping(tmp_path: Path) -> None:
+    _write_source_tree(tmp_path)
 
     staged = MODULE.stage_artifacts(tmp_path)
 
-    assert len(staged) == 4
-    for source_name, destination_name in MODULE._ARTIFACTS.items():
-        destination = tmp_path / "src/codex_plugin_scanner/guard/contracts/data/guard-cloud-review" / destination_name
-        assert destination.read_text(encoding="utf-8") == source_name
+    assert set(staged) == {tmp_path / "src" / destination for destination in _MAPPINGS.values()}
+    for source_name, destination_name in _MAPPINGS.items():
+        staged_file = tmp_path / "src" / destination_name
+        assert staged_file.read_text(encoding="utf-8") == source_name
 
 
 def test_stage_artifacts_fails_closed_when_source_is_missing(tmp_path: Path) -> None:
-    _write_artifacts(tmp_path)
-    (tmp_path / "contracts/guard-cloud-review/v2/contract.json").unlink()
+    _write_source_tree(tmp_path)
+    (tmp_path / "contracts/extensions/trust-class-map.v1.json").unlink()
 
-    with pytest.raises(FileNotFoundError, match=r"contract\.json"):
+    with pytest.raises(FileNotFoundError, match=r"trust-class-map\.v1\.json"):
         MODULE.stage_artifacts(tmp_path)
+
+
+def test_stage_artifacts_fails_closed_without_mapping_table(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'x'\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"force-include"):
+        MODULE.stage_artifacts(tmp_path)
+
+
+def test_staging_this_repository_materializes_the_extension_trust_map() -> None:
+    """The real pyproject mappings must include the runtime trust-class map."""
+
+    repo_root = Path(__file__).resolve().parents[1]
+    mappings = MODULE._force_includes(repo_root / "pyproject.toml")
+
+    assert any(
+        destination.endswith("guard/contracts/data/extensions/trust-class-map.v1.json")
+        for destination in mappings.values()
+    )


### PR DESCRIPTION
## Summary
- Stage every `[tool.hatch.build.targets.wheel.force-include]` mapping into the source tree before PyInstaller freezes, instead of only the four Guard Cloud Review artifacts.
- Core releases that carry the extension trust-class map froze into binaries whose packaged resource lookup failed, fell back to a repository-relative path, and crashed before reporting their version — so recent stable releases published wheels without the signed desktop-core sidecars.
- Tests now cover generic mapping staging, missing-source fail-closed behavior, and that this repository's mappings include the extension trust-class map.

## Testing
- `uv run --no-sync pytest tests/test_stage_guard_cloud_review_artifacts.py`
