### PR TITLE
feat(release): generate release notes from merged pull requests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1444,6 +1444,19 @@ jobs:
         env:
           VERSION: ${{ needs.build.outputs.version }}
         run: cp "${{ steps.provenance.outputs.bundle-path }}" "dist/hol-guard-v${VERSION}.intoto.jsonl"
+      - name: Generate release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.build.outputs.version }}
+          CHANNEL: ${{ needs.build.outputs.channel }}
+          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
+        run: |
+          python3 scripts/ci/generate_release_notes.py \
+            --version "$VERSION" \
+            --channel "$CHANNEL" \
+            --repo "$GITHUB_REPOSITORY" \
+            --source-sha "$SOURCE_SHA" \
+            --output "$RUNNER_TEMP/release-notes.md"
       - name: Create discoverable main release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -1485,16 +1498,8 @@ jobs:
             done
             exit 0
           fi
-          body_file=$(mktemp)
-          cat > "$body_file" <<EOF
-          Guard ${VERSION}
-
-          Install this release:
-
-          \`\`\`bash
-          uv tool install "hol-guard[cisco]==${VERSION}"
-          \`\`\`
-          EOF
+          body_file="$RUNNER_TEMP/release-notes.md"
+          [[ -s "$body_file" ]]
           mapfile -d '' ASSET_FILES < <(find dist -maxdepth 1 -type f -print0 | sort -z)
           gh release create "$tag" \
             --repo "${{ github.repository }}" \
@@ -1549,6 +1554,19 @@ jobs:
         env:
           VERSION: ${{ needs.build.outputs.version }}
         run: cp "${{ steps.provenance.outputs.bundle-path }}" "dist/hol-guard-v${VERSION}.intoto.jsonl"
+      - name: Generate release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.build.outputs.version }}
+          CHANNEL: ${{ needs.build.outputs.channel }}
+          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
+        run: |
+          python3 scripts/ci/generate_release_notes.py \
+            --version "$VERSION" \
+            --channel "$CHANNEL" \
+            --repo "$GITHUB_REPOSITORY" \
+            --source-sha "$SOURCE_SHA" \
+            --output "$RUNNER_TEMP/release-notes.md"
       - name: Create discoverable alpha prerelease
         env:
           GH_TOKEN: ${{ github.token }}
@@ -1589,16 +1607,8 @@ jobs:
             done
             exit 0
           fi
-          body_file=$(mktemp)
-          cat > "$body_file" <<EOF
-          Guard ${VERSION} is an opt-in prerelease. Stable installations remain on the stable channel.
-
-          Install this exact alpha:
-
-          \`\`\`bash
-          uv tool install "hol-guard[cisco]==${VERSION}"
-          \`\`\`
-          EOF
+          body_file="$RUNNER_TEMP/release-notes.md"
+          [[ -s "$body_file" ]]
           mapfile -d '' ASSET_FILES < <(find dist -maxdepth 1 -type f -print0 | sort -z)
           gh release create "$tag" \
             --repo "${{ github.repository }}" \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1414,6 +1414,7 @@ jobs:
       attestations: write
       contents: write
       id-token: write
+      pull-requests: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
@@ -1450,13 +1451,7 @@ jobs:
           VERSION: ${{ needs.build.outputs.version }}
           CHANNEL: ${{ needs.build.outputs.channel }}
           SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
-        run: |
-          python3 scripts/ci/generate_release_notes.py \
-            --version "$VERSION" \
-            --channel "$CHANNEL" \
-            --repo "$GITHUB_REPOSITORY" \
-            --source-sha "$SOURCE_SHA" \
-            --output "$RUNNER_TEMP/release-notes.md"
+        run: python3 scripts/ci/generate_release_notes.py --version "$VERSION" --channel "$CHANNEL" --repo "$GITHUB_REPOSITORY" --source-sha "$SOURCE_SHA" --output "$RUNNER_TEMP/release-notes.md"
       - name: Create discoverable main release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -1524,6 +1519,7 @@ jobs:
       attestations: write
       contents: write
       id-token: write
+      pull-requests: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
@@ -1560,13 +1556,7 @@ jobs:
           VERSION: ${{ needs.build.outputs.version }}
           CHANNEL: ${{ needs.build.outputs.channel }}
           SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
-        run: |
-          python3 scripts/ci/generate_release_notes.py \
-            --version "$VERSION" \
-            --channel "$CHANNEL" \
-            --repo "$GITHUB_REPOSITORY" \
-            --source-sha "$SOURCE_SHA" \
-            --output "$RUNNER_TEMP/release-notes.md"
+        run: python3 scripts/ci/generate_release_notes.py --version "$VERSION" --channel "$CHANNEL" --repo "$GITHUB_REPOSITORY" --source-sha "$SOURCE_SHA" --output "$RUNNER_TEMP/release-notes.md"
       - name: Create discoverable alpha prerelease
         env:
           GH_TOKEN: ${{ github.token }}

--- a/scripts/ci/generate_release_notes.py
+++ b/scripts/ci/generate_release_notes.py
@@ -44,6 +44,7 @@ BULLETED_SECTIONS = {"feat", "fix"}
 
 MAX_SUMMARY_BULLETS = 3
 MAX_BULLET_CHARS = 220
+MAX_RENDERED_CHANGES = 80
 
 
 @dataclass
@@ -322,6 +323,25 @@ def render_sections(changes: Sequence[Change], repo: str) -> str:
     return "\n\n".join(blocks)
 
 
+def render_condensed_sections(changes: Sequence[Change], repo: str) -> str:
+    """Summarize very large histories (no previous tag) instead of listing every entry.
+
+    GitHub caps release bodies at 125,000 characters; a first-of-channel release
+    covering the full project history would exceed that, so render per-section
+    counts plus a link into the commit history.
+    """
+    counts: list[tuple[str, int]] = []
+    for section in SECTION_ORDER:
+        entries = [change for change in changes if change.section == section]
+        if entries:
+            counts.append((SECTION_TITLES.get(section, "Internal"), len(entries)))
+    lines = ["## Changes by category", ""]
+    lines.extend(f"- **{title}**: {count}" for title, count in counts)
+    lines.append("")
+    lines.append(f"This release spans too many changes to list; browse the [full commit history](https://github.com/{repo}/commits/{changes[0].sha}).")
+    return "\n".join(lines)
+
+
 def render_notes(
     changes: Sequence[Change],
     *,
@@ -361,16 +381,25 @@ def render_notes(
         since = f" since [Guard {previous_version}](https://github.com/{repo}/releases/tag/{previous_tag})"
         lines.append(f"**{' • '.join(heading_stats)}**{since}." if heading_stats else f"Released{since}.")
     elif heading_stats:
-        lines.append(f"**{' • '.join(heading_stats)}**.")
+        scope_note = (
+            " — the first release on this channel, covering the full history to this point"
+            if changes
+            else ""
+        )
+        lines.append(f"**{' • '.join(heading_stats)}**{scope_note}.")
     lines.append("")
 
-    sections = render_sections(changes, repo)
-    if sections:
-        lines.append(sections)
+    if len(changes) > MAX_RENDERED_CHANGES:
+        lines.append(render_condensed_sections(changes))
         lines.append("")
     else:
-        lines.append("This release ships no user-facing changes; it refreshes release artifacts only.")
-        lines.append("")
+        sections = render_sections(changes, repo)
+        if sections:
+            lines.append(sections)
+            lines.append("")
+        else:
+            lines.append("This release ships no user-facing changes; it refreshes release artifacts only.")
+            lines.append("")
 
     lines.append("## Install")
     lines.append("")

--- a/scripts/ci/generate_release_notes.py
+++ b/scripts/ci/generate_release_notes.py
@@ -64,6 +64,8 @@ class Change:
 
     @property
     def section(self) -> str:
+        if self.type == "build":
+            return "ci"
         return self.type if self.type in SECTION_TITLES else "internal"
 
     @property
@@ -77,6 +79,11 @@ class Change:
     @property
     def contributor(self) -> str:
         return self.pr_author or self.author
+
+    @property
+    def is_login_contributor(self) -> bool:
+        """Whether the contributor name is a verified GitHub login from PR metadata."""
+        return self.pr_author is not None
 
 
 def parse_subject(subject: str) -> dict | None:
@@ -268,15 +275,21 @@ def enrich_with_pull_requests(changes: list[Change], repo: str) -> None:
             change.description = parsed["description"]
 
 
-def human_contributors(changes: Sequence[Change]) -> list[str]:
-    names: list[str] = []
+def human_contributors(changes: Sequence[Change]) -> list[tuple[str, bool]]:
+    """Distinct human contributors as ``(name, is_github_login)`` pairs.
+
+    A name is only a verified login when it came from PR metadata; fallback
+    Git display names are plain text so they never render as @mentions.
+    """
+    contributors: list[tuple[str, bool]] = []
     for change in changes:
         name = change.contributor
         if not name or name.endswith("[bot]") or name == "anonymous":
             continue
-        if name not in names:
-            names.append(name)
-    return names
+        entry = (name, change.is_login_contributor)
+        if entry not in contributors:
+            contributors.append(entry)
+    return contributors
 
 
 def entry_line(change: Change, repo: str) -> str:
@@ -374,7 +387,8 @@ def render_notes(
         )
         lines.append("")
     if contributors:
-        lines.append(f"Thanks {', '.join(f'@{name}' for name in contributors)}!")
+        credited = [f"@{name}" if is_login else name for name, is_login in contributors]
+        lines.append(f"Thanks {', '.join(credited)}!")
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"
 

--- a/scripts/ci/generate_release_notes.py
+++ b/scripts/ci/generate_release_notes.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+"""Generate Guard GitHub release notes from git history and pull request metadata."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+
+CONVENTIONAL_PATTERN = re.compile(
+    r"^(?P<type>[a-z]+)(?:\((?P<scope>[^)]+)\))?(?P<breaking>!)?:[ ]+"
+    r"(?P<description>.+?)(?:[ ]+\(#(?P<pr>\d+)\))?$"
+)
+MERGE_COMMIT_PATTERN = re.compile(r"^Merge pull request #(?P<pr>\d+) from ")
+STABLE_TAG_PATTERN = re.compile(r"^v(\d+\.\d+\.\d+)$")
+ALPHA_TAG_PATTERN = re.compile(r"^alpha/v(\d+\.\d+\.\d+(?:a|b|rc)\d+)$")
+VERSION_PATTERN = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:(a|b|rc)(\d+))?$")
+
+SECTION_TITLES: dict[str, str] = {
+    "feat": "Features",
+    "fix": "Fixes",
+    "perf": "Performance",
+    "refactor": "Refactoring",
+    "docs": "Documentation",
+    "test": "Tests",
+    "ci": "CI & automation",
+    "build": "CI & automation",
+}
+SECTION_ORDER = [
+    "feat",
+    "fix",
+    "perf",
+    "refactor",
+    "docs",
+    "test",
+    "ci",
+    "internal",
+]
+BULLETED_SECTIONS = {"feat", "fix"}
+
+MAX_SUMMARY_BULLETS = 3
+MAX_BULLET_CHARS = 220
+
+
+@dataclass
+class Change:
+    """One commit landing in the release, enriched with PR metadata when available."""
+
+    sha: str
+    subject: str
+    author: str
+    type: str
+    scope: str | None = None
+    breaking: bool = False
+    description: str = ""
+    pr_number: int | None = None
+    pr_title: str | None = None
+    pr_author: str | None = None
+    summary_bullets: list[str] = field(default_factory=list)
+
+    @property
+    def section(self) -> str:
+        return self.type if self.type in SECTION_TITLES else "internal"
+
+    @property
+    def display_description(self) -> str:
+        source = self.pr_title or self.subject
+        parsed = parse_subject(source)
+        if parsed:
+            return parsed["description"]
+        return source
+
+    @property
+    def contributor(self) -> str:
+        return self.pr_author or self.author
+
+
+def parse_subject(subject: str) -> dict | None:
+    """Parse a conventional-commit subject like ``feat(extensions): ... (#2761)``."""
+    match = CONVENTIONAL_PATTERN.match(subject.strip())
+    if not match:
+        return None
+    parsed = match.groupdict()
+    return {
+        "type": parsed["type"],
+        "scope": parsed["scope"],
+        "breaking": bool(parsed["breaking"]),
+        "description": parsed["description"],
+        "pr": int(parsed["pr"]) if parsed["pr"] else None,
+    }
+
+
+def version_sort_key(version: str) -> tuple | None:
+    """Return a sortable key for ``3.0.70`` / ``3.0.0a290`` style versions.
+
+    Pre-release markers (``a``/``b``/``rc``) sort below the stable release,
+    matching PEP 440 ordering for the forms Guard publishes.
+    """
+    match = VERSION_PATTERN.match(version)
+    if not match:
+        return None
+    major, minor, patch, marker, marker_number = match.groups()
+    if marker:
+        return (int(major), int(minor), int(patch), marker, int(marker_number))
+    return (int(major), int(minor), int(patch), "zz", 0)
+
+
+def parse_version_tag(tag: str) -> tuple | None:
+    """Return a sortable key for ``v3.0.70`` / ``alpha/v3.0.0a290`` style tags."""
+    match = STABLE_TAG_PATTERN.match(tag)
+    if match:
+        return version_sort_key(match.group(1))
+    match = ALPHA_TAG_PATTERN.match(tag)
+    if match:
+        return version_sort_key(match.group(1))
+    return None
+
+
+def channel_tags(tags: Iterable[str], channel: str) -> list[str]:
+    pattern = STABLE_TAG_PATTERN if channel == "stable" else ALPHA_TAG_PATTERN
+    return [tag for tag in tags if pattern.match(tag)]
+
+
+def select_previous_tag(tags: Iterable[str], current_version: str, channel: str) -> str | None:
+    """Pick the closest same-channel tag strictly below ``current_version``."""
+    current = version_sort_key(current_version)
+    if current is None:
+        return None
+    candidates = []
+    for tag in channel_tags(tags, channel):
+        key = parse_version_tag(tag)
+        if key is not None and key < current:
+            candidates.append((key, tag))
+    return max(candidates)[1] if candidates else None
+
+
+def extract_summary_bullets(body: str | None, limit: int = MAX_SUMMARY_BULLETS) -> list[str]:
+    """Pull the leading bullets out of a PR body's ``## Summary`` section."""
+    if not body:
+        return []
+    lines = body.splitlines()
+    bullets: list[str] = []
+    in_summary = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            heading = stripped.lstrip("#").strip().lower().rstrip(":")
+            in_summary = heading == "summary"
+            continue
+        if not in_summary:
+            continue
+        if not stripped:
+            if bullets:
+                break
+            continue
+        if stripped.startswith(("-", "*")):
+            bullet = stripped.lstrip("-*").strip()
+            if len(bullet) > MAX_BULLET_CHARS:
+                cut = bullet[: MAX_BULLET_CHARS - 1].rsplit(" ", 1)[0].rstrip(" ,;:-")
+                bullet = f"{cut}…"
+            bullets.append(bullet)
+            if len(bullets) >= limit:
+                break
+        elif bullets:
+            break
+    return bullets
+
+
+def run_git(args: Sequence[str], cwd: str | None = None) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=cwd,
+    )
+    return result.stdout
+
+
+def load_changes(end_ref: str, start_ref: str | None, cwd: str | None = None) -> list[Change]:
+    """Read first-parent commits in ``start_ref..end_ref``.
+
+    Following the first-parent chain yields one entry per landed pull request
+    (squash commits carry their own subject; true merge commits carry
+    ``Merge pull request #N`` and are retitled from the PR metadata later).
+    Pure merge machinery such as branch-to-branch merges carries no change and
+    is skipped.
+    """
+    revision = f"{start_ref}..{end_ref}" if start_ref else end_ref
+    log = run_git(
+        ["log", "--first-parent", "--format=%H%x1f%s%x1f%an", revision],
+        cwd=cwd,
+    )
+    changes: list[Change] = []
+    for line in log.splitlines():
+        if not line.strip():
+            continue
+        sha, subject, author = line.split("\x1f", maxsplit=2)
+        if subject.startswith("Merge ") and not MERGE_COMMIT_PATTERN.match(subject):
+            continue
+        changes.append(
+            Change(sha=sha, subject=subject, author=author, type="internal", description=subject)
+        )
+    for change in changes:
+        parsed = parse_subject(change.pr_title or change.subject)
+        if parsed:
+            change.type = parsed["type"]
+            change.scope = parsed["scope"]
+            change.breaking = parsed["breaking"]
+            change.description = parsed["description"]
+            if parsed["pr"]:
+                change.pr_number = parsed["pr"]
+        else:
+            merge_match = MERGE_COMMIT_PATTERN.match(change.subject)
+            if merge_match:
+                change.pr_number = int(merge_match.group("pr"))
+    return changes
+
+
+def fetch_pull_request(repo: str, number: int) -> dict | None:
+    """Best-effort PR lookup via the GitHub CLI; returns None when unavailable."""
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{repo}/pulls/{number}"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    user = payload.get("user") or {}
+    return {
+        "title": payload.get("title"),
+        "author": user.get("login"),
+        "body": payload.get("body"),
+    }
+
+
+def enrich_with_pull_requests(changes: list[Change], repo: str) -> None:
+    """Replace merge-commit subjects with PR titles and attach PR summaries."""
+    seen: dict[int, dict | None] = {}
+    for number in sorted({change.pr_number for change in changes if change.pr_number}):
+        seen[number] = fetch_pull_request(repo, number)
+    for change in changes:
+        if change.pr_number is None:
+            continue
+        payload = seen.get(change.pr_number)
+        if not payload:
+            continue
+        change.pr_title = payload["title"]
+        change.pr_author = payload["author"]
+        change.summary_bullets = extract_summary_bullets(payload["body"])
+        parsed = parse_subject(change.pr_title or "")
+        if parsed:
+            change.type = parsed["type"]
+            change.scope = parsed["scope"]
+            change.breaking = change.breaking or parsed["breaking"]
+            change.description = parsed["description"]
+
+
+def human_contributors(changes: Sequence[Change]) -> list[str]:
+    names: list[str] = []
+    for change in changes:
+        name = change.contributor
+        if not name or name.endswith("[bot]") or name == "anonymous":
+            continue
+        if name not in names:
+            names.append(name)
+    return names
+
+
+def entry_line(change: Change, repo: str) -> str:
+    description = change.display_description
+    if description and description[0].islower():
+        description = description[0].upper() + description[1:]
+    breaking = " **(breaking)**" if change.breaking else ""
+    if change.pr_number:
+        link = f"[#{change.pr_number}](https://github.com/{repo}/pull/{change.pr_number})"
+    else:
+        link = f"[`{change.sha[:7]}`](https://github.com/{repo}/commit/{change.sha})"
+    if change.scope:
+        return f"- **{change.scope}**: {description} ({link}){breaking}"
+    return f"- {description} ({link}){breaking}"
+
+
+def render_sections(changes: Sequence[Change], repo: str) -> str:
+    blocks: list[str] = []
+    for section in SECTION_ORDER:
+        entries = [change for change in changes if change.section == section]
+        if not entries:
+            continue
+        lines = [f"## {SECTION_TITLES.get(section, 'Internal')}", ""]
+        for change in entries:
+            lines.append(entry_line(change, repo))
+            if section in BULLETED_SECTIONS:
+                for bullet in change.summary_bullets:
+                    lines.append(f"  - {bullet}")
+        blocks.append("\n".join(lines))
+    return "\n\n".join(blocks)
+
+
+def render_notes(
+    changes: Sequence[Change],
+    *,
+    version: str,
+    channel: str,
+    repo: str,
+    tag: str,
+    previous_tag: str | None,
+    source_sha: str,
+) -> str:
+    """Render the full release-notes body for one Guard release."""
+    contributors = human_contributors(changes)
+    pr_count = len({change.pr_number for change in changes if change.pr_number})
+    heading_stats = []
+    if changes:
+        heading_stats.append(f"{len(changes)} commit{'s' if len(changes) != 1 else ''}")
+    if pr_count:
+        heading_stats.append(f"{pr_count} merged pull request{'s' if pr_count != 1 else ''}")
+    if contributors:
+        heading_stats.append(f"{len(contributors)} contributor{'s' if len(contributors) != 1 else ''}")
+
+    short_sha = source_sha[:7]
+    lines: list[str] = []
+    if channel == "alpha":
+        lines.append(
+            f"Guard {version} is an opt-in prerelease cut from "
+            f"[`{short_sha}`](https://github.com/{repo}/commit/{source_sha}). "
+            "Stable installations remain on the stable channel."
+        )
+    else:
+        lines.append(
+            f"Guard {version} is a stable release cut from "
+            f"[`{short_sha}`](https://github.com/{repo}/commit/{source_sha})."
+        )
+    if previous_tag:
+        previous_version = previous_tag.removeprefix("alpha/").lstrip("v")
+        since = f" since [Guard {previous_version}](https://github.com/{repo}/releases/tag/{previous_tag})"
+        lines.append(f"**{' • '.join(heading_stats)}**{since}." if heading_stats else f"Released{since}.")
+    elif heading_stats:
+        lines.append(f"**{' • '.join(heading_stats)}**.")
+    lines.append("")
+
+    sections = render_sections(changes, repo)
+    if sections:
+        lines.append(sections)
+        lines.append("")
+    else:
+        lines.append("This release ships no user-facing changes; it refreshes release artifacts only.")
+        lines.append("")
+
+    lines.append("## Install")
+    lines.append("")
+    lines.append("Install this release:")
+    lines.append("")
+    lines.append("```bash")
+    lines.append(f'uv tool install "hol-guard[cisco]=={version}"')
+    lines.append("```")
+    lines.append("")
+    if previous_tag:
+        lines.append(
+            f"**Full changelog**: [{previous_tag}...{tag}]"
+            f"(https://github.com/{repo}/compare/{previous_tag}...{tag})"
+        )
+        lines.append("")
+    if contributors:
+        lines.append(f"Thanks {', '.join(f'@{name}' for name in contributors)}!")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True, help="Release version, e.g. 3.0.70")
+    parser.add_argument("--channel", required=True, choices=["stable", "alpha"])
+    parser.add_argument("--repo", default=None, help="OWNER/REPO, defaults to the origin remote")
+    parser.add_argument("--tag", default=None, help="Release tag; defaults from version and channel")
+    parser.add_argument("--previous-tag", default=None, help="Previous same-channel tag; auto-detected when omitted")
+    parser.add_argument("--source-sha", default=None, help="Release commit; defaults to resolving --tag")
+    parser.add_argument("--end-ref", default=None, help="Git ref covering the release commits (default: tag/sha)")
+    parser.add_argument("--output", default=None, help="Write notes here instead of stdout")
+    parser.add_argument(
+        "--skip-pr-metadata",
+        action="store_true",
+        help="Do not call the GitHub API for PR titles and summaries",
+    )
+    args = parser.parse_args()
+
+    if args.repo is None:
+        origin = run_git(["remote", "get-url", "origin"]).strip()
+        match = re.search(r"[:/]([^/:]+)/([^/]+?)(?:\.git)?$", origin)
+        if not match:
+            print("Unable to derive OWNER/REPO from the origin remote", file=sys.stderr)
+            return 1
+        repo = f"{match.group(1)}/{match.group(2)}"
+    else:
+        repo = args.repo
+
+    tag = args.tag or (f"alpha/v{args.version}" if args.channel == "alpha" else f"v{args.version}")
+    source_sha = args.source_sha
+    if source_sha is None:
+        try:
+            source_sha = run_git(["rev-parse", "--verify", f"{args.end_ref or tag}^{{commit}}"]).strip()
+        except subprocess.CalledProcessError:
+            source_sha = ""
+    if not source_sha:
+        print(f"Unable to resolve release commit for {args.end_ref or tag}", file=sys.stderr)
+        return 1
+
+    previous_tag = args.previous_tag
+    if previous_tag is None:
+        tags = run_git(["tag", "--list"]).split()
+        previous_tag = select_previous_tag(tags, args.version, args.channel)
+
+    changes = load_changes(args.end_ref or source_sha, previous_tag)
+    if not args.skip_pr_metadata:
+        enrich_with_pull_requests(changes, repo)
+    notes = render_notes(
+        changes,
+        version=args.version,
+        channel=args.channel,
+        repo=repo,
+        tag=tag,
+        previous_tag=previous_tag,
+        source_sha=source_sha,
+    )
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as handle:
+            handle.write(notes)
+    else:
+        sys.stdout.write(notes)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        exit_code = main()
+    except BrokenPipeError:
+        exit_code = 0
+    raise SystemExit(exit_code)

