### PR TITLE
fix(guard): normalize bundled desktop runtime owners

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_guard_cli.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_guard_cli.py
@@ -22,12 +22,27 @@ _CURRENT_HOL_GUARD_SHIM = "current-hol-guard"
 
 
 def _desktop_core_shim_for_executable(executable: Path) -> Path | None:
-    versions_dir = executable.parent.parent
-    if versions_dir.name == "versions":
-        parent = versions_dir.parent
-    elif len(executable.parents) > 4 and executable.parents[3].name == "bundled":
-        parent = executable.parents[4]
-    else:
+    executable_name = executable.name.lower()
+    if executable_name not in {"hol-guard", "hol-guard.exe"}:
+        return None
+    parent = None
+    for ancestor in executable.parents:
+        try:
+            relative_parts = executable.relative_to(ancestor).parts
+        except ValueError:
+            continue
+        if ancestor.name == "versions" and len(relative_parts) == 2:
+            parent = ancestor.parent
+            break
+        if ancestor.name != "bundled":
+            continue
+        if len(relative_parts) == 3 and relative_parts[1] == "bin":
+            parent = ancestor.parent
+            break
+        if len(relative_parts) == 4 and relative_parts[1:3] == ("lib", "hol-guard-core"):
+            parent = ancestor.parent
+            break
+    if parent is None:
         return None
     unix = parent / _CURRENT_HOL_GUARD_SHIM
     windows = parent / f"{_CURRENT_HOL_GUARD_SHIM}.cmd"

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hook_guard_cli.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hook_guard_cli.py
@@ -27,14 +27,15 @@ def _desktop_core_shim_for_executable(executable: Path) -> Path | None:
         return None
     parent = None
     for ancestor in executable.parents:
+        ancestor_name = ancestor.name.lower()
         try:
             relative_parts = executable.relative_to(ancestor).parts
         except ValueError:
             continue
-        if ancestor.name == "versions" and len(relative_parts) == 2:
+        if ancestor_name == "versions" and len(relative_parts) == 2:
             parent = ancestor.parent
             break
-        if ancestor.name != "bundled":
+        if ancestor_name != "bundled":
             continue
         if len(relative_parts) == 3 and relative_parts[1] == "bin":
             parent = ancestor.parent

--- a/src/codex_plugin_scanner/guard/adapters/pi_extension_runtime_ownership.py
+++ b/src/codex_plugin_scanner/guard/adapters/pi_extension_runtime_ownership.py
@@ -8,6 +8,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from ..stable_guard_cli import desktop_core_shim_for_executable
+
 _DESKTOP_RUNTIME_OWNER_ENV = "HOL_GUARD_DESKTOP_RUNTIME_OWNER"
 
 
@@ -67,8 +69,17 @@ def _stable_guard_cli_command(home_dir: Path) -> str:
         if not candidate:
             continue
         path = Path(candidate).expanduser().absolute()
+        try:
+            resolved = path.resolve(strict=True)
+        except (OSError, RuntimeError):
+            continue
         normalized = str(path).replace("\\", "/").lower()
         if "/tmp/.mount_" in normalized or "/private/tmp/.mount_" in normalized:
+            continue
+        desktop_shim = desktop_core_shim_for_executable(resolved)
+        if desktop_shim is not None:
+            if desktop_shim.is_file() and os.access(desktop_shim, os.X_OK):
+                return str(desktop_shim)
             continue
         if path.is_file() and os.access(path, os.X_OK):
             return str(path)

--- a/src/codex_plugin_scanner/guard/adapters/pi_extension_runtime_ownership.py
+++ b/src/codex_plugin_scanner/guard/adapters/pi_extension_runtime_ownership.py
@@ -70,8 +70,8 @@ def _stable_guard_cli_command(home_dir: Path) -> str:
             continue
         path = Path(candidate).expanduser().absolute()
         try:
-            resolved = path.resolve(strict=True)
-        except (OSError, RuntimeError):
+            resolved = path.resolve(strict=False)
+        except RuntimeError:
             continue
         normalized = str(path).replace("\\", "/").lower()
         if "/tmp/.mount_" in normalized or "/private/tmp/.mount_" in normalized:
