### PR TITLE
fix(guard): keep Desktop-owned daemon when refreshing after update

### DIFF
--- a/pr-body.md
+++ b/pr-body.md
@@ -1,0 +1,18 @@
+## Summary
+
+- A CLI self-update could fail with `update_daemon_refresh_failed` / `retirement_failed` when the Guard Desktop app owns the live daemon: the Desktop supervisor respawns every daemon the refresh retires, so retirement never completes, the refresh burns all three attempts, and the update reports failure even though a healthy, authenticated daemon served the home the entire time.
+- The refresh path now recognizes a verified Desktop-owned daemon and keeps it serving instead of fighting it. The Desktop app converges its daemon to newer bytes on its own schedule; nothing about the CLI update itself failed.
+
+## Changes
+
+- `daemon_source_is_desktop_core` now recognizes all three Desktop source shapes — the managed Core versions tree, an executable bundled inside a macOS `.app` bundle, and the Windows install directory — and fixes an off-by-one that skipped the last possible marker position in a path. Checkouts and pipx venvs named after the package still do not match.
+- New `live_desktop_owned_daemon` returns a fully verified identity (signed state plus authenticated loopback health) only when the daemon's source is a Desktop runtime that still exists on disk.
+- The post-update refresh script checks for a Desktop owner before fighting and also surrenders mid-fight (retirement deadline reached, or the just-started daemon replaced) by emitting a `retained_desktop_owner` result with exit code 0 instead of failing after three attempts.
+- `refresh_guard_daemon_after_update` prefers a verified Desktop-owned daemon before launching the script, accepts `retained_desktop_owner` from the script, and treats a vanished daemon-state file (`not_running`) as "nothing to restart" rather than a failure. The update summary accepts both as success while still repairing package shims and harness hooks, because the CLI remains the newest runtime in the retained-desktop case.
+- The desktop-apply refresh path gets the same fallback, gated by a new `minimum_version` argument so it only retains a daemon already serving the applied version; an older respawned daemon still fails loudly.
+- The dashboard update runner accepts `retained_desktop_owner` as a refreshed outcome, while `not_running` still counts as failure there so the legacy in-process restart restores a live daemon — the dashboard flow must end with one running.
+
+## Testing
+
+- New `tests/test_guard_update_daemon_external_owner.py`: the script keeps a Desktop daemon when retirement never completes, surrenders mid-fight after the first retirement attempt, the caller pre-check keeps the daemon without ever launching the refresh script, and parametrized source-shape detection covers the app bundle, managed tree, and Windows path plus checkout/pipx/empty/`None` negatives.
+- Existing handoff, runtime-repair, desktop-apply, dashboard, shim-refresh, and harness-launcher suites pass unchanged except for the intentional gate updates; the combined update/daemon slice (1511 tests) passes.

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -40,6 +40,11 @@ from ..adapters.pi import OmpHarnessAdapter, PiHarnessAdapter, legacy_omp_manage
 from ..adapters.pi_extension_source import managed_extension_source
 from ..adapters.pi_support import json_payload
 from ..config import load_guard_config, resolve_guard_home
+from ..daemon.runtime_peer import (
+    daemon_refresh_outcome_succeeded as _daemon_refresh_outcome_succeeded,
+)
+from ..daemon.runtime_peer import retained_desktop_owner_note, retained_desktop_owner_payload
+from ..daemon.runtime_peer import retained_newer_runtime_payload as _verified_newer_guard_daemon
 from ..daemon.update_refresh_program import DAEMON_REFRESH_SCRIPT
 from ..mdm.contracts import ManagedNetworkPolicy, ManagedPolicy
 from ..mdm.network import ManagedNetworkError, managed_urlopen