--- a/scripts/ci/generate_release_notes.py
+++ b/scripts/ci/generate_release_notes.py
@@ -390,7 +390,7 @@ def render_notes(
     lines.append("")
 
     if len(changes) > MAX_RENDERED_CHANGES:
-        lines.append(render_condensed_sections(changes))
+        lines.append(render_condensed_sections(changes, repo))
         lines.append("")
     else:
         sections = render_sections(changes, repo)

--- a/tests/test_cisco_install_surfaces.py
+++ b/tests/test_cisco_install_surfaces.py
@@ -123,7 +123,9 @@ def test_repo_controlled_surfaces_prefer_cisco_extra_where_supported() -> None:
     assert "uv sync --frozen --extra dev --extra cisco --group cisco-mcp --python 3.13" in ci_workflow
     assert "uv sync --frozen --extra dev --python ${{ matrix.python-version }}" in ci_workflow
     assert "uv sync --frozen --extra dev --extra publish --extra cisco" in publish_workflow
-    assert 'uv tool install "hol-guard[cisco]==' in publish_workflow
+    assert "scripts/ci/generate_release_notes.py" in publish_workflow
+    release_notes_script = (ROOT / "scripts" / "ci" / "generate_release_notes.py").read_text(encoding="utf-8")
+    assert 'uv tool install "hol-guard[cisco]==' in release_notes_script
     assert "COPY docker-requirements.txt LICENSE README.md /app/" in dockerfile
     assert "FROM python:3.13-slim@" in dockerfile
     assert "FROM python:3.14-slim" not in dockerfile

--- a/tests/test_generate_release_notes.py
+++ b/tests/test_generate_release_notes.py
@@ -131,6 +131,14 @@ def test_render_notes_groups_sections_and_links_everything() -> None:
             pr_number=2760,
             pr_title="refactor(guard)!: share duplicated helpers",
         ),
