### PR TITLE
fix(scanner): flatten test-file classifier alternation

### DIFF
--- a/src/codex_plugin_scanner/checks/security.py
+++ b/src/codex_plugin_scanner/checks/security.py
@@ -83,7 +83,7 @@ EXAMPLE_PATH_HINTS = {
     "fixtures",
     "fixture",
 }
-TEST_FILE_RE = re.compile(r"(?:^test_|(?:\.test|\.spec|_test)\.[^.]+$)", re.I)
+TEST_FILE_RE = re.compile(r"(?:^test_|\.test\.[^.]+$|\.spec\.[^.]+$|_test\.[^.]+$)", re.I)
 PLACEHOLDER_MARKERS = (
     "redacted",
     "changeme",


### PR DESCRIPTION
## Summary
- Flatten the test-file classifier regex into four explicit alternatives so static analysis no longer flags ambiguous operator precedence, with an unchanged match language

## Testing
- `pytest tests/test_guard_static_analysis_regex_equivalence.py tests/test_security.py tests/test_scanner_false_positive_regressions.py` — 53 passed
- `pytest tests/test_guard_command_decision_diff.py` — 6 passed
- `ruff check` and `ruff format --check` on the changed file
- `scripts/ci/code_quality_audit.py` passes
