### PR TITLE
fix(tests): stabilize load-sensitive hook and scheduler tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,6 +391,7 @@ jobs:
           tests/test_guard_extension_control_recovery.py
           tests/test_guard_sandbox.py
           tests/test_guard_js_lockfile_resolution_phase11.py
+          tests/test_guard_runtime_hook_scheduler.py
           --tb=short
 
   compatibility:

--- a/ci/code-quality-baseline.json
+++ b/ci/code-quality-baseline.json
@@ -431,7 +431,7 @@
     "src/codex_plugin_scanner/verification.py::_check_marketplace": 115
   },
   "oversized_files": {
-    ".github/workflows/ci.yml": 671,
+    ".github/workflows/ci.yml": 672,
     ".github/workflows/desktop-core-alpha-feed.yml": 539,
     ".github/workflows/publish.yml": 1718,
     "dashboard/src/app.tsx": 1052,
@@ -720,7 +720,7 @@
     "tests/test_guard_supply_chain_daemon.py": 613,
     "tests/test_guard_supply_chain_evaluator.py": 3384,
     "tests/test_guard_supply_chain_sync.py": 886,
-    "tests/test_guard_surface_server.py": 4656,
+    "tests/test_guard_surface_server.py": 4664,
     "tests/test_guard_temporary_mcp_approvals.py": 620,
     "tests/test_guard_threat_intel.py": 577,
     "tests/test_guard_update_artifact.py": 1088,
@@ -731,7 +731,7 @@
     "tests/test_opencode_adapter.py": 1042,
     "tests/test_opencode_pretool.py": 788,
     "tests/test_pi_adapter.py": 997,
-    "tests/test_pi_hook_latency.py": 534,
+    "tests/test_pi_hook_latency.py": 547,
     "tests/test_policy_bundle_parser.py": 1216,
     "tests/test_policy_bundle_trust_regressions.py": 686,
     "tests/test_policy_bundle_v2.py": 537,

--- a/ci/code-quality-baseline.json
+++ b/ci/code-quality-baseline.json
@@ -720,7 +720,7 @@
     "tests/test_guard_supply_chain_daemon.py": 613,
     "tests/test_guard_supply_chain_evaluator.py": 3384,
     "tests/test_guard_supply_chain_sync.py": 886,
-    "tests/test_guard_surface_server.py": 4664,
+    "tests/test_guard_surface_server.py": 4685,
     "tests/test_guard_temporary_mcp_approvals.py": 620,
     "tests/test_guard_threat_intel.py": 577,
     "tests/test_guard_update_artifact.py": 1088,

--- a/tests/test_guard_daemon_acceptance.py
+++ b/tests/test_guard_daemon_acceptance.py
@@ -10,7 +10,9 @@ from typing import Protocol, cast
 
 import pytest
 
+from codex_plugin_scanner.guard.daemon import server as daemon_server_module
 from codex_plugin_scanner.guard.daemon.runtime_hook_scheduler import RuntimeHookScheduler
+from tests.coverage_ci import under_coverage_scale
 from tests.guard_daemon_acceptance_fixtures import (
     WorkloadSpec,
     assert_adversarial_nodeids_resolve,
@@ -29,7 +31,18 @@ def test_adversarial_workload_nodeids_resolve() -> None:
 
 
 @pytest.mark.parametrize("workload", load_correctness_workloads(), ids=_fixture_id)
-def test_packaged_correctness_workloads(workload: WorkloadSpec, tmp_path: Path) -> None:
+def test_packaged_correctness_workloads(
+    workload: WorkloadSpec, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Coverage tracing inflates every request round trip; scale the transport
+    # admission deadline and the latency SLA budgets so the workload verdicts
+    # (deny/allow/fairness) stay the assertion target, not tracer overhead.
+    coverage_scale = under_coverage_scale(3.0)
+    monkeypatch.setattr(
+        daemon_server_module,
+        "_RUNTIME_HOOK_ADMISSION_TIMEOUT_SECONDS",
+        daemon_server_module._RUNTIME_HOOK_ADMISSION_TIMEOUT_SECONDS * coverage_scale,
+    )
     result = run_workload(workload, root=tmp_path)
     expected_secrets = sum(
         (client["requests"] + workload["secret_stride"] - 1) // workload["secret_stride"]
@@ -46,9 +59,9 @@ def test_packaged_correctness_workloads(workload: WorkloadSpec, tmp_path: Path) 
     assert result.queue_bounded
     assert result.rss_growth_bytes < 128 * 1024 * 1024
     # Codex requests add an authenticated challenge round trip in the mixed-harness profile.
-    p95_limit_ms = 1_000 if workload["id"] == "mixed-harness-fairness" else 750
+    p95_limit_ms = (1_000 if workload["id"] == "mixed-harness-fairness" else 750) * coverage_scale
     assert result.p95_ms < p95_limit_ms
-    assert result.p99_ms < 2_500
+    assert result.p99_ms < 2_500 * coverage_scale
     assert result.browser_launches == 0
     assert result.inbox_requests == 0
     if len(result.dispatch_counts) == 4:

--- a/tests/test_guard_runtime_hook_scheduler.py
+++ b/tests/test_guard_runtime_hook_scheduler.py
@@ -4,8 +4,10 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 
+import pytest
+
 from codex_plugin_scanner.guard.daemon.runtime_hook_scheduler import RuntimeHookScheduler
-from tests.coverage_ci import under_coverage_scale
+from tests.coverage_ci import UNDER_COVERAGE_TRACING, under_coverage_scale
 
 
 def test_scheduler_waits_for_capacity_instead_of_rejecting() -> None:
@@ -61,6 +63,10 @@ def test_scheduler_dynamic_capacity_wakes_waiter() -> None:
     assert scheduler.stats()["active_limit"] == 1
 
 
+@pytest.mark.skipif(
+    UNDER_COVERAGE_TRACING,
+    reason="Concurrent scheduler throughput shifts under coverage tracing; run untraced",
+)
 def test_scheduler_handles_48_routine_reviews_without_capacity_rejection() -> None:
     coverage_scale = under_coverage_scale(3.0)
     scheduler = RuntimeHookScheduler(

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -4662,3 +4662,24 @@ class TestGuardDaemonFastHookPath:
             monkeypatch.delenv("HOL_GUARD_HOOK_FAST_PATH", raising=False)
 
         assert result["model_output_action"] != "allow_original"
+
+
+def test_unauthorized_response_waits_for_audit_recording() -> None:
+    calls: list[str] = []
+
+    class _OrderingStub:
+        def _record_auth_audit_event(self) -> None:
+            calls.append("audit")
+
+        def _write_json(
+            self,
+            body: dict[str, object],
+            *,
+            status: int = 200,
+            extra_headers: dict[str, str] | None = None,
+        ) -> None:
+            calls.append(f"json:{status}")
+
+    daemon_server_module._GuardDaemonHandler._write_unauthorized(_OrderingStub())  # pyright: ignore[reportPrivateUsage]
+
+    assert calls == ["audit", "json:401"]

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -1152,14 +1152,23 @@ class TestGuardSurfaceServer:
                 method="POST",
             )
             with pytest.raises(urllib.error.HTTPError) as error:
-                urllib.request.urlopen(request, timeout=5)
+                urllib.request.urlopen(request, timeout=15)
         finally:
             daemon.stop()
 
         assert error.value.code == 401
         payload = json.loads(error.value.read().decode("utf-8"))
         assert payload["error"] == "unauthorized"
-        events = store.list_events(event_name="daemon.auth.unauthorized")
+        # The unauthorized audit is persisted before the 401 is written, but the
+        # sqlite write can lag under shard load; poll briefly instead of racing it.
+        events: list[dict[str, object]] = []
+        audit_deadline = time.monotonic() + 10.0
+        while time.monotonic() < audit_deadline:
+            events = store.list_events(event_name="daemon.auth.unauthorized")
+            if events:
+                break
+            time.sleep(0.05)
+        assert events, "unauthorized audit event was never persisted"
         assert events[-1]["payload"]["path"] == "/v1/hooks/claude-code"
 
     def test_guard_daemon_claude_hook_endpoint_returns_notification_context_with_auth(self, tmp_path) -> None:

--- a/tests/test_pi_hook_latency.py
+++ b/tests/test_pi_hook_latency.py
@@ -16,10 +16,12 @@ from typing import Protocol, cast
 
 import pytest
 
+from codex_plugin_scanner.guard.daemon import server as daemon_server_module
 from codex_plugin_scanner.guard.daemon.hook_process_runner import HookProcessReview
 from codex_plugin_scanner.guard.daemon.manager import GUARD_DAEMON_COMPATIBILITY_VERSION
 from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
 from codex_plugin_scanner.guard.store import GuardStore
+from tests.coverage_ci import under_coverage_scale
 
 
 class _DaemonInternals(Protocol):
@@ -71,12 +73,23 @@ def _pi_hook_request(*, daemon: GuardDaemonServer, guard_home: str, call_id: str
     )
 
 
-def test_review_required_pi_hook_returns_before_worker_deadline(tmp_path: Path) -> None:
+def test_review_required_pi_hook_returns_before_worker_deadline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     guard_home = tmp_path / "guard-home"
     store = GuardStore(guard_home)
     (guard_home / "config.toml").write_text(
         'security_level = "custom"\n[risk_actions]\nlocal_secret_read = "review"\n',
         encoding="utf-8",
+    )
+    # The transport admission deadline binds hint-less reviews; coverage tracing
+    # slows the review pipeline past it into the deliberate fail-open path, so
+    # covered CI runs scale the deadline and the asserted latency bound together.
+    coverage_scale = under_coverage_scale(3.0)
+    monkeypatch.setattr(
+        daemon_server_module,
+        "_RUNTIME_HOOK_ADMISSION_TIMEOUT_SECONDS",
+        daemon_server_module._RUNTIME_HOOK_ADMISSION_TIMEOUT_SECONDS * coverage_scale,
     )
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
@@ -101,7 +114,7 @@ def test_review_required_pi_hook_returns_before_worker_deadline(tmp_path: Path) 
     )
     try:
         started = time.monotonic()
-        with urllib.request.urlopen(request, timeout=2) as response:
+        with urllib.request.urlopen(request, timeout=2 * coverage_scale) as response:
             result = _read_json_object(response)
         elapsed = time.monotonic() - started
     finally:
@@ -109,7 +122,7 @@ def test_review_required_pi_hook_returns_before_worker_deadline(tmp_path: Path) 
 
     assert result["decision"] == "deny"
     assert store.count_pending_requests(harness="pi") == 1
-    assert elapsed < 1.45
+    assert elapsed < 1.45 * coverage_scale
 
 
 def test_pi_hook_is_not_queued_behind_unrelated_overlay_free_review(


### PR DESCRIPTION
## Summary
- Poll for the daemon unauthorized audit event instead of racing the sqlite write under shard load, and raise the hook client timeout to the retry budget used by the network helpers
- Scale the pi hook review transport deadline and its latency bound under coverage tracing so tracer overhead cannot push the review into the deliberate fail-open path
- Scale the packaged correctness workload admission deadline and p95/p99 SLA budgets under tracing so the workload verdicts (deny/allow/fairness) stay the assertion target
- Move the 48-review scheduler throughput test to the untraced scheduling-sensitive CI job, matching the established pattern for thread-starvation-sensitive tests

## Testing
- `pytest tests/test_pi_hook_latency.py tests/test_guard_surface_server.py` — 122 passed
- `pytest "tests/test_pi_hook_latency.py::test_review_required_pi_hook_returns_before_worker_deadline"` 5x with `GUARD_PYTEST_UNDER_COVERAGE=1 --cov` — all passed
- `pytest tests/test_guard_daemon_acceptance.py::test_packaged_correctness_workloads` traced and untraced — all passed
- `pytest tests/test_guard_runtime_hook_scheduler.py` untraced (16 passed) and traced (skip fires)
- `ruff check` / `ruff format --check`, `scripts/ci/test_inventory.py`, `scripts/ci/code_quality_audit.py` — all pass

## Notes
- Product fail-open and audit-before-respond ordering are unchanged; only test-side timing accommodations and CI job placement changed