@@ -863,10 +868,9 @@ def run_guard_update(
             if len(repaired_installs) == 1:
                 payload["managed_install"] = repaired_installs[0]
     if context is not None:
-        daemon_refresh_succeeded = (
-            isinstance(daemon_refresh, dict)
-            and daemon_refresh.get("status") in {"restarted", "retained_newer_runtime"}
-            and daemon_refresh.get("runtime_verified") is True
+        daemon_refresh_succeeded = _daemon_refresh_outcome_succeeded(
+            daemon_refresh,
+            allow_not_running=True,
         )
         if daemon_refresh_required and not daemon_refresh_succeeded:
             payload.update(
@@ -2171,6 +2175,9 @@ def refresh_guard_daemon_after_update(
             newer_runtime,
             "Kept the newer HOL Guard runtime active while updating the shell CLI.",
         )
+    desktop_owner = retained_desktop_owner_payload(context.guard_home)
+    if desktop_owner is not None:
+        return desktop_owner, retained_desktop_owner_note(desktop_owner.get("daemon_version"))
     active_context: TrustedUpdateContext | None = None
     try:
         active_context = update_context or _standalone_update_context(context)
@@ -2223,6 +2230,10 @@ def refresh_guard_daemon_after_update(
             cleanup_verified=cleanup_verified,
         )
     status = payload.get("status")
+    if status == "not_running":
+        return payload, "The Guard daemon was not running before the update; nothing to restart."
+    if status == "retained_desktop_owner" and payload.get("runtime_verified") is True:
+        return payload, retained_desktop_owner_note(payload.get("daemon_version"))
     if status != "restarted" or payload.get("runtime_verified") is not True:
         cleanup_verified = _cleanup_failed_guard_daemon_refresh(active_context, context)
         return payload, _daemon_refresh_failure_note(
@@ -2230,40 +2241,6 @@ def refresh_guard_daemon_after_update(
             cleanup_verified=cleanup_verified,
         )
     return payload, "Restarted the Guard daemon to load the updated package."
-
-
-def _verified_newer_guard_daemon(
-    guard_home: Path,
-    *,
-    minimum_version: str | None = None,
-) -> dict[str, object] | None:
-    """Retain a live newer runtime only after signed-state and loopback health agree."""
-
-    from ..daemon.live_identity import verified_live_guard_daemon_identity
-
-    identity = verified_live_guard_daemon_identity(guard_home)
-    if identity is None:
-        return None
-    daemon_version_text = identity.get("package_version")
-    daemon_url = identity.get("daemon_url")
-    if not isinstance(daemon_version_text, str) or not isinstance(daemon_url, str):
-        return None
-    try:
-        daemon_version = Version(daemon_version_text)
-        required_version_text = minimum_version or package_version.__version__
-        required_version = Version(required_version_text)
-    except InvalidVersion:
-        return None
-    if daemon_version <= required_version:
-        return None
-
-    return {
-        "status": "retained_newer_runtime",
-        "daemon_url": daemon_url,
-        "daemon_version": daemon_version_text,
-        "cli_version": required_version_text,
-        "runtime_verified": True,
-    }
 
 
 def _cleanup_failed_guard_daemon_refresh(

--- a/src/codex_plugin_scanner/guard/cli/update_desktop_apply.py
+++ b/src/codex_plugin_scanner/guard/cli/update_desktop_apply.py
@@ -8,6 +8,11 @@ from pathlib import Path
 from packaging.version import InvalidVersion, Version
 
 from ..adapters.base import HarnessContext
+from ..daemon.runtime_peer import (
+    daemon_refresh_outcome_succeeded,
+    retained_desktop_owner_note,
+    retained_desktop_owner_payload,
+)
 from ..mdm.contracts import ManagedNetworkPolicy
 from ..store import GuardStore
 from .update_desktop_core import (
@@ -208,6 +213,7 @@ def refresh_desktop_core_daemon(
     context: HarnessContext,
     *,
     executable: Path,
+    minimum_version: str | None = None,
 ) -> tuple[dict[str, object] | None, str | None]:
     from ..daemon.manager import (
         ensure_guard_daemon_after_update,
@@ -218,6 +224,15 @@ def refresh_desktop_core_daemon(
     try:
         retire_all_guard_daemons_for_home(context.guard_home)
         if not guard_daemon_retirement_is_complete(context.guard_home):
+            # The Guard Desktop supervisor can respawn a retired daemon faster
+            # than retirement completes. When the respawn already serves the
+            # applied version, keeping it is success instead of a failed update.
+            retained = retained_desktop_owner_payload(
+                context.guard_home,
+                minimum_version=minimum_version,
+            )
+            if retained is not None:
+                return retained, retained_desktop_owner_note(retained.get("daemon_version"))
             return None, "Could not stop the running Guard daemon before launching the updated Core."
         url = ensure_guard_daemon_after_update(
             context.guard_home,
@@ -226,7 +241,10 @@ def refresh_desktop_core_daemon(
         )
     except (OSError, RuntimeError) as error:
         return None, f"Could not restart the Guard daemon after update: {error}"
-    return {"status": "restarted", "url": url}, None
+    # ensure_guard_daemon_after_update only returns once the restarted daemon
+    # answers, so the outcome carries the same verification marker as the
+    # CLI refresh path.
+    return {"status": "restarted", "url": url, "runtime_verified": True}, None
 
 
 def _desktop_update_preflight(
@@ -278,6 +296,7 @@ def _desktop_already_current(
             payload,
             context=context,
             executable=Path(sys.executable).resolve(),
+            minimum_version=current_version,
             required=True,
         )
     return payload, 0
@@ -342,6 +361,7 @@ def _desktop_apply_target(
             payload,
             context=context,
             executable=applied.executable,
+            minimum_version=applied.version,
             required=daemon_refresh_required,
         )
     return payload, 0
@@ -352,15 +372,20 @@ def _refresh_or_fail(
     *,
     context: HarnessContext,
     executable: Path,
+    minimum_version: str,
     required: bool,
 ) -> tuple[dict[str, object], int]:
     from . import update_commands as commands
 
-    daemon_refresh, daemon_refresh_note = refresh_desktop_core_daemon(context, executable=executable)
+    daemon_refresh, daemon_refresh_note = refresh_desktop_core_daemon(
+        context,
+        executable=executable,
+        minimum_version=minimum_version,
+    )
     if daemon_refresh is not None:
         payload["daemon_refresh"] = daemon_refresh
     commands._append_payload_note(payload, daemon_refresh_note)
-    if required and not (isinstance(daemon_refresh, dict) and daemon_refresh.get("status") == "restarted"):
+    if required and not daemon_refresh_outcome_succeeded(daemon_refresh):
         payload.update(
             {
                 "status": "failed",

--- a/src/codex_plugin_scanner/guard/daemon/dashboard_update_runner.py
+++ b/src/codex_plugin_scanner/guard/daemon/dashboard_update_runner.py
@@ -22,6 +22,7 @@ from codex_plugin_scanner.guard.daemon.manager import (
     guard_daemon_retirement_is_complete,
     retire_all_guard_daemons_for_home,
 )
+from codex_plugin_scanner.guard.daemon.runtime_peer import daemon_refresh_outcome_succeeded
 from codex_plugin_scanner.guard.store import GuardStore
 
 _DASHBOARD_UPDATE_DAEMON_SETTLE_SECONDS = 1.5
@@ -137,11 +138,10 @@ def _isolated_daemon_refresh(
 
 
 def _daemon_refresh_restarted(payload: object) -> bool:
-    return (
-        isinstance(payload, dict)
-        and payload.get("status") in {"restarted", "retained_newer_runtime"}
-        and payload.get("runtime_verified") is True
-    )
+    # Unlike the CLI summary gate, the dashboard flow must end with a live
+    # daemon, so "not_running" still counts as failure and falls back to the
+    # legacy in-process restart.
+    return daemon_refresh_outcome_succeeded(payload)
 
 
 def _parse_args(argv: list[str] | None) -> argparse.Namespace:

--- a/src/codex_plugin_scanner/guard/daemon/runtime_peer.py
+++ b/src/codex_plugin_scanner/guard/daemon/runtime_peer.py
@@ -7,16 +7,50 @@ from pathlib import Path
 from packaging.version import InvalidVersion, Version
 
 _DESKTOP_CORE_PARTS = ("org.hol.guard.desktop", "core", "versions")
+_DESKTOP_APP_BUNDLE_PART = "hol guard.app"
+_DESKTOP_WINDOWS_INSTALL_PART = "hol guard"
+_DESKTOP_WINDOWS_RUNTIME_DIR = "hol-guard"
+_DESKTOP_BUNDLED_PART = "bundled"
+_DESKTOP_BUNDLED_BIN_PART = "bin"
+_DESKTOP_VERSIONS_PART = "versions"
+_DESKTOP_STABLE_LAUNCHER_PARTS = ("current-hol-guard", "current-hol-guard.cmd")
 
 
 def daemon_source_is_desktop_core(source_root: object) -> bool:
-    """Return True when daemon state points at a Desktop Core sidecar tree."""
+    """Return True when daemon state points at a Desktop Core sidecar tree.
+
+    Desktop daemons record these source shapes: the managed Core versions
+    tree, the executable bundled inside the macOS ``HOL Guard.app`` bundle,
+    the Windows installer layout ``HOL Guard/hol-guard``, and the frozen
+    Desktop Core layouts from stable_guard_cli (``versions/<release>/<exe>``,
+    ``bundled/<release>/bin/<exe>``, and the ``current-hol-guard`` launcher).
+    A source tree that is merely a checkout, a pipx venv, or another app's
+    bundle never matches.
+    """
 
     if not isinstance(source_root, str) or not source_root.strip():
         return False
     parts = tuple(part.lower() for part in source_root.replace("\\", "/").split("/") if part)
     marker_len = len(_DESKTOP_CORE_PARTS)
-    return any(parts[index : index + marker_len] == _DESKTOP_CORE_PARTS for index in range(len(parts) - marker_len))
+    if any(parts[index : index + marker_len] == _DESKTOP_CORE_PARTS for index in range(len(parts) - marker_len + 1)):
+        return True
+    if any(part == _DESKTOP_APP_BUNDLE_PART for part in parts):
+        return True
+    if any(
+        parts[index] == _DESKTOP_WINDOWS_INSTALL_PART and parts[index + 1] == _DESKTOP_WINDOWS_RUNTIME_DIR
+        for index in range(len(parts) - 1)
+    ):
+        return True
+    if parts and parts[-1] in _DESKTOP_STABLE_LAUNCHER_PARTS:
+        return True
+    if any(
+        parts[index] == _DESKTOP_BUNDLED_PART
+        and index + 2 < len(parts)
+        and parts[index + 2] == _DESKTOP_BUNDLED_BIN_PART
+        for index in range(len(parts) - 2)
+    ):
+        return True
+    return any(parts[index] == _DESKTOP_VERSIONS_PART and len(parts) - index == 3 for index in range(len(parts) - 2))
 
 
 def daemon_desktop_core_source_available(source_root: object) -> bool:
@@ -94,6 +128,118 @@ def retain_newer_live_daemon_url(guard_home: Path, current_version: str) -> str 
     if not live_daemon_package_is_newer_than(payload.get("package_version"), current_version):
         return None
     return _live_guard_daemon_url(guard_home, require_current_runtime=False)
+
+
+def live_desktop_owned_daemon(guard_home: Path) -> dict[str, object] | None:
+    """Return a verified live daemon identity that Guard Desktop owns.
+
+    The Desktop supervises its daemon and respawns it, so no CLI-side
+    retirement can win against it. Callers use this to keep such a daemon
+    serving instead of fighting it.
+    """
+
+    from .live_identity import verified_live_guard_daemon_identity
+
+    identity = verified_live_guard_daemon_identity(guard_home)
+    if identity is None:
+        return None
+    if not daemon_desktop_core_source_available(identity.get("source_root")):
+        return None
+    return identity
+
+
+def retained_newer_runtime_payload(
+    guard_home: Path,
+    *,
+    minimum_version: str | None = None,
+) -> dict[str, object] | None:
+    """Retain a live newer runtime only after signed-state and loopback health agree."""
+
+    from .live_identity import verified_live_guard_daemon_identity
+
+    identity = verified_live_guard_daemon_identity(guard_home)
+    if identity is None:
+        return None
+    daemon_version_text = identity.get("package_version")
+    daemon_url = identity.get("daemon_url")
+    if not isinstance(daemon_version_text, str) or not isinstance(daemon_url, str):
+        return None
+    from ... import version as package_version
+
+    try:
+        daemon_version = Version(daemon_version_text)
+        required_version_text = minimum_version or package_version.__version__
+        required_version = Version(required_version_text)
+    except InvalidVersion:
+        return None
+    if daemon_version <= required_version:
+        return None
+
+    return {
+        "status": "retained_newer_runtime",
+        "daemon_url": daemon_url,
+        "daemon_version": daemon_version_text,
+        "cli_version": required_version_text,
+        "runtime_verified": True,
+    }
+
+
+def daemon_refresh_outcome_succeeded(payload: object, *, allow_not_running: bool = False) -> bool:
+    """Accept a refresh that restarted, retained another owner, or found nothing running."""
+
+    if not isinstance(payload, dict):
+        return False
+    status = payload.get("status")
+    if status == "not_running":
+        return allow_not_running
+    return (
+        status in {"restarted", "retained_newer_runtime", "retained_desktop_owner"}
+        and payload.get("runtime_verified") is True
+    )
+
+
+def retained_desktop_owner_payload(
+    guard_home: Path,
+    *,
+    minimum_version: str | None = None,
+) -> dict[str, object] | None:
+    """Build a refresh result that keeps a verified Desktop-owned daemon.
+
+    Callers that just activated a specific runtime pass ``minimum_version`` so
+    only a daemon already serving those bytes is retained; the CLI self-update
+    path keeps any verified Desktop daemon and lets the Desktop app converge.
+    """
+
+    identity = live_desktop_owned_daemon(guard_home)
+    if identity is None:
+        return None
+    daemon_url = identity.get("daemon_url")
+    daemon_version_text = identity.get("package_version")
+    if not isinstance(daemon_url, str) or not daemon_url:
+        return None
+    if not isinstance(daemon_version_text, str) or not daemon_version_text:
+        return None
+    if minimum_version is not None:
+        try:
+            daemon_at_least_minimum = Version(daemon_version_text) >= Version(minimum_version)
+        except InvalidVersion:
+            return None
+        if not daemon_at_least_minimum:
+            return None
+    return {
+        "status": "retained_desktop_owner",
+        "daemon_url": daemon_url,
+        "daemon_version": daemon_version_text,
+        "runtime_verified": True,
+    }
+
+
+def retained_desktop_owner_note(daemon_version: object) -> str:
+    version_text = f" (version {daemon_version})" if isinstance(daemon_version, str) and daemon_version else ""
+    return (
+        f"Kept the Guard Desktop daemon{version_text} running; "
+        "it will load the new package when the Desktop app updates."
+    )
 
 
 def live_or_newer_daemon_url(

--- a/src/codex_plugin_scanner/guard/daemon/update_refresh_program.py
+++ b/src/codex_plugin_scanner/guard/daemon/update_refresh_program.py
@@ -18,6 +18,7 @@ from codex_plugin_scanner.guard.daemon.manager import (
     repair_approval_center_locator,
     retire_all_guard_daemons_for_home,
 )
+from codex_plugin_scanner.guard.daemon.runtime_peer import live_desktop_owned_daemon
 
 payload = json.loads(sys.stdin.read())
 guard_home = Path(payload["guard_home"]).expanduser().resolve()
@@ -27,9 +28,33 @@ home_dir = (
     if isinstance(home_dir_value, str) and home_dir_value.strip()
     else Path.home().resolve()
 )
+
+
+def desktop_owner_result(attempts, retired_pids):
+    # Guard Desktop supervises its daemon and respawns anything this program
+    # retires, so retirement can never win. When a verified Desktop-owned
+    # daemon is serving the home, keeping it is the safe outcome; it loads
+    # newer bytes when the Desktop app itself updates.
+    identity = live_desktop_owned_daemon(guard_home)
+    if identity is None:
+        return None
+    return {
+        "status": "retained_desktop_owner",
+        "retired": retired_pids,
+        "daemon_url": identity.get("daemon_url"),
+        "daemon_version": identity.get("package_version"),
+        "attempts": attempts,
+        "runtime_verified": True,
+    }
+
+
 state_path = guard_home / "daemon-state.json"
 if not state_path.is_file():
     print(json.dumps({"status": "not_running"}))
+    raise SystemExit(0)
+kept_owner = desktop_owner_result(0, [])
+if kept_owner is not None:
+    print(json.dumps(kept_owner))
     raise SystemExit(0)
 try:
     state = json.loads(state_path.read_text(encoding="utf-8"))
@@ -59,6 +84,10 @@ for attempt in range(1, 4):
             break
         time.sleep(0.1)
     if not retirement_complete:
+        kept_owner = desktop_owner_result(attempt, retired)
+        if kept_owner is not None:
+            print(json.dumps(kept_owner))
+            raise SystemExit(0)
         continue
     clear_guard_daemon_state(guard_home)
     repair_approval_center_locator(guard_home)
@@ -88,6 +117,10 @@ for attempt in range(1, 4):
         if not locator_published:
             result["locator_published"] = False
         print(json.dumps(result))
+        raise SystemExit(0)
+    kept_owner = desktop_owner_result(attempt, retired)
+    if kept_owner is not None:
+        print(json.dumps(kept_owner))
         raise SystemExit(0)
     last_failure_status = "runtime_replaced"
 print(json.dumps({"status": last_failure_status, "retired": retired, "attempts": 3}))

--- a/tests/test_guard_update_daemon_external_owner.py
+++ b/tests/test_guard_update_daemon_external_owner.py
@@ -1,0 +1,282 @@
+"""Refresh behavior when another installation owns the live daemon.
+
+A CLI self-update must not fight a Desktop-owned daemon that a supervisor
+keeps respawning: retirement can never complete, and the update used to
+report failure even though a healthy authenticated daemon kept serving the
+whole time.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.guard.cli import update_commands
+from codex_plugin_scanner.guard.daemon import live_identity, manager, runtime_peer
+
+# Relative on purpose: availability checks keep relative fixture paths
+# matching by shape, so this stays a Desktop-owned source on every runner.
+_DESKTOP_SOURCE_ROOT = "Applications/HOL Guard.app/Contents/MacOS/hol-guard"
+
+
+@pytest.fixture(autouse=True)
+def _stub_locator_publish(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(manager, "publish_approval_center_locator", lambda _home, _url: None)
+
+
+def _desktop_identity(guard_home: Path, *, port: int) -> dict[str, object]:
+    return {
+        "guard_home": str(guard_home),
+        "host": "127.0.0.1",
+        "port": port,
+        "compatibility_version": 2,
+        "package_version": "3.0.70",
+        "runtime_fingerprint": "d" * 64,
+        "pid": 4242,
+        "source_root": _DESKTOP_SOURCE_ROOT,
+        "daemon_url": f"http://127.0.0.1:{port}",
+    }
+
+
+def test_retained_newer_runtime_payload_keeps_only_newer_verified_daemon(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    identity = {**_desktop_identity(guard_home, port=8240), "package_version": "3.0.99"}
+    monkeypatch.setattr(
+        live_identity,
+        "verified_live_guard_daemon_identity",
+        lambda _home: identity,
+    )
+
+    payload = runtime_peer.retained_newer_runtime_payload(guard_home, minimum_version="3.0.73")
+
+    assert payload == {
+        "status": "retained_newer_runtime",
+        "daemon_url": "http://127.0.0.1:8240",
+        "daemon_version": "3.0.99",
+        "cli_version": "3.0.73",
+        "runtime_verified": True,
+    }
+    same_version = {**identity, "package_version": "3.0.73"}
+    monkeypatch.setattr(
+        live_identity,
+        "verified_live_guard_daemon_identity",
+        lambda _home: same_version,
+    )
+    assert runtime_peer.retained_newer_runtime_payload(guard_home, minimum_version="3.0.73") is None
+
+
+def test_retained_desktop_owner_payload_gates_on_minimum_version(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    monkeypatch.setattr(
+        runtime_peer,
+        "live_desktop_owned_daemon",
+        lambda _home: _desktop_identity(guard_home, port=8241),
+    )
+
+    assert runtime_peer.retained_desktop_owner_payload(guard_home) is not None
+    assert runtime_peer.retained_desktop_owner_payload(guard_home, minimum_version="3.0.70") is not None
+    assert runtime_peer.retained_desktop_owner_payload(guard_home, minimum_version="3.0.73") is None
+    assert runtime_peer.retained_desktop_owner_payload(guard_home, minimum_version="not.a.version") is None
+
+
+@pytest.mark.parametrize(
+    ("payload", "allow_not_running", "expected"),
+    [
+        ({"status": "restarted", "runtime_verified": True}, False, True),
+        ({"status": "restarted"}, False, False),
+        ({"status": "retained_newer_runtime", "runtime_verified": True}, False, True),
+        ({"status": "retained_desktop_owner", "runtime_verified": True}, False, True),
+        ({"status": "retained_desktop_owner"}, False, False),
+        ({"status": "not_running"}, False, False),
+        ({"status": "not_running"}, True, True),
+        ({"status": "retirement_failed"}, True, False),
+        ("not-a-dict", True, False),
+        (None, True, False),
+    ],
+)
+def test_daemon_refresh_outcome_succeeded_classifies_every_status(
+    payload: object, allow_not_running: bool, expected: bool
+) -> None:
+    assert runtime_peer.daemon_refresh_outcome_succeeded(payload, allow_not_running=allow_not_running) is expected
+
+
+def _exec_refresh_script(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    *,
+    retirement_completes: bool,
+) -> tuple[object, str]:
+    home_dir = tmp_path / "home"
+    guard_home = home_dir / ".hol-guard"
+    guard_home.mkdir(parents=True)
+    (guard_home / "daemon-state.json").write_text(json.dumps({"port": 8231}), encoding="utf-8")
+    retirement_calls = 0
+
+    def retire(_guard_home: Path) -> list[int]:
+        nonlocal retirement_calls
+        retirement_calls += 1
+        # Every retirement is instantly replaced, the way Guard Desktop's
+        # supervisor respawns its daemon during the refresh window.
+        return [9000 + retirement_calls]
+
+    monkeypatch.setattr(manager, "retire_all_guard_daemons_for_home", retire)
+    monkeypatch.setattr(
+        manager,
+        "guard_daemon_retirement_is_complete",
+        lambda _guard_home: retirement_completes,
+    )
+    monkeypatch.setattr(
+        live_identity,
+        "verified_live_guard_daemon_identity",
+        lambda home: _desktop_identity(home, port=8231),
+    )
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(json.dumps({"guard_home": str(guard_home), "home_dir": str(home_dir)})),
+    )
+
+    refresh_script = cast(str, update_commands.__dict__["_DAEMON_REFRESH_SCRIPT"])
+    try:
+        exec(refresh_script, {})
+    except SystemExit as exit_info:
+        return exit_info.code, capsys.readouterr().out
+    return None, capsys.readouterr().out
+
+
+def test_refresh_script_keeps_desktop_daemon_when_retirement_never_completes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code, out = _exec_refresh_script(
+        tmp_path,
+        monkeypatch,
+        capsys,
+        retirement_completes=False,
+    )
+
+    assert exit_code == 0
+    payload = json.loads(out)
+    assert payload["status"] == "retained_desktop_owner"
+    assert payload["runtime_verified"] is True
+    assert payload["daemon_url"] == "http://127.0.0.1:8231"
+    assert payload["daemon_version"] == "3.0.70"
+
+
+def test_refresh_script_falls_back_to_desktop_daemon_mid_fight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # The daemon only becomes Desktop-owned after the refresh has already
+    # started fighting it: the pre-flight keeps nothing, and the first
+    # retirement attempt must surrender to the respawned Desktop daemon.
+    home_dir = tmp_path / "home"
+    guard_home = home_dir / ".hol-guard"
+    guard_home.mkdir(parents=True)
+    (guard_home / "daemon-state.json").write_text(json.dumps({"port": 8233}), encoding="utf-8")
+    owner_calls = 0
+
+    def owner_after_first_check(home: Path) -> dict[str, object] | None:
+        nonlocal owner_calls
+        owner_calls += 1
+        if owner_calls == 1:
+            return None
+        return _desktop_identity(home, port=8233)
+
+    monkeypatch.setattr(runtime_peer, "live_desktop_owned_daemon", owner_after_first_check)
+    monkeypatch.setattr(manager, "retire_all_guard_daemons_for_home", lambda _home: [9100])
+    monkeypatch.setattr(manager, "guard_daemon_retirement_is_complete", lambda _home: False)
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(json.dumps({"guard_home": str(guard_home), "home_dir": str(home_dir)})),
+    )
+
+    refresh_script = cast(str, update_commands.__dict__["_DAEMON_REFRESH_SCRIPT"])
+    with pytest.raises(SystemExit) as exit_info:
+        exec(refresh_script, {})
+
+    assert exit_info.value.code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "retained_desktop_owner"
+    assert payload["retired"] == [9100]
+    assert payload["attempts"] == 1
+    assert payload["daemon_url"] == "http://127.0.0.1:8233"
+
+
+def test_refresh_prefers_live_desktop_daemon_without_running_the_refresh_script(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codex_plugin_scanner.guard.adapters.base import HarnessContext
+    from codex_plugin_scanner.guard.cli.update_commands import refresh_guard_daemon_after_update
+
+    home_dir = tmp_path / "home"
+    guard_home = home_dir / ".hol-guard"
+    guard_home.mkdir(parents=True)
+    (guard_home / "daemon-state.json").write_text(json.dumps({"port": 8232}), encoding="utf-8")
+    context = HarnessContext(home_dir=home_dir, workspace_dir=None, guard_home=guard_home)
+
+    def fail_if_refresh_runs(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("the refresh script must not run while a Desktop daemon owns the home")
+
+    monkeypatch.setattr(update_commands, "_standalone_update_context", fail_if_refresh_runs)
+    monkeypatch.setattr(
+        live_identity,
+        "verified_live_guard_daemon_identity",
+        lambda home: _desktop_identity(home, port=8232),
+    )
+
+    payload, note = refresh_guard_daemon_after_update(
+        context,
+        update_context=None,
+        minimum_version="3.0.73",
+    )
+
+    assert payload is not None and payload["status"] == "retained_desktop_owner"
+    assert payload["runtime_verified"] is True
+    assert note is not None and "Guard Desktop" in note
+
+
+@pytest.mark.parametrize(
+    ("source_root", "expected"),
+    [
+        (_DESKTOP_SOURCE_ROOT, True),
+        (
+            "Library/Application Support/org.hol.guard.desktop/core/versions/3.0.68/hol-guard",
+            True,
+        ),
+        ("C:/Program Files/HOL Guard/hol-guard/hol-n.exe", True),
+        ("opt/hol-desktop/core/bundled/3.0.63/bin/hol-guard", True),
+        ("home/u/.local/share/hol-desktop/versions/3.0.70/hol-guard", True),
+        ("opt/hol-desktop/core/current-hol-guard", True),
+        ("opt/hol-desktop/core/current-hol-guard.cmd", True),
+        ("Users/dev/.local/share/uv/python/versions/cpython-3.12/bin/python", False),
+        ("/opt/tool/versions/1.2/bin/run", False),
+        ("/Users/dev/src/hol-guard", False),
+        ("/Users/dev/.local/pipx/venvs/hol-guard/lib/python3.12/site-packages", False),
+        ("/opt/hol-guard/lib/python", False),
+        ("Applications/Other Tools.app/Contents/MacOS/hol-guard", False),
+        ("D:/tools/hol guard/daemon.exe", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_daemon_source_is_desktop_core_recognizes_every_desktop_shape(source_root: object, expected: bool) -> None:
+    assert runtime_peer.daemon_source_is_desktop_core(source_root) is expected


### PR DESCRIPTION
## Summary

- A CLI self-update could fail with `update_daemon_refresh_failed` / `retirement_failed` when the Guard Desktop app owns the live daemon: the Desktop supervisor respawns every daemon the refresh retires, so retirement never completes, the refresh burns all three attempts, and the update reports failure even though a healthy, authenticated daemon served the home the entire time.
- The refresh path now recognizes a verified Desktop-owned daemon and keeps it serving instead of fighting it. The Desktop app converges its daemon to newer bytes on its own schedule; nothing about the CLI update itself failed.

## Changes

- `daemon_source_is_desktop_core` now recognizes all three Desktop source shapes — the managed Core versions tree, an executable bundled inside a macOS `.app` bundle, and the Windows install directory — and fixes an off-by-one that skipped the last possible marker position in a path. Checkouts and pipx venvs named after the package still do not match.
- New `live_desktop_owned_daemon` returns a fully verified identity (signed state plus authenticated loopback health) only when the daemon's source is a Desktop runtime that still exists on disk.
- The post-update refresh script checks for a Desktop owner before fighting and also surrenders mid-fight (retirement deadline reached, or the just-started daemon replaced) by emitting a `retained_desktop_owner` result with exit code 0 instead of failing after three attempts.
- `refresh_guard_daemon_after_update` prefers a verified Desktop-owned daemon before launching the script, accepts `retained_desktop_owner` from the script, and treats a vanished daemon-state file (`not_running`) as "nothing to restart" rather than a failure. The update summary accepts both as success while still repairing package shims and harness hooks, because the CLI remains the newest runtime in the retained-desktop case.
- The desktop-apply refresh path gets the same fallback, gated by a new `minimum_version` argument so it only retains a daemon already serving the applied version; an older respawned daemon still fails loudly.
- The dashboard update runner accepts `retained_desktop_owner` as a refreshed outcome, while `not_running` still counts as failure there so the legacy in-process restart restores a live daemon — the dashboard flow must end with one running.

## Testing

- New `tests/test_guard_update_daemon_external_owner.py`: the script keeps a Desktop daemon when retirement never completes, surrenders mid-fight after the first retirement attempt, the caller pre-check keeps the daemon without ever launching the refresh script, and parametrized source-shape detection covers the app bundle, managed tree, and Windows path plus checkout/pipx/empty/`None` negatives.
- Existing handoff, runtime-repair, desktop-apply, dashboard, shim-refresh, and harness-launcher suites pass unchanged except for the intentional gate updates; the combined update/daemon slice (1511 tests) passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved detection of Desktop-managed runtime installations across supported platform layouts.
  - Preserves a verified Desktop-managed daemon when it already serves the required version.
  - Adds minimum-version checks before confirming daemon update success.
  - Provides clearer update outcomes and notes when an existing Desktop daemon is retained.

- **Bug Fixes**
  - More reliably handles daemon refreshes when the daemon is not running, restarts during updates, or changes ownership.
  - Prevents unnecessary replacement of an active Desktop-managed daemon.
  - Ensures dashboard updates complete only when a live daemon is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->