@@ -80,6 +80,8 @@ def _stable_guard_cli_command(home_dir: Path) -> str:
         if desktop_shim is not None:
             if desktop_shim.is_file() and os.access(desktop_shim, os.X_OK):
                 return str(desktop_shim)
+            # A versioned Desktop executable is not durable enough to own a
+            # generated extension. Continue to the official install instead.
             continue
         if path.is_file() and os.access(path, os.X_OK):
             return str(path)

--- a/src/codex_plugin_scanner/guard/stable_guard_cli.py
+++ b/src/codex_plugin_scanner/guard/stable_guard_cli.py
@@ -37,13 +37,14 @@ def _desktop_core_root(executable: Path) -> Path | None:
     if executable_name not in {"hol-guard", "hol-guard.exe"}:
         return None
     for ancestor in executable.parents:
+        ancestor_name = ancestor.name.lower()
         try:
             relative_parts = executable.relative_to(ancestor).parts
         except ValueError:
             continue
-        if ancestor.name == "versions" and len(relative_parts) == 2:
+        if ancestor_name == "versions" and len(relative_parts) == 2:
             return ancestor.parent
-        if ancestor.name != "bundled":
+        if ancestor_name != "bundled":
             continue
         if len(relative_parts) == 3 and relative_parts[1] == "bin":
             return ancestor.parent

--- a/src/codex_plugin_scanner/guard/stable_guard_cli.py
+++ b/src/codex_plugin_scanner/guard/stable_guard_cli.py
@@ -18,12 +18,8 @@ CURRENT_HOL_GUARD_SHIM = "current-hol-guard"
 def desktop_core_shim_for_executable(executable: Path) -> Path | None:
     """Return the stable ``current-hol-guard`` launcher next to a versioned Core."""
 
-    versions_dir = executable.parent.parent
-    if versions_dir.name == "versions":
-        parent = versions_dir.parent
-    elif len(executable.parents) > 4 and executable.parents[3].name == "bundled":
-        parent = executable.parents[4]
-    else:
+    parent = _desktop_core_root(executable)
+    if parent is None:
         return None
     unix = parent / CURRENT_HOL_GUARD_SHIM
     windows = parent / f"{CURRENT_HOL_GUARD_SHIM}.cmd"
@@ -34,6 +30,26 @@ def desktop_core_shim_for_executable(executable: Path) -> Path | None:
             return unix
         return windows
     return unix
+
+
+def _desktop_core_root(executable: Path) -> Path | None:
+    executable_name = executable.name.lower()
+    if executable_name not in {"hol-guard", "hol-guard.exe"}:
+        return None
+    for ancestor in executable.parents:
+        try:
+            relative_parts = executable.relative_to(ancestor).parts
+        except ValueError:
+            continue
+        if ancestor.name == "versions" and len(relative_parts) == 2:
+            return ancestor.parent
+        if ancestor.name != "bundled":
+            continue
+        if len(relative_parts) == 3 and relative_parts[1] == "bin":
+            return ancestor.parent
+        if len(relative_parts) == 4 and relative_parts[1:3] == ("lib", "hol-guard-core"):
+            return ancestor.parent
+    return None
 
 
 def frozen_cli_path_is_runnable(path: Path) -> bool:

--- a/tests/test_cursor_hook_guard_cli.py
+++ b/tests/test_cursor_hook_guard_cli.py
@@ -46,6 +46,15 @@ def test_resolve_frozen_cli_recognizes_bundled_desktop_wrapper(tmp_path: Path) -
     assert desktop_core_shim_for_executable(bundled) == core_dir / "current-hol-guard"
 
 
