### PR TITLE
fix(ci): pass Gitleaks license into Security Gates

### DIFF
--- a/.github/workflows/security-gates.yml
+++ b/.github/workflows/security-gates.yml
@@ -69,6 +69,8 @@ jobs:
     name: Gitleaks
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:

--- a/.github/workflows/security-gates.yml
+++ b/.github/workflows/security-gates.yml
@@ -69,8 +69,6 @@ jobs:
     name: Gitleaks
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    env:
-      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
@@ -143,6 +141,8 @@ jobs:
           echo "log_opts=${BASE_SHA}..${HEAD_SHA}" >> "$GITHUB_OUTPUT"
       - name: Run Gitleaks on isolated commit range
         if: steps.gitleaks-scope.outputs.mode == 'git'
+        env:
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
         run: >-
           gitleaks git
           --log-opts="${{ steps.gitleaks-range.outputs.log_opts }}"
@@ -152,4 +152,6 @@ jobs:
           "${{ steps.gitleaks-range.outputs.repository }}"
       - name: Run Gitleaks on working tree
         if: steps.gitleaks-scope.outputs.mode == 'dir'
+        env:
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
         run: gitleaks dir --no-banner --redact --exit-code 1 .

--- a/tests/test_security_gates_gitleaks_license.py
+++ b/tests/test_security_gates_gitleaks_license.py
@@ -8,15 +8,37 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_PATH = ROOT / ".github" / "workflows" / "security-gates.yml"
+LICENSE_SECRET = "${{ secrets.GITLEAKS_LICENSE }}"
+SCAN_STEP_NAMES = frozenset(
+    {
+        "Run Gitleaks on isolated commit range",
+        "Run Gitleaks on working tree",
+    }
+)
 
 
-def test_gitleaks_job_reads_repository_license_secret() -> None:
+def test_gitleaks_license_is_limited_to_scan_steps() -> None:
     workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
     assert isinstance(workflow, dict)
     jobs = workflow["jobs"]
     assert isinstance(jobs, dict)
     gitleaks = jobs["gitleaks"]
     assert isinstance(gitleaks, dict)
-    env = gitleaks["env"]
-    assert isinstance(env, dict)
-    assert env["GITLEAKS_LICENSE"] == "${{ secrets.GITLEAKS_LICENSE }}"
+    assert "env" not in gitleaks or "GITLEAKS_LICENSE" not in (gitleaks.get("env") or {})
+
+    steps = gitleaks["steps"]
+    assert isinstance(steps, list)
+    licensed_steps: list[str] = []
+    for step in steps:
+        assert isinstance(step, dict)
+        name = step.get("name")
+        env = step.get("env")
+        has_license = isinstance(env, dict) and env.get("GITLEAKS_LICENSE") == LICENSE_SECRET
+        if has_license:
+            assert isinstance(name, str)
+            licensed_steps.append(name)
+            continue
+        if isinstance(env, dict):
+            assert "GITLEAKS_LICENSE" not in env
+
+    assert set(licensed_steps) == SCAN_STEP_NAMES

--- a/tests/test_security_gates_gitleaks_license.py
+++ b/tests/test_security_gates_gitleaks_license.py
@@ -41,4 +41,5 @@ def test_gitleaks_license_is_limited_to_scan_steps() -> None:
         if isinstance(env, dict):
             assert "GITLEAKS_LICENSE" not in env
 
+    assert len(licensed_steps) == len(SCAN_STEP_NAMES)
     assert set(licensed_steps) == SCAN_STEP_NAMES

--- a/tests/test_security_gates_gitleaks_license.py
+++ b/tests/test_security_gates_gitleaks_license.py
@@ -1,0 +1,22 @@
+"""Contracts for the Security Gates Gitleaks license environment."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "security-gates.yml"
+
+
+def test_gitleaks_job_reads_repository_license_secret() -> None:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    assert isinstance(workflow, dict)
+    jobs = workflow["jobs"]
+    assert isinstance(jobs, dict)
+    gitleaks = jobs["gitleaks"]
+    assert isinstance(gitleaks, dict)
+    env = gitleaks["env"]
+    assert isinstance(env, dict)
+    assert env["GITLEAKS_LICENSE"] == "${{ secrets.GITLEAKS_LICENSE }}"


### PR DESCRIPTION
## Summary
- Pass `secrets.GITLEAKS_LICENSE` into the Security Gates Gitleaks job.

## Testing
- `uv run pytest tests/test_security_gates_gitleaks_license.py tests/test_privileged_workflow_policy.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated security scanning workflow configuration so the scanning license is provided only to the isolated commit-range and working-tree scan steps.
  - Prevented the license from being configured at the overall job level, reducing unnecessary exposure during other workflow steps.

- **Tests**
  - Added automated checks confirming the license is unavailable at the job level and configured only for the two intended scanning steps.
  - Added validation to ensure no duplicate or unexpected licensed scan steps are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->