### PR TITLE
fix(release): tolerate eventual PyPI artifact propagation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1045,7 +1045,7 @@ jobs:
             if [[ "$guard_status" == "present" && "$scanner_status" == "exact" ]]; then
               break
             fi
-            if [[ "$guard_status" != "absent" && "$guard_status" != "present" ]] || \
+            if [[ "$guard_status" != "absent" && "$guard_status" != "present" && "$guard_status" != "pending" ]] || \
               [[ "$scanner_status" != "absent" && "$scanner_status" != "exact" ]] || \
               [[ "$attempt" == "60" ]]; then
               echo "PyPI did not expose the exact release artifacts" >&2

--- a/scripts/release_registry_retry.py
+++ b/scripts/release_registry_retry.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import math
+import time
+import urllib.error
+from collections.abc import Callable, Mapping
+from typing import Final, TypeVar
+
+if __package__:
+    from .release_registry_types import Registry, RegistryVerificationError, ReleaseInspection
+else:
+    from release_registry_types import (  # pyright: ignore[reportImplicitRelativeImport]
+        Registry,
+        RegistryVerificationError,
+        ReleaseInspection,
+    )
+
+REGISTRY_RETRY_ATTEMPTS: Final = 6
+REGISTRY_RETRY_INITIAL_DELAY_SECONDS: Final = 2.0
+REGISTRY_RETRY_MAX_DELAY_SECONDS: Final = 30.0
+REGISTRY_RETRY_MAX_ATTEMPTS: Final = REGISTRY_RETRY_ATTEMPTS
+REGISTRY_RETRY_MAX_TOTAL_DELAY_SECONDS: Final = 60.0
+
+Sleeper = Callable[[float], None]
+Fetcher = Callable[[str], bytes]
+_Result = TypeVar("_Result")
+
+
+class _RetryableRegistryError(RegistryVerificationError):
+    """A registry response may become valid during the bounded retry window."""
+
+
+class _PendingRegistryError(_RetryableRegistryError):
+    """A valid release response is visible before its distribution list propagates."""
+
+
+def _fetch_payload(
+    url: str,
+    *,
+    fetcher: Fetcher,
+    allow_not_found: bool = False,
+) -> bytes | None:
+    try:
+        return fetcher(url)
+    except urllib.error.HTTPError as exc:
+        if allow_not_found and exc.code == 404:
+            return None
+        if exc.code == 404 or exc.code in {408, 425, 429} or 500 <= exc.code < 600:
+            raise _RetryableRegistryError(f"Registry request failed with HTTP {exc.code}") from exc
+        raise RegistryVerificationError(f"Registry request failed with HTTP {exc.code}") from exc
+    except RegistryVerificationError:
+        raise
+    except (OSError, TimeoutError, urllib.error.URLError) as exc:
+        raise _RetryableRegistryError("Registry request failed") from exc
+
+
+def _compare_digest_sets(
+    local_hashes: Mapping[str, str],
+    remote_hashes: Mapping[str, str],
+    *,
+    registry: Registry,
+) -> None:
+    local_names = set(local_hashes)
+    remote_names = set(remote_hashes)
+    if local_names != remote_names:
+        missing = sorted(local_names - remote_names)
+        extra = sorted(remote_names - local_names)
+        details: list[str] = []
+        if missing:
+            details.append(f"missing={','.join(missing)}")
+        if extra:
+            details.append(f"extra={','.join(extra)}")
+        mismatch = RegistryVerificationError(
+            f"{registry.value} distribution set does not match the local build ({'; '.join(details)})"
+        )
+        if _is_eventually_complete_distribution_set(local_hashes, remote_hashes):
+            raise _RetryableRegistryError(str(mismatch))
+        raise mismatch
+    mismatched = sorted(filename for filename, digest in local_hashes.items() if remote_hashes[filename] != digest)
+    if mismatched:
+        raise RegistryVerificationError(f"{registry.value} distribution digest mismatch:{','.join(mismatched)}")
+
+
+def _is_eventually_complete_distribution_set(
+    local_hashes: Mapping[str, str],
+    remote_hashes: Mapping[str, str],
+) -> bool:
+    """Return true only for a matching remote subset missing local artifacts."""
+
+    local_names = set(local_hashes)
+    remote_names = set(remote_hashes)
+    return remote_names < local_names and all(
+        local_hashes[filename] == remote_hashes[filename] for filename in remote_names
+    )
+
+
+def _retry_delay(attempt: int, *, initial: float, maximum: float) -> float:
+    capped_attempt = min(attempt, REGISTRY_RETRY_MAX_ATTEMPTS - 1)
+    return min(maximum, initial * (2**capped_attempt))
+
+
+def _is_valid_retry_delay_value(delay: object) -> bool:
+    if isinstance(delay, bool) or not isinstance(delay, (int, float)):
+        return False
+    return isinstance(delay, int) or math.isfinite(delay)
+
+
+def _validate_retry_settings(
+    attempts: int,
+    initial_delay: float,
+    maximum_delay: float,
+) -> None:
+    if isinstance(attempts, bool) or not isinstance(attempts, int) or not 1 <= attempts <= REGISTRY_RETRY_MAX_ATTEMPTS:
+        raise RegistryVerificationError(
+            f"Registry retry attempts must be between one and {REGISTRY_RETRY_MAX_ATTEMPTS}"
+        )
+    if not all(_is_valid_retry_delay_value(delay) for delay in (initial_delay, maximum_delay)):
+        raise RegistryVerificationError("Registry retry delays must be finite numbers")
+    if initial_delay < 0 or maximum_delay < initial_delay:
+        raise RegistryVerificationError("Registry retry delays must be non-negative and ordered")
+    if maximum_delay > REGISTRY_RETRY_MAX_TOTAL_DELAY_SECONDS:
+        raise RegistryVerificationError(
+            f"Registry retry delay must not exceed {REGISTRY_RETRY_MAX_TOTAL_DELAY_SECONDS:g} seconds"
+        )
+    total_delay = sum(
+        _retry_delay(attempt, initial=initial_delay, maximum=maximum_delay) for attempt in range(attempts - 1)
+    )
+    if total_delay > REGISTRY_RETRY_MAX_TOTAL_DELAY_SECONDS:
+        raise RegistryVerificationError(
+            f"Registry retry delay budget must not exceed {REGISTRY_RETRY_MAX_TOTAL_DELAY_SECONDS:g} seconds"
+        )
+
+
+def _wait_for_retry(
+    attempt: int,
+    *,
+    attempts: int,
+    initial_delay: float,
+    maximum_delay: float,
+    sleep: Sleeper,
+) -> bool:
+    if attempt == attempts - 1:
+        return False
+    sleep(_retry_delay(attempt, initial=initial_delay, maximum=maximum_delay))
+    return True
+
+
+def _retry_registry_operation(
+    operation: Callable[[], _Result],
+    *,
+    retry_attempts: int = REGISTRY_RETRY_ATTEMPTS,
+    retry_initial_delay_seconds: float = REGISTRY_RETRY_INITIAL_DELAY_SECONDS,
+    retry_max_delay_seconds: float = REGISTRY_RETRY_MAX_DELAY_SECONDS,
+    sleep: Sleeper | None = None,
+) -> _Result:
+    _validate_retry_settings(
+        retry_attempts,
+        retry_initial_delay_seconds,
+        retry_max_delay_seconds,
+    )
+    sleep_fn = time.sleep if sleep is None else sleep
+
+    for attempt in range(retry_attempts):
+        try:
+            return operation()
+        except _RetryableRegistryError:
+            if not _wait_for_retry(
+                attempt,
+                attempts=retry_attempts,
+                initial_delay=retry_initial_delay_seconds,
+                maximum_delay=retry_max_delay_seconds,
+                sleep=sleep_fn,
+            ):
+                raise
+
+    raise AssertionError("Registry operation exhausted without a result")
+
+
+def _inspect_release_with_retry(
+    registry: Registry,
+    version_text: str,
+    *,
+    inspector: Callable[..., ReleaseInspection],
+    project_name: str,
+    fetcher: Callable[[str], bytes],
+    retry_attempts: int = REGISTRY_RETRY_ATTEMPTS,
+    retry_initial_delay_seconds: float = REGISTRY_RETRY_INITIAL_DELAY_SECONDS,
+    retry_max_delay_seconds: float = REGISTRY_RETRY_MAX_DELAY_SECONDS,
+    pending_on_incomplete: bool = False,
+    sleep: Sleeper | None = None,
+) -> ReleaseInspection | None:
+    def inspect_once() -> ReleaseInspection | None:
+        try:
+            return inspector(registry, version_text, project_name=project_name, fetcher=fetcher)
+        except _PendingRegistryError:
+            if not pending_on_incomplete:
+                raise
+            return None
+
+    return _retry_registry_operation(
+        inspect_once,
+        retry_attempts=retry_attempts,
+        retry_initial_delay_seconds=retry_initial_delay_seconds,
+        retry_max_delay_seconds=retry_max_delay_seconds,
+        sleep=sleep,
+    )

--- a/scripts/verify_release_registry.py
+++ b/scripts/verify_release_registry.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import math
 import os
 import re
 import sys
 import tempfile
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -39,9 +41,19 @@ else:
 DEFAULT_PROJECT_NAME: Final = "hol-guard"
 SUPPORTED_PROJECT_NAMES: Final = ("hol-guard", "plugin-scanner")
 MAX_RESPONSE_BYTES: Final = 256 * 1024 * 1024
