### PR TITLE
fix(release): use binary units for PyPI storage quota

### DIFF
--- a/scripts/pypi_project_storage.py
+++ b/scripts/pypi_project_storage.py
@@ -13,7 +13,8 @@ from typing import Any
 from packaging.version import InvalidVersion, Version
 
 PYPI_JSON_URL = "https://pypi.org/pypi/hol-guard/json"
-PYPI_PROJECT_LIMIT_BYTES = 10_000_000_000
+PYPI_PROJECT_LIMIT_GIB = 10
+PYPI_PROJECT_LIMIT_BYTES = PYPI_PROJECT_LIMIT_GIB * 1024**3
 
 
 def release_size_bytes(files: object) -> int:
@@ -130,8 +131,17 @@ def main(argv: list[str] | None = None) -> int:
         )
     )
     if args.fail_if_over_limit and over_limit:
-        print("PyPI hol-guard is over the 10 GB project limit.", file=sys.stderr)
-        print("Remove old 3.0.0a native wheels and sdists, then rerun publish.", file=sys.stderr)
+        print(
+            f"PyPI hol-guard is at or over the {PYPI_PROJECT_LIMIT_GIB} GiB project limit.",
+            file=sys.stderr,
+        )
+        if reclaimable:
+            print("Remove old 3.0.0a native wheels and sdists, then rerun publish.", file=sys.stderr)
+        else:
+            print(
+                "No reclaimable 3.0.0a native wheels or sdists were found; review PyPI storage before retrying.",
+                file=sys.stderr,
+            )
         return 1
     return 0
 

--- a/tests/test_pypi_project_storage.py
+++ b/tests/test_pypi_project_storage.py
@@ -5,6 +5,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_PATH = ROOT / "scripts" / "pypi_project_storage.py"
 SPEC = importlib.util.spec_from_file_location("pypi_project_storage", SCRIPT_PATH)
@@ -59,6 +61,49 @@ def test_storage_report_fails_when_over_limit(tmp_path: Path) -> None:
     assert pypi_project_storage.main(["--payload", str(payload_path), "--fail-if-over-limit"]) == 1
 
 
+def test_storage_limit_uses_binary_gib_and_rejects_exact_boundary() -> None:
+    limit = 10 * 1024**3
+
+    assert limit == pypi_project_storage.PYPI_PROJECT_LIMIT_BYTES
+    assert pypi_project_storage.over_project_limit(limit - 1, 1) is True
+    assert pypi_project_storage.over_project_limit(limit - 2, 1) is False
+
+
+def test_pending_upload_near_decimal_limit_fits_binary_limit() -> None:
+    used_bytes = 9_964_936_050
+    pending_bytes = 38_802_982
+
+    assert used_bytes + pending_bytes == 10_003_739_032
+    assert pypi_project_storage.over_project_limit(used_bytes, pending_bytes) is False
+
+
+def test_over_limit_without_reclaimable_files_has_safe_message(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    payload_path = tmp_path / "pypi.json"
+    payload_path.write_text(
+        json.dumps(
+            {
+                "releases": {
+                    "3.0.6": [
+                        {
+                            "filename": "hol_guard-3.0.6.tar.gz",
+                            "size": pypi_project_storage.PYPI_PROJECT_LIMIT_BYTES,
+                        }
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert pypi_project_storage.main(["--payload", str(payload_path), "--fail-if-over-limit"]) == 1
+    error = capsys.readouterr().err
+    assert "at or over the 10 GiB project limit" in error
+    assert "No reclaimable 3.0.0a native wheels or sdists were found" in error
+    assert "Remove old" not in error
+
+
 def test_storage_report_counts_pending_upload_bytes(tmp_path: Path) -> None:
     payload_path = tmp_path / "pypi.json"
     payload_path.write_text(
@@ -95,10 +140,7 @@ def test_storage_report_counts_pending_upload_bytes(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     assert (
-        pypi_project_storage.main(
-            ["--payload", str(tight), "--fail-if-over-limit", "--pending-dir", str(pending)]
-        )
-        == 1
+        pypi_project_storage.main(["--payload", str(tight), "--fail-if-over-limit", "--pending-dir", str(pending)]) == 1
     )
 
 


### PR DESCRIPTION
## Summary
- Match the PyPI project storage check to its 10 GiB default instead of decimal gigabytes.
- Preserve the conservative quota boundary and avoid deletion advice when no eligible artifacts exist.
- Add regression coverage for pending uploads, binary-unit boundaries, and error messages.

## Testing
- `uv run pytest -q tests/test_pypi_project_storage.py`
- `uv run ruff check scripts/pypi_project_storage.py tests/test_pypi_project_storage.py`
- `uv run ruff format --check scripts/pypi_project_storage.py tests/test_pypi_project_storage.py`
- `uv run basedpyright --level error scripts/pypi_project_storage.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected PyPI project storage-limit calculations to use a precise 10 GiB binary limit.
  * Updated over-limit messages to accurately report the limit and provide appropriate guidance when reclaimable artifacts are unavailable.

* **Tests**
  * Added coverage for storage-limit boundaries, pending uploads, and over-limit messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->