### PR TITLE
fix(guard): make setup failures actionable

### DIFF
--- a/dashboard/e2e/extension-authority-recovery.spec.ts
+++ b/dashboard/e2e/extension-authority-recovery.spec.ts
@@ -11,7 +11,7 @@ import {
 const DAEMON = "guardDaemon=http://127.0.0.1:4175";
 const catalogDigest = "a".repeat(64);
 const catalog = { schema_version: "1.0.0", catalog_digest: catalogDigest, extensions: [] };
-const authority = (health: "tampered" | "protected") => ({
+const authority = (health: "tampered" | "protected" | "unenrolled") => ({
   schema_version: "1.0.0",
   health,
   revision: health === "protected" ? 0 : 4,
@@ -22,11 +22,19 @@ const authority = (health: "tampered" | "protected") => ({
   failures: health === "tampered" ? [{ code: "snapshot_missing", detail: "Authority snapshot is missing." }] : [],
 });
 
-async function mountRecoveryFixture(page: Page): Promise<void> {
+async function mountRecoveryFixture(page: Page, setup?: {
+  configured: boolean;
+  enabled: boolean;
+  failSettings: boolean;
+}): Promise<void> {
   let repaired = false;
   await page.route("**/v1/**", async (route) => {
     const request = route.request();
     const path = new URL(request.url()).pathname;
+    if (path.endsWith("/settings") && setup?.failSettings) {
+      await route.fulfill({ status: 503, contentType: "application/json", body: JSON.stringify({ error: "unavailable" }) });
+      return;
+    }
     let body: unknown = {};
     if (path.endsWith("/initialize")) body = { auth_token: "e2e-extension-token" };
     else if (path.endsWith("/runtime")) body = freeStateSnapshot;
@@ -39,15 +47,18 @@ async function mountRecoveryFixture(page: Page): Promise<void> {
         ...defaultSettingsPayload.settings,
         approval_gate: {
           ...defaultSettingsPayload.settings.approval_gate,
-          enabled: true,
-          configured: true,
+          enabled: setup?.enabled ?? true,
+          configured: setup?.configured ?? true,
           totp_enabled: true,
         },
       },
     };
     else if (path.endsWith("/inventory")) body = emptyInventoryPayload;
     else if (path.endsWith("/extension-controls/catalog")) body = catalog;
-    else if (path.endsWith("/extension-controls/effective")) body = authority(repaired ? "protected" : "tampered");
+    else if (path.endsWith("/extension-controls/effective")) {
+      const recoveryHealth = repaired ? "protected" : "tampered";
+      body = authority(setup ? "unenrolled" : recoveryHealth);
+    }
     else if (path.endsWith("/extension-controls/recover-authority")) {
       const payload = request.postDataJSON() as { approval_totp_code?: string };
       if (!payload.approval_totp_code) {
@@ -61,6 +72,31 @@ async function mountRecoveryFixture(page: Page): Promise<void> {
     await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
   });
 }
+
+for (const configured of [false, true]) {
+  test(`enrollment routes ${configured ? "disabled" : "unconfigured"} approval to settings`, async ({ page }) => {
+    const runtimeErrors: string[] = [];
+    page.on("pageerror", (error) => runtimeErrors.push(error.message));
+    await mountRecoveryFixture(page, { configured, enabled: false, failSettings: false });
+    await page.goto(`/extensions?${DAEMON}`);
+    await expect(page.getByRole("heading", { name: "Set up approval before enrollment" })).toBeVisible();
+    await expect(page.getByText("hol-guard command controls enroll", { exact: true })).toHaveCount(0);
+    await page.getByRole("button", { name: "Set up approval", exact: true }).click();
+    await expect(page).toHaveURL(/\/settings\?.*section=approval/);
+    await expect(runtimeErrors).toEqual([]);
+  });
+}
+
+test("enrollment waits for approval lookup and refreshes on Check again", async ({ page }) => {
+  const setup = { configured: true, enabled: true, failSettings: true };
+  await mountRecoveryFixture(page, setup);
+  await page.goto(`/extensions?${DAEMON}`);
+  await expect(page.getByRole("heading", { name: "Checking approval setup" })).toBeVisible();
+  await expect(page.getByText("hol-guard command controls enroll", { exact: true })).toHaveCount(0);
+  setup.failSettings = false;
+  await page.getByRole("button", { name: "Check again", exact: true }).click();
+  await expect(page.getByRole("button", { name: "Copy setup command", exact: true })).toBeVisible();
+});
 
 test("authenticated extension recovery shows progress and reaches protected state", async ({ page }) => {
   const runtimeErrors: string[] = [];

--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -558,7 +558,6 @@ export function App() {
   const handleOpenInsights = useCallback(() => navigate("/evidence?view=insights"), [navigate]);
   const handleOpenCommands = useCallback(() => navigate("/evidence?view=commands"), [navigate]);
   const handleOpenSettings = useCallback(() => navigate("/settings"), []);
-  const handleOpenApprovalSettings = useCallback(() => navigate("/settings?section=approval"), []);
   const handleOpenSupplyChain = useCallback(() => navigate("/supply-chain"), []);
   const handleOpenPolicy = useCallback(() => navigate("/policy"), []);
   const handleOpenHelp = useCallback(() => setHelpOpen(true), []);
@@ -994,10 +993,7 @@ export function App() {
       extensionsContent={
         <ErrorBoundary onReset={handleGoHome}>
           <Suspense fallback={<LazyFallback />}>
-            <ExtensionsWorkspace
-              runtime={runtime.kind === "ready" ? runtime.snapshot : null}
-              onOpenApprovalSettings={handleOpenApprovalSettings}
-            />
+            <ExtensionsWorkspace runtime={runtime.kind === "ready" ? runtime.snapshot : null} onNavigate={navigate} />
           </Suspense>
         </ErrorBoundary>
       }

--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -558,6 +558,7 @@ export function App() {
   const handleOpenInsights = useCallback(() => navigate("/evidence?view=insights"), [navigate]);
   const handleOpenCommands = useCallback(() => navigate("/evidence?view=commands"), [navigate]);
   const handleOpenSettings = useCallback(() => navigate("/settings"), []);
+  const handleOpenApprovalSettings = useCallback(() => navigate("/settings?section=approval"), []);
   const handleOpenSupplyChain = useCallback(() => navigate("/supply-chain"), []);
   const handleOpenPolicy = useCallback(() => navigate("/policy"), []);
   const handleOpenHelp = useCallback(() => setHelpOpen(true), []);
@@ -993,7 +994,10 @@ export function App() {
       extensionsContent={
         <ErrorBoundary onReset={handleGoHome}>
           <Suspense fallback={<LazyFallback />}>
-            <ExtensionsWorkspace runtime={runtime.kind === "ready" ? runtime.snapshot : null} />
+            <ExtensionsWorkspace
+              runtime={runtime.kind === "ready" ? runtime.snapshot : null}
+              onOpenApprovalSettings={handleOpenApprovalSettings}
+            />
           </Suspense>
         </ErrorBoundary>
       }

--- a/dashboard/src/extensions-workspace.test.ts
+++ b/dashboard/src/extensions-workspace.test.ts
@@ -98,6 +98,28 @@ assert.match(approvalSetupMarkup, /Set up approval/);
 assert.doesNotMatch(approvalSetupMarkup, /command controls enroll/);
 assert.doesNotMatch(approvalSetupMarkup, /Copy setup command/);
 
+const disabledApprovalMarkup = renderToStaticMarkup(createElement(ProtectionAuthorityNotice, {
+  effective: { ...baseEffective, health: "unenrolled" },
+  approvalGate: { enabled: false, configured: true, cooldown_seconds: 0, cooldown_active: false, cooldown_expires_at: null, locked_until: null, fail_closed: true, strict_all_decisions: false, totp_enabled: false },
+  onAction: () => undefined,
+  onCheckAgain: () => undefined,
+  onOpenApprovalSettings: () => undefined,
+}));
+assert.match(disabledApprovalMarkup, /Set up approval before enrollment/);
+assert.doesNotMatch(disabledApprovalMarkup, /command controls enroll/);
+
+const pendingApprovalMarkup = renderToStaticMarkup(createElement(ProtectionAuthorityNotice, {
+  effective: { ...baseEffective, health: "unenrolled" },
+  approvalGate: null,
+  onAction: () => undefined,
+  onCheckAgain: () => undefined,
+  onOpenApprovalSettings: () => undefined,
+}));
+assert.match(pendingApprovalMarkup, /Checking approval setup/);
+assert.match(pendingApprovalMarkup, /check again/i);
+assert.doesNotMatch(pendingApprovalMarkup, /command controls enroll/);
+assert.doesNotMatch(pendingApprovalMarkup, /Copy setup command/);
+
 const protectedMarkup = renderToStaticMarkup(createElement(ProtectionAuthorityNotice, {
   effective: { ...baseEffective, health: "protected" },
   approvalGate: { enabled: true, configured: true, cooldown_seconds: 0, cooldown_active: false, cooldown_expires_at: null, locked_until: null, fail_closed: true, strict_all_decisions: false, totp_enabled: false },

--- a/dashboard/src/extensions-workspace.test.ts
+++ b/dashboard/src/extensions-workspace.test.ts
@@ -53,6 +53,7 @@ const repairMarkup = renderToStaticMarkup(createElement(ProtectionAuthorityNotic
   approvalGate: { enabled: true, configured: true, cooldown_seconds: 0, cooldown_active: false, cooldown_expires_at: null, locked_until: null, fail_closed: true, strict_all_decisions: false, totp_enabled: false },
   onAction: () => undefined,
   onCheckAgain: () => undefined,
+  onOpenApprovalSettings: () => undefined,
 }));
 assert.match(repairMarkup, /Protection needs repair/);
 assert.match(repairMarkup, /Repair protection/);
@@ -67,6 +68,7 @@ const degradedAckMarkup = renderToStaticMarkup(createElement(ProtectionAuthority
   approvalGate: { enabled: true, configured: true, cooldown_seconds: 0, cooldown_active: false, cooldown_expires_at: null, locked_until: null, fail_closed: true, strict_all_decisions: false, totp_enabled: false },
   onAction: () => undefined,
   onCheckAgain: () => undefined,
+  onOpenApprovalSettings: () => undefined,
 }));
 assert.match(degradedAckMarkup, /Protection is limited/);
 assert.match(degradedAckMarkup, /Copy repair command/);
@@ -77,17 +79,31 @@ const unenrolledMarkup = renderToStaticMarkup(createElement(ProtectionAuthorityN
   approvalGate: { enabled: true, configured: true, cooldown_seconds: 0, cooldown_active: false, cooldown_expires_at: null, locked_until: null, fail_closed: true, strict_all_decisions: false, totp_enabled: false },
   onAction: () => undefined,
   onCheckAgain: () => undefined,
+  onOpenApprovalSettings: () => undefined,
 }));
 assert.match(unenrolledMarkup, /Finish setting up protection/);
 assert.match(unenrolledMarkup, /command controls enroll/);
 assert.match(unenrolledMarkup, /Copy setup command/);
 assert.doesNotMatch(unenrolledMarkup, /bg-amber-50/, "setup guidance is informational, not a failure");
 
+const approvalSetupMarkup = renderToStaticMarkup(createElement(ProtectionAuthorityNotice, {
+  effective: { ...baseEffective, health: "unenrolled" },
+  approvalGate: { enabled: false, configured: false, cooldown_seconds: 0, cooldown_active: false, cooldown_expires_at: null, locked_until: null, fail_closed: true, strict_all_decisions: false, totp_enabled: false },
+  onAction: () => undefined,
+  onCheckAgain: () => undefined,
+  onOpenApprovalSettings: () => undefined,
+}));
+assert.match(approvalSetupMarkup, /Set up approval before enrollment/);
+assert.match(approvalSetupMarkup, /Set up approval/);
+assert.doesNotMatch(approvalSetupMarkup, /command controls enroll/);
+assert.doesNotMatch(approvalSetupMarkup, /Copy setup command/);
+
 const protectedMarkup = renderToStaticMarkup(createElement(ProtectionAuthorityNotice, {
   effective: { ...baseEffective, health: "protected" },
   approvalGate: { enabled: true, configured: true, cooldown_seconds: 0, cooldown_active: false, cooldown_expires_at: null, locked_until: null, fail_closed: true, strict_all_decisions: false, totp_enabled: false },
   onAction: () => undefined,
   onCheckAgain: () => undefined,
+  onOpenApprovalSettings: () => undefined,
 }));
 assert.equal(protectedMarkup, "", "no authority surface renders when protection is healthy");
 

--- a/dashboard/src/protection-center/components/protection-authority-notice.tsx
+++ b/dashboard/src/protection-center/components/protection-authority-notice.tsx
@@ -31,7 +31,7 @@ type AuthorityNoticeView = {
  */
 function authorityNoticeView(
   health: EffectiveExtensionControls["health"],
-  approvalGateConfigured: boolean | null,
+  approvalGateReady: boolean | null,
 ): AuthorityNoticeView {
   switch (health) {
     case "tampered":
@@ -75,7 +75,21 @@ function authorityNoticeView(
         terminalSummary: "Run this in your terminal to rebuild the trusted settings.",
       };
     default:
-      if (approvalGateConfigured === false) {
+      if (approvalGateReady === null) {
+        return {
+          tone: "info",
+          title: "Checking approval setup",
+          body: "Guard is checking whether this device is ready to enroll trusted protection settings. Enrollment steps will appear when the check finishes. If this takes too long, check again.",
+          action: { kind: "none" },
+          actionLabel: null,
+          actionDetail: null,
+          command: "",
+          commandLabel: "",
+          copyButtonLabel: "",
+          terminalSummary: "",
+        };
+      }
+      if (!approvalGateReady) {
         return {
           tone: "info",
           title: "Set up approval before enrollment",
@@ -115,8 +129,10 @@ export function ProtectionAuthorityNotice(props: {
   onOpenApprovalSettings: () => void;
 }) {
   const health = props.effective.health;
-  if (health === "protected") return null;
-  const view = authorityNoticeView(health, props.approvalGate?.configured ?? null);
+  const approvalGateReady = props.approvalGate === null
+    ? null
+    : props.approvalGate.configured && props.approvalGate.enabled;
+  const view = authorityNoticeView(health, approvalGateReady);
   const [proofOpen, setProofOpen] = useState(false);
   const [pendingAction, setPendingAction] = useState<"repair" | "acknowledge" | null>(null);
   const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle");
@@ -125,6 +141,7 @@ export function ProtectionAuthorityNotice(props: {
   useEffect(() => {
     if (props.status) setProofOpen(false);
   }, [props.status]);
+  if (health === "protected") return null;
   const gatePending = props.approvalGate === null;
 
   const copyCommand = async () => {
@@ -164,7 +181,7 @@ export function ProtectionAuthorityNotice(props: {
             }}
             className="inline-flex min-h-11 items-center rounded-xl bg-brand-blue px-4 text-sm font-semibold text-white hover:bg-brand-dark disabled:opacity-60"
           >{gatePending && !props.error ? "Loading approval settings…" : view.actionLabel}</button> : null}
-          {view.action.kind === "none" ? <button
+          {view.action.kind === "none" && view.command ? <button
             type="button"
             onClick={() => { void copyCommand(); }}
             className="inline-flex min-h-11 items-center gap-2 rounded-xl bg-brand-blue px-4 text-sm font-semibold text-white hover:bg-brand-dark"

--- a/dashboard/src/protection-center/components/protection-authority-notice.tsx
+++ b/dashboard/src/protection-center/components/protection-authority-notice.tsx
@@ -7,6 +7,7 @@ import type { EffectiveExtensionControls } from "../../extension-controls-api";
 export type AuthorityNoticeAction =
   | { kind: "repair" }
   | { kind: "acknowledge" }
+  | { kind: "configure-approval" }
   | { kind: "none" };
 
 type AuthorityNoticeView = {
@@ -28,7 +29,10 @@ type AuthorityNoticeView = {
  * one path forward: a proof-bound dashboard action where the daemon supports
  * it, or the terminal command with a copy button where it does not.
  */
-function authorityNoticeView(health: EffectiveExtensionControls["health"]): AuthorityNoticeView {
+function authorityNoticeView(
+  health: EffectiveExtensionControls["health"],
+  approvalGateConfigured: boolean | null,
+): AuthorityNoticeView {
   switch (health) {
     case "tampered":
     case "recovery-required":
@@ -71,6 +75,20 @@ function authorityNoticeView(health: EffectiveExtensionControls["health"]): Auth
         terminalSummary: "Run this in your terminal to rebuild the trusted settings.",
       };
     default:
+      if (approvalGateConfigured === false) {
+        return {
+          tone: "info",
+          title: "Set up approval before enrollment",
+          body: "Extension controls require a local approval password or Authenticator before this device can create trusted protection settings. Set up approval first, then return here to enroll.",
+          action: { kind: "configure-approval" },
+          actionLabel: "Set up approval",
+          actionDetail: null,
+          command: "",
+          commandLabel: "",
+          copyButtonLabel: "",
+          terminalSummary: "",
+        };
+      }
       return {
         tone: "info",
         title: "Finish setting up protection",
@@ -94,10 +112,11 @@ export function ProtectionAuthorityNotice(props: {
   approvalGate: Parameters<typeof ApprovalProofModal>[0]["approvalGate"];
   onAction: (kind: "repair" | "acknowledge", credentials: { approval_password?: string; approval_totp_code?: string }) => void;
   onCheckAgain: () => void;
+  onOpenApprovalSettings: () => void;
 }) {
   const health = props.effective.health;
   if (health === "protected") return null;
-  const view = authorityNoticeView(health);
+  const view = authorityNoticeView(health, props.approvalGate?.configured ?? null);
   const [proofOpen, setProofOpen] = useState(false);
   const [pendingAction, setPendingAction] = useState<"repair" | "acknowledge" | null>(null);
   const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle");
@@ -135,7 +154,14 @@ export function ProtectionAuthorityNotice(props: {
             type="button"
             aria-busy={props.busy}
             disabled={props.busy || gatePending}
-            onClick={() => { setPendingAction(view.action.kind === "repair" ? "repair" : "acknowledge"); setProofOpen(true); }}
+            onClick={() => {
+              if (view.action.kind === "configure-approval") {
+                props.onOpenApprovalSettings();
+                return;
+              }
+              setPendingAction(view.action.kind === "repair" ? "repair" : "acknowledge");
+              setProofOpen(true);
+            }}
             className="inline-flex min-h-11 items-center rounded-xl bg-brand-blue px-4 text-sm font-semibold text-white hover:bg-brand-dark disabled:opacity-60"
           >{gatePending && !props.error ? "Loading approval settings…" : view.actionLabel}</button> : null}
           {view.action.kind === "none" ? <button
@@ -153,7 +179,7 @@ export function ProtectionAuthorityNotice(props: {
         {props.busy ? <p role="status" className={`mt-3 text-sm font-medium ${warning ? "text-amber-950" : "text-brand-dark"}`}>{pendingAction === "acknowledge" ? "Confirming the limited state…" : "Repairing local protection…"}</p> : null}
         {props.error ? <p role="alert" className="mt-3 rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800">{props.error}</p> : null}
         {props.status ? <p role="status" className="mt-3 text-sm font-medium text-brand-dark">{props.status}</p> : null}
-        <details className="mt-4">
+        {view.command ? <details className="mt-4">
           <summary className={`cursor-pointer text-sm font-semibold ${warning ? "text-amber-950" : "text-brand-dark"}`}>{view.commandLabel}</summary>
           <p className={`mt-2 text-sm leading-6 ${warning ? "text-amber-950/80" : "text-brand-dark/70"}`}>{view.terminalSummary}</p>
           <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center">
@@ -164,10 +190,10 @@ export function ProtectionAuthorityNotice(props: {
               className="inline-flex min-h-11 shrink-0 items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 text-sm font-semibold text-brand-blue hover:border-brand-blue/40"
             >{copyState === "copied" ? <HiMiniClipboardDocumentCheck className="size-4" aria-hidden="true" /> : <HiMiniClipboard className="size-4" aria-hidden="true" />}{copyState === "copied" ? "Copied" : "Copy command"}</button>
           </div>
-        </details>
+        </details> : null}
       </div>
     </div>
-    {proofOpen && view.action.kind !== "none" ? <ApprovalProofModal
+    {proofOpen && (view.action.kind === "repair" || view.action.kind === "acknowledge") ? <ApprovalProofModal
       title={view.action.kind === "repair" ? "Repair protection" : "Acknowledge limited state"}
       detail={view.actionDetail ?? ""}
       confirmLabel={view.actionLabel ?? "Confirm"}

--- a/dashboard/src/protection-center/protection-center-workspace.tsx
+++ b/dashboard/src/protection-center/protection-center-workspace.tsx
@@ -126,7 +126,7 @@ export function buildExtensionMutation(
 
 export function ProtectionCenterWorkspace(props: {
   runtime?: GuardRuntimeSnapshot | null;
-  onOpenApprovalSettings: () => void;
+  onNavigate: (path: string) => void;
 }) {
   const [state, setState] = useState<LoadState>({ kind: "loading" });
   const [routeState, setRouteState] = useState<RouteState>(() => currentExtensionRouteState());
@@ -136,7 +136,7 @@ export function ProtectionCenterWorkspace(props: {
   const [recoveryBusy, setRecoveryBusy] = useState(false);
   const [recoveryError, setRecoveryError] = useState<string | null>(null);
   const [recoveryStatus, setRecoveryStatus] = useState<string | null>(null);
-  const { resolvedApprovalGate, resolveApprovalGate } = useResolvedApprovalGate(null);
+  const { resolvedApprovalGate, resolveApprovalGate, refreshApprovalGate } = useResolvedApprovalGate(null);
   const aliasRedirected = useRef<string | null>(null);
   const overviewKeepAlive = useRef(false);
   const localClis = useLocalCliCatalog();
@@ -301,10 +301,14 @@ export function ProtectionCenterWorkspace(props: {
   const handleCheckAgain = useCallback(() => {
     void load();
     setRecoveryError(null);
-    void resolveApprovalGate({ failClosed: true }).catch(() => {
+    void refreshApprovalGate({ failClosed: true }).catch(() => {
       setRecoveryError("Guard could not load the local approval settings yet. Check the connection and try again, or run `hol-guard command controls recover-authority` in your terminal.");
     });
-  }, [load, resolveApprovalGate]);
+  }, [load, refreshApprovalGate]);
+
+  const handleOpenApprovalSettings = useCallback(() => {
+    props.onNavigate("/settings?section=approval");
+  }, [props.onNavigate]);
 
   const authorityNeedsAttention = state.kind === "ready" && state.effective.health !== "protected";
   useEffect(() => {
@@ -350,7 +354,7 @@ export function ProtectionCenterWorkspace(props: {
           approvalGate={resolvedApprovalGate}
           onAction={handleAuthorityAction}
           onCheckAgain={handleCheckAgain}
-          onOpenApprovalSettings={props.onOpenApprovalSettings}
+          onOpenApprovalSettings={handleOpenApprovalSettings}
         />
       ) : null}
       {state.kind === "ready" && recoveryStatus && !healthBroken && !showOverview ? (

--- a/dashboard/src/protection-center/protection-center-workspace.tsx
+++ b/dashboard/src/protection-center/protection-center-workspace.tsx
@@ -124,7 +124,10 @@ export function buildExtensionMutation(
   };
 }
 
-export function ProtectionCenterWorkspace(props: { runtime?: GuardRuntimeSnapshot | null }) {
+export function ProtectionCenterWorkspace(props: {
+  runtime?: GuardRuntimeSnapshot | null;
+  onOpenApprovalSettings: () => void;
+}) {
   const [state, setState] = useState<LoadState>({ kind: "loading" });
   const [routeState, setRouteState] = useState<RouteState>(() => currentExtensionRouteState());
   const [pending, setPending] = useState<ProtectionPendingChange | null>(null);
@@ -347,6 +350,7 @@ export function ProtectionCenterWorkspace(props: { runtime?: GuardRuntimeSnapsho
           approvalGate={resolvedApprovalGate}
           onAction={handleAuthorityAction}
           onCheckAgain={handleCheckAgain}
+          onOpenApprovalSettings={props.onOpenApprovalSettings}
         />
       ) : null}
       {state.kind === "ready" && recoveryStatus && !healthBroken && !showOverview ? (

--- a/dashboard/src/secondary-risk-dedupe.test.ts
+++ b/dashboard/src/secondary-risk-dedupe.test.ts
@@ -36,6 +36,30 @@ const COMPOUND_SHELL_PRIMARY_DETAIL =
 const definitionSummary = "Guard reviewed the definition at /workspace/.omp/skills/memory/SKILL.md. No separate shell launch command was recorded for this item.";
 assert.equal(resolveStoppedCommandText({ ...BASE_REQUEST, artifact_type: "skill", launch_summary: definitionSummary }), definitionSummary);
 
+const NATIVE_TOOL_ACTION_REQUEST: GuardApprovalRequest = {
+  ...BASE_REQUEST,
+  artifact_type: "tool_action_request",
+  launch_target: "Requested `bash` action `rm -f /workspace/project/output.txt` (Destructive shell command).",
+  launch_summary: "Launches with `rm -f /workspace/project/output.txt`.",
+};
+assert.equal(
+  resolveStoppedCommandText(NATIVE_TOOL_ACTION_REQUEST),
+  "rm -f /workspace/project/output.txt",
+  "SRD-00: dashboard prefers the full native command over a nested request summary target",
+);
+
+const LONG_NATIVE_COMMAND = `rm -f ${"x".repeat(200)}`;
+assert.equal(
+  resolveStoppedCommandText({
+    ...BASE_REQUEST,
+    artifact_type: "tool_action_request",
+    launch_target: LONG_NATIVE_COMMAND,
+    launch_summary: `Launches with \`${LONG_NATIVE_COMMAND.slice(0, 139)}…\`.`,
+  }),
+  LONG_NATIVE_COMMAND,
+  "SRD-00b: dashboard preserves a full structured native command over a truncated prose summary",
+);
+
 const COMPOUND_FINDINGS_DUPLICATE_RISK_REQUEST: GuardApprovalRequest = {
   ...BASE_REQUEST,
   request_id: "srd-compound-findings-duplicate-risk",

--- a/dashboard/src/secondary-risk-dedupe.test.ts
+++ b/dashboard/src/secondary-risk-dedupe.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import type { GuardApprovalRequest } from "./guard-types";
-import { resolveSecondaryRiskSummary } from "./secondary-risk-dedupe";
+import { resolveSecondaryRiskSummary, resolveStoppedCommandText } from "./secondary-risk-dedupe";
 
 const BASE_REQUEST: GuardApprovalRequest = {
   request_id: "srd-req-1",
@@ -32,6 +32,9 @@ const BASE_REQUEST: GuardApprovalRequest = {
 
 const COMPOUND_SHELL_PRIMARY_DETAIL =
   "Sensitive native tool action (unresolved shell execution context): Guard could not prove the working directory for every shell segment and requires one conservative decision before the user confirms execution (shell_cwd_workspace_escape). Use a literal, existing in-workspace directory with deterministic cd/pushd/popd control flow, or run the command from the intended directory.";
+
+const definitionSummary = "Guard reviewed the definition at /workspace/.omp/skills/memory/SKILL.md. No separate shell launch command was recorded for this item.";
+assert.equal(resolveStoppedCommandText({ ...BASE_REQUEST, artifact_type: "skill", launch_summary: definitionSummary }), definitionSummary);
 
 const COMPOUND_FINDINGS_DUPLICATE_RISK_REQUEST: GuardApprovalRequest = {
   ...BASE_REQUEST,

--- a/dashboard/src/secondary-risk-dedupe.test.ts
+++ b/dashboard/src/secondary-risk-dedupe.test.ts
@@ -47,6 +47,14 @@ assert.equal(
   "rm -f /workspace/project/output.txt",
   "SRD-00: dashboard prefers the full native command over a nested request summary target",
 );
+assert.equal(
+  resolveStoppedCommandText({
+    ...NATIVE_TOOL_ACTION_REQUEST,
+    launch_summary: "  Launches with `rm -f /workspace/project/output.txt`.  ",
+  }),
+  "rm -f /workspace/project/output.txt",
+  "SRD-00a: dashboard trims padded native launch summaries before extraction",
+);
 
 const LONG_NATIVE_COMMAND = `rm -f ${"x".repeat(200)}`;
 assert.equal(

--- a/dashboard/src/secondary-risk-dedupe.ts
+++ b/dashboard/src/secondary-risk-dedupe.ts
@@ -63,8 +63,19 @@ export function resolveStoppedCommandText(item: GuardApprovalRequest): string {
       return envelopeText;
     }
   }
-  if (item.launch_target?.trim()) {
-    return item.launch_target;
+  const launchTarget = item.launch_target?.trim();
+  const launchTargetIsRequestSummary =
+    item.artifact_type === "tool_action_request" &&
+    launchTarget?.startsWith("Requested `") &&
+    launchTarget.includes(" action `");
+  if (launchTargetIsRequestSummary && item.launch_summary?.trim()) {
+    const launchSummaryCommand = item.launch_summary.match(/^Launches with `(.+)`\.$/);
+    if (launchSummaryCommand?.[1]) {
+      return launchSummaryCommand[1];
+    }
+  }
+  if (launchTarget) {
+    return launchTarget;
   }
   if (item.launch_summary?.trim()) {
     const commandMatch = item.launch_summary.match(/`([^`]+)`/);

--- a/dashboard/src/secondary-risk-dedupe.ts
+++ b/dashboard/src/secondary-risk-dedupe.ts
@@ -68,8 +68,9 @@ export function resolveStoppedCommandText(item: GuardApprovalRequest): string {
     item.artifact_type === "tool_action_request" &&
     launchTarget?.startsWith("Requested `") &&
     launchTarget.includes(" action `");
-  if (launchTargetIsRequestSummary && item.launch_summary?.trim()) {
-    const launchSummaryCommand = item.launch_summary.match(/^Launches with `(.+)`\.$/);
+  const launchSummary = item.launch_summary?.trim();
+  if (launchTargetIsRequestSummary && launchSummary) {
+    const launchSummaryCommand = launchSummary.match(/^Launches with `(.+)`\.$/);
     if (launchSummaryCommand?.[1]) {
       return launchSummaryCommand[1];
     }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
@@ -4058,7 +4058,7 @@ function protectionCenterLoadError(message) {
     detail: message.trim() || "Guard could not load protection settings. Local protection continues. Try again."
   };
 }
-function authorityNoticeView(health) {
+function authorityNoticeView(health, approvalGateConfigured) {
   switch (health) {
     case "tampered":
     case "recovery-required":
@@ -4101,6 +4101,20 @@ function authorityNoticeView(health) {
         terminalSummary: "Run this in your terminal to rebuild the trusted settings."
       };
     default:
+      if (approvalGateConfigured === false) {
+        return {
+          tone: "info",
+          title: "Set up approval before enrollment",
+          body: "Extension controls require a local approval password or Authenticator before this device can create trusted protection settings. Set up approval first, then return here to enroll.",
+          action: { kind: "configure-approval" },
+          actionLabel: "Set up approval",
+          actionDetail: null,
+          command: "",
+          commandLabel: "",
+          copyButtonLabel: "",
+          terminalSummary: ""
+        };
+      }
       return {
         tone: "info",
         title: "Finish setting up protection",
@@ -4118,7 +4132,7 @@ function authorityNoticeView(health) {
 function ProtectionAuthorityNotice(props) {
   const health = props.effective.health;
   if (health === "protected") return null;
-  const view = authorityNoticeView(health);
+  const view = authorityNoticeView(health, props.approvalGate?.configured ?? null);
   const [proofOpen, setProofOpen] = reactExports.useState(false);
   const [pendingAction, setPendingAction] = reactExports.useState(null);
   const [copyState, setCopyState] = reactExports.useState("idle");
@@ -4150,6 +4164,10 @@ function ProtectionAuthorityNotice(props) {
               "aria-busy": props.busy,
               disabled: props.busy || gatePending,
               onClick: () => {
+                if (view.action.kind === "configure-approval") {
+                  props.onOpenApprovalSettings();
+                  return;
+                }
                 setPendingAction(view.action.kind === "repair" ? "repair" : "acknowledge");
                 setProofOpen(true);
               },
@@ -4185,7 +4203,7 @@ function ProtectionAuthorityNotice(props) {
         props.busy ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { role: "status", className: `mt-3 text-sm font-medium ${warning2 ? "text-amber-950" : "text-brand-dark"}`, children: pendingAction === "acknowledge" ? "Confirming the limited state…" : "Repairing local protection…" }) : null,
         props.error ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { role: "alert", className: "mt-3 rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800", children: props.error }) : null,
         props.status ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { role: "status", className: "mt-3 text-sm font-medium text-brand-dark", children: props.status }) : null,
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("details", { className: "mt-4", children: [
+        view.command ? /* @__PURE__ */ jsxRuntimeExports.jsxs("details", { className: "mt-4", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("summary", { className: `cursor-pointer text-sm font-semibold ${warning2 ? "text-amber-950" : "text-brand-dark"}`, children: view.commandLabel }),
           /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: `mt-2 text-sm leading-6 ${warning2 ? "text-amber-950/80" : "text-brand-dark/70"}`, children: view.terminalSummary }),
           /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-2 flex flex-col gap-2 sm:flex-row sm:items-center", children: [
@@ -4205,10 +4223,10 @@ function ProtectionAuthorityNotice(props) {
               }
             )
           ] })
-        ] })
+        ] }) : null
       ] })
     ] }),
-    proofOpen && view.action.kind !== "none" ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+    proofOpen && (view.action.kind === "repair" || view.action.kind === "acknowledge") ? /* @__PURE__ */ jsxRuntimeExports.jsx(
       ApprovalProofModal,
       {
         title: view.action.kind === "repair" ? "Repair protection" : "Acknowledge limited state",
@@ -5893,7 +5911,8 @@ function ProtectionCenterWorkspace(props) {
         status: recoveryStatus,
         approvalGate: resolvedApprovalGate,
         onAction: handleAuthorityAction,
-        onCheckAgain: handleCheckAgain
+        onCheckAgain: handleCheckAgain,
+        onOpenApprovalSettings: props.onOpenApprovalSettings
       }
     ) : null,
     state.kind === "ready" && recoveryStatus && !healthBroken && !showOverview ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { role: "status", className: "mb-3 text-sm font-medium text-emerald-800", children: recoveryStatus }) : null,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
@@ -4058,7 +4058,7 @@ function protectionCenterLoadError(message) {
     detail: message.trim() || "Guard could not load protection settings. Local protection continues. Try again."
   };
 }
-function authorityNoticeView(health, approvalGateConfigured) {
+function authorityNoticeView(health, approvalGateReady) {
   switch (health) {
     case "tampered":
     case "recovery-required":
@@ -4101,7 +4101,21 @@ function authorityNoticeView(health, approvalGateConfigured) {
         terminalSummary: "Run this in your terminal to rebuild the trusted settings."
       };
     default:
-      if (approvalGateConfigured === false) {
+      if (approvalGateReady === null) {
+        return {
+          tone: "info",
+          title: "Checking approval setup",
+          body: "Guard is checking whether this device is ready to enroll trusted protection settings. Enrollment steps will appear when the check finishes. If this takes too long, check again.",
+          action: { kind: "none" },
+          actionLabel: null,
+          actionDetail: null,
+          command: "",
+          commandLabel: "",
+          copyButtonLabel: "",
+          terminalSummary: ""
+        };
+      }
+      if (!approvalGateReady) {
         return {
           tone: "info",
           title: "Set up approval before enrollment",
@@ -4131,14 +4145,15 @@ function authorityNoticeView(health, approvalGateConfigured) {
 }
 function ProtectionAuthorityNotice(props) {
   const health = props.effective.health;
-  if (health === "protected") return null;
-  const view = authorityNoticeView(health, props.approvalGate?.configured ?? null);
+  const approvalGateReady = props.approvalGate === null ? null : props.approvalGate.configured && props.approvalGate.enabled;
+  const view = authorityNoticeView(health, approvalGateReady);
   const [proofOpen, setProofOpen] = reactExports.useState(false);
   const [pendingAction, setPendingAction] = reactExports.useState(null);
   const [copyState, setCopyState] = reactExports.useState("idle");
   reactExports.useEffect(() => {
     if (props.status) setProofOpen(false);
   }, [props.status]);
+  if (health === "protected") return null;
   const gatePending = props.approvalGate === null;
   const copyCommand = async () => {
     try {
@@ -4175,7 +4190,7 @@ function ProtectionAuthorityNotice(props) {
               children: gatePending && !props.error ? "Loading approval settings…" : view.actionLabel
             }
           ) : null,
-          view.action.kind === "none" ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          view.action.kind === "none" && view.command ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
             "button",
             {
               type: "button",
@@ -5730,7 +5745,7 @@ function ProtectionCenterWorkspace(props) {
   const [recoveryBusy, setRecoveryBusy] = reactExports.useState(false);
   const [recoveryError, setRecoveryError] = reactExports.useState(null);
   const [recoveryStatus, setRecoveryStatus] = reactExports.useState(null);
-  const { resolvedApprovalGate, resolveApprovalGate } = useResolvedApprovalGate(null);
+  const { resolvedApprovalGate, resolveApprovalGate, refreshApprovalGate } = useResolvedApprovalGate(null);
   const aliasRedirected = reactExports.useRef(null);
   const overviewKeepAlive = reactExports.useRef(false);
   const localClis = useLocalCliCatalog();
@@ -5874,10 +5889,13 @@ function ProtectionCenterWorkspace(props) {
   const handleCheckAgain = reactExports.useCallback(() => {
     void load();
     setRecoveryError(null);
-    void resolveApprovalGate({ failClosed: true }).catch(() => {
+    void refreshApprovalGate({ failClosed: true }).catch(() => {
       setRecoveryError("Guard could not load the local approval settings yet. Check the connection and try again, or run `hol-guard command controls recover-authority` in your terminal.");
     });
-  }, [load, resolveApprovalGate]);
+  }, [load, refreshApprovalGate]);
+  const handleOpenApprovalSettings = reactExports.useCallback(() => {
+    props.onNavigate("/settings?section=approval");
+  }, [props.onNavigate]);
   const authorityNeedsAttention = state.kind === "ready" && state.effective.health !== "protected";
   reactExports.useEffect(() => {
     if (!authorityNeedsAttention) return;
@@ -5912,7 +5930,7 @@ function ProtectionCenterWorkspace(props) {
         approvalGate: resolvedApprovalGate,
         onAction: handleAuthorityAction,
         onCheckAgain: handleCheckAgain,
-        onOpenApprovalSettings: props.onOpenApprovalSettings
+        onOpenApprovalSettings: handleOpenApprovalSettings
       }
     ) : null,
     state.kind === "ready" && recoveryStatus && !healthBroken && !showOverview ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { role: "status", className: "mb-3 text-sm font-medium text-emerald-800", children: recoveryStatus }) : null,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -14635,8 +14635,9 @@ function resolveStoppedCommandText(item) {
   }
   const launchTarget = item.launch_target?.trim();
   const launchTargetIsRequestSummary = item.artifact_type === "tool_action_request" && launchTarget?.startsWith("Requested `") && launchTarget.includes(" action `");
-  if (launchTargetIsRequestSummary && item.launch_summary?.trim()) {
-    const launchSummaryCommand = item.launch_summary.match(/^Launches with `(.+)`\.$/);
+  const launchSummary = item.launch_summary?.trim();
+  if (launchTargetIsRequestSummary && launchSummary) {
+    const launchSummaryCommand = launchSummary.match(/^Launches with `(.+)`\.$/);
     if (launchSummaryCommand?.[1]) {
       return launchSummaryCommand[1];
     }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -14633,8 +14633,16 @@ function resolveStoppedCommandText(item) {
       return envelopeText;
     }
   }
-  if (item.launch_target?.trim()) {
-    return item.launch_target;
+  const launchTarget = item.launch_target?.trim();
+  const launchTargetIsRequestSummary = item.artifact_type === "tool_action_request" && launchTarget?.startsWith("Requested `") && launchTarget.includes(" action `");
+  if (launchTargetIsRequestSummary && item.launch_summary?.trim()) {
+    const launchSummaryCommand = item.launch_summary.match(/^Launches with `(.+)`\.$/);
+    if (launchSummaryCommand?.[1]) {
+      return launchSummaryCommand[1];
+    }
+  }
+  if (launchTarget) {
+    return launchTarget;
   }
   if (item.launch_summary?.trim()) {
     const commandMatch = item.launch_summary.match(/`([^`]+)`/);

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -31598,7 +31598,6 @@ function App() {
   const handleOpenInsights = reactExports.useCallback(() => navigate("/evidence?view=insights"), [navigate]);
   const handleOpenCommands = reactExports.useCallback(() => navigate("/evidence?view=commands"), [navigate]);
   const handleOpenSettings = reactExports.useCallback(() => navigate("/settings"), []);
-  const handleOpenApprovalSettings = reactExports.useCallback(() => navigate("/settings?section=approval"), []);
   const handleOpenSupplyChain = reactExports.useCallback(() => navigate("/supply-chain"), []);
   reactExports.useCallback(() => navigate("/policy"), []);
   const handleOpenHelp = reactExports.useCallback(() => setHelpOpen(true), []);
@@ -31973,13 +31972,7 @@ function App() {
           }
         ) }) : null,
         appDetailContent: /* @__PURE__ */ jsxRuntimeExports.jsx(ErrorBoundary, { onReset: handleGoHome, children: /* @__PURE__ */ jsxRuntimeExports.jsx(reactExports.Suspense, { fallback: /* @__PURE__ */ jsxRuntimeExports.jsx(LazyFallback, {}), children: appDetailContent }) }),
-        extensionsContent: /* @__PURE__ */ jsxRuntimeExports.jsx(ErrorBoundary, { onReset: handleGoHome, children: /* @__PURE__ */ jsxRuntimeExports.jsx(reactExports.Suspense, { fallback: /* @__PURE__ */ jsxRuntimeExports.jsx(LazyFallback, {}), children: /* @__PURE__ */ jsxRuntimeExports.jsx(
-          ExtensionsWorkspace,
-          {
-            runtime: runtime.kind === "ready" ? runtime.snapshot : null,
-            onOpenApprovalSettings: handleOpenApprovalSettings
-          }
-        ) }) }),
+        extensionsContent: /* @__PURE__ */ jsxRuntimeExports.jsx(ErrorBoundary, { onReset: handleGoHome, children: /* @__PURE__ */ jsxRuntimeExports.jsx(reactExports.Suspense, { fallback: /* @__PURE__ */ jsxRuntimeExports.jsx(LazyFallback, {}), children: /* @__PURE__ */ jsxRuntimeExports.jsx(ExtensionsWorkspace, { runtime: runtime.kind === "ready" ? runtime.snapshot : null, onNavigate: navigate }) }) }),
         settingsContent: /* @__PURE__ */ jsxRuntimeExports.jsx(reactExports.Suspense, { fallback: /* @__PURE__ */ jsxRuntimeExports.jsx(LazyFallback, {}), children: /* @__PURE__ */ jsxRuntimeExports.jsx(SettingsWorkspace, { onApprovalGateChange: setApprovalGate }) }),
         supplyChainHubContent: runtime.kind === "ready" ? /* @__PURE__ */ jsxRuntimeExports.jsx(reactExports.Suspense, { fallback: /* @__PURE__ */ jsxRuntimeExports.jsx(LazyFallback, {}), children: /* @__PURE__ */ jsxRuntimeExports.jsx(
           SupplyChainHubWorkspace,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -31598,6 +31598,7 @@ function App() {
   const handleOpenInsights = reactExports.useCallback(() => navigate("/evidence?view=insights"), [navigate]);
   const handleOpenCommands = reactExports.useCallback(() => navigate("/evidence?view=commands"), [navigate]);
   const handleOpenSettings = reactExports.useCallback(() => navigate("/settings"), []);
+  const handleOpenApprovalSettings = reactExports.useCallback(() => navigate("/settings?section=approval"), []);
   const handleOpenSupplyChain = reactExports.useCallback(() => navigate("/supply-chain"), []);
   reactExports.useCallback(() => navigate("/policy"), []);
   const handleOpenHelp = reactExports.useCallback(() => setHelpOpen(true), []);
@@ -31972,7 +31973,13 @@ function App() {
           }
         ) }) : null,
         appDetailContent: /* @__PURE__ */ jsxRuntimeExports.jsx(ErrorBoundary, { onReset: handleGoHome, children: /* @__PURE__ */ jsxRuntimeExports.jsx(reactExports.Suspense, { fallback: /* @__PURE__ */ jsxRuntimeExports.jsx(LazyFallback, {}), children: appDetailContent }) }),
-        extensionsContent: /* @__PURE__ */ jsxRuntimeExports.jsx(ErrorBoundary, { onReset: handleGoHome, children: /* @__PURE__ */ jsxRuntimeExports.jsx(reactExports.Suspense, { fallback: /* @__PURE__ */ jsxRuntimeExports.jsx(LazyFallback, {}), children: /* @__PURE__ */ jsxRuntimeExports.jsx(ExtensionsWorkspace, { runtime: runtime.kind === "ready" ? runtime.snapshot : null }) }) }),
+        extensionsContent: /* @__PURE__ */ jsxRuntimeExports.jsx(ErrorBoundary, { onReset: handleGoHome, children: /* @__PURE__ */ jsxRuntimeExports.jsx(reactExports.Suspense, { fallback: /* @__PURE__ */ jsxRuntimeExports.jsx(LazyFallback, {}), children: /* @__PURE__ */ jsxRuntimeExports.jsx(
+          ExtensionsWorkspace,
+          {
+            runtime: runtime.kind === "ready" ? runtime.snapshot : null,
+            onOpenApprovalSettings: handleOpenApprovalSettings
+          }
+        ) }) }),
         settingsContent: /* @__PURE__ */ jsxRuntimeExports.jsx(reactExports.Suspense, { fallback: /* @__PURE__ */ jsxRuntimeExports.jsx(LazyFallback, {}), children: /* @__PURE__ */ jsxRuntimeExports.jsx(SettingsWorkspace, { onApprovalGateChange: setApprovalGate }) }),
         supplyChainHubContent: runtime.kind === "ready" ? /* @__PURE__ */ jsxRuntimeExports.jsx(reactExports.Suspense, { fallback: /* @__PURE__ */ jsxRuntimeExports.jsx(LazyFallback, {}), children: /* @__PURE__ */ jsxRuntimeExports.jsx(
           SupplyChainHubWorkspace,

--- a/src/codex_plugin_scanner/guard/incident.py
+++ b/src/codex_plugin_scanner/guard/incident.py
@@ -240,12 +240,12 @@ def _launch_summary(
                 return prompt_summary
         if artifact_type != "tool_call" or artifact is None or "mcp_tool_identity" in artifact.metadata:
             return "Guard reviewed this interaction directly. No shell launch command was recorded."
+    if artifact_type == "tool_action_request" and artifact is not None and artifact.command:
+        command_parts = [artifact.command, *artifact.args]
+        return f"Launches with `{_truncate(' '.join(command_parts))}`."
     if launch_target:
         return f"Launches with `{_truncate(launch_target)}`."
     if artifact is not None:
-        if artifact_type == "tool_action_request" and artifact.command:
-            command_parts = [artifact.command, *artifact.args]
-            return f"Launches with `{_truncate(' '.join(command_parts))}`."
         request_summary = artifact.metadata.get("request_summary")
         if isinstance(request_summary, str) and request_summary:
             return request_summary

--- a/src/codex_plugin_scanner/guard/incident.py
+++ b/src/codex_plugin_scanner/guard/incident.py
@@ -34,6 +34,10 @@ _ARTIFACT_LABELS = {
     "artifact": "Artifact",
 }
 
+_DIRECT_INTERACTION_ARTIFACT_TYPES = frozenset(
+    {"tool_call", "tool_action_request", "file_read_request", "prompt_request"}
+)
+
 
 def build_incident_context(
     *,
@@ -226,6 +230,15 @@ def _launch_summary(
     artifact_type: str | None,
     config_path: str | None,
 ) -> str:
+    if artifact_type in _DIRECT_INTERACTION_ARTIFACT_TYPES:
+        if artifact is not None:
+            request_summary = artifact.metadata.get("request_summary")
+            if isinstance(request_summary, str) and request_summary:
+                return request_summary
+            prompt_summary = artifact.metadata.get("prompt_summary")
+            if isinstance(prompt_summary, str) and prompt_summary:
+                return prompt_summary
+        return "Guard reviewed this interaction directly. No shell launch command was recorded."
     if launch_target:
         return f"Launches with `{_truncate(launch_target)}`."
     if artifact is not None:
@@ -245,8 +258,6 @@ def _launch_summary(
             f"Guard reviewed the definition at {_short_config_path(config_path)}. "
             "No separate shell launch command was recorded for this item."
         )
-    if artifact_type in {"tool_call", "tool_action_request", "file_read_request", "prompt_request"}:
-        return "Guard reviewed this interaction directly. No shell launch command was recorded."
     return "Guard reviewed this item directly. No shell launch command was recorded."
 
 

--- a/src/codex_plugin_scanner/guard/incident.py
+++ b/src/codex_plugin_scanner/guard/incident.py
@@ -242,11 +242,11 @@ def _launch_summary(
             return f"Launches with `{_truncate(' '.join(command_parts))}`."
     if config_path:
         return (
-            f"Guard reviewed the definition at `{_short_config_path(config_path)}`. "
+            f"Guard reviewed the definition at {_short_config_path(config_path)}. "
             "No separate shell launch command was recorded for this item."
         )
     if artifact_type in {"tool_call", "tool_action_request", "file_read_request", "prompt_request"}:
-        return "Guard reviewed this interaction directly; it did not use a shell launch command."
+        return "Guard reviewed this interaction directly. No shell launch command was recorded."
     return "Guard reviewed this item directly. No shell launch command was recorded."
 
 

--- a/src/codex_plugin_scanner/guard/incident.py
+++ b/src/codex_plugin_scanner/guard/incident.py
@@ -35,7 +35,7 @@ _ARTIFACT_LABELS = {
 }
 
 _DIRECT_INTERACTION_ARTIFACT_TYPES = frozenset(
-    {"tool_call", "tool_action_request", "file_read_request", "prompt_request"}
+    {"tool_call", "file_read_request", "prompt_request"}
 )
 
 
@@ -238,10 +238,14 @@ def _launch_summary(
             prompt_summary = artifact.metadata.get("prompt_summary")
             if isinstance(prompt_summary, str) and prompt_summary:
                 return prompt_summary
-        return "Guard reviewed this interaction directly. No shell launch command was recorded."
+        if artifact_type != "tool_call" or artifact is None or "mcp_tool_identity" in artifact.metadata:
+            return "Guard reviewed this interaction directly. No shell launch command was recorded."
     if launch_target:
         return f"Launches with `{_truncate(launch_target)}`."
     if artifact is not None:
+        if artifact_type == "tool_action_request" and artifact.command:
+            command_parts = [artifact.command, *artifact.args]
+            return f"Launches with `{_truncate(' '.join(command_parts))}`."
         request_summary = artifact.metadata.get("request_summary")
         if isinstance(request_summary, str) and request_summary:
             return request_summary

--- a/src/codex_plugin_scanner/guard/incident.py
+++ b/src/codex_plugin_scanner/guard/incident.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from .models import GuardAction, GuardArtifact
+from .redaction import redact_text
 
 _HARNESS_LABELS = {
     "codex": "Codex",
@@ -34,9 +35,7 @@ _ARTIFACT_LABELS = {
     "artifact": "Artifact",
 }
 
-_DIRECT_INTERACTION_ARTIFACT_TYPES = frozenset(
-    {"tool_call", "file_read_request", "prompt_request"}
-)
+_DIRECT_INTERACTION_ARTIFACT_TYPES = frozenset({"tool_call", "file_read_request", "prompt_request"})
 
 
 def build_incident_context(
@@ -242,8 +241,10 @@ def _launch_summary(
             return "Guard reviewed this interaction directly. No shell launch command was recorded."
     if artifact_type == "tool_action_request" and artifact is not None and artifact.command:
         command_parts = [artifact.command, *artifact.args]
-        return f"Launches with `{_truncate(' '.join(command_parts))}`."
+        return f"Launches with `{_redacted_command(command_parts)}`."
     if launch_target:
+        if artifact_type == "tool_action_request":
+            return f"Launches with `{redact_text(launch_target).text}`."
         return f"Launches with `{_truncate(launch_target)}`."
     if artifact is not None:
         request_summary = artifact.metadata.get("request_summary")
@@ -256,7 +257,7 @@ def _launch_summary(
             return f"Connects to `{artifact.url}`."
         if artifact.command:
             command_parts = [artifact.command, *artifact.args]
-            return f"Launches with `{_truncate(' '.join(command_parts))}`."
+            return f"Launches with `{_truncate(_redacted_command(command_parts))}`."
     if config_path:
         return (
             f"Guard reviewed the definition at {_short_config_path(config_path)}. "
@@ -290,3 +291,7 @@ def _truncate(value: str, limit: int = 140) -> str:
     if len(value) <= limit:
         return value
     return f"{value[: limit - 1]}…"
+
+
+def _redacted_command(parts: list[str]) -> str:
+    return redact_text(" ".join(parts)).text

--- a/src/codex_plugin_scanner/guard/incident.py
+++ b/src/codex_plugin_scanner/guard/incident.py
@@ -27,6 +27,10 @@ _ARTIFACT_LABELS = {
     "package_request": "Package request",
     "prompt_request": "Prompt request",
     "file_read_request": "File read request",
+    "skill": "Skill",
+    "skill_file": "Skill file",
+    "extension": "Extension",
+    "instruction": "Instruction",
     "artifact": "Artifact",
 }
 
@@ -82,7 +86,12 @@ def build_incident_context(
             f"`{short_config_path}` for {harness_label}."
         )
     why_now = _why_now_text(changed_fields, presentation_action, harness_label, artifact_type)
-    launch_summary = _launch_summary(artifact=artifact, launch_target=launch_target)
+    launch_summary = _launch_summary(
+        artifact=artifact,
+        launch_target=launch_target,
+        artifact_type=artifact_type,
+        config_path=config_path,
+    )
     risk_headline = risk_summary or _fallback_risk_headline(policy_action)
     return {
         "artifact_label": artifact_label,
@@ -210,7 +219,13 @@ def _trigger_verb(*, policy_action: GuardAction, changed_fields: list[str]) -> s
     return "paused"
 
 
-def _launch_summary(*, artifact: GuardArtifact | None, launch_target: str | None) -> str:
+def _launch_summary(
+    *,
+    artifact: GuardArtifact | None,
+    launch_target: str | None,
+    artifact_type: str | None,
+    config_path: str | None,
+) -> str:
     if launch_target:
         return f"Launches with `{_truncate(launch_target)}`."
     if artifact is not None:
@@ -225,7 +240,14 @@ def _launch_summary(*, artifact: GuardArtifact | None, launch_target: str | None
         if artifact.command:
             command_parts = [artifact.command, *artifact.args]
             return f"Launches with `{_truncate(' '.join(command_parts))}`."
-    return "Launch details were not available."
+    if config_path:
+        return (
+            f"Guard reviewed the definition at `{_short_config_path(config_path)}`. "
+            "No separate shell launch command was recorded for this item."
+        )
+    if artifact_type in {"tool_call", "tool_action_request", "file_read_request", "prompt_request"}:
+        return "Guard reviewed this interaction directly; it did not use a shell launch command."
+    return "Guard reviewed this item directly. No shell launch command was recorded."
 
 
 def _short_config_path(config_path: str | None) -> str:

--- a/tests/test_guard_incident_decision_copy.py
+++ b/tests/test_guard_incident_decision_copy.py
@@ -114,7 +114,7 @@ def test_direct_tool_interaction_explains_why_no_launch_command_exists() -> None
     )
 
     assert incident["launch_summary"] == (
-        "Guard reviewed this interaction directly; it did not use a shell launch command."
+        "Guard reviewed this interaction directly. No shell launch command was recorded."
     )
 
 

--- a/tests/test_guard_incident_decision_copy.py
+++ b/tests/test_guard_incident_decision_copy.py
@@ -151,7 +151,7 @@ def test_populated_mcp_tool_call_does_not_turn_tool_name_into_shell_launch() -> 
     )
 
 
-def test_command_bearing_native_request_keeps_validated_request_summary() -> None:
+def test_command_bearing_native_request_keeps_command_over_generic_summary() -> None:
     artifact = GuardArtifact(
         artifact_id="copilot:project:tool-action:rm",
         name="bash destructive shell command",
@@ -160,7 +160,7 @@ def test_command_bearing_native_request_keeps_validated_request_summary() -> Non
         source_scope="project",
         config_path="/workspace/.github/hooks/guard.json",
         command="rm -f /workspace/project/output.txt",
-        metadata={"request_summary": "Requested `bash` action `rm -f /workspace/project/output.txt`."},
+        metadata={"request_summary": "Guard requires approval because no command rule matched this tool action."},
     )
 
     incident = build_incident_context(
@@ -177,7 +177,7 @@ def test_command_bearing_native_request_keeps_validated_request_summary() -> Non
         risk_summary=None,
     )
 
-    assert incident["launch_summary"] == artifact.metadata["request_summary"]
+    assert incident["launch_summary"] == "Launches with `rm -f /workspace/project/output.txt`."
 
 
 @pytest.mark.parametrize(

--- a/tests/test_guard_incident_decision_copy.py
+++ b/tests/test_guard_incident_decision_copy.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from codex_plugin_scanner.guard.incident import build_incident_context
+from codex_plugin_scanner.guard.mcp_tool_calls import build_tool_call_artifact
 from codex_plugin_scanner.guard.models import GuardAction, GuardArtifact
 
 
@@ -116,6 +117,67 @@ def test_direct_tool_interaction_explains_why_no_launch_command_exists() -> None
     assert incident["launch_summary"] == (
         "Guard reviewed this interaction directly. No shell launch command was recorded."
     )
+
+
+def test_populated_mcp_tool_call_does_not_turn_tool_name_into_shell_launch() -> None:
+    artifact = build_tool_call_artifact(
+        harness="omp",
+        server_name="filesystem",
+        tool_name="read_file",
+        source_scope="project",
+        config_path="/workspace/.mcp.json",
+        transport="stdio",
+    )
+
+    incident = build_incident_context(
+        harness="omp",
+        artifact=artifact,
+        artifact_id=artifact.artifact_id,
+        artifact_name=artifact.name,
+        artifact_type=artifact.artifact_type,
+        source_scope=artifact.source_scope,
+        config_path=artifact.config_path,
+        changed_fields=["runtime_tool_call"],
+        policy_action="review",
+        launch_target=(
+            'read_file {"path":"/workspace/project/README.md"} '
+            "[arguments-sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef]"
+        ),
+        risk_summary=None,
+    )
+
+    assert incident["launch_summary"] == (
+        "Guard reviewed this interaction directly. No shell launch command was recorded."
+    )
+
+
+def test_command_bearing_native_request_keeps_validated_request_summary() -> None:
+    artifact = GuardArtifact(
+        artifact_id="copilot:project:tool-action:rm",
+        name="bash destructive shell command",
+        harness="copilot",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path="/workspace/.github/hooks/guard.json",
+        command="rm -f /workspace/project/output.txt",
+        metadata={"request_summary": "Requested `bash` action `rm -f /workspace/project/output.txt`."},
+    )
+
+    incident = build_incident_context(
+        harness="copilot",
+        artifact=artifact,
+        artifact_id=artifact.artifact_id,
+        artifact_name=artifact.name,
+        artifact_type=artifact.artifact_type,
+        source_scope=artifact.source_scope,
+        config_path=artifact.config_path,
+        changed_fields=["tool_action_request"],
+        policy_action="require-reapproval",
+        launch_target="rm -f /workspace/project/output.txt",
+        risk_summary=None,
+    )
+
+    assert incident["launch_summary"] == artifact.metadata["request_summary"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_guard_incident_decision_copy.py
+++ b/tests/test_guard_incident_decision_copy.py
@@ -75,7 +75,7 @@ def test_non_launch_skill_summary_identifies_the_reviewed_definition() -> None:
         harness="omp",
         source_scope="project",
         artifact_type="skill",
-        config_path="/home/vye/.omp/skills/memory-interaction/SKILL.md",
+        config_path="/workspace/.omp/skills/memory-interaction/SKILL.md",
     )
 
     incident = build_incident_context(

--- a/tests/test_guard_incident_decision_copy.py
+++ b/tests/test_guard_incident_decision_copy.py
@@ -195,6 +195,63 @@ def test_command_bearing_native_request_keeps_command_over_generic_summary() -> 
     assert incident["launch_summary"] == "Launches with `rm -f /workspace/project/output.txt`."
 
 
+def test_native_raw_command_credentials_are_redacted_in_incident_copy() -> None:
+    retained_tail = "retained-command-tail-" + ("x" * 180)
+    raw_command = (
+        f"bash -lc 'rm -f /workspace/project/output.txt --token=sk-testcredential123 --marker={retained_tail}'"
+    )
+    request = extract_sensitive_tool_action_request("bash", {"command": raw_command})
+    assert request is not None
+    assert request.raw_command_text == raw_command
+    artifact = build_tool_action_request_artifact(
+        "copilot",
+        request,
+        config_path="/workspace/.github/hooks/guard.json",
+        source_scope="project",
+    )
+
+    incident = build_incident_context(
+        harness="copilot",
+        artifact=artifact,
+        artifact_id=artifact.artifact_id,
+        artifact_name=artifact.name,
+        artifact_type=artifact.artifact_type,
+        source_scope=artifact.source_scope,
+        config_path=artifact.config_path,
+        changed_fields=["tool_action_request"],
+        policy_action="require-reapproval",
+        launch_target=str(artifact.metadata["request_summary"]),
+        risk_summary=None,
+    )
+
+    assert "sk-testcredential123" not in incident["launch_summary"]
+    assert "--token=sk-*****" in incident["launch_summary"]
+    assert retained_tail in incident["launch_summary"]
+
+
+def test_native_raw_launch_target_is_redacted_without_truncating_command_tail() -> None:
+    retained_tail = "raw-target-tail-" + ("y" * 180)
+    raw_target = f"rm -f /workspace/project/output.txt --token=sk-testcredential123 --marker={retained_tail}"
+
+    incident = build_incident_context(
+        harness="copilot",
+        artifact=None,
+        artifact_id="copilot:project:tool-action",
+        artifact_name="bash destructive shell command",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path="/workspace/.github/hooks/guard.json",
+        changed_fields=["tool_action_request"],
+        policy_action="require-reapproval",
+        launch_target=raw_target,
+        risk_summary=None,
+    )
+
+    assert "sk-testcredential123" not in incident["launch_summary"]
+    assert "--token=sk-*****" in incident["launch_summary"]
+    assert retained_tail in incident["launch_summary"]
+
+
 @pytest.mark.parametrize(
     ("policy_action", "expected_trigger", "headline_fragment"),
     [

--- a/tests/test_guard_incident_decision_copy.py
+++ b/tests/test_guard_incident_decision_copy.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 
 from codex_plugin_scanner.guard.incident import build_incident_context
 from codex_plugin_scanner.guard.mcp_tool_calls import build_tool_call_artifact
 from codex_plugin_scanner.guard.models import GuardAction, GuardArtifact
+from codex_plugin_scanner.guard.runtime.secret_file_requests import (
+    build_tool_action_request_artifact,
+    extract_sensitive_tool_action_request,
+)
 
 
 @pytest.mark.parametrize(
@@ -152,15 +158,24 @@ def test_populated_mcp_tool_call_does_not_turn_tool_name_into_shell_launch() -> 
 
 
 def test_command_bearing_native_request_keeps_command_over_generic_summary() -> None:
-    artifact = GuardArtifact(
-        artifact_id="copilot:project:tool-action:rm",
-        name="bash destructive shell command",
-        harness="copilot",
-        artifact_type="tool_action_request",
-        source_scope="project",
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "rm -f /workspace/project/output.txt"},
+    )
+    assert request is not None
+    artifact = build_tool_action_request_artifact(
+        "copilot",
+        request,
         config_path="/workspace/.github/hooks/guard.json",
-        command="rm -f /workspace/project/output.txt",
-        metadata={"request_summary": "Guard requires approval because no command rule matched this tool action."},
+        source_scope="project",
+    )
+    runtime_launch_target = str(artifact.metadata["request_summary"])
+    artifact = replace(
+        artifact,
+        metadata={
+            **artifact.metadata,
+            "request_summary": "Guard requires approval because no command rule matched this tool action.",
+        },
     )
 
     incident = build_incident_context(
@@ -173,7 +188,7 @@ def test_command_bearing_native_request_keeps_command_over_generic_summary() -> 
         config_path=artifact.config_path,
         changed_fields=["tool_action_request"],
         policy_action="require-reapproval",
-        launch_target="rm -f /workspace/project/output.txt",
+        launch_target=runtime_launch_target,
         risk_summary=None,
     )
 

--- a/tests/test_guard_incident_decision_copy.py
+++ b/tests/test_guard_incident_decision_copy.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from codex_plugin_scanner.guard.incident import build_incident_context
-from codex_plugin_scanner.guard.models import GuardAction
+from codex_plugin_scanner.guard.models import GuardAction, GuardArtifact
 
 
 @pytest.mark.parametrize(
@@ -66,6 +66,56 @@ def test_allowed_removal_is_recorded_instead_of_presented_as_a_pause() -> None:
     assert incident["trigger_summary"].startswith("HOL Guard reviewed")
     assert incident["why_now"].startswith("HOL Guard recorded")
     assert "allows the action to continue" in incident["why_now"]
+
+
+def test_non_launch_skill_summary_identifies_the_reviewed_definition() -> None:
+    artifact = GuardArtifact(
+        artifact_id="omp:project:skill:memory-interaction",
+        name="memory-interaction",
+        harness="omp",
+        source_scope="project",
+        artifact_type="skill",
+        config_path="/home/vye/.omp/skills/memory-interaction/SKILL.md",
+    )
+
+    incident = build_incident_context(
+        harness="omp",
+        artifact=artifact,
+        artifact_id=artifact.artifact_id,
+        artifact_name=artifact.name,
+        artifact_type=artifact.artifact_type,
+        source_scope=artifact.source_scope,
+        config_path=artifact.config_path,
+        changed_fields=["first_seen"],
+        policy_action="review",
+        launch_target=None,
+        risk_summary=None,
+    )
+
+    assert incident["artifact_label"] == "Skill"
+    assert "memory-interaction/SKILL.md" in incident["launch_summary"]
+    assert "No separate shell launch command" in incident["launch_summary"]
+    assert "details were not available" not in incident["launch_summary"].lower()
+
+
+def test_direct_tool_interaction_explains_why_no_launch_command_exists() -> None:
+    incident = build_incident_context(
+        harness="omp",
+        artifact=None,
+        artifact_id="omp:project:memory-interaction",
+        artifact_name="memory-interaction",
+        artifact_type="tool_call",
+        source_scope="project",
+        config_path=None,
+        changed_fields=["first_seen"],
+        policy_action="review",
+        launch_target=None,
+        risk_summary=None,
+    )
+
+    assert incident["launch_summary"] == (
+        "Guard reviewed this interaction directly; it did not use a shell launch command."
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- replace the generic "Launch details were not available" fallback with artifact source or direct-interaction context
- identify skills, skill files, extensions, and instructions by their real artifact labels
- prevent Extensions from offering an enrollment command that must fail before the approval gate is configured
- route approval-gate setup directly to the Approval settings section, then retain the existing enrollment flow once configured

## Verification

- `uv run --no-sync pytest -q tests/test_guard_incident_decision_copy.py tests/test_guard_risk.py` (616 passed)
- `uv run --no-sync ruff format --check src/codex_plugin_scanner/guard/incident.py tests/test_guard_incident_decision_copy.py`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/incident.py tests/test_guard_incident_decision_copy.py`
- `uv run --no-sync basedpyright --level error` (0 errors)
- `cd dashboard && bun run test`
- `cd dashboard && bun run build`
- `cd dashboard && bun x playwright test e2e/extension-authority-recovery.spec.ts --grep enrollment --workers=1` (3 Chromium flows passed)

## Baseline note

- `cd dashboard && pnpm exec tsc --noEmit` remains red on existing unrelated dashboard diagnostics; no diagnostic referenced the changed production files. The repository's CI-authoritative Bun test and build commands pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer approval enrollment guidance while setup is loading, disabled, or incomplete.
  * Added navigation from enrollment notices directly to approval settings.
  * Added a “Check again” action to refresh approval status after setup changes.

* **Bug Fixes**
  * Enrollment messaging now hides terminal commands until approval setup is ready.
  * Incident summaries provide more specific explanations and artifact labels when launch details are unavailable.
  * Improved display of full commands while protecting sensitive credentials in incident details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->