+REGISTRY_RETRY_ATTEMPTS: Final = 6
+REGISTRY_RETRY_INITIAL_DELAY_SECONDS: Final = 2.0
+REGISTRY_RETRY_MAX_DELAY_SECONDS: Final = 30.0
+REGISTRY_RETRY_MAX_ATTEMPTS: Final = REGISTRY_RETRY_ATTEMPTS
+REGISTRY_RETRY_MAX_TOTAL_DELAY_SECONDS: Final = 60.0
 _SHA256: Final[re.Pattern[str]] = re.compile(r"[0-9a-f]{64}")
 
 Fetcher = Callable[[str], bytes]
+Sleeper = Callable[[float], None]
+
+
+class _RetryableRegistryError(RegistryVerificationError):
+    """A registry response may become valid during the bounded retry window."""
 
 
 def stdlib_fetch(url: str) -> bytes:
@@ -97,11 +109,13 @@ def _fetch_payload(
     except urllib.error.HTTPError as exc:
         if allow_not_found and exc.code == 404:
             return None
+        if exc.code == 404 or exc.code in {408, 425, 429} or 500 <= exc.code < 600:
+            raise _RetryableRegistryError(f"Registry request failed with HTTP {exc.code}") from exc
         raise RegistryVerificationError(f"Registry request failed with HTTP {exc.code}") from exc
     except RegistryVerificationError:
         raise
     except (OSError, TimeoutError, urllib.error.URLError) as exc:
-        raise RegistryVerificationError("Registry request failed") from exc
+        raise _RetryableRegistryError("Registry request failed") from exc
 
 
 def _decode_object(payload: bytes, *, label: str) -> dict[str, object]:
@@ -223,8 +237,10 @@ def inspect_release(
     if info_version != version:
         raise RegistryVerificationError("Registry release response returned the wrong version")
     urls = document.get("urls")
-    if not isinstance(urls, list) or not urls:
+    if not isinstance(urls, list):
         raise RegistryVerificationError("Existing registry release has no distribution files")
+    if not urls:
+        raise _RetryableRegistryError("Existing registry release has no distribution files yet")
 
     files: list[ReleaseFile] = []
     seen: set[str] = set()
@@ -246,7 +262,7 @@ def inspect_release(
         download_url = _validated_download_url(item.get("url"), filename, registry)
         files.append(ReleaseFile(filename=filename, sha256=sha256, download_url=download_url))
     if not files:
-        raise RegistryVerificationError("Existing registry release has no distribution files")
+        raise _RetryableRegistryError("Existing registry release has no distribution files yet")
     return ReleaseInspection(
         registry=registry,
         version=str(version),
@@ -321,12 +337,76 @@ def _compare_digest_sets(
             details.append(f"missing={','.join(missing)}")
         if extra:
             details.append(f"extra={','.join(extra)}")
-        raise RegistryVerificationError(
+        mismatch = RegistryVerificationError(
             f"{registry.value} distribution set does not match the local build ({'; '.join(details)})"
         )
+        if _is_eventually_complete_distribution_set(local_hashes, remote_hashes):
+            raise _RetryableRegistryError(str(mismatch))
+        raise mismatch
     mismatched = sorted(filename for filename, digest in local_hashes.items() if remote_hashes[filename] != digest)
     if mismatched:
         raise RegistryVerificationError(f"{registry.value} distribution digest mismatch: {','.join(mismatched)}")
+
+
+def _is_eventually_complete_distribution_set(
+    local_hashes: Mapping[str, str],
+    remote_hashes: Mapping[str, str],
+) -> bool:
+    """Return true only for a matching remote subset missing local artifacts."""
+
+    local_names = set(local_hashes)
+    remote_names = set(remote_hashes)
+    return remote_names < local_names and all(
+        local_hashes[filename] == remote_hashes[filename] for filename in remote_names
+    )
+
+
+def _retry_delay(attempt: int, *, initial: float, maximum: float) -> float:
+    capped_attempt = min(attempt, REGISTRY_RETRY_MAX_ATTEMPTS - 1)
+    return min(maximum, initial * (2**capped_attempt))
+
+
+def _validate_retry_settings(
+    attempts: int,
+    initial_delay: float,
+    maximum_delay: float,
+) -> None:
+    if isinstance(attempts, bool) or not isinstance(attempts, int) or not 1 <= attempts <= REGISTRY_RETRY_MAX_ATTEMPTS:
+        raise RegistryVerificationError(
+            f"Registry retry attempts must be between one and {REGISTRY_RETRY_MAX_ATTEMPTS}"
+        )
+    if any(
+        isinstance(delay, bool) or not isinstance(delay, (int, float)) or not math.isfinite(delay)
+        for delay in (initial_delay, maximum_delay)
+    ):
+        raise RegistryVerificationError("Registry retry delays must be finite numbers")
+    if initial_delay < 0 or maximum_delay < initial_delay:
+        raise RegistryVerificationError("Registry retry delays must be non-negative and ordered")
+    if maximum_delay > REGISTRY_RETRY_MAX_TOTAL_DELAY_SECONDS:
+        raise RegistryVerificationError(
+            f"Registry retry delay must not exceed {REGISTRY_RETRY_MAX_TOTAL_DELAY_SECONDS:g} seconds"
+        )
+    total_delay = sum(
+        _retry_delay(attempt, initial=initial_delay, maximum=maximum_delay) for attempt in range(attempts - 1)
+    )
+    if total_delay > REGISTRY_RETRY_MAX_TOTAL_DELAY_SECONDS:
+        raise RegistryVerificationError(
+            f"Registry retry delay budget must not exceed {REGISTRY_RETRY_MAX_TOTAL_DELAY_SECONDS:g} seconds"
+        )
+
+
+def _wait_for_retry(
+    attempt: int,
+    *,
+    attempts: int,
+    initial_delay: float,
+    maximum_delay: float,
+    sleep: Sleeper,
+) -> bool:
+    if attempt == attempts - 1:
+        return False
+    sleep(_retry_delay(attempt, initial=initial_delay, maximum=maximum_delay))
+    return True
 
 
 def download_verified_release(
@@ -366,27 +446,60 @@ def verify_registry_release(
     project_name: str = DEFAULT_PROJECT_NAME,
     download_dir: Path | None = None,
     fetcher: Fetcher = stdlib_fetch,
+    retry_attempts: int = REGISTRY_RETRY_ATTEMPTS,
+    retry_initial_delay_seconds: float = REGISTRY_RETRY_INITIAL_DELAY_SECONDS,
+    retry_max_delay_seconds: float = REGISTRY_RETRY_MAX_DELAY_SECONDS,
+    sleep: Sleeper | None = None,
 ) -> RegistryResult:
     local_hashes = compute_local_distribution_hashes(dist_dir, version_text, project_name)
-    inspection = inspect_release(registry, version_text, project_name=project_name, fetcher=fetcher)
-    if not inspection.exists:
-        return RegistryResult(
-            registry=registry,
-            status="absent",
-            version=inspection.version,
-            files=tuple(sorted(local_hashes)),
-        )
-    _compare_digest_sets(local_hashes, inspection.digests, registry=registry)
-    downloaded = (
-        download_verified_release(inspection, download_dir, fetcher=fetcher) if download_dir is not None else ()
+    _validate_retry_settings(
+        retry_attempts,
+        retry_initial_delay_seconds,
+        retry_max_delay_seconds,
     )
-    return RegistryResult(
-        registry=registry,
-        status="exact",
-        version=inspection.version,
-        files=tuple(sorted(local_hashes)),
-        downloaded_paths=downloaded,
-    )
+    sleep_fn = time.sleep if sleep is None else sleep
+
+    for attempt in range(retry_attempts):
+        try:
+            inspection = inspect_release(registry, version_text, project_name=project_name, fetcher=fetcher)
+            if not inspection.exists:
+                if not _wait_for_retry(
+                    attempt,
+                    attempts=retry_attempts,
+                    initial_delay=retry_initial_delay_seconds,
+                    maximum_delay=retry_max_delay_seconds,
+                    sleep=sleep_fn,
+                ):
+                    return RegistryResult(
+                        registry=registry,
+                        status="absent",
+                        version=inspection.version,
+                        files=tuple(sorted(local_hashes)),
+                    )
+                continue
+
+            _compare_digest_sets(local_hashes, inspection.digests, registry=registry)
+            downloaded = (
+                download_verified_release(inspection, download_dir, fetcher=fetcher) if download_dir is not None else ()
+            )
+            return RegistryResult(
+                registry=registry,
+                status="exact",
+                version=inspection.version,
+                files=tuple(sorted(local_hashes)),
+                downloaded_paths=downloaded,
+            )
+        except _RetryableRegistryError:
+            if not _wait_for_retry(
+                attempt,
+                attempts=retry_attempts,
+                initial_delay=retry_initial_delay_seconds,
+                maximum_delay=retry_max_delay_seconds,
+                sleep=sleep_fn,
+            ):
+                raise
+
+    raise AssertionError("Registry verification exhausted without a result")
 
 
 def verify_testpypi_release(
@@ -396,6 +509,10 @@ def verify_testpypi_release(
     project_name: str = DEFAULT_PROJECT_NAME,
     download_dir: Path | None = None,
     fetcher: Fetcher = stdlib_fetch,
+    retry_attempts: int = REGISTRY_RETRY_ATTEMPTS,
+    retry_initial_delay_seconds: float = REGISTRY_RETRY_INITIAL_DELAY_SECONDS,
+    retry_max_delay_seconds: float = REGISTRY_RETRY_MAX_DELAY_SECONDS,
+    sleep: Sleeper | None = None,
 ) -> TestPyPIResult:
     """Compatibility wrapper for existing TestPyPI workflow callers."""
 
@@ -406,6 +523,10 @@ def verify_testpypi_release(
         project_name=project_name,
         download_dir=download_dir,
         fetcher=fetcher,
+        retry_attempts=retry_attempts,
+        retry_initial_delay_seconds=retry_initial_delay_seconds,
+        retry_max_delay_seconds=retry_max_delay_seconds,
+        sleep=sleep,
     )
 
 

--- a/scripts/verify_release_registry.py
+++ b/scripts/verify_release_registry.py
@@ -366,6 +366,12 @@ def _retry_delay(attempt: int, *, initial: float, maximum: float) -> float:
     return min(maximum, initial * (2**capped_attempt))
 
 
+def _is_valid_retry_delay_value(delay: object) -> bool:
+    if isinstance(delay, bool) or not isinstance(delay, (int, float)):
+        return False
+    return isinstance(delay, int) or math.isfinite(delay)
+
+
 def _validate_retry_settings(
     attempts: int,
     initial_delay: float,
@@ -375,10 +381,7 @@ def _validate_retry_settings(
         raise RegistryVerificationError(
             f"Registry retry attempts must be between one and {REGISTRY_RETRY_MAX_ATTEMPTS}"
         )
-    if any(
-        isinstance(delay, bool) or not isinstance(delay, (int, float)) or not math.isfinite(delay)
-        for delay in (initial_delay, maximum_delay)
-    ):
+    if not all(_is_valid_retry_delay_value(delay) for delay in (initial_delay, maximum_delay)):
         raise RegistryVerificationError("Registry retry delays must be finite numbers")
     if initial_delay < 0 or maximum_delay < initial_delay:
         raise RegistryVerificationError("Registry retry delays must be non-negative and ordered")

--- a/scripts/verify_release_registry.py
+++ b/scripts/verify_release_registry.py
@@ -3,16 +3,13 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import math
 import os
 import re
 import sys
 import tempfile
-import time
-import urllib.error
 import urllib.parse
 import urllib.request
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Final
 
@@ -20,6 +17,7 @@ from packaging.utils import InvalidSdistFilename, InvalidWheelFilename, parse_sd
 from packaging.version import InvalidVersion, Version
 
 if __package__:
+    from . import release_registry_retry
     from .release_registry_types import (
         Registry,
         RegistryResult,
@@ -29,6 +27,7 @@ if __package__:
         TestPyPIResult,
     )
 else:
+    import release_registry_retry  # pyright: ignore[reportImplicitRelativeImport]
     from release_registry_types import (  # pyright: ignore[reportImplicitRelativeImport]
         Registry,
         RegistryResult,
@@ -41,19 +40,9 @@ else:
 DEFAULT_PROJECT_NAME: Final = "hol-guard"
 SUPPORTED_PROJECT_NAMES: Final = ("hol-guard", "plugin-scanner")
 MAX_RESPONSE_BYTES: Final = 256 * 1024 * 1024
-REGISTRY_RETRY_ATTEMPTS: Final = 6
-REGISTRY_RETRY_INITIAL_DELAY_SECONDS: Final = 2.0
-REGISTRY_RETRY_MAX_DELAY_SECONDS: Final = 30.0
-REGISTRY_RETRY_MAX_ATTEMPTS: Final = REGISTRY_RETRY_ATTEMPTS
-REGISTRY_RETRY_MAX_TOTAL_DELAY_SECONDS: Final = 60.0
 _SHA256: Final[re.Pattern[str]] = re.compile(r"[0-9a-f]{64}")
 
 Fetcher = Callable[[str], bytes]
-Sleeper = Callable[[float], None]
-
-
-class _RetryableRegistryError(RegistryVerificationError):
-    """A registry response may become valid during the bounded retry window."""
 
 
 def stdlib_fetch(url: str) -> bytes:
@@ -98,26 +87,6 @@ def _release_url(registry: Registry, project_name: str, version: str) -> str:
     return f"https://{registry.api_host}/pypi/{_validated_project_name(project_name)}/{quoted_version}/json"
 
 
-def _fetch_payload(
-    url: str,
-    *,
-    fetcher: Fetcher,
-    allow_not_found: bool = False,
-) -> bytes | None:
-    try:
-        return fetcher(url)
-    except urllib.error.HTTPError as exc:
-        if allow_not_found and exc.code == 404:
-            return None
-        if exc.code == 404 or exc.code in {408, 425, 429} or 500 <= exc.code < 600:
-            raise _RetryableRegistryError(f"Registry request failed with HTTP {exc.code}") from exc
-        raise RegistryVerificationError(f"Registry request failed with HTTP {exc.code}") from exc
-    except RegistryVerificationError:
-        raise
-    except (OSError, TimeoutError, urllib.error.URLError) as exc:
-        raise _RetryableRegistryError("Registry request failed") from exc
-
-
 def _decode_object(payload: bytes, *, label: str) -> dict[str, object]:
     try:
         decoded = json.loads(payload.decode("utf-8"))
@@ -146,7 +115,7 @@ def list_registry_versions(
     project_name: str = DEFAULT_PROJECT_NAME,
     fetcher: Fetcher = stdlib_fetch,
 ) -> tuple[str, ...]:
-    payload = _fetch_payload(_project_url(registry, project_name), fetcher=fetcher)
+    payload = release_registry_retry._fetch_payload(_project_url(registry, project_name), fetcher=fetcher)
     if payload is None:
         raise RegistryVerificationError("Registry project response was unexpectedly absent")
     document = _decode_object(payload, label="Registry project response")
@@ -221,7 +190,7 @@ def inspect_release(
     fetcher: Fetcher = stdlib_fetch,
 ) -> ReleaseInspection:
     version = _canonical_public_version(version_text, label="Requested version")
-    payload = _fetch_payload(
+    payload = release_registry_retry._fetch_payload(
         _release_url(registry, project_name, str(version)),
         fetcher=fetcher,
         allow_not_found=True,
@@ -240,7 +209,7 @@ def inspect_release(
     if not isinstance(urls, list):
         raise RegistryVerificationError("Existing registry release has no distribution files")
     if not urls:
-        raise _RetryableRegistryError("Existing registry release has no distribution files yet")
+        raise release_registry_retry._PendingRegistryError("Existing registry release has no distribution files yet")
 
     files: list[ReleaseFile] = []
     seen: set[str] = set()
@@ -262,7 +231,7 @@ def inspect_release(
         download_url = _validated_download_url(item.get("url"), filename, registry)
         files.append(ReleaseFile(filename=filename, sha256=sha256, download_url=download_url))
     if not files:
-        raise _RetryableRegistryError("Existing registry release has no distribution files yet")
+        raise release_registry_retry._PendingRegistryError("Existing registry release has no distribution files yet")
     return ReleaseInspection(
         registry=registry,
         version=str(version),
@@ -321,97 +290,6 @@ def compute_local_distribution_hashes(
     return hashes
 
 
-def _compare_digest_sets(
-    local_hashes: Mapping[str, str],
-    remote_hashes: Mapping[str, str],
-    *,
-    registry: Registry,
-) -> None:
-    local_names = set(local_hashes)
-    remote_names = set(remote_hashes)
-    if local_names != remote_names:
-        missing = sorted(local_names - remote_names)
-        extra = sorted(remote_names - local_names)
-        details: list[str] = []
-        if missing:
-            details.append(f"missing={','.join(missing)}")
-        if extra:
-            details.append(f"extra={','.join(extra)}")
-        mismatch = RegistryVerificationError(
-            f"{registry.value} distribution set does not match the local build ({'; '.join(details)})"
-        )
-        if _is_eventually_complete_distribution_set(local_hashes, remote_hashes):
-            raise _RetryableRegistryError(str(mismatch))
-        raise mismatch
-    mismatched = sorted(filename for filename, digest in local_hashes.items() if remote_hashes[filename] != digest)
-    if mismatched:
-        raise RegistryVerificationError(f"{registry.value} distribution digest mismatch: {','.join(mismatched)}")
-
-
-def _is_eventually_complete_distribution_set(
-    local_hashes: Mapping[str, str],
-    remote_hashes: Mapping[str, str],
-) -> bool:
-    """Return true only for a matching remote subset missing local artifacts."""
-
-    local_names = set(local_hashes)
-    remote_names = set(remote_hashes)
-    return remote_names < local_names and all(
-        local_hashes[filename] == remote_hashes[filename] for filename in remote_names
-    )
-
-
-def _retry_delay(attempt: int, *, initial: float, maximum: float) -> float:
-    capped_attempt = min(attempt, REGISTRY_RETRY_MAX_ATTEMPTS - 1)
-    return min(maximum, initial * (2**capped_attempt))
-
-
-def _is_valid_retry_delay_value(delay: object) -> bool:
-    if isinstance(delay, bool) or not isinstance(delay, (int, float)):
-        return False
-    return isinstance(delay, int) or math.isfinite(delay)
-
-
-def _validate_retry_settings(
-    attempts: int,
-    initial_delay: float,
-    maximum_delay: float,
-) -> None:
-    if isinstance(attempts, bool) or not isinstance(attempts, int) or not 1 <= attempts <= REGISTRY_RETRY_MAX_ATTEMPTS:
-        raise RegistryVerificationError(
-            f"Registry retry attempts must be between one and {REGISTRY_RETRY_MAX_ATTEMPTS}"
-        )
-    if not all(_is_valid_retry_delay_value(delay) for delay in (initial_delay, maximum_delay)):
-        raise RegistryVerificationError("Registry retry delays must be finite numbers")
-    if initial_delay < 0 or maximum_delay < initial_delay:
-        raise RegistryVerificationError("Registry retry delays must be non-negative and ordered")
-    if maximum_delay > REGISTRY_RETRY_MAX_TOTAL_DELAY_SECONDS:
-        raise RegistryVerificationError(
-            f"Registry retry delay must not exceed {REGISTRY_RETRY_MAX_TOTAL_DELAY_SECONDS:g} seconds"
-        )
-    total_delay = sum(
-        _retry_delay(attempt, initial=initial_delay, maximum=maximum_delay) for attempt in range(attempts - 1)
-    )
-    if total_delay > REGISTRY_RETRY_MAX_TOTAL_DELAY_SECONDS:
-        raise RegistryVerificationError(
-            f"Registry retry delay budget must not exceed {REGISTRY_RETRY_MAX_TOTAL_DELAY_SECONDS:g} seconds"
-        )
-
-
-def _wait_for_retry(
-    attempt: int,
-    *,
-    attempts: int,
-    initial_delay: float,
-    maximum_delay: float,
-    sleep: Sleeper,
-) -> bool:
-    if attempt == attempts - 1:
-        return False
-    sleep(_retry_delay(attempt, initial=initial_delay, maximum=maximum_delay))
-    return True
-
-
 def download_verified_release(
     inspection: ReleaseInspection,
     destination: Path,
@@ -426,7 +304,7 @@ def download_verified_release(
         temporary_dir = Path(temporary_dir_text)
         staged: list[tuple[Path, Path]] = []
         for item in inspection.files:
-            payload = _fetch_payload(item.download_url, fetcher=fetcher)
+            payload = release_registry_retry._fetch_payload(item.download_url, fetcher=fetcher)
             if payload is None:
                 raise RegistryVerificationError(f"Registry distribution was absent: {item.filename}")
             actual_digest = hashlib.sha256(payload).hexdigest()
@@ -449,52 +327,40 @@ def verify_registry_release(
     project_name: str = DEFAULT_PROJECT_NAME,
     download_dir: Path | None = None,
     fetcher: Fetcher = stdlib_fetch,
-    retry_attempts: int = REGISTRY_RETRY_ATTEMPTS,
-    retry_initial_delay_seconds: float = REGISTRY_RETRY_INITIAL_DELAY_SECONDS,
-    retry_max_delay_seconds: float = REGISTRY_RETRY_MAX_DELAY_SECONDS,
-    sleep: Sleeper | None = None,
+    retry_attempts: int = release_registry_retry.REGISTRY_RETRY_ATTEMPTS,
+    retry_initial_delay_seconds: float = release_registry_retry.REGISTRY_RETRY_INITIAL_DELAY_SECONDS,
+    retry_max_delay_seconds: float = release_registry_retry.REGISTRY_RETRY_MAX_DELAY_SECONDS,
+    sleep: release_registry_retry.Sleeper | None = None,
 ) -> RegistryResult:
     local_hashes = compute_local_distribution_hashes(dist_dir, version_text, project_name)
-    _validate_retry_settings(
-        retry_attempts,
-        retry_initial_delay_seconds,
-        retry_max_delay_seconds,
-    )
-    sleep_fn = time.sleep if sleep is None else sleep
 
-    for attempt in range(retry_attempts):
-        try:
-            inspection = inspect_release(registry, version_text, project_name=project_name, fetcher=fetcher)
-            if not inspection.exists:
-                return RegistryResult(
-                    registry=registry,
-                    status="absent",
-                    version=inspection.version,
-                    files=tuple(sorted(local_hashes)),
-                )
-
-            _compare_digest_sets(local_hashes, inspection.digests, registry=registry)
-            downloaded = (
-                download_verified_release(inspection, download_dir, fetcher=fetcher) if download_dir is not None else ()
-            )
+    def verify_once() -> RegistryResult:
+        inspection = inspect_release(registry, version_text, project_name=project_name, fetcher=fetcher)
+        if not inspection.exists:
             return RegistryResult(
                 registry=registry,
-                status="exact",
+                status="absent",
                 version=inspection.version,
                 files=tuple(sorted(local_hashes)),
-                downloaded_paths=downloaded,
             )
-        except _RetryableRegistryError:
-            if not _wait_for_retry(
-                attempt,
-                attempts=retry_attempts,
-                initial_delay=retry_initial_delay_seconds,
-                maximum_delay=retry_max_delay_seconds,
-                sleep=sleep_fn,
-            ):
-                raise
 
-    raise AssertionError("Registry verification exhausted without a result")
+        release_registry_retry._compare_digest_sets(local_hashes, inspection.digests, registry=registry)
+        downloaded = download_verified_release(inspection, download_dir, fetcher=fetcher) if download_dir else ()
+        return RegistryResult(
+            registry=registry,
+            status="exact",
+            version=inspection.version,
+            files=tuple(sorted(local_hashes)),
+            downloaded_paths=downloaded,
+        )
+
+    return release_registry_retry._retry_registry_operation(
+        verify_once,
+        retry_attempts=retry_attempts,
+        retry_initial_delay_seconds=retry_initial_delay_seconds,
+        retry_max_delay_seconds=retry_max_delay_seconds,
+        sleep=sleep,
+    )
 
 
 def verify_testpypi_release(
@@ -504,10 +370,10 @@ def verify_testpypi_release(
     project_name: str = DEFAULT_PROJECT_NAME,
     download_dir: Path | None = None,
     fetcher: Fetcher = stdlib_fetch,
-    retry_attempts: int = REGISTRY_RETRY_ATTEMPTS,
-    retry_initial_delay_seconds: float = REGISTRY_RETRY_INITIAL_DELAY_SECONDS,
-    retry_max_delay_seconds: float = REGISTRY_RETRY_MAX_DELAY_SECONDS,
-    sleep: Sleeper | None = None,
+    retry_attempts: int = release_registry_retry.REGISTRY_RETRY_ATTEMPTS,
+    retry_initial_delay_seconds: float = release_registry_retry.REGISTRY_RETRY_INITIAL_DELAY_SECONDS,
+    retry_max_delay_seconds: float = release_registry_retry.REGISTRY_RETRY_MAX_DELAY_SECONDS,
+    sleep: release_registry_retry.Sleeper | None = None,
 ) -> TestPyPIResult:
     """Compatibility wrapper for existing TestPyPI workflow callers."""
 
@@ -587,7 +453,12 @@ def _parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: Sequence[str] | None = None, *, fetcher: Fetcher = stdlib_fetch) -> int:
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    fetcher: Fetcher = stdlib_fetch,
+    sleep: release_registry_retry.Sleeper | None = None,
+) -> int:
     args = _parser().parse_args(argv)
     command = getattr(args, "command", None)
     try:
@@ -596,13 +467,26 @@ def main(argv: Sequence[str] | None = None, *, fetcher: Fetcher = stdlib_fetch) 
             output: object = list_registry_versions(registry, project_name=args.project, fetcher=fetcher)
         elif command == "inspect-release":
             registry = Registry(args.registry)
-            inspection = inspect_release(
+            version = _canonical_public_version(args.version, label="Requested version")
+            inspection = release_registry_retry._inspect_release_with_retry(
                 registry,
-                args.version,
+                str(version),
+                inspector=inspect_release,
                 project_name=args.project,
                 fetcher=fetcher,
+                pending_on_incomplete=True,
+                sleep=sleep,
             )
-            output = _inspection_output(inspection)
+            output = (
+                {
+                    "registry": registry.value,
+                    "version": str(version),
+                    "status": "pending",
+                    "files": [],
+                }
+                if inspection is None
+                else _inspection_output(inspection)
+            )
         elif command == "verify-testpypi":
             result = verify_testpypi_release(
                 args.version,

--- a/scripts/verify_release_registry.py
+++ b/scripts/verify_release_registry.py
@@ -466,20 +466,12 @@ def verify_registry_release(
         try:
             inspection = inspect_release(registry, version_text, project_name=project_name, fetcher=fetcher)
             if not inspection.exists:
-                if not _wait_for_retry(
-                    attempt,
-                    attempts=retry_attempts,
-                    initial_delay=retry_initial_delay_seconds,
-                    maximum_delay=retry_max_delay_seconds,
-                    sleep=sleep_fn,
-                ):
-                    return RegistryResult(
-                        registry=registry,
-                        status="absent",
-                        version=inspection.version,
-                        files=tuple(sorted(local_hashes)),
-                    )
-                continue
+                return RegistryResult(
+                    registry=registry,
+                    status="absent",
+                    version=inspection.version,
+                    files=tuple(sorted(local_hashes)),
+                )
 
             _compare_digest_sets(local_hashes, inspection.digests, registry=registry)
             downloaded = (

--- a/tests/test_release_registry_retry.py
+++ b/tests/test_release_registry_retry.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import urllib.error
+from email.message import Message
+from pathlib import Path
+
+import pytest
+import yaml
+
+import scripts.release_registry_retry as retry_module
+from scripts.verify_release_registry import (
+    Registry,
+    RegistryVerificationError,
+    main,
+    verify_registry_release,
+    verify_testpypi_release,
+)
+
+VERSION = "2.2.0a1"
+WHEEL = f"hol_guard-{VERSION}-py3-none-any.whl"
+SDIST = f"hol_guard-{VERSION}.tar.gz"
+WHEEL_BYTES = b"wheel-content"
+SDIST_BYTES = b"sdist-content"
+
+
+class SequencedFetcher:
+    def __init__(self, url: str, responses: list[bytes | Exception]) -> None:
+        self.url = url
+        self.responses = responses
+        self.calls: list[str] = []
+
+    def __call__(self, url: str) -> bytes:
+        self.calls.append(url)
+        if url != self.url:
+            raise AssertionError(f"Unexpected fetch: {url}")
+        if not self.responses:
+            raise AssertionError("Fetcher response sequence was exhausted")
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+class DownloadFetcher:
+    def __init__(
+        self,
+        release_url: str,
+        release_payload: bytes,
+        files: dict[str, bytes],
+        failing_url: str,
+        failure_count: int,
+    ) -> None:
+        self.release_url = release_url
+        self.release_payload = release_payload
+        self.files = files
+        self.failing_url = failing_url
+        self.remaining_failures = failure_count
+        self.calls: list[str] = []
+
+    def __call__(self, url: str) -> bytes:
+        self.calls.append(url)
+        if url == self.release_url:
+            return self.release_payload
+        if url not in self.files:
+            raise AssertionError(f"Unexpected fetch: {url}")
+        if url == self.failing_url and self.remaining_failures:
+            self.remaining_failures -= 1
+            raise _http_error(url, 404)
+        return self.files[url]
+
+
+def _release_url(registry: Registry, version: str = VERSION, project_name: str = "hol-guard") -> str:
+    return f"https://{registry.api_host}/pypi/{project_name}/{version}/json"
+
+
+def _file_url(registry: Registry, filename: str) -> str:
+    return f"https://{registry.file_host}/packages/{filename}"
+
+
+def _http_error(url: str, code: int) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(url, code, "failure", Message(), io.BytesIO())
+
+
+def _sha(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _release_payload(
+    registry: Registry,
+    files: dict[str, tuple[bytes, str | None]],
+    *,
+    version: str = VERSION,
+) -> bytes:
+    urls = []
+    for filename, (payload, override_digest) in files.items():
+        urls.append(
+            {
+                "filename": filename,
+                "digests": {"sha256": override_digest or _sha(payload)},
+                "url": _file_url(registry, filename),
+            }
+        )
+    return json.dumps({"info": {"version": version}, "urls": urls}).encode()
+
+
+def _local_dist(tmp_path: Path) -> Path:
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / WHEEL).write_bytes(WHEEL_BYTES)
+    (dist / SDIST).write_bytes(SDIST_BYTES)
+    return dist
+
+
+def test_inspect_release_cli_reports_pending_then_present_for_empty_metadata(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    url = _release_url(Registry.TESTPYPI)
+    incomplete_payload = json.dumps({"info": {"version": VERSION}, "urls": []}).encode()
+    complete_payload = _release_payload(
+        Registry.TESTPYPI,
+        {WHEEL: (WHEEL_BYTES, None), SDIST: (SDIST_BYTES, None)},
+    )
+    fetcher = SequencedFetcher(url, [incomplete_payload, complete_payload])
+    delays: list[float] = []
+
+    inspect_args = ["inspect-release", "--registry", "testpypi", "--version", VERSION]
+    assert main(inspect_args, fetcher=fetcher, sleep=delays.append) == 0
+
+    pending_output = json.loads(capsys.readouterr().out)
+    assert pending_output["status"] == "pending"
+    assert pending_output["files"] == []
+    assert fetcher.calls == [url]
+    assert delays == []
+
+    assert main(inspect_args, fetcher=fetcher, sleep=delays.append) == 0
+
+    present_output = json.loads(capsys.readouterr().out)
+    assert present_output["status"] == "present"
+    assert fetcher.calls == [url, url]
+    assert delays == []
+
+
+def test_verify_registry_release_reports_absent_without_internal_retry(tmp_path: Path) -> None:
+    dist = _local_dist(tmp_path)
+    url = _release_url(Registry.PYPI)
+    fetcher = SequencedFetcher(url, [_http_error(url, 404)])
+    delays: list[float] = []
+
+    result = verify_registry_release(
+        Registry.PYPI,
+        VERSION,
+        dist,
+        fetcher=fetcher,
+        retry_attempts=2,
+        sleep=delays.append,
+    )
+
+    assert result.status == "absent"
+    assert fetcher.calls == [url]
+    assert delays == []
+
+
+def test_verify_registry_release_retries_transient_metadata_error(tmp_path: Path) -> None:
+    dist = _local_dist(tmp_path)
+    url = _release_url(Registry.PYPI)
+    payload = _release_payload(
+        Registry.PYPI,
+        {WHEEL: (WHEEL_BYTES, None), SDIST: (SDIST_BYTES, None)},
+    )
+    fetcher = SequencedFetcher(url, [_http_error(url, 503), payload])
+    delays: list[float] = []
+
+    result = verify_registry_release(
+        Registry.PYPI,
+        VERSION,
+        dist,
+        fetcher=fetcher,
+        retry_attempts=2,
+        sleep=delays.append,
+    )
+
+    assert result.status == "exact"
+    assert fetcher.calls == [url, url]
+    assert delays == [retry_module.REGISTRY_RETRY_INITIAL_DELAY_SECONDS]
+
+
+def test_verify_registry_release_retries_partial_pypi_metadata(tmp_path: Path) -> None:
+    dist = _local_dist(tmp_path)
+    url = _release_url(Registry.PYPI)
+    partial_payload = _release_payload(Registry.PYPI, {WHEEL: (WHEEL_BYTES, None)})
+    complete_payload = _release_payload(
+        Registry.PYPI,
+        {WHEEL: (WHEEL_BYTES, None), SDIST: (SDIST_BYTES, None)},
+    )
+    fetcher = SequencedFetcher(url, [partial_payload, complete_payload])
+    delays: list[float] = []
+
+    result = verify_registry_release(
+        Registry.PYPI,
+        VERSION,
+        dist,
+        fetcher=fetcher,
+        retry_attempts=2,
+        sleep=delays.append,
+    )
+
+    assert result.status == "exact"
+    assert fetcher.calls == [url, url]
+    assert delays == [retry_module.REGISTRY_RETRY_INITIAL_DELAY_SECONDS]
+
+
+def test_verify_registry_release_fails_after_persistent_partial_metadata(tmp_path: Path) -> None:
+    dist = _local_dist(tmp_path)
+    url = _release_url(Registry.PYPI)
+    partial_payload = _release_payload(Registry.PYPI, {WHEEL: (WHEEL_BYTES, None)})
+    fetcher = SequencedFetcher(url, [partial_payload, partial_payload, partial_payload])
+    delays: list[float] = []
+
+    with pytest.raises(RegistryVerificationError, match=r"missing=hol_guard-2\.2\.0a1\.tar\.gz"):
+        verify_registry_release(
+            Registry.PYPI,
+            VERSION,
+            dist,
+            fetcher=fetcher,
+            retry_attempts=3,
+            retry_initial_delay_seconds=0,
+            retry_max_delay_seconds=0,
+            sleep=delays.append,
+        )
+
+    assert fetcher.calls == [url, url, url]
+    assert delays == [0, 0]
+
+
+def test_verify_registry_release_retries_transient_download_404(tmp_path: Path) -> None:
+    dist = _local_dist(tmp_path)
+    release_url = _release_url(Registry.PYPI)
+    payload = _release_payload(
+        Registry.PYPI,
+        {WHEEL: (WHEEL_BYTES, None), SDIST: (SDIST_BYTES, None)},
+    )
+    wheel_url = _file_url(Registry.PYPI, WHEEL)
+    fetcher = DownloadFetcher(
+        release_url,
+        payload,
+        {
+            wheel_url: WHEEL_BYTES,
+            _file_url(Registry.PYPI, SDIST): SDIST_BYTES,
+        },
+        wheel_url,
+        failure_count=1,
+    )
+    delays: list[float] = []
+
+    result = verify_registry_release(
+        Registry.PYPI,
+        VERSION,
+        dist,
+        download_dir=tmp_path / "verified",
+        fetcher=fetcher,
+        retry_attempts=2,
+        sleep=delays.append,
+    )
+
+    assert result.status == "exact"
+    assert {path.name: path.read_bytes() for path in result.downloaded_paths} == {
+        WHEEL: WHEEL_BYTES,
+        SDIST: SDIST_BYTES,
+    }
+    assert fetcher.calls.count(release_url) == 2
+    assert fetcher.calls.count(wheel_url) == 2
+    assert delays == [retry_module.REGISTRY_RETRY_INITIAL_DELAY_SECONDS]
+
+
+def test_verify_registry_release_fails_after_persistent_download_404(tmp_path: Path) -> None:
+    dist = _local_dist(tmp_path)
+    release_url = _release_url(Registry.PYPI)
+    payload = _release_payload(
+        Registry.PYPI,
+        {WHEEL: (WHEEL_BYTES, None), SDIST: (SDIST_BYTES, None)},
+    )
+    wheel_url = _file_url(Registry.PYPI, WHEEL)
+    download_dir = tmp_path / "verified"
+    fetcher = DownloadFetcher(
+        release_url,
+        payload,
+        {
+            wheel_url: WHEEL_BYTES,
+            _file_url(Registry.PYPI, SDIST): SDIST_BYTES,
+        },
+        wheel_url,
+        failure_count=3,
+    )
+    delays: list[float] = []
+
+    with pytest.raises(RegistryVerificationError, match="HTTP 404"):
+        verify_registry_release(
+            Registry.PYPI,
+            VERSION,
+            dist,
+            download_dir=download_dir,
+            fetcher=fetcher,
+            retry_attempts=3,
+            retry_initial_delay_seconds=0,
+            retry_max_delay_seconds=0,
+            sleep=delays.append,
+        )
+
+    assert fetcher.calls.count(release_url) == 3
+    assert fetcher.calls.count(wheel_url) == 3
+    assert not (download_dir / WHEEL).exists()
+    assert not (download_dir / SDIST).exists()
+    assert delays == [0, 0]
+
+
+@pytest.mark.parametrize(
+    "retry_settings",
+    [
+        {"retry_attempts": 10**100},
+        {"retry_max_delay_seconds": 10**1000},
+        {"retry_initial_delay_seconds": 61, "retry_max_delay_seconds": 61},
+        {"retry_attempts": 6, "retry_initial_delay_seconds": 3, "retry_max_delay_seconds": 30},
+        {"retry_initial_delay_seconds": float("nan"), "retry_max_delay_seconds": 1},
+    ],
+)
+def test_verify_registry_release_rejects_unbounded_retry_settings(
+    tmp_path: Path,
+    retry_settings: dict[str, int | float],
+) -> None:
+    dist = _local_dist(tmp_path)
+    fetcher = SequencedFetcher("unused", [])
+
+    with pytest.raises(RegistryVerificationError, match="Registry retry"):
+        verify_registry_release(Registry.PYPI, VERSION, dist, fetcher=fetcher, **retry_settings)
+
+    assert fetcher.calls == []
+
+
+@pytest.mark.parametrize(
+    "files",
+    [
+        {WHEEL: (b"different", None), SDIST: (SDIST_BYTES, None)},
+        {WHEEL: (WHEEL_BYTES, None)},
+        {
+            WHEEL: (WHEEL_BYTES, None),
+            SDIST: (SDIST_BYTES, None),
+            f"hol_guard-{VERSION}-py2-none-any.whl": (b"extra", None),
+        },
+    ],
+)
+def test_verify_testpypi_rejects_mismatch_partial_and_extra(
+    tmp_path: Path,
+    files: dict[str, tuple[bytes, str | None]],
+) -> None:
+    dist = _local_dist(tmp_path)
+    url = _release_url(Registry.TESTPYPI)
+    fetcher = SequencedFetcher(url, [_release_payload(Registry.TESTPYPI, files)])
+
+    with pytest.raises(RegistryVerificationError):
+        verify_testpypi_release(VERSION, dist, fetcher=fetcher, retry_attempts=1)
+
+
+def test_alpha_post_publish_probe_allows_pending_guard_metadata() -> None:
+    workflow_path = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "publish.yml"
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    verify_step = next(
+        step
+        for step in workflow["jobs"]["publish-alpha-pypi"]["steps"]
+        if step.get("name") == "Download and verify exact PyPI artifacts"
+    )
+
+    assert 'guard_status" != "pending"' in verify_step["run"]

--- a/tests/test_verify_release_registry.py
+++ b/tests/test_verify_release_registry.py
@@ -63,52 +63,6 @@ class FakeFetcher:
         return response
 
 
-class SequencedFetcher:
-    def __init__(self, url: str, responses: list[bytes | Exception]) -> None:
-        self.url = url
-        self.responses = responses
-        self.calls: list[str] = []
-
-    def __call__(self, url: str) -> bytes:
-        self.calls.append(url)
-        if url != self.url:
-            raise AssertionError(f"Unexpected fetch: {url}")
-        if not self.responses:
-            raise AssertionError("Fetcher response sequence was exhausted")
-        response = self.responses.pop(0)
-        if isinstance(response, Exception):
-            raise response
-        return response
-
-
-class DownloadFetcher:
-    def __init__(
-        self,
-        release_url: str,
-        release_payload: bytes,
-        files: dict[str, bytes],
-        failing_url: str,
-        failure_count: int,
-    ) -> None:
-        self.release_url = release_url
-        self.release_payload = release_payload
-        self.files = files
-        self.failing_url = failing_url
-        self.remaining_failures = failure_count
-        self.calls: list[str] = []
-
-    def __call__(self, url: str) -> bytes:
-        self.calls.append(url)
-        if url == self.release_url:
-            return self.release_payload
-        if url not in self.files:
-            raise AssertionError(f"Unexpected fetch: {url}")
-        if url == self.failing_url and self.remaining_failures:
-            self.remaining_failures -= 1
-            raise _http_error(url, 404)
-        return self.files[url]
-
-
 def _project_url(registry: Registry, project_name: str = "hol-guard") -> str:
     return f"https://{registry.api_host}/pypi/{project_name}/json"
 
@@ -397,7 +351,7 @@ def test_verify_testpypi_accepts_absent_release(tmp_path: Path) -> None:
     url = _release_url(Registry.TESTPYPI)
     fetcher = FakeFetcher({url: _http_error(url, 404)})
 
-    result = verify_testpypi_release(VERSION, dist, fetcher=fetcher, retry_attempts=1)
+    result = verify_testpypi_release(VERSION, dist, fetcher=fetcher)
 
     assert result.status == "absent"
     assert set(result.files) == {WHEEL, SDIST}
@@ -409,7 +363,7 @@ def test_generic_registry_reconciliation_reports_absent(tmp_path: Path, registry
     url = _release_url(registry)
     fetcher = FakeFetcher({url: _http_error(url, 404)})
 
-    result = verify_registry_release(registry, VERSION, dist, fetcher=fetcher, retry_attempts=1)
+    result = verify_registry_release(registry, VERSION, dist, fetcher=fetcher)
 
     assert result.registry is registry
     assert result.status == "absent"
@@ -509,225 +463,6 @@ def test_verify_release_cli_reconciles_pypi_without_exposing_urls(
     assert "pythonhosted.org" not in output
 
 
-def test_verify_registry_release_reports_absent_without_internal_retry(tmp_path: Path) -> None:
-    dist = _local_dist(tmp_path)
-    url = _release_url(Registry.PYPI)
-    fetcher = SequencedFetcher(url, [_http_error(url, 404)])
-    delays: list[float] = []
-
-    result = verify_registry_release(
-        Registry.PYPI,
-        VERSION,
-        dist,
-        fetcher=fetcher,
-        retry_attempts=2,
-        sleep=delays.append,
-    )
-
-    assert result.status == "absent"
-    assert fetcher.calls == [url]
-    assert delays == []
-
-
-def test_verify_registry_release_retries_transient_metadata_error(tmp_path: Path) -> None:
-    dist = _local_dist(tmp_path)
-    url = _release_url(Registry.PYPI)
-    payload = _release_payload(
-        Registry.PYPI,
-        {WHEEL: (WHEEL_BYTES, None), SDIST: (SDIST_BYTES, None)},
-    )
-    fetcher = SequencedFetcher(url, [_http_error(url, 503), payload])
-    delays: list[float] = []
-
-    result = verify_registry_release(
-        Registry.PYPI,
-        VERSION,
-        dist,
-        fetcher=fetcher,
-        retry_attempts=2,
-        sleep=delays.append,
-    )
-
-    assert result.status == "exact"
-    assert fetcher.calls == [url, url]
-    assert delays == [registry_module.REGISTRY_RETRY_INITIAL_DELAY_SECONDS]
-
-
-def test_verify_registry_release_retries_partial_pypi_metadata(tmp_path: Path) -> None:
-    dist = _local_dist(tmp_path)
-    url = _release_url(Registry.PYPI)
-    partial_payload = _release_payload(Registry.PYPI, {WHEEL: (WHEEL_BYTES, None)})
-    complete_payload = _release_payload(
-        Registry.PYPI,
-        {WHEEL: (WHEEL_BYTES, None), SDIST: (SDIST_BYTES, None)},
-    )
-    fetcher = SequencedFetcher(url, [partial_payload, complete_payload])
-    delays: list[float] = []
-
-    result = verify_registry_release(
-        Registry.PYPI,
-        VERSION,
-        dist,
-        fetcher=fetcher,
-        retry_attempts=2,
-        sleep=delays.append,
-    )
-
-    assert result.status == "exact"
-    assert fetcher.calls == [url, url]
-    assert delays == [registry_module.REGISTRY_RETRY_INITIAL_DELAY_SECONDS]
-
-
-def test_verify_registry_release_fails_after_persistent_partial_metadata(tmp_path: Path) -> None:
-    dist = _local_dist(tmp_path)
-    url = _release_url(Registry.PYPI)
-    partial_payload = _release_payload(Registry.PYPI, {WHEEL: (WHEEL_BYTES, None)})
-    fetcher = SequencedFetcher(url, [partial_payload, partial_payload, partial_payload])
-    delays: list[float] = []
-
-    with pytest.raises(RegistryVerificationError, match=r"missing=hol_guard-2\.2\.0a1\.tar\.gz"):
-        verify_registry_release(
-            Registry.PYPI,
-            VERSION,
-            dist,
-            fetcher=fetcher,
-            retry_attempts=3,
-            retry_initial_delay_seconds=0,
-            retry_max_delay_seconds=0,
-            sleep=delays.append,
-        )
-
-    assert fetcher.calls == [url, url, url]
-    assert delays == [0, 0]
-
-
-def test_verify_registry_release_retries_transient_download_404(tmp_path: Path) -> None:
-    dist = _local_dist(tmp_path)
-    release_url = _release_url(Registry.PYPI)
-    payload = _release_payload(
-        Registry.PYPI,
-        {WHEEL: (WHEEL_BYTES, None), SDIST: (SDIST_BYTES, None)},
-    )
-    wheel_url = _file_url(Registry.PYPI, WHEEL)
-    fetcher = DownloadFetcher(
-        release_url,
-        payload,
-        {
-            wheel_url: WHEEL_BYTES,
-            _file_url(Registry.PYPI, SDIST): SDIST_BYTES,
-        },
-        wheel_url,
-        failure_count=1,
-    )
-    delays: list[float] = []
-
-    result = verify_registry_release(
-        Registry.PYPI,
-        VERSION,
-        dist,
-        download_dir=tmp_path / "verified",
-        fetcher=fetcher,
-        retry_attempts=2,
-        sleep=delays.append,
-    )
-
-    assert result.status == "exact"
-    assert {path.name: path.read_bytes() for path in result.downloaded_paths} == {
-        WHEEL: WHEEL_BYTES,
-        SDIST: SDIST_BYTES,
-    }
-    assert fetcher.calls.count(release_url) == 2
-    assert fetcher.calls.count(wheel_url) == 2
-    assert delays == [registry_module.REGISTRY_RETRY_INITIAL_DELAY_SECONDS]
-
-
-def test_verify_registry_release_fails_after_persistent_download_404(tmp_path: Path) -> None:
-    dist = _local_dist(tmp_path)
-    release_url = _release_url(Registry.PYPI)
-    payload = _release_payload(
-        Registry.PYPI,
-        {WHEEL: (WHEEL_BYTES, None), SDIST: (SDIST_BYTES, None)},
-    )
-    wheel_url = _file_url(Registry.PYPI, WHEEL)
-    download_dir = tmp_path / "verified"
-    fetcher = DownloadFetcher(
-        release_url,
-        payload,
-        {
-            wheel_url: WHEEL_BYTES,
-            _file_url(Registry.PYPI, SDIST): SDIST_BYTES,
-        },
-        wheel_url,
-        failure_count=3,
-    )
-    delays: list[float] = []
-
-    with pytest.raises(RegistryVerificationError, match="HTTP 404"):
-        verify_registry_release(
-            Registry.PYPI,
-            VERSION,
-            dist,
-            download_dir=download_dir,
-            fetcher=fetcher,
-            retry_attempts=3,
-            retry_initial_delay_seconds=0,
-            retry_max_delay_seconds=0,
-            sleep=delays.append,
-        )
-
-    assert fetcher.calls.count(release_url) == 3
-    assert fetcher.calls.count(wheel_url) == 3
-    assert not (download_dir / WHEEL).exists()
-    assert not (download_dir / SDIST).exists()
-    assert delays == [0, 0]
-
-
-@pytest.mark.parametrize(
-    "retry_settings",
-    [
-        {"retry_attempts": 10**100},
-        {"retry_max_delay_seconds": 10**1000},
-        {"retry_initial_delay_seconds": 61, "retry_max_delay_seconds": 61},
-        {"retry_attempts": 6, "retry_initial_delay_seconds": 3, "retry_max_delay_seconds": 30},
-        {"retry_initial_delay_seconds": float("nan"), "retry_max_delay_seconds": 1},
-    ],
-)
-def test_verify_registry_release_rejects_unbounded_retry_settings(
-    tmp_path: Path,
-    retry_settings: dict[str, int | float],
-) -> None:
-    dist = _local_dist(tmp_path)
-    fetcher = FakeFetcher({})
-
-    with pytest.raises(RegistryVerificationError, match="Registry retry"):
-        verify_registry_release(Registry.PYPI, VERSION, dist, fetcher=fetcher, **retry_settings)
-
-    assert fetcher.calls == []
-
-
-@pytest.mark.parametrize(
-    "files",
-    [
-        {WHEEL: (b"different", None), SDIST: (SDIST_BYTES, None)},
-        {WHEEL: (WHEEL_BYTES, None)},
-        {
-            WHEEL: (WHEEL_BYTES, None),
-            SDIST: (SDIST_BYTES, None),
-            f"hol_guard-{VERSION}-py2-none-any.whl": (b"extra", None),
-        },
-    ],
-)
-def test_verify_testpypi_rejects_mismatch_partial_and_extra(
-    tmp_path: Path,
-    files: dict[str, tuple[bytes, str | None]],
-) -> None:
-    dist = _local_dist(tmp_path)
-    fetcher = FakeFetcher({_release_url(Registry.TESTPYPI): _release_payload(Registry.TESTPYPI, files)})
-
-    with pytest.raises(RegistryVerificationError):
-        verify_testpypi_release(VERSION, dist, fetcher=fetcher, retry_attempts=1)
-
-
 def test_generic_pypi_reconciliation_rejects_digest_mismatch(tmp_path: Path) -> None:
     dist = _local_dist(tmp_path)
     payload = _release_payload(
@@ -738,7 +473,6 @@ def test_generic_pypi_reconciliation_rejects_digest_mismatch(tmp_path: Path) -> 
 
     with pytest.raises(RegistryVerificationError, match="pypi distribution digest mismatch"):
         verify_registry_release(Registry.PYPI, VERSION, dist, fetcher=fetcher)
-    assert fetcher.calls == [_release_url(Registry.PYPI)]
 
 
 def test_download_rejects_tampered_bytes_without_writing_target(tmp_path: Path) -> None:

--- a/tests/test_verify_release_registry.py
+++ b/tests/test_verify_release_registry.py
@@ -666,6 +666,7 @@ def test_verify_registry_release_fails_after_persistent_download_404(tmp_path: P
     "retry_settings",
     [
         {"retry_attempts": 10**100},
+        {"retry_max_delay_seconds": 10**1000},
         {"retry_initial_delay_seconds": 61, "retry_max_delay_seconds": 61},
         {"retry_attempts": 6, "retry_initial_delay_seconds": 3, "retry_max_delay_seconds": 30},
         {"retry_initial_delay_seconds": float("nan"), "retry_max_delay_seconds": 1},

--- a/tests/test_verify_release_registry.py
+++ b/tests/test_verify_release_registry.py
@@ -63,6 +63,52 @@ class FakeFetcher:
         return response
 
 
+class SequencedFetcher:
+    def __init__(self, url: str, responses: list[bytes | Exception]) -> None:
+        self.url = url
+        self.responses = responses
+        self.calls: list[str] = []
+
+    def __call__(self, url: str) -> bytes:
+        self.calls.append(url)
+        if url != self.url:
+            raise AssertionError(f"Unexpected fetch: {url}")
+        if not self.responses:
+            raise AssertionError("Fetcher response sequence was exhausted")
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+class DownloadFetcher:
+    def __init__(
+        self,
+        release_url: str,
+        release_payload: bytes,
+        files: dict[str, bytes],
+        failing_url: str,
+        failure_count: int,
+    ) -> None:
+        self.release_url = release_url
+        self.release_payload = release_payload
+        self.files = files
+        self.failing_url = failing_url
+        self.remaining_failures = failure_count
+        self.calls: list[str] = []
+
+    def __call__(self, url: str) -> bytes:
+        self.calls.append(url)
+        if url == self.release_url:
+            return self.release_payload
+        if url not in self.files:
+            raise AssertionError(f"Unexpected fetch: {url}")
+        if url == self.failing_url and self.remaining_failures:
+            self.remaining_failures -= 1
+            raise _http_error(url, 404)
+        return self.files[url]
+
+
 def _project_url(registry: Registry, project_name: str = "hol-guard") -> str:
     return f"https://{registry.api_host}/pypi/{project_name}/json"
 
@@ -351,7 +397,7 @@ def test_verify_testpypi_accepts_absent_release(tmp_path: Path) -> None:
     url = _release_url(Registry.TESTPYPI)
     fetcher = FakeFetcher({url: _http_error(url, 404)})
 
-    result = verify_testpypi_release(VERSION, dist, fetcher=fetcher)
+    result = verify_testpypi_release(VERSION, dist, fetcher=fetcher, retry_attempts=1)
 
     assert result.status == "absent"
     assert set(result.files) == {WHEEL, SDIST}
@@ -363,7 +409,7 @@ def test_generic_registry_reconciliation_reports_absent(tmp_path: Path, registry
     url = _release_url(registry)
     fetcher = FakeFetcher({url: _http_error(url, 404)})
 
-    result = verify_registry_release(registry, VERSION, dist, fetcher=fetcher)
+    result = verify_registry_release(registry, VERSION, dist, fetcher=fetcher, retry_attempts=1)
 
     assert result.registry is registry
     assert result.status == "absent"
@@ -463,6 +509,181 @@ def test_verify_release_cli_reconciles_pypi_without_exposing_urls(
     assert "pythonhosted.org" not in output
 
 
+def test_verify_registry_release_retries_until_pypi_release_appears(tmp_path: Path) -> None:
+    dist = _local_dist(tmp_path)
+    url = _release_url(Registry.PYPI)
+    payload = _release_payload(
+        Registry.PYPI,
+        {WHEEL: (WHEEL_BYTES, None), SDIST: (SDIST_BYTES, None)},
+    )
+    fetcher = SequencedFetcher(url, [_http_error(url, 404), payload])
+    delays: list[float] = []
+
+    result = verify_registry_release(
+        Registry.PYPI,
+        VERSION,
+        dist,
+        fetcher=fetcher,
+        retry_attempts=2,
+        sleep=delays.append,
+    )
+
+    assert result.status == "exact"
+    assert fetcher.calls == [url, url]
+    assert delays == [registry_module.REGISTRY_RETRY_INITIAL_DELAY_SECONDS]
+
+
+def test_verify_registry_release_retries_partial_pypi_metadata(tmp_path: Path) -> None:
+    dist = _local_dist(tmp_path)
+    url = _release_url(Registry.PYPI)
+    partial_payload = _release_payload(Registry.PYPI, {WHEEL: (WHEEL_BYTES, None)})
+    complete_payload = _release_payload(
+        Registry.PYPI,
+        {WHEEL: (WHEEL_BYTES, None), SDIST: (SDIST_BYTES, None)},
+    )
+    fetcher = SequencedFetcher(url, [partial_payload, complete_payload])
+    delays: list[float] = []
+
+    result = verify_registry_release(
+        Registry.PYPI,
+        VERSION,
+        dist,
+        fetcher=fetcher,
+        retry_attempts=2,
+        sleep=delays.append,
+    )
+
+    assert result.status == "exact"
+    assert fetcher.calls == [url, url]
+    assert delays == [registry_module.REGISTRY_RETRY_INITIAL_DELAY_SECONDS]
+
+
+def test_verify_registry_release_fails_after_persistent_partial_metadata(tmp_path: Path) -> None:
+    dist = _local_dist(tmp_path)
+    url = _release_url(Registry.PYPI)
+    partial_payload = _release_payload(Registry.PYPI, {WHEEL: (WHEEL_BYTES, None)})
+    fetcher = SequencedFetcher(url, [partial_payload, partial_payload, partial_payload])
+    delays: list[float] = []
+
+    with pytest.raises(RegistryVerificationError, match=r"missing=hol_guard-2\.2\.0a1\.tar\.gz"):
+        verify_registry_release(
+            Registry.PYPI,
+            VERSION,
+            dist,
+            fetcher=fetcher,
+            retry_attempts=3,
+            retry_initial_delay_seconds=0,
+            retry_max_delay_seconds=0,
+            sleep=delays.append,
+        )
+
+    assert fetcher.calls == [url, url, url]
+    assert delays == [0, 0]
+
+
+def test_verify_registry_release_retries_transient_download_404(tmp_path: Path) -> None:
+    dist = _local_dist(tmp_path)
+    release_url = _release_url(Registry.PYPI)
+    payload = _release_payload(
+        Registry.PYPI,
+        {WHEEL: (WHEEL_BYTES, None), SDIST: (SDIST_BYTES, None)},
+    )
+    wheel_url = _file_url(Registry.PYPI, WHEEL)
+    fetcher = DownloadFetcher(
+        release_url,
+        payload,
+        {
+            wheel_url: WHEEL_BYTES,
+            _file_url(Registry.PYPI, SDIST): SDIST_BYTES,
+        },
+        wheel_url,
+        failure_count=1,
+    )
+    delays: list[float] = []
+
+    result = verify_registry_release(
+        Registry.PYPI,
+        VERSION,
+        dist,
+        download_dir=tmp_path / "verified",
+        fetcher=fetcher,
+        retry_attempts=2,
+        sleep=delays.append,
+    )
+
+    assert result.status == "exact"
+    assert {path.name: path.read_bytes() for path in result.downloaded_paths} == {
+        WHEEL: WHEEL_BYTES,
+        SDIST: SDIST_BYTES,
+    }
+    assert fetcher.calls.count(release_url) == 2
+    assert fetcher.calls.count(wheel_url) == 2
+    assert delays == [registry_module.REGISTRY_RETRY_INITIAL_DELAY_SECONDS]
+
+
+def test_verify_registry_release_fails_after_persistent_download_404(tmp_path: Path) -> None:
+    dist = _local_dist(tmp_path)
+    release_url = _release_url(Registry.PYPI)
+    payload = _release_payload(
+        Registry.PYPI,
+        {WHEEL: (WHEEL_BYTES, None), SDIST: (SDIST_BYTES, None)},
+    )
+    wheel_url = _file_url(Registry.PYPI, WHEEL)
+    download_dir = tmp_path / "verified"
+    fetcher = DownloadFetcher(
+        release_url,
+        payload,
+        {
+            wheel_url: WHEEL_BYTES,
+            _file_url(Registry.PYPI, SDIST): SDIST_BYTES,
+        },
+        wheel_url,
+        failure_count=3,
+    )
+    delays: list[float] = []
+
+    with pytest.raises(RegistryVerificationError, match="HTTP 404"):
+        verify_registry_release(
+            Registry.PYPI,
+            VERSION,
+            dist,
+            download_dir=download_dir,
+            fetcher=fetcher,
+            retry_attempts=3,
+            retry_initial_delay_seconds=0,
+            retry_max_delay_seconds=0,
+            sleep=delays.append,
+        )
+
+    assert fetcher.calls.count(release_url) == 3
+    assert fetcher.calls.count(wheel_url) == 3
+    assert not (download_dir / WHEEL).exists()
+    assert not (download_dir / SDIST).exists()
+    assert delays == [0, 0]
+
+
+@pytest.mark.parametrize(
+    "retry_settings",
+    [
+        {"retry_attempts": 10**100},
+        {"retry_initial_delay_seconds": 61, "retry_max_delay_seconds": 61},
+        {"retry_attempts": 6, "retry_initial_delay_seconds": 3, "retry_max_delay_seconds": 30},
+        {"retry_initial_delay_seconds": float("nan"), "retry_max_delay_seconds": 1},
+    ],
+)
+def test_verify_registry_release_rejects_unbounded_retry_settings(
+    tmp_path: Path,
+    retry_settings: dict[str, int | float],
+) -> None:
+    dist = _local_dist(tmp_path)
+    fetcher = FakeFetcher({})
+
+    with pytest.raises(RegistryVerificationError, match="Registry retry"):
+        verify_registry_release(Registry.PYPI, VERSION, dist, fetcher=fetcher, **retry_settings)
+
+    assert fetcher.calls == []
+
+
 @pytest.mark.parametrize(
     "files",
     [
@@ -483,7 +704,7 @@ def test_verify_testpypi_rejects_mismatch_partial_and_extra(
     fetcher = FakeFetcher({_release_url(Registry.TESTPYPI): _release_payload(Registry.TESTPYPI, files)})
 
     with pytest.raises(RegistryVerificationError):
-        verify_testpypi_release(VERSION, dist, fetcher=fetcher)
+        verify_testpypi_release(VERSION, dist, fetcher=fetcher, retry_attempts=1)
 
 
 def test_generic_pypi_reconciliation_rejects_digest_mismatch(tmp_path: Path) -> None:
@@ -496,6 +717,7 @@ def test_generic_pypi_reconciliation_rejects_digest_mismatch(tmp_path: Path) -> 
 
     with pytest.raises(RegistryVerificationError, match="pypi distribution digest mismatch"):
         verify_registry_release(Registry.PYPI, VERSION, dist, fetcher=fetcher)
+    assert fetcher.calls == [_release_url(Registry.PYPI)]
 
 
 def test_download_rejects_tampered_bytes_without_writing_target(tmp_path: Path) -> None:

--- a/tests/test_verify_release_registry.py
+++ b/tests/test_verify_release_registry.py
@@ -509,14 +509,34 @@ def test_verify_release_cli_reconciles_pypi_without_exposing_urls(
     assert "pythonhosted.org" not in output
 
 
-def test_verify_registry_release_retries_until_pypi_release_appears(tmp_path: Path) -> None:
+def test_verify_registry_release_reports_absent_without_internal_retry(tmp_path: Path) -> None:
+    dist = _local_dist(tmp_path)
+    url = _release_url(Registry.PYPI)
+    fetcher = SequencedFetcher(url, [_http_error(url, 404)])
+    delays: list[float] = []
+
+    result = verify_registry_release(
+        Registry.PYPI,
+        VERSION,
+        dist,
+        fetcher=fetcher,
+        retry_attempts=2,
+        sleep=delays.append,
+    )
+
+    assert result.status == "absent"
+    assert fetcher.calls == [url]
+    assert delays == []
+
+
+def test_verify_registry_release_retries_transient_metadata_error(tmp_path: Path) -> None:
     dist = _local_dist(tmp_path)
     url = _release_url(Registry.PYPI)
     payload = _release_payload(
         Registry.PYPI,
         {WHEEL: (WHEEL_BYTES, None), SDIST: (SDIST_BYTES, None)},
     )
-    fetcher = SequencedFetcher(url, [_http_error(url, 404), payload])
+    fetcher = SequencedFetcher(url, [_http_error(url, 503), payload])
     delays: list[float] = []
 
     result = verify_registry_release(


### PR DESCRIPTION
## Summary

- Add bounded retries for transient registry metadata and artifact visibility.
- Preserve strict version, project, artifact-set, URL, and digest validation.
- Cover eventual metadata, transient and persistent download failures, and retry-budget rejection.

## Testing

- `uv run --no-sync pytest -q tests/test_verify_release_registry.py`
- `uv run --no-sync ruff check scripts/verify_release_registry.py tests/test_verify_release_registry.py`
- `uv run --no-sync ruff format --check scripts/verify_release_registry.py tests/test_verify_release_registry.py`
- `uv run --with packaging==25.0 basedpyright scripts/verify_release_registry.py`
- Codex Security diff scan: no findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release verification now automatically retries temporary registry and network failures.
  * Verification retries releases that are not yet fully available or whose distribution files are incomplete.
  * Retry timing supports configurable attempts and exponential backoff limits.
  * The release inspection command validates versions and reports releases that are still pending.

* **Bug Fixes**
  * Reduced verification failures caused by temporary registry responses, delayed release availability, and transient download errors.
  * Releases confirmed as absent are reported immediately instead of being retried.
  * Publishing checks now continue while release metadata is pending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->