+def test_resolve_frozen_cli_normalizes_desktop_directory_case(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.stable_guard_cli import desktop_core_shim_for_executable
+
+    core_dir = tmp_path / "core"
+    bundled = core_dir / "Bundled" / "3.0.63" / "bin" / "HOL-Guard"
+
+    assert desktop_core_shim_for_executable(bundled) == core_dir / "current-hol-guard"
+
+
 def test_resolved_cursor_hook_guard_cli_rewrites_argv0_only(tmp_path: Path) -> None:
     core_dir = tmp_path / "core"
     versioned = core_dir / "versions" / "3.0.55" / "hol-guard"
@@ -80,7 +89,8 @@ def test_cursor_hook_script_template_includes_guard_cli_resolver() -> None:
     from codex_plugin_scanner.guard.adapters.cursor_hooks import _HOOK_SCRIPT_TEMPLATE
 
     assert "_resolve_cursor_hook_guard_cli_argv0" in HOOK_SCRIPT_TEMPLATE_RESOLVER
-    assert 'ancestor.name != "bundled"' in HOOK_SCRIPT_TEMPLATE_RESOLVER
+    assert "ancestor_name = ancestor.name.lower()" in HOOK_SCRIPT_TEMPLATE_RESOLVER
+    assert 'ancestor_name != "bundled"' in HOOK_SCRIPT_TEMPLATE_RESOLVER
     assert 'relative_parts[1] == "bin"' in HOOK_SCRIPT_TEMPLATE_RESOLVER
     assert "_resolved_guard_cli()" in HOOK_SCRIPT_TEMPLATE_RESOLVER
     assert "_resolve_cursor_hook_guard_cli_argv0" in _HOOK_SCRIPT_TEMPLATE

--- a/tests/test_cursor_hook_guard_cli.py
+++ b/tests/test_cursor_hook_guard_cli.py
@@ -37,6 +37,15 @@ def test_resolve_frozen_cli_recognizes_bundled_desktop_layout(tmp_path: Path) ->
     assert desktop_core_shim_for_executable(bundled) == core_dir / "current-hol-guard"
 
 
+def test_resolve_frozen_cli_recognizes_bundled_desktop_wrapper(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.stable_guard_cli import desktop_core_shim_for_executable
+
+    core_dir = tmp_path / "core"
+    bundled = core_dir / "bundled" / "3.0.63" / "bin" / "hol-guard"
+
+    assert desktop_core_shim_for_executable(bundled) == core_dir / "current-hol-guard"
+
+
 def test_resolved_cursor_hook_guard_cli_rewrites_argv0_only(tmp_path: Path) -> None:
     core_dir = tmp_path / "core"
     versioned = core_dir / "versions" / "3.0.55" / "hol-guard"
@@ -71,7 +80,8 @@ def test_cursor_hook_script_template_includes_guard_cli_resolver() -> None:
     from codex_plugin_scanner.guard.adapters.cursor_hooks import _HOOK_SCRIPT_TEMPLATE
 
     assert "_resolve_cursor_hook_guard_cli_argv0" in HOOK_SCRIPT_TEMPLATE_RESOLVER
-    assert 'executable.parents[3].name == "bundled"' in HOOK_SCRIPT_TEMPLATE_RESOLVER
+    assert 'ancestor.name != "bundled"' in HOOK_SCRIPT_TEMPLATE_RESOLVER
+    assert 'relative_parts[1] == "bin"' in HOOK_SCRIPT_TEMPLATE_RESOLVER
     assert "_resolved_guard_cli()" in HOOK_SCRIPT_TEMPLATE_RESOLVER
     assert "_resolve_cursor_hook_guard_cli_argv0" in _HOOK_SCRIPT_TEMPLATE
     assert "_resolved_guard_cli()" in _HOOK_SCRIPT_TEMPLATE

--- a/tests/test_guard_shim_refresh.py
+++ b/tests/test_guard_shim_refresh.py
@@ -102,7 +102,7 @@ class ShimRefreshTest(unittest.TestCase):
             encoding="utf-8",
         )
         stable_cli.chmod(0o755)
-        desktop_owner = desktop_root / "bundled" / "3.0.0" / "lib" / "hol-guard-core" / "hol-guard"
+        desktop_owner = desktop_root / "bundled" / "3.0.63" / "bin" / "hol-guard"
         desktop_owner.parent.mkdir(parents=True)
         desktop_owner.write_text("#!/bin/sh\nexit 99\n", encoding="utf-8")
         desktop_owner.chmod(0o755)

--- a/tests/test_pi_extension_runtime_ownership.py
+++ b/tests/test_pi_extension_runtime_ownership.py
@@ -74,6 +74,27 @@ def test_managed_extension_prefers_persistent_desktop_runtime_owner(
 
 
 @pytest.mark.skipif(pi_extension_runtime_ownership.os.name == "nt", reason="POSIX runtime ownership contract")
+def test_managed_extension_maps_versioned_desktop_wrapper_to_stable_launcher(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    core_root = tmp_path / "core"
+    desktop_owner = core_root / "bundled" / "3.0.63" / "bin" / "hol-guard"
+    desktop_owner.parent.mkdir(parents=True)
+    desktop_owner.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    desktop_owner.chmod(0o755)
+    stable_owner = core_root / "current-hol-guard"
+    stable_owner.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    stable_owner.chmod(0o755)
+    monkeypatch.setenv("HOL_GUARD_DESKTOP_RUNTIME_OWNER", str(desktop_owner))
+
+    source = _source(tmp_path)
+
+    assert f"const GUARD_CLI_WRAPPER_COMMAND = {json.dumps(str(stable_owner))};" in source
+    assert f"const GUARD_DAEMON_RECOVERY_COMMAND = {json.dumps(str(stable_owner))};" in source
+    assert str(desktop_owner) not in source
+
+
+@pytest.mark.skipif(pi_extension_runtime_ownership.os.name == "nt", reason="POSIX runtime ownership contract")
 def test_managed_extension_rejects_transient_path_when_official_cli_is_absent(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_pi_extension_runtime_ownership.py
+++ b/tests/test_pi_extension_runtime_ownership.py
@@ -95,6 +95,44 @@ def test_managed_extension_maps_versioned_desktop_wrapper_to_stable_launcher(
 
 
 @pytest.mark.skipif(pi_extension_runtime_ownership.os.name == "nt", reason="POSIX runtime ownership contract")
+def test_managed_extension_uses_stable_launcher_while_versioned_owner_is_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    core_root = tmp_path / "core"
+    desktop_owner = core_root / "bundled" / "3.0.63" / "bin" / "hol-guard"
+    stable_owner = core_root / "current-hol-guard"
+    stable_owner.parent.mkdir(parents=True)
+    stable_owner.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    stable_owner.chmod(0o755)
+    monkeypatch.setenv("HOL_GUARD_DESKTOP_RUNTIME_OWNER", str(desktop_owner))
+
+    source = _source(tmp_path)
+
+    assert f"const GUARD_CLI_WRAPPER_COMMAND = {json.dumps(str(stable_owner))};" in source
+
+
+@pytest.mark.skipif(pi_extension_runtime_ownership.os.name == "nt", reason="POSIX runtime ownership contract")
+def test_managed_extension_rejects_versioned_owner_without_stable_launcher(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    official_cli = home / ".local" / "bin" / "hol-guard"
+    official_cli.parent.mkdir(parents=True)
+    official_cli.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    official_cli.chmod(0o755)
+    desktop_owner = tmp_path / "core" / "bundled" / "3.0.63" / "bin" / "hol-guard"
+    desktop_owner.parent.mkdir(parents=True)
+    desktop_owner.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    desktop_owner.chmod(0o755)
+    monkeypatch.setenv("HOL_GUARD_DESKTOP_RUNTIME_OWNER", str(desktop_owner))
+
+    source = _source(tmp_path)
+
+    assert f"const GUARD_CLI_WRAPPER_COMMAND = {json.dumps(str(official_cli))};" in source
+    assert str(desktop_owner) not in source
+
+
+@pytest.mark.skipif(pi_extension_runtime_ownership.os.name == "nt", reason="POSIX runtime ownership contract")
 def test_managed_extension_rejects_transient_path_when_official_cli_is_absent(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- recognize Linux Desktop Core wrappers under the bundled release `bin` directory
- bind generated Pi-family extensions and frozen harness launchers to the stable current-Core launcher
- cover the installed Desktop layout with launcher refresh and runtime ownership regressions

## Testing
- `uv run --no-sync pytest -q tests/test_guard_harness_launcher.py tests/test_guard_shim_refresh.py tests/test_cursor_hook_guard_cli.py tests/test_cursor_hook_rebind.py tests/test_cursor_frozen_hook_command.py tests/test_pi_adapter.py tests/test_pi_extension_runtime_ownership.py tests/test_guard_frozen_daemon_runtime.py tests/test_guard_command_decision_diff.py`
- `uv run --no-sync basedpyright --level error`
- `uv run --no-sync python tests/guard_command_decision_diff.py --check`
- `uv run --no-sync python scripts/ci/code_quality_audit.py --root . --baseline ci/code-quality-baseline.json`
- `uv build`