+        _change(
+            sha="d" * 40,
+            subject="build(wheels): pin the native toolchain",
+            type="build",
+            scope="wheels",
+            description="pin the native toolchain",
+            pr_number=None,
+        ),
     ]
     notes = render_notes(
         changes,
@@ -142,15 +150,17 @@ def test_render_notes_groups_sections_and_links_everything() -> None:
         source_sha="a" * 40,
     )
     assert "Guard 3.0.68 is a stable release cut from [`aaaaaaa`]" in notes
-    assert "**3 commits • 3 merged pull requests • 2 contributors** since [Guard 3.0.67]" in notes
+    assert "**4 commits • 3 merged pull requests • 2 contributors** since [Guard 3.0.67]" in notes
     assert "## Features" in notes and "## Fixes" not in notes
     assert "## CI & automation" in notes and "## Refactoring" in notes
+    assert "Pin the native toolchain" in notes
     assert "[#2761](https://github.com/hashgraph-online/hol-guard/pull/2761)" in notes
     assert "  - Reviews destructive Artisan operations" in notes
     assert "**(breaking)**" in notes
     assert 'uv tool install "hol-guard[cisco]==3.0.68"' in notes
     assert "[v3.0.67...v3.0.68](https://github.com/hashgraph-online/hol-guard/compare/v3.0.67...v3.0.68)" in notes
-    assert "Thanks @kantorcodes, @Michael Kantor!" in notes
+    assert "Thanks @kantorcodes, Michael Kantor!" in notes
+    assert "@Michael Kantor" not in notes
 
 
 def test_render_notes_alpha_channel_and_empty_history() -> None:

--- a/tests/test_generate_release_notes.py
+++ b/tests/test_generate_release_notes.py
@@ -163,6 +163,35 @@ def test_render_notes_groups_sections_and_links_everything() -> None:
     assert "@Michael Kantor" not in notes
 
 
+def test_render_notes_condenses_histories_too_large_to_list() -> None:
+    changes = [
+        _change(
+            sha=f"{i:040x}",
+            subject=f"fix(guard): repair thing {i} (#{i + 1})",
+            type="fix" if i % 2 else "feat",
+            scope="guard",
+            description=f"repair thing {i}",
+            pr_number=i + 1,
+        )
+        for i in range(200)
+    ]
+    notes = render_notes(
+        changes,
+        version="2.1.0a1",
+        channel="alpha",
+        repo=REPO,
+        tag="alpha/v2.1.0a1",
+        previous_tag=None,
+        source_sha="e" * 40,
+    )
+    assert "first release on this channel" in notes
+    assert "## Changes by category" in notes
+    assert "- **Features**: 100" in notes and "- **Fixes**: 100" in notes
+    assert "full commit history" in notes
+    assert "repair thing 5" not in notes
+    assert len(notes) < 10000
+
+
 def test_render_notes_alpha_channel_and_empty_history() -> None:
     alpha = render_notes(
         [_change()],

--- a/tests/test_generate_release_notes.py
+++ b/tests/test_generate_release_notes.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from scripts.ci.generate_release_notes import (
+    Change,
+    enrich_with_pull_requests,
+    extract_summary_bullets,
+    load_changes,
+    parse_subject,
+    render_notes,
+    select_previous_tag,
+    version_sort_key,
+)
+
+REPO = "hashgraph-online/hol-guard"
+
+
+def _change(**kwargs) -> Change:
+    defaults = {
+        "sha": "a" * 40,
+        "subject": "feat(guard): do a thing (#1)",
+        "author": "Michael Kantor",
+        "type": "feat",
+        "scope": "guard",
+        "description": "do a thing",
+        "pr_number": 1,
+    }
+    defaults.update(kwargs)
+    return Change(**defaults)
+
+
+def test_parse_subject_extracts_type_scope_breaking_and_pr() -> None:
+    parsed = parse_subject("feat(extensions)!: add Laravel Artisan command safety extension (#2761)")
+    assert parsed == {
+        "type": "feat",
+        "scope": "extensions",
+        "breaking": True,
+        "description": "add Laravel Artisan command safety extension",
+        "pr": 2761,
+    }
+
+
+def test_parse_subject_handles_scopeless_and_non_conventional_subjects() -> None:
+    assert parse_subject("fix: repair the doctor install probe (#9)") == {
+        "type": "fix",
+        "scope": None,
+        "breaking": False,
+        "description": "repair the doctor install probe",
+        "pr": 9,
+    }
+    assert parse_subject("Merge pull request #5 from guard/release") is None
+    assert parse_subject("some release bookkeeping") is None
+
+
+def test_version_sort_key_orders_preleases_below_stable() -> None:
+    assert version_sort_key("3.0.10") > version_sort_key("3.0.9")
+    assert version_sort_key("3.0.0") > version_sort_key("3.0.0a290")
+    assert version_sort_key("3.0.0a290") > version_sort_key("3.0.0a289")
+    assert version_sort_key("not-a-version") is None
+
+
+def test_select_previous_tag_picks_closest_same_channel_tag() -> None:
+    tags = ["v3.0.7", "v3.0.68", "v3.0.69", "v3.0.70", "alpha/v3.0.0a290"]
+    assert select_previous_tag(tags, "3.0.70", "stable") == "v3.0.69"
+    assert select_previous_tag(tags, "3.0.68", "stable") == "v3.0.7"
+    assert select_previous_tag(["v3.0.69", "alpha/v3.0.0a290"], "3.0.70", "stable") == "v3.0.69"
+    assert select_previous_tag(["alpha/v3.0.0a289", "alpha/v3.0.0a290"], "3.0.0a290", "alpha") == "alpha/v3.0.0a289"
+    assert select_previous_tag(["v2.2.128"], "3.0.0", "stable") == "v2.2.128"
+    assert select_previous_tag(["v3.0.1"], "3.0.1", "stable") is None
+
+
+def test_extract_summary_bullets_reads_summary_section_with_limits() -> None:
+    body = (
+        "## Summary\n"
+        "- Adds a Laravel Artisan command safety extension\n"
+        "- Covers direct and interpreter-wrapped launch forms\n"
+        "- Declares safe counterparts for dry-run flags\n"
+        "- Fourth bullet beyond the limit\n"
+        "\n"
+        "## Testing\n"
+        "-pytest\n"
+    )
+    assert extract_summary_bullets(body, limit=3) == [
+        "Adds a Laravel Artisan command safety extension",
+        "Covers direct and interpreter-wrapped launch forms",
+        "Declares safe counterparts for dry-run flags",
+    ]
+    assert extract_summary_bullets(None) == []
+    assert extract_summary_bullets("## Testing\n- nothing") == []
+
+
+def test_extract_summary_bullets_truncates_at_word_boundary() -> None:
+    bullet = "word " * 80
+    bullets = extract_summary_bullets(f"## Summary\n- {bullet}")
+    assert len(bullets) == 1
+    assert bullets[0].endswith("…")
+    assert len(bullets[0]) <= 220
+
+
+def test_render_notes_groups_sections_and_links_everything() -> None:
+    changes = [
+        _change(
+            subject="feat(extensions): add Laravel Artisan command safety extension (#2761)",
+            description="add Laravel Artisan command safety extension",
+            scope="extensions",
+            pr_number=2761,
+            pr_title="feat(extensions): add Laravel Artisan command safety extension",
+            pr_author="kantorcodes",
+            summary_bullets=["Reviews destructive Artisan operations"],
+        ),
+        _change(
+            sha="b" * 40,
+            subject="ci(sonar): import sharded pytest coverage (#2759)",
+            author="github-actions[bot]",
+            type="ci",
+            scope="sonar",
+            description="import sharded pytest coverage",
+            pr_number=2759,
+            pr_title="ci(sonar): import sharded pytest coverage",
+        ),
+        _change(
+            sha="c" * 40,
+            subject="refactor(guard)!: share duplicated helpers (#2760)",
+            type="refactor",
+            scope="guard",
+            breaking=True,
+            description="share duplicated helpers",
+            pr_number=2760,
+            pr_title="refactor(guard)!: share duplicated helpers",
+        ),
+    ]
+    notes = render_notes(
+        changes,
+        version="3.0.68",
+        channel="stable",
+        repo=REPO,
+        tag="v3.0.68",
+        previous_tag="v3.0.67",
+        source_sha="a" * 40,
+    )
+    assert "Guard 3.0.68 is a stable release cut from [`aaaaaaa`]" in notes
+    assert "**3 commits • 3 merged pull requests • 2 contributors** since [Guard 3.0.67]" in notes
+    assert "## Features" in notes and "## Fixes" not in notes
+    assert "## CI & automation" in notes and "## Refactoring" in notes
+    assert "[#2761](https://github.com/hashgraph-online/hol-guard/pull/2761)" in notes
+    assert "  - Reviews destructive Artisan operations" in notes
+    assert "**(breaking)**" in notes
+    assert 'uv tool install "hol-guard[cisco]==3.0.68"' in notes
+    assert "[v3.0.67...v3.0.68](https://github.com/hashgraph-online/hol-guard/compare/v3.0.67...v3.0.68)" in notes
+    assert "Thanks @kantorcodes, @Michael Kantor!" in notes
+
+
+def test_render_notes_alpha_channel_and_empty_history() -> None:
+    alpha = render_notes(
+        [_change()],
+        version="3.0.0a290",
+        channel="alpha",
+        repo=REPO,
+        tag="alpha/v3.0.0a290",
+        previous_tag="alpha/v3.0.0a289",
+        source_sha="a" * 40,
+    )
+    assert "opt-in prerelease" in alpha
+    assert "since [Guard 3.0.0a289]" in alpha
+
+    empty = render_notes(
+        [],
+        version="3.0.71",
+        channel="stable",
+        repo=REPO,
+        tag="v3.0.71",
+        previous_tag="v3.0.70",
+        source_sha="d" * 40,
+    )
+    assert "no user-facing changes" in empty
+    assert 'uv tool install "hol-guard[cisco]==3.0.71"' in empty
+
+
+def _git(repo: Path, *args: str) -> None:
+    env = {"GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull, "PATH": os.environ["PATH"]}
+    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True, env=env)
+
+
+def test_load_changes_parses_commit_range(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "--initial-branch=main")
+    _git(repo, "config", "user.email", "guard@example.test")
+    _git(repo, "config", "user.name", "Guard Tests")
+    (repo / "file.txt").write_text("one", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "feat(guard): first feature (#1)")
+    _git(repo, "tag", "v3.0.1")
+    (repo / "file.txt").write_text("two", encoding="utf-8")
+    _git(repo, "commit", "-am", "fix(doctor): repair install probe (#2)")
+    (repo / "file.txt").write_text("three", encoding="utf-8")
+    _git(repo, "commit", "-am", "Merge pull request #2 from guard/fix")
+
+    changes = load_changes("HEAD", "v3.0.1", cwd=repo)
+    subjects = [change.subject for change in changes]
+    assert "fix(doctor): repair install probe (#2)" in subjects
+    fix = next(change for change in changes if change.type == "fix")
+    assert fix.scope == "doctor" and fix.pr_number == 2
+
+    merge = next(change for change in changes if change.subject.startswith("Merge pull request"))
+    assert merge.pr_number == 2
+
+
+def test_enrich_with_pull_requests_uses_pr_metadata(monkeypatch) -> None:
+    changes = [
+        _change(
+            subject="Merge pull request #5 from guard/feature",
+            type="internal",
+            scope=None,
+            description="Merge pull request #5 from guard/feature",
+            pr_number=5,
+        )
+    ]
+    monkeypatch.setattr(
+        "scripts.ci.generate_release_notes.fetch_pull_request",
+        lambda repo, number: {
+            "title": "feat(cli): add pattern search (#5)",
+            "author": "kantorcodes",
+            "body": "## Summary\n- Search command patterns from the terminal",
+        },
+    )
+    enrich_with_pull_requests(changes, REPO)
+    change = changes[0]
+    assert change.type == "feat" and change.scope == "cli"
+    assert change.pr_number == 5 and change.pr_author == "kantorcodes"
+    assert change.summary_bullets == ["Search command patterns from the terminal"]


### PR DESCRIPTION
## Summary
- Add `scripts/ci/generate_release_notes.py`, which builds release notes for stable and alpha releases from the first-parent commit range since the previous same-channel tag, enriches entries with PR titles and `## Summary` bullets from the GitHub API, and renders conventional-commit sections (Features, Fixes, CI & automation, and friends) with PR links, breaking-change markers, contributor credits, and a compare link.
- Wire the generator into the `release-main` and `release-alpha` jobs in `publish.yml`, replacing the hardcoded install-snippet release body so every new release documents the pull requests it shipped.
- Cover the generator with `tests/test_generate_release_notes.py` (parsing, tag selection, summary extraction, rendering, and a real git-range test) and repoint the release-body install-snippet assertion in `tests/test_cisco_install_surfaces.py` at the generator.

## Testing
- `uv run pytest tests/test_generate_release_notes.py tests/test_release_train_workflow.py tests/test_cisco_install_surfaces.py -q`
- `uv run ruff check scripts/ci/generate_release_notes.py tests/test_generate_release_notes.py tests/test_cisco_install_surfaces.py`
- `actionlint .github/workflows/publish.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release notes are now automatically generated from Git history and pull-request details.
  * Release notes include categorized changes, installation instructions, changelog links, and contributor credits.
  * Separate notes are generated for stable and alpha releases.

* **Reliability**
  * Releases are prevented from being created when generated notes are empty.
  * Release-note generation handles unavailable metadata and incomplete repository history gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->