### PR TITLE
fix(store): bound quarantine snapshots and stale update staging

### DIFF
--- a/dashboard/src/desktop-embed.ts
+++ b/dashboard/src/desktop-embed.ts
@@ -1,0 +1,20 @@
+/**
+ * True when this dashboard runs inside the HOL Guard Desktop window. Desktop
+ * owns the managed Core runtime and its updater (menu-bar "Check for
+ * Updates"), so the embedded dashboard must not offer a second, competing
+ * update action against the same runtime.
+ */
+export function dashboardEmbedsInDesktop(): boolean {
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const fragment = window.location.hash.startsWith("#")
+      ? window.location.hash.slice(1)
+      : window.location.hash;
+    for (const [key, value] of new URLSearchParams(fragment)) {
+      params.set(key, value);
+    }
+    return params.get("desktop_embed") === "1";
+  } catch {
+    return false;
+  }
+}

--- a/dashboard/src/desktop-embed.ts
+++ b/dashboard/src/desktop-embed.ts
@@ -4,17 +4,29 @@
  * Updates"), so the embedded dashboard must not offer a second, competing
  * update action against the same runtime.
  */
+let memoForHref: string | null = null;
+let memoResult = false;
+
 export function dashboardEmbedsInDesktop(): boolean {
+  let href: string;
   try {
-    const params = new URLSearchParams(window.location.search);
-    const fragment = window.location.hash.startsWith("#")
-      ? window.location.hash.slice(1)
-      : window.location.hash;
-    for (const [key, value] of new URLSearchParams(fragment)) {
-      params.set(key, value);
-    }
-    return params.get("desktop_embed") === "1";
+    href = window.location.href;
   } catch {
+    // No usable location yet (for example a server-side render): report
+    // not-embedded without latching the memo.
     return false;
   }
+  if (memoForHref === href) {
+    return memoResult;
+  }
+  const params = new URLSearchParams(window.location.search);
+  const fragment = window.location.hash.startsWith("#")
+    ? window.location.hash.slice(1)
+    : window.location.hash;
+  for (const [key, value] of new URLSearchParams(fragment)) {
+    params.set(key, value);
+  }
+  memoForHref = href;
+  memoResult = params.get("desktop_embed") === "1";
+  return memoResult;
 }

--- a/dashboard/src/desktop-embed.ts
+++ b/dashboard/src/desktop-embed.ts
@@ -4,10 +4,18 @@
  * Updates"), so the embedded dashboard must not offer a second, competing
  * update action against the same runtime.
  */
+let embeddedLatch = false;
 let memoForHref: string | null = null;
 let memoResult = false;
 
 export function dashboardEmbedsInDesktop(): boolean {
+  // Once the Desktop handoff is seen it stays true for the session: internal
+  // navigation replaces the URL with routes that no longer carry the
+  // desktop_embed parameter, and a daemon-origin redirect rebuilds the URL
+  // the same way — neither turns an embedded dashboard standalone.
+  if (embeddedLatch) {
+    return true;
+  }
   let href: string;
   try {
     href = window.location.href;
@@ -28,5 +36,6 @@ export function dashboardEmbedsInDesktop(): boolean {
   }
   memoForHref = href;
   memoResult = params.get("desktop_embed") === "1";
+  embeddedLatch = memoResult;
   return memoResult;
 }

--- a/dashboard/src/guard-update-copy.ts
+++ b/dashboard/src/guard-update-copy.ts
@@ -1,0 +1,81 @@
+import type { GuardUpdatePhase, GuardUpdateStatus } from "./guard-types";
+
+export function updateStatusLabel(status: GuardUpdateStatus | null | undefined): string {
+  if (!status) {
+    return "Checking version…";
+  }
+  if (status.update_available && status.latest_version) {
+    return `Version ${status.latest_version} is ready`;
+  }
+  return `Version ${status.current_version}`;
+}
+
+function shouldPromptRecoveryReinstall(status: GuardUpdateStatus | null | undefined): boolean {
+  return (
+    status?.recovery_reinstall_available === true &&
+    status?.auto_updatable !== true &&
+    status?.version_check?.update_available === true
+  );
+}
+
+function recoveryReinstallHelpCopy(status: GuardUpdateStatus | null | undefined): string | null {
+  if (!shouldPromptRecoveryReinstall(status)) {
+    return null;
+  }
+  const blockedReason = status?.blocked_reason ?? "";
+  if (blockedReason.includes("local wheel whose source file is no longer available")) {
+    return "This install came from a local wheel whose source file is no longer available, so automatic updates are off. Reinstall from PyPI to switch it back to a normal package; Guard restarts briefly and saved approvals stay.";
+  }
+  if (blockedReason.includes("local wheel")) {
+    return "This install came from a local wheel, so automatic updates are off. Reinstall from PyPI to switch it back to a normal package; Guard restarts briefly and saved approvals stay.";
+  }
+  return "This install came from a local folder, so automatic updates are off. Reinstall from PyPI to switch it back to a normal package; Guard restarts briefly and saved approvals stay.";
+}
+
+export function updateHelpCopy(
+  status: GuardUpdateStatus | null | undefined,
+  phase: GuardUpdatePhase,
+  errorMessage?: string | null,
+  embeddedInDesktop = false,
+): string | null {
+  if (phase === "updating") {
+    return "Guard is installing the update. The dashboard will pause briefly and reopen when ready.";
+  }
+  if (phase === "reconnecting") {
+    return "Reconnecting to Guard after the update…";
+  }
+  if (phase === "error") {
+    if (embeddedInDesktop) {
+      return (
+        errorMessage?.trim() ||
+        "The update did not finish. Use Check for Updates in the HOL Guard menu bar and watch its progress there."
+      );
+    }
+    return errorMessage?.trim() || "The update did not finish. The installed version stays in place. Try again, or run hol-guard update from your terminal.";
+  }
+  if (status?.update_suppressed) {
+    if (status.retry_command) {
+      return `Automatic update already ran but this install is still behind. Run ${status.retry_command} in your terminal.`;
+    }
+    if (status.update_attempt_message) {
+      return status.update_attempt_message;
+    }
+    return "Automatic update already ran but this install is still behind the latest release.";
+  }
+  if (status?.update_available) {
+    if (embeddedInDesktop) {
+      return "Updates run through the HOL Guard app. Use Check for Updates in the HOL Guard menu-bar icon, and the app installs this version with its own progress screen.";
+    }
+    return "This restarts Guard for a moment. Open approvals will stay saved.";
+  }
+  if (status && !status.auto_updatable && status.recovery_reinstall_available) {
+    if (embeddedInDesktop) {
+      return "This install needs a recovery repair. Try Check for Updates in the HOL Guard menu bar first; if the app cannot repair it, run the recovery reinstall from your terminal.";
+    }
+    return recoveryReinstallHelpCopy(status);
+  }
+  if (status && !status.auto_updatable && status.blocked_reason) {
+    return status.blocked_reason;
+  }
+  return null;
+}

--- a/dashboard/src/guard-update-copy.ts
+++ b/dashboard/src/guard-update-copy.ts
@@ -10,7 +10,7 @@ export function updateStatusLabel(status: GuardUpdateStatus | null | undefined):
   return `Version ${status.current_version}`;
 }
 
-function shouldPromptRecoveryReinstall(status: GuardUpdateStatus | null | undefined): boolean {
+export function shouldPromptRecoveryReinstall(status: GuardUpdateStatus | null | undefined): boolean {
   return (
     status?.recovery_reinstall_available === true &&
     status?.auto_updatable !== true &&

--- a/dashboard/src/guard-update-panel.tsx
+++ b/dashboard/src/guard-update-panel.tsx
@@ -13,6 +13,7 @@ import {
   type GuardUpdateChannelProof,
 } from "./guard-api";
 import { AlphaChannelDialog } from "./alpha-update-channel-dialog";
+import { dashboardEmbedsInDesktop } from "./desktop-embed";
 import { buildApprovalProofCredentials } from "./approval-proof-inline";
 import type {
   GuardApprovalGatePublicConfig,
@@ -109,14 +110,22 @@ function updateHelpCopy(
 export function GuardUpdatePanel(props: GuardUpdatePanelProps) {
   const version = props.guardVersion ?? props.updateStatus?.current_version ?? null;
   const phase = props.updatePhase ?? "idle";
+  const embeddedInDesktop = dashboardEmbedsInDesktop();
   const helpCopy = updateHelpCopy(props.updateStatus, phase, props.updateError);
+  // Inside the Desktop window, updates belong to the app's own updater;
+  // a second button here would race it against the same runtime.
   const showUpdateButton =
+    !embeddedInDesktop &&
     props.updateStatus?.update_available === true &&
     props.updateStatus.auto_updatable &&
     props.updateStatus.update_suppressed !== true &&
     phase !== "updating" &&
     phase !== "reconnecting";
-  const showReinstallButton = shouldPromptRecoveryReinstall(props.updateStatus) && phase !== "updating" && phase !== "reconnecting";
+  const showReinstallButton =
+    !embeddedInDesktop &&
+    shouldPromptRecoveryReinstall(props.updateStatus) &&
+    phase !== "updating" &&
+    phase !== "reconnecting";
   const busy = phase === "updating" || phase === "reconnecting";
   const useAlpha = props.updateStatus?.release_channel === "alpha" || (
     props.updateStatus == null && readRememberedGuardUpdateChannel() === "alpha"
@@ -196,7 +205,12 @@ export function GuardUpdatePanel(props: GuardUpdatePanelProps) {
       {props.updateStatus?.update_available ? (
         <p className="text-[11px] leading-relaxed text-brand-dark/75">{updateStatusLabel(props.updateStatus)}</p>
       ) : null}
-      {helpCopy ? (
+      {embeddedInDesktop && props.updateStatus?.update_available ? (
+        <p className="text-[11px] leading-relaxed text-brand-dark/70">
+          Updates run through the HOL Guard app. Use Check for Updates in the HOL Guard menu-bar
+          icon, and the app installs this version with its own progress screen.
+        </p>
+      ) : helpCopy ? (
         <p className="text-[11px] leading-relaxed text-brand-dark/70">{helpCopy}</p>
       ) : null}
       {showUpdateButton && props.onUpdateGuard ? (

--- a/dashboard/src/guard-update-panel.tsx
+++ b/dashboard/src/guard-update-panel.tsx
@@ -14,7 +14,7 @@ import {
 } from "./guard-api";
 import { AlphaChannelDialog } from "./alpha-update-channel-dialog";
 import { dashboardEmbedsInDesktop } from "./desktop-embed";
-import { updateStatusLabel, updateHelpCopy } from "./guard-update-copy";
+import { shouldPromptRecoveryReinstall, updateHelpCopy, updateStatusLabel } from "./guard-update-copy";
 import { buildApprovalProofCredentials } from "./approval-proof-inline";
 import type {
   GuardApprovalGatePublicConfig,

--- a/dashboard/src/guard-update-panel.tsx
+++ b/dashboard/src/guard-update-panel.tsx
@@ -76,6 +76,7 @@ function updateHelpCopy(
   status: GuardUpdateStatus | null | undefined,
   phase: GuardUpdatePhase,
   errorMessage?: string | null,
+  embeddedInDesktop = false,
 ): string | null {
   if (phase === "updating") {
     return "Guard is installing the update. The dashboard will pause briefly and reopen when ready.";
@@ -84,6 +85,12 @@ function updateHelpCopy(
     return "Reconnecting to Guard after the update…";
   }
   if (phase === "error") {
+    if (embeddedInDesktop) {
+      return (
+        errorMessage?.trim() ||
+        "The update did not finish. Use Check for Updates in the HOL Guard menu bar and watch its progress there."
+      );
+    }
     return errorMessage?.trim() || "The update did not finish. The installed version stays in place. Try again, or run hol-guard update from your terminal.";
   }
   if (status?.update_suppressed) {
@@ -96,6 +103,9 @@ function updateHelpCopy(
     return "Automatic update already ran but this install is still behind the latest release.";
   }
   if (status?.update_available) {
+    if (embeddedInDesktop) {
+      return "Updates run through the HOL Guard app. Use Check for Updates in the HOL Guard menu-bar icon, and the app installs this version with its own progress screen.";
+    }
     return "This restarts Guard for a moment. Open approvals will stay saved.";
   }
   if (status && !status.auto_updatable && status.recovery_reinstall_available) {
@@ -111,7 +121,7 @@ export function GuardUpdatePanel(props: GuardUpdatePanelProps) {
   const version = props.guardVersion ?? props.updateStatus?.current_version ?? null;
   const phase = props.updatePhase ?? "idle";
   const embeddedInDesktop = dashboardEmbedsInDesktop();
-  const helpCopy = updateHelpCopy(props.updateStatus, phase, props.updateError);
+  const helpCopy = updateHelpCopy(props.updateStatus, phase, props.updateError, embeddedInDesktop);
   // Inside the Desktop window, updates belong to the app's own updater;
   // a second button here would race it against the same runtime.
   const showUpdateButton =
@@ -205,12 +215,7 @@ export function GuardUpdatePanel(props: GuardUpdatePanelProps) {
       {props.updateStatus?.update_available ? (
         <p className="text-[11px] leading-relaxed text-brand-dark/75">{updateStatusLabel(props.updateStatus)}</p>
       ) : null}
-      {embeddedInDesktop && props.updateStatus?.update_available ? (
-        <p className="text-[11px] leading-relaxed text-brand-dark/70">
-          Updates run through the HOL Guard app. Use Check for Updates in the HOL Guard menu-bar
-          icon, and the app installs this version with its own progress screen.
-        </p>
-      ) : helpCopy ? (
+      {helpCopy ? (
         <p className="text-[11px] leading-relaxed text-brand-dark/70">{helpCopy}</p>
       ) : null}
       {showUpdateButton && props.onUpdateGuard ? (

--- a/dashboard/src/guard-update-panel.tsx
+++ b/dashboard/src/guard-update-panel.tsx
@@ -14,6 +14,7 @@ import {
 } from "./guard-api";
 import { AlphaChannelDialog } from "./alpha-update-channel-dialog";
 import { dashboardEmbedsInDesktop } from "./desktop-embed";
+import { updateStatusLabel, updateHelpCopy } from "./guard-update-copy";
 import { buildApprovalProofCredentials } from "./approval-proof-inline";
 import type {
   GuardApprovalGatePublicConfig,
@@ -39,83 +40,6 @@ export type GuardUpdatePanelProps = {
   onSetUpdateChannel?: (channel: "stable" | "alpha", proof?: GuardUpdateChannelProof) => void | Promise<void>;
   compact?: boolean;
 };
-
-function updateStatusLabel(status: GuardUpdateStatus | null | undefined): string {
-  if (!status) {
-    return "Checking version…";
-  }
-  if (status.update_available && status.latest_version) {
-    return `Version ${status.latest_version} is ready`;
-  }
-  return `Version ${status.current_version}`;
-}
-
-function shouldPromptRecoveryReinstall(status: GuardUpdateStatus | null | undefined): boolean {
-  return (
-    status?.recovery_reinstall_available === true &&
-    status?.auto_updatable !== true &&
-    status?.version_check?.update_available === true
-  );
-}
-
-function recoveryReinstallHelpCopy(status: GuardUpdateStatus | null | undefined): string | null {
-  if (!shouldPromptRecoveryReinstall(status)) {
-    return null;
-  }
-  const blockedReason = status?.blocked_reason ?? "";
-  if (blockedReason.includes("local wheel whose source file is no longer available")) {
-    return "This install came from a local wheel whose source file is no longer available, so automatic updates are off. Reinstall from PyPI to switch it back to a normal package; Guard restarts briefly and saved approvals stay.";
-  }
-  if (blockedReason.includes("local wheel")) {
-    return "This install came from a local wheel, so automatic updates are off. Reinstall from PyPI to switch it back to a normal package; Guard restarts briefly and saved approvals stay.";
-  }
-  return "This install came from a local folder, so automatic updates are off. Reinstall from PyPI to switch it back to a normal package; Guard restarts briefly and saved approvals stay.";
-}
-
-function updateHelpCopy(
-  status: GuardUpdateStatus | null | undefined,
-  phase: GuardUpdatePhase,
-  errorMessage?: string | null,
-  embeddedInDesktop = false,
-): string | null {
-  if (phase === "updating") {
-    return "Guard is installing the update. The dashboard will pause briefly and reopen when ready.";
-  }
-  if (phase === "reconnecting") {
-    return "Reconnecting to Guard after the update…";
-  }
-  if (phase === "error") {
-    if (embeddedInDesktop) {
-      return (
-        errorMessage?.trim() ||
-        "The update did not finish. Use Check for Updates in the HOL Guard menu bar and watch its progress there."
-      );
-    }
-    return errorMessage?.trim() || "The update did not finish. The installed version stays in place. Try again, or run hol-guard update from your terminal.";
-  }
-  if (status?.update_suppressed) {
-    if (status.retry_command) {
-      return `Automatic update already ran but this install is still behind. Run ${status.retry_command} in your terminal.`;
-    }
-    if (status.update_attempt_message) {
-      return status.update_attempt_message;
-    }
-    return "Automatic update already ran but this install is still behind the latest release.";
-  }
-  if (status?.update_available) {
-    if (embeddedInDesktop) {
-      return "Updates run through the HOL Guard app. Use Check for Updates in the HOL Guard menu-bar icon, and the app installs this version with its own progress screen.";
-    }
-    return "This restarts Guard for a moment. Open approvals will stay saved.";
-  }
-  if (status && !status.auto_updatable && status.recovery_reinstall_available) {
-    return recoveryReinstallHelpCopy(status);
-  }
-  if (status && !status.auto_updatable && status.blocked_reason) {
-    return status.blocked_reason;
-  }
-  return null;
-}
 
 export function GuardUpdatePanel(props: GuardUpdatePanelProps) {
   const version = props.guardVersion ?? props.updateStatus?.current_version ?? null;

--- a/dashboard/src/guard-update.test.ts
+++ b/dashboard/src/guard-update.test.ts
@@ -374,6 +374,7 @@ assert(
 
 // Embedded in the HOL Guard Desktop window, the panel must defer updates to
 // the app's own updater instead of offering a second, competing action.
+const priorWindow = (globalThis as { window?: unknown }).window;
 Object.assign(globalThis, {
   window: {
     location: { search: "?desktop_embed=1", hash: "" },
@@ -401,5 +402,7 @@ assert(
   "embedded dashboard should point at the app's updater",
 );
 assert(embeddedMarkup.includes("v3.0.0a239"), "embedded dashboard should still show the running version");
+
+(globalThis as { window?: unknown }).window = priorWindow;
 
 console.log("guard-update.test.ts: all tests passed");

--- a/dashboard/src/guard-update.test.ts
+++ b/dashboard/src/guard-update.test.ts
@@ -403,6 +403,61 @@ assert(
 );
 assert(embeddedMarkup.includes("v3.0.0a239"), "embedded dashboard should still show the running version");
 
+// Internal navigation replaces the URL with routes that drop desktop_embed;
+// once the handoff was seen, the dashboard stays embedded for the session.
+const embeddedNavigationStatus = normalizeGuardUpdateStatus({
+  current_version: "3.0.0a239",
+  latest_version: "3.0.0a241",
+  installer: "desktop",
+  version_check: { source: "desktop_core", status: "stale", current_version: "3.0.0a239", latest_version: "3.0.0a241", update_available: true },
+  auto_updatable: true,
+  update_available: true,
+  blocked_reason: null,
+});
+Object.assign(globalThis, {
+  window: {
+    location: { href: "http://127.0.0.1:5474/about", search: "", hash: "" },
+    sessionStorage: rememberedChannelStorage,
+    localStorage: rememberedChannelStorage,
+  },
+});
+const navigatedMarkup = renderToStaticMarkup(
+  createElement(GuardUpdatePanel, {
+    updateStatus: embeddedNavigationStatus,
+    onUpdateGuard: () => undefined,
+  }),
+);
+assert(!navigatedMarkup.includes("Update Guard"), "navigation inside the embedded dashboard must not restore the Update Guard button");
+
+// A recovery-reinstall prompt inside the Desktop window must not point at the
+// hidden PyPI reinstall action.
+Object.assign(globalThis, {
+  window: {
+    location: { href: "http://127.0.0.1:5474/", search: "?desktop_embed=1", hash: "" },
+    sessionStorage: rememberedChannelStorage,
+    localStorage: rememberedChannelStorage,
+  },
+});
+const reinstallMarkup = renderToStaticMarkup(
+  createElement(GuardUpdatePanel, {
+    updateStatus: normalizeGuardUpdateStatus({
+      current_version: "3.0.0a239",
+      latest_version: "3.0.0a241",
+      installer: "desktop",
+      auto_updatable: false,
+      update_available: false,
+      recovery_reinstall_available: true,
+      blocked_reason: "This install came from a local wheel whose source file is no longer available, so automatic updates are off.",
+    }),
+    onReinstallGuard: () => undefined,
+  }),
+);
+assert(!reinstallMarkup.includes("Reinstall from PyPI"), "embedded dashboard must not offer its own reinstall button");
+assert(
+  reinstallMarkup.includes("Check for Updates in the HOL Guard menu bar"),
+  "embedded reinstall prompt should point at the app first",
+);
+
 (globalThis as { window?: unknown }).window = priorWindow;
 
 console.log("guard-update.test.ts: all tests passed");

--- a/dashboard/src/guard-update.test.ts
+++ b/dashboard/src/guard-update.test.ts
@@ -372,4 +372,34 @@ assert(
   "failed desktop updates should say the current install remains",
 );
 
+// Embedded in the HOL Guard Desktop window, the panel must defer updates to
+// the app's own updater instead of offering a second, competing action.
+Object.assign(globalThis, {
+  window: {
+    location: { search: "?desktop_embed=1", hash: "" },
+    sessionStorage: rememberedChannelStorage,
+    localStorage: rememberedChannelStorage,
+  },
+});
+const embeddedMarkup = renderToStaticMarkup(
+  createElement(GuardUpdatePanel, {
+    updateStatus: normalizeGuardUpdateStatus({
+      current_version: "3.0.0a239",
+      latest_version: "3.0.0a241",
+      installer: "desktop",
+      version_check: { source: "desktop_core", status: "stale", current_version: "3.0.0a239", latest_version: "3.0.0a241", update_available: true },
+      auto_updatable: true,
+      update_available: true,
+      blocked_reason: null,
+    }),
+    onUpdateGuard: () => undefined,
+  }),
+);
+assert(!embeddedMarkup.includes("Update Guard"), "embedded dashboard must not offer its own Update Guard button");
+assert(
+  embeddedMarkup.includes("Check for Updates in the HOL Guard menu-bar"),
+  "embedded dashboard should point at the app's updater",
+);
+assert(embeddedMarkup.includes("v3.0.0a239"), "embedded dashboard should still show the running version");
+
 console.log("guard-update.test.ts: all tests passed");

--- a/src/codex_plugin_scanner/guard/cli/update_subprocess.py
+++ b/src/codex_plugin_scanner/guard/cli/update_subprocess.py
@@ -29,6 +29,7 @@ from typing import BinaryIO
 from ..mdm.network import platform_system_proxies
 from ..redaction import redact_sensitive_text
 from ..shims import _trusted_python_flags
+from ..update_staging import note_update_activity, reject_linked_path_components
 from ..windows_paths import (
     trusted_windows_roaming_appdata,
     trusted_windows_system_directories,
@@ -772,9 +773,9 @@ def _prepare_neutral_directories(guard_home: Path) -> tuple[Path, Path, Path]:
         if not expanded_home.is_absolute():
             raise UpdateSubprocessError("update_neutral_cwd_unavailable")
         lexical_home = Path(os.path.normpath(str(expanded_home)))
-        _reject_linked_path_components(lexical_home)
+        reject_linked_path_components(lexical_home)
         lexical_home.mkdir(parents=True, exist_ok=True)
-        _reject_linked_path_components(lexical_home)
+        reject_linked_path_components(lexical_home)
         home_metadata = lexical_home.lstat()
         if (
             not stat.S_ISDIR(home_metadata.st_mode)
@@ -798,23 +799,12 @@ def _prepare_neutral_directories(guard_home: Path) -> tuple[Path, Path, Path]:
                 metadata = directory.stat()
                 if metadata.st_mode & 0o077 or metadata.st_uid != os.geteuid():
                     raise UpdateSubprocessError("update_neutral_cwd_unavailable")
+        note_update_activity(guard_home)
         return runtime, neutral_home, neutral_tmp
     except UpdateSubprocessError:
         raise
     except (OSError, RuntimeError) as error:
         raise UpdateSubprocessError("update_neutral_cwd_unavailable") from error
-
-
-def _reject_linked_path_components(path: Path) -> None:
-    current = Path(path.anchor)
-    for part in path.parts[1:]:
-        current /= part
-        try:
-            metadata = current.lstat()
-        except FileNotFoundError:
-            return
-        if stat.S_ISLNK(metadata.st_mode) or _metadata_is_reparse(metadata):
-            raise UpdateSubprocessError("update_neutral_cwd_unavailable")
 
 
 def _metadata_is_reparse(metadata: os.stat_result) -> bool:

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -19901,17 +19901,26 @@ function AlphaChannelDialog({
     ] })
   ] });
 }
+let memoForHref = null;
+let memoResult = false;
 function dashboardEmbedsInDesktop() {
+  let href;
   try {
-    const params = new URLSearchParams(window.location.search);
-    const fragment = window.location.hash.startsWith("#") ? window.location.hash.slice(1) : window.location.hash;
-    for (const [key, value] of new URLSearchParams(fragment)) {
-      params.set(key, value);
-    }
-    return params.get("desktop_embed") === "1";
+    href = window.location.href;
   } catch {
     return false;
   }
+  if (memoForHref === href) {
+    return memoResult;
+  }
+  const params = new URLSearchParams(window.location.search);
+  const fragment = window.location.hash.startsWith("#") ? window.location.hash.slice(1) : window.location.hash;
+  for (const [key, value] of new URLSearchParams(fragment)) {
+    params.set(key, value);
+  }
+  memoForHref = href;
+  memoResult = params.get("desktop_embed") === "1";
+  return memoResult;
 }
 var reactDomExports = requireReactDom();
 const GUARD_OVERLAY_ROOT_ID = "guard-overlay-root";
@@ -20149,7 +20158,7 @@ function recoveryReinstallHelpCopy(status) {
   }
   return "This install came from a local folder, so automatic updates are off. Reinstall from PyPI to switch it back to a normal package; Guard restarts briefly and saved approvals stay.";
 }
-function updateHelpCopy(status, phase, errorMessage) {
+function updateHelpCopy(status, phase, errorMessage, embeddedInDesktop = false) {
   if (phase === "updating") {
     return "Guard is installing the update. The dashboard will pause briefly and reopen when ready.";
   }
@@ -20157,6 +20166,9 @@ function updateHelpCopy(status, phase, errorMessage) {
     return "Reconnecting to Guard after the update…";
   }
   if (phase === "error") {
+    if (embeddedInDesktop) {
+      return errorMessage?.trim() || "The update did not finish. Use Check for Updates in the HOL Guard menu bar and watch its progress there.";
+    }
     return errorMessage?.trim() || "The update did not finish. The installed version stays in place. Try again, or run hol-guard update from your terminal.";
   }
   if (status?.update_suppressed) {
@@ -20169,6 +20181,9 @@ function updateHelpCopy(status, phase, errorMessage) {
     return "Automatic update already ran but this install is still behind the latest release.";
   }
   if (status?.update_available) {
+    if (embeddedInDesktop) {
+      return "Updates run through the HOL Guard app. Use Check for Updates in the HOL Guard menu-bar icon, and the app installs this version with its own progress screen.";
+    }
     return "This restarts Guard for a moment. Open approvals will stay saved.";
   }
   if (status && !status.auto_updatable && status.recovery_reinstall_available) {
@@ -20183,7 +20198,7 @@ function GuardUpdatePanel(props) {
   const version = props.guardVersion ?? props.updateStatus?.current_version ?? null;
   const phase = props.updatePhase ?? "idle";
   const embeddedInDesktop = dashboardEmbedsInDesktop();
-  const helpCopy = updateHelpCopy(props.updateStatus, phase, props.updateError);
+  const helpCopy = updateHelpCopy(props.updateStatus, phase, props.updateError, embeddedInDesktop);
   const showUpdateButton = !embeddedInDesktop && props.updateStatus?.update_available === true && props.updateStatus.auto_updatable && props.updateStatus.update_suppressed !== true && phase !== "updating" && phase !== "reconnecting";
   const showReinstallButton = !embeddedInDesktop && shouldPromptRecoveryReinstall(props.updateStatus) && phase !== "updating" && phase !== "reconnecting";
   const busy = phase === "updating" || phase === "reconnecting";
@@ -20255,7 +20270,7 @@ function GuardUpdatePanel(props) {
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: props.compact ? "space-y-1" : "space-y-2", children: [
     updateChannelSummary,
     props.updateStatus?.update_available ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] leading-relaxed text-brand-dark/75", children: updateStatusLabel(props.updateStatus) }) : null,
-    embeddedInDesktop && props.updateStatus?.update_available ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] leading-relaxed text-brand-dark/70", children: "Updates run through the HOL Guard app. Use Check for Updates in the HOL Guard menu-bar icon, and the app installs this version with its own progress screen." }) : helpCopy ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] leading-relaxed text-brand-dark/70", children: helpCopy }) : null,
+    helpCopy ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] leading-relaxed text-brand-dark/70", children: helpCopy }) : null,
     showUpdateButton && props.onUpdateGuard ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
       "button",
       {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -19936,11 +19936,11 @@ function updateStatusLabel(status) {
   }
   return `Version ${status.current_version}`;
 }
-function shouldPromptRecoveryReinstall$1(status) {
+function shouldPromptRecoveryReinstall(status) {
   return status?.recovery_reinstall_available === true && status?.auto_updatable !== true && status?.version_check?.update_available === true;
 }
 function recoveryReinstallHelpCopy(status) {
-  if (!shouldPromptRecoveryReinstall$1(status)) {
+  if (!shouldPromptRecoveryReinstall(status)) {
     return null;
   }
   const blockedReason = status?.blocked_reason ?? "";

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -19901,9 +19901,13 @@ function AlphaChannelDialog({
     ] })
   ] });
 }
+let embeddedLatch = false;
 let memoForHref = null;
 let memoResult = false;
 function dashboardEmbedsInDesktop() {
+  if (embeddedLatch) {
+    return true;
+  }
   let href;
   try {
     href = window.location.href;
@@ -19920,7 +19924,72 @@ function dashboardEmbedsInDesktop() {
   }
   memoForHref = href;
   memoResult = params.get("desktop_embed") === "1";
+  embeddedLatch = memoResult;
   return memoResult;
+}
+function updateStatusLabel(status) {
+  if (!status) {
+    return "Checking version…";
+  }
+  if (status.update_available && status.latest_version) {
+    return `Version ${status.latest_version} is ready`;
+  }
+  return `Version ${status.current_version}`;
+}
+function shouldPromptRecoveryReinstall$1(status) {
+  return status?.recovery_reinstall_available === true && status?.auto_updatable !== true && status?.version_check?.update_available === true;
+}
+function recoveryReinstallHelpCopy(status) {
+  if (!shouldPromptRecoveryReinstall$1(status)) {
+    return null;
+  }
+  const blockedReason = status?.blocked_reason ?? "";
+  if (blockedReason.includes("local wheel whose source file is no longer available")) {
+    return "This install came from a local wheel whose source file is no longer available, so automatic updates are off. Reinstall from PyPI to switch it back to a normal package; Guard restarts briefly and saved approvals stay.";
+  }
+  if (blockedReason.includes("local wheel")) {
+    return "This install came from a local wheel, so automatic updates are off. Reinstall from PyPI to switch it back to a normal package; Guard restarts briefly and saved approvals stay.";
+  }
+  return "This install came from a local folder, so automatic updates are off. Reinstall from PyPI to switch it back to a normal package; Guard restarts briefly and saved approvals stay.";
+}
+function updateHelpCopy(status, phase, errorMessage, embeddedInDesktop = false) {
+  if (phase === "updating") {
+    return "Guard is installing the update. The dashboard will pause briefly and reopen when ready.";
+  }
+  if (phase === "reconnecting") {
+    return "Reconnecting to Guard after the update…";
+  }
+  if (phase === "error") {
+    if (embeddedInDesktop) {
+      return errorMessage?.trim() || "The update did not finish. Use Check for Updates in the HOL Guard menu bar and watch its progress there.";
+    }
+    return errorMessage?.trim() || "The update did not finish. The installed version stays in place. Try again, or run hol-guard update from your terminal.";
+  }
+  if (status?.update_suppressed) {
+    if (status.retry_command) {
+      return `Automatic update already ran but this install is still behind. Run ${status.retry_command} in your terminal.`;
+    }
+    if (status.update_attempt_message) {
+      return status.update_attempt_message;
+    }
+    return "Automatic update already ran but this install is still behind the latest release.";
+  }
+  if (status?.update_available) {
+    if (embeddedInDesktop) {
+      return "Updates run through the HOL Guard app. Use Check for Updates in the HOL Guard menu-bar icon, and the app installs this version with its own progress screen.";
+    }
+    return "This restarts Guard for a moment. Open approvals will stay saved.";
+  }
+  if (status && !status.auto_updatable && status.recovery_reinstall_available) {
+    if (embeddedInDesktop) {
+      return "This install needs a recovery repair. Try Check for Updates in the HOL Guard menu bar first; if the app cannot repair it, run the recovery reinstall from your terminal.";
+    }
+    return recoveryReinstallHelpCopy(status);
+  }
+  if (status && !status.auto_updatable && status.blocked_reason) {
+    return status.blocked_reason;
+  }
+  return null;
 }
 var reactDomExports = requireReactDom();
 const GUARD_OVERLAY_ROOT_ID = "guard-overlay-root";
@@ -20133,67 +20202,6 @@ function GuardUpdateChannelSummary(props) {
 const UPDATE_STATUS_POLL_MS = 6e4;
 const RECONNECT_POLL_MS = 1500;
 const RECONNECT_TIMEOUT_MS = 18e4;
-function updateStatusLabel(status) {
-  if (!status) {
-    return "Checking version…";
-  }
-  if (status.update_available && status.latest_version) {
-    return `Version ${status.latest_version} is ready`;
-  }
-  return `Version ${status.current_version}`;
-}
-function shouldPromptRecoveryReinstall(status) {
-  return status?.recovery_reinstall_available === true && status?.auto_updatable !== true && status?.version_check?.update_available === true;
-}
-function recoveryReinstallHelpCopy(status) {
-  if (!shouldPromptRecoveryReinstall(status)) {
-    return null;
-  }
-  const blockedReason = status?.blocked_reason ?? "";
-  if (blockedReason.includes("local wheel whose source file is no longer available")) {
-    return "This install came from a local wheel whose source file is no longer available, so automatic updates are off. Reinstall from PyPI to switch it back to a normal package; Guard restarts briefly and saved approvals stay.";
-  }
-  if (blockedReason.includes("local wheel")) {
-    return "This install came from a local wheel, so automatic updates are off. Reinstall from PyPI to switch it back to a normal package; Guard restarts briefly and saved approvals stay.";
-  }
-  return "This install came from a local folder, so automatic updates are off. Reinstall from PyPI to switch it back to a normal package; Guard restarts briefly and saved approvals stay.";
-}
-function updateHelpCopy(status, phase, errorMessage, embeddedInDesktop = false) {
-  if (phase === "updating") {
-    return "Guard is installing the update. The dashboard will pause briefly and reopen when ready.";
-  }
-  if (phase === "reconnecting") {
-    return "Reconnecting to Guard after the update…";
-  }
-  if (phase === "error") {
-    if (embeddedInDesktop) {
-      return errorMessage?.trim() || "The update did not finish. Use Check for Updates in the HOL Guard menu bar and watch its progress there.";
-    }
-    return errorMessage?.trim() || "The update did not finish. The installed version stays in place. Try again, or run hol-guard update from your terminal.";
-  }
-  if (status?.update_suppressed) {
-    if (status.retry_command) {
-      return `Automatic update already ran but this install is still behind. Run ${status.retry_command} in your terminal.`;
-    }
-    if (status.update_attempt_message) {
-      return status.update_attempt_message;
-    }
-    return "Automatic update already ran but this install is still behind the latest release.";
-  }
-  if (status?.update_available) {
-    if (embeddedInDesktop) {
-      return "Updates run through the HOL Guard app. Use Check for Updates in the HOL Guard menu-bar icon, and the app installs this version with its own progress screen.";
-    }
-    return "This restarts Guard for a moment. Open approvals will stay saved.";
-  }
-  if (status && !status.auto_updatable && status.recovery_reinstall_available) {
-    return recoveryReinstallHelpCopy(status);
-  }
-  if (status && !status.auto_updatable && status.blocked_reason) {
-    return status.blocked_reason;
-  }
-  return null;
-}
 function GuardUpdatePanel(props) {
   const version = props.guardVersion ?? props.updateStatus?.current_version ?? null;
   const phase = props.updatePhase ?? "idle";

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -19901,6 +19901,18 @@ function AlphaChannelDialog({
     ] })
   ] });
 }
+function dashboardEmbedsInDesktop() {
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const fragment = window.location.hash.startsWith("#") ? window.location.hash.slice(1) : window.location.hash;
+    for (const [key, value] of new URLSearchParams(fragment)) {
+      params.set(key, value);
+    }
+    return params.get("desktop_embed") === "1";
+  } catch {
+    return false;
+  }
+}
 var reactDomExports = requireReactDom();
 const GUARD_OVERLAY_ROOT_ID = "guard-overlay-root";
 function ensureGuardOverlayRoot() {
@@ -20170,9 +20182,10 @@ function updateHelpCopy(status, phase, errorMessage) {
 function GuardUpdatePanel(props) {
   const version = props.guardVersion ?? props.updateStatus?.current_version ?? null;
   const phase = props.updatePhase ?? "idle";
+  const embeddedInDesktop = dashboardEmbedsInDesktop();
   const helpCopy = updateHelpCopy(props.updateStatus, phase, props.updateError);
-  const showUpdateButton = props.updateStatus?.update_available === true && props.updateStatus.auto_updatable && props.updateStatus.update_suppressed !== true && phase !== "updating" && phase !== "reconnecting";
-  const showReinstallButton = shouldPromptRecoveryReinstall(props.updateStatus) && phase !== "updating" && phase !== "reconnecting";
+  const showUpdateButton = !embeddedInDesktop && props.updateStatus?.update_available === true && props.updateStatus.auto_updatable && props.updateStatus.update_suppressed !== true && phase !== "updating" && phase !== "reconnecting";
+  const showReinstallButton = !embeddedInDesktop && shouldPromptRecoveryReinstall(props.updateStatus) && phase !== "updating" && phase !== "reconnecting";
   const busy = phase === "updating" || phase === "reconnecting";
   const useAlpha = props.updateStatus?.release_channel === "alpha" || props.updateStatus == null && readRememberedGuardUpdateChannel() === "alpha";
   const [alphaModalOpen, setAlphaModalOpen] = reactExports.useState(false);
@@ -20242,7 +20255,7 @@ function GuardUpdatePanel(props) {
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: props.compact ? "space-y-1" : "space-y-2", children: [
     updateChannelSummary,
     props.updateStatus?.update_available ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] leading-relaxed text-brand-dark/75", children: updateStatusLabel(props.updateStatus) }) : null,
-    helpCopy ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] leading-relaxed text-brand-dark/70", children: helpCopy }) : null,
+    embeddedInDesktop && props.updateStatus?.update_available ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] leading-relaxed text-brand-dark/70", children: "Updates run through the HOL Guard app. Use Check for Updates in the HOL Guard menu-bar icon, and the app installs this version with its own progress screen." }) : helpCopy ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] leading-relaxed text-brand-dark/70", children: helpCopy }) : null,
     showUpdateButton && props.onUpdateGuard ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
       "button",
       {

--- a/src/codex_plugin_scanner/guard/sqlite_recovery.py
+++ b/src/codex_plugin_scanner/guard/sqlite_recovery.py
@@ -103,7 +103,16 @@ def _quarantine_event_sort_key(base: str, fallback_mtime: float) -> tuple[str, s
     stamp = ""
     if name.startswith("guard.db.corrupt-"):
         stamp = name[len("guard.db.corrupt-") :]
-    if stamp and stamp[:1].isdigit():
+    # Only the exact `%Y%m%dT%H%M%S%fZ` quarantine shape ranks as stamped;
+    # a digit-led but malformed name must not outrank real event ids.
+    if (
+        len(stamp) >= 21
+        and stamp[:8].isdigit()
+        and stamp[8] == "T"
+        and stamp[9:15].isdigit()
+        and stamp[15:21].isdigit()
+        and stamp[21] == "Z"
+    ):
         return ("1", stamp, fallback_mtime)
     return ("0", "", fallback_mtime)
 

--- a/src/codex_plugin_scanner/guard/sqlite_recovery.py
+++ b/src/codex_plugin_scanner/guard/sqlite_recovery.py
@@ -89,6 +89,45 @@ def sqlite_store_is_proven_unusable(
     return second_state == "fatal" and confirmed_identity == final_identity
 
 
+def prune_quarantined_store_snapshots(guard_home: Path, *, keep: int = 2) -> int:
+    """Delete the oldest quarantined store snapshots beyond ``keep`` events.
+
+    Every quarantine preserves a full copy of an unusable database, which on
+    long-lived installs reaches multiple gigabytes per event. Without this
+    sweep the Guard home grows without bound and every later start pays for
+    it. The newest ``keep`` events stay available for support diagnostics.
+    """
+
+    groups: dict[str, float] = {}
+    with suppress(OSError):
+        for entry in guard_home.glob("guard.db.corrupt-*"):
+            if entry.is_symlink() or not entry.is_file():
+                continue
+            # Group the base database with its -wal/-shm sidecars by the
+            # shared quarantine id prefix.
+            name = entry.name
+            base = name
+            for ending in ("-wal", "-shm"):
+                if name.endswith(ending):
+                    base = name[: -len(ending)]
+                    break
+            try:
+                modified = entry.stat().st_mtime
+            except OSError:
+                continue
+            groups[base] = max(groups.get(base, modified), modified)
+    if keep >= len(groups):
+        return 0
+    stale_prefixes = sorted(groups, key=lambda base: groups[base], reverse=True)[keep:]
+    removed = 0
+    for base in stale_prefixes:
+        for ending in ("", "-wal", "-shm"):
+            with suppress(OSError):
+                (guard_home / f"{base}{ending}").unlink()
+                removed += 1
+    return removed
+
+
 def restore_readable_sqlite_store(*, destination: Path, quarantined: Path) -> bool:
     """Move a quarantined store back when it still opens and passes integrity."""
 

--- a/src/codex_plugin_scanner/guard/sqlite_recovery.py
+++ b/src/codex_plugin_scanner/guard/sqlite_recovery.py
@@ -106,7 +106,7 @@ def _quarantine_event_sort_key(base: str, fallback_mtime: float) -> tuple[str, s
     # Only the exact `%Y%m%dT%H%M%S%fZ` quarantine shape ranks as stamped;
     # a digit-led but malformed name must not outrank real event ids.
     if (
-        len(stamp) >= 21
+        len(stamp) >= 22
         and stamp[:8].isdigit()
         and stamp[8] == "T"
         and stamp[9:15].isdigit()

--- a/src/codex_plugin_scanner/guard/sqlite_recovery.py
+++ b/src/codex_plugin_scanner/guard/sqlite_recovery.py
@@ -89,6 +89,25 @@ def sqlite_store_is_proven_unusable(
     return second_state == "fatal" and confirmed_identity == final_identity
 
 
+def _quarantine_event_sort_key(base: str, fallback_mtime: float) -> tuple[str, str, float]:
+    """Order quarantine events by the timestamp encoded in their id.
+
+    ``Path.replace`` preserves the moved file's mtime, which is the source
+    database's last write — not the moment of quarantine — so a newly
+    quarantined long-idle database must not sort as older than an earlier
+    event. The ``...-<stamp>Z-<uuid>`` suffix encodes the event time; names
+    without a parseable stamp fall back to mtime and sort oldest.
+    """
+
+    name = base
+    stamp = ""
+    if name.startswith("guard.db.corrupt-"):
+        stamp = name[len("guard.db.corrupt-") :]
+    if stamp and stamp[:1].isdigit():
+        return ("1", stamp, fallback_mtime)
+    return ("0", "", fallback_mtime)
+
+
 def prune_quarantined_store_snapshots(guard_home: Path, *, keep: int = 2) -> int:
     """Delete the oldest quarantined store snapshots beyond ``keep`` events.
 
@@ -98,7 +117,8 @@ def prune_quarantined_store_snapshots(guard_home: Path, *, keep: int = 2) -> int
     it. The newest ``keep`` events stay available for support diagnostics.
     """
 
-    groups: dict[str, float] = {}
+    keep = max(0, int(keep))
+    groups: dict[str, tuple[str, str, float]] = {}
     with suppress(OSError):
         for entry in guard_home.glob("guard.db.corrupt-*"):
             if entry.is_symlink() or not entry.is_file():
@@ -115,10 +135,12 @@ def prune_quarantined_store_snapshots(guard_home: Path, *, keep: int = 2) -> int
                 modified = entry.stat().st_mtime
             except OSError:
                 continue
-            groups[base] = max(groups.get(base, modified), modified)
+            key = _quarantine_event_sort_key(base, modified)
+            previous = groups.get(base)
+            groups[base] = key if previous is None else max(previous, key)
     if keep >= len(groups):
         return 0
-    stale_prefixes = sorted(groups, key=lambda base: groups[base], reverse=True)[keep:]
+    stale_prefixes = sorted(groups, key=groups.__getitem__, reverse=True)[keep:]
     removed = 0
     for base in stale_prefixes:
         for ending in ("", "-wal", "-shm"):

--- a/src/codex_plugin_scanner/guard/sqlite_recovery.py
+++ b/src/codex_plugin_scanner/guard/sqlite_recovery.py
@@ -144,8 +144,14 @@ def prune_quarantined_store_snapshots(guard_home: Path, *, keep: int = 2) -> int
     removed = 0
     for base in stale_prefixes:
         for ending in ("", "-wal", "-shm"):
+            candidate = guard_home / f"{base}{ending}"
             with suppress(OSError):
-                (guard_home / f"{base}{ending}").unlink()
+                # Recheck before unlinking: a sidecar may have been swapped
+                # for a symlink since the grouping pass, and a dangling link
+                # must never be followed or counted as a removed snapshot.
+                if candidate.is_symlink() or not candidate.is_file():
+                    continue
+                candidate.unlink()
                 removed += 1
     return removed
 

--- a/src/codex_plugin_scanner/guard/store_storage_maintenance.py
+++ b/src/codex_plugin_scanner/guard/store_storage_maintenance.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import sqlite3
 from collections.abc import Sequence
-from contextlib import AbstractContextManager
+from contextlib import AbstractContextManager, suppress
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Final, Protocol, cast
+
+from .sqlite_recovery import prune_quarantined_store_snapshots
+from .update_staging import prune_stale_update_staging
 
 STORAGE_MAINTENANCE_MIGRATION_VERSION: Final = 20
 STORAGE_QUERY_INDEX_MIGRATION_VERSION: Final = 21
@@ -133,6 +136,12 @@ class StoreStorageMaintenanceMixin:
             )
         if completed:
             _run_passive_housekeeping(self)
+            # File-level sweeps (not SQL): keep quarantined store snapshots
+            # and stale updater staging from accumulating for the whole life
+            # of the install.
+            with suppress(OSError):
+                prune_quarantined_store_snapshots(self.guard_home)
+            prune_stale_update_staging(self.guard_home)
         return StorageMaintenanceResult(
             ran=True,
             completed=completed,

--- a/src/codex_plugin_scanner/guard/store_storage_maintenance.py
+++ b/src/codex_plugin_scanner/guard/store_storage_maintenance.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 from contextlib import AbstractContextManager, suppress
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Final, Protocol, cast
 
 from .sqlite_recovery import prune_quarantined_store_snapshots

--- a/src/codex_plugin_scanner/guard/store_storage_maintenance.py
+++ b/src/codex_plugin_scanner/guard/store_storage_maintenance.py
@@ -24,6 +24,8 @@ _MAX_BATCH_SIZE: Final = 10_000
 
 
 class _ConnectionOwner(Protocol):
+    guard_home: Path
+
     def _connect(self) -> AbstractContextManager[sqlite3.Connection]: ...
 
 

--- a/src/codex_plugin_scanner/guard/store_storage_maintenance.py
+++ b/src/codex_plugin_scanner/guard/store_storage_maintenance.py
@@ -141,7 +141,8 @@ class StoreStorageMaintenanceMixin:
             # of the install.
             with suppress(OSError):
                 prune_quarantined_store_snapshots(self.guard_home)
-            prune_stale_update_staging(self.guard_home)
+            with suppress(OSError):
+                prune_stale_update_staging(self.guard_home)
         return StorageMaintenanceResult(
             ran=True,
             completed=completed,

--- a/src/codex_plugin_scanner/guard/update_staging.py
+++ b/src/codex_plugin_scanner/guard/update_staging.py
@@ -9,7 +9,6 @@ import time
 from pathlib import Path
 
 _STAGING_PRUNE_AGE_SECONDS = 7 * 24 * 60 * 60
-_ACTIVITY_FRESH_SECONDS = 24 * 60 * 60
 _UPDATE_RUNTIME_DIR_NAME = "update-runtime"
 _ACTIVITY_MARKER_NAME = "active.json"
 
@@ -19,13 +18,14 @@ def note_update_activity(guard_home: Path) -> None:
 
     The marker's mtime is the signal: the staging sweep refuses to delete
     anything while it is fresh, because the reused staging roots keep their
-    old directory mtimes even while an update writes deep inside them.
+    old directory mtimes even while an update writes deep inside them. A
+    write failure raises so the updater treats an unmarkable tree as
+    unavailable instead of running unprotected.
     """
 
     marker = guard_home / _UPDATE_RUNTIME_DIR_NAME / _ACTIVITY_MARKER_NAME
-    with contextlib.suppress(OSError):
-        marker.parent.mkdir(parents=True, exist_ok=True)
-        marker.write_text('{"staging": "active"}\n', encoding="utf-8")
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text('{"staging": "active"}\n', encoding="utf-8")
 
 
 def prune_stale_update_staging(
@@ -45,9 +45,15 @@ def prune_stale_update_staging(
     """
 
     runtime = guard_home / _UPDATE_RUNTIME_DIR_NAME
+    # Never traverse through a linked component: rmtree below a symlinked
+    # runtime tree would delete whatever the link points at.
+    try:
+        reject_linked_path_components(runtime)
+    except OSError:
+        return
     marker = runtime / _ACTIVITY_MARKER_NAME
     try:
-        if time.time() - marker.stat().st_mtime < _ACTIVITY_FRESH_SECONDS:
+        if time.time() - marker.stat().st_mtime < _STAGING_PRUNE_AGE_SECONDS:
             return
     except OSError:
         pass

--- a/src/codex_plugin_scanner/guard/update_staging.py
+++ b/src/codex_plugin_scanner/guard/update_staging.py
@@ -4,11 +4,28 @@ from __future__ import annotations
 
 import contextlib
 import shutil
+import stat as stat_module
 import time
 from pathlib import Path
 
 _STAGING_PRUNE_AGE_SECONDS = 7 * 24 * 60 * 60
+_ACTIVITY_FRESH_SECONDS = 24 * 60 * 60
 _UPDATE_RUNTIME_DIR_NAME = "update-runtime"
+_ACTIVITY_MARKER_NAME = "active.json"
+
+
+def note_update_activity(guard_home: Path) -> None:
+    """Record that a trusted update is using the staging tree right now.
+
+    The marker's mtime is the signal: the staging sweep refuses to delete
+    anything while it is fresh, because the reused staging roots keep their
+    old directory mtimes even while an update writes deep inside them.
+    """
+
+    marker = guard_home / _UPDATE_RUNTIME_DIR_NAME / _ACTIVITY_MARKER_NAME
+    with contextlib.suppress(OSError):
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text('{"staging": "active"}\n', encoding="utf-8")
 
 
 def prune_stale_update_staging(
@@ -21,18 +38,26 @@ def prune_stale_update_staging(
     The trusted updater runs each update with a neutral HOME and wheel staging
     under ``<guard_home>/update-runtime``; without a sweep those directories
     accumulate for the life of the install (multiple gigabytes on long-lived
-    machines). Entries older than the age gate are deleted, so an update that
-    started recently — including one running right now — is never touched.
+    machines). Every child of the runtime tree older than the age gate is
+    deleted — including subdirectories future updaters may introduce — except
+    the activity marker, and the whole sweep is skipped while that marker says
+    an update ran recently enough to still own the tree.
     """
 
     runtime = guard_home / _UPDATE_RUNTIME_DIR_NAME
+    marker = runtime / _ACTIVITY_MARKER_NAME
+    try:
+        if time.time() - marker.stat().st_mtime < _ACTIVITY_FRESH_SECONDS:
+            return
+    except OSError:
+        pass
     cutoff = time.time() - age_seconds
-    for staging in (runtime / "home", runtime / "tmp", runtime / "wheels"):
-        try:
-            children = list(staging.iterdir())
-        except OSError:
-            continue
-        for child in children:
+    # The whole walk stays inside the guard: iterdir lists lazily, so a
+    # missing or vanishing runtime directory raises mid-iteration.
+    try:
+        for child in runtime.iterdir():
+            if child.name == _ACTIVITY_MARKER_NAME:
+                continue
             try:
                 if child.lstat().st_mtime > cutoff:
                     continue
@@ -43,3 +68,24 @@ def prune_stale_update_staging(
             else:
                 with contextlib.suppress(OSError):
                     child.unlink()
+    except OSError:
+        return
+
+
+def reject_linked_path_components(path: Path) -> None:
+    """Reject any symlinked component of ``path`` (moved from the updater).
+
+    The neutral staging directories must never resolve through a link an
+    attacker could swap; shared here so the staging sweep and the updater
+    validate paths identically.
+    """
+
+    current = Path(path.anchor)
+    for part in path.parts[1:]:
+        current /= part
+        try:
+            metadata = current.lstat()
+        except FileNotFoundError:
+            return
+        if stat_module.S_ISLNK(metadata.st_mode) or bool(int(getattr(metadata, "st_file_attributes", 0)) & 0x400):
+            raise OSError("symlinked staging path component")

--- a/src/codex_plugin_scanner/guard/update_staging.py
+++ b/src/codex_plugin_scanner/guard/update_staging.py
@@ -1,0 +1,45 @@
+"""Pruning of updater staging that outlives the updates that created it."""
+
+from __future__ import annotations
+
+import contextlib
+import shutil
+import time
+from pathlib import Path
+
+_STAGING_PRUNE_AGE_SECONDS = 7 * 24 * 60 * 60
+_UPDATE_RUNTIME_DIR_NAME = "update-runtime"
+
+
+def prune_stale_update_staging(
+    guard_home: Path,
+    *,
+    age_seconds: int = _STAGING_PRUNE_AGE_SECONDS,
+) -> None:
+    """Best-effort cleanup of update staging left by finished or abandoned runs.
+
+    The trusted updater runs each update with a neutral HOME and wheel staging
+    under ``<guard_home>/update-runtime``; without a sweep those directories
+    accumulate for the life of the install (multiple gigabytes on long-lived
+    machines). Entries older than the age gate are deleted, so an update that
+    started recently — including one running right now — is never touched.
+    """
+
+    runtime = guard_home / _UPDATE_RUNTIME_DIR_NAME
+    cutoff = time.time() - age_seconds
+    for staging in (runtime / "home", runtime / "tmp", runtime / "wheels"):
+        try:
+            children = list(staging.iterdir())
+        except OSError:
+            continue
+        for child in children:
+            try:
+                if child.lstat().st_mtime > cutoff:
+                    continue
+            except OSError:
+                continue
+            if child.is_dir() and not child.is_symlink():
+                shutil.rmtree(child, ignore_errors=True)
+            else:
+                with contextlib.suppress(OSError):
+                    child.unlink()

--- a/tests/test_guard_store_quarantine_retention.py
+++ b/tests/test_guard_store_quarantine_retention.py
@@ -66,28 +66,69 @@ def _age(path: Path, *, age_seconds: int) -> None:
     os.utime(path, (stamp, stamp))
 
 
+def test_prune_orders_events_by_quarantine_stamp_not_file_mtime(tmp_path: Path) -> None:
+    # Path.replace preserves the source database's mtime, so a freshly
+    # quarantined long-idle database must not sort older than an earlier
+    # event whose database was written until it died.
+    _write_snapshot(tmp_path, "guard.db.corrupt-20260101T000000000000Z-old-event", age_seconds=0)
+    _write_snapshot(tmp_path, "guard.db.corrupt-20260905T132908303335Z-new-event", age_seconds=30 * 24 * 60 * 60)
+
+    prune_quarantined_store_snapshots(tmp_path, keep=1)
+
+    assert (tmp_path / "guard.db.corrupt-20260905T132908303335Z-new-event").exists()
+    assert not (tmp_path / "guard.db.corrupt-20260101T000000000000Z-old-event").exists()
+
+
+def test_prune_keeps_unstamped_snapshots_furthest_back(tmp_path: Path) -> None:
+    _write_snapshot(tmp_path, "guard.db.corrupt-20260905T132908303335Z-stamped", age_seconds=100 * 24 * 60 * 60)
+    _write_snapshot(tmp_path, "guard.db.corrupt-legacy-unstamped", age_seconds=60)
+
+    prune_quarantined_store_snapshots(tmp_path, keep=1)
+
+    # A parseable quarantine stamp always outranks a legacy name, whatever
+    # the moved files' mtimes say.
+    assert (tmp_path / "guard.db.corrupt-20260905T132908303335Z-stamped").exists()
+    assert not (tmp_path / "guard.db.corrupt-legacy-unstamped").exists()
+
+
 def test_stale_update_staging_is_pruned_but_recent_staging_stays(tmp_path: Path) -> None:
     runtime = tmp_path / "guard-home" / "update-runtime"
-    stale_home = runtime / "home" / "Library"
-    fresh_tmp = runtime / "tmp" / "in-flight"
-    stale_wheels = runtime / "wheels" / "artifact-stale"
-    fresh_wheels = runtime / "wheels" / "artifact-fresh"
-    for directory in (stale_home, fresh_tmp, stale_wheels, fresh_wheels):
+    stale_home = runtime / "home"
+    fresh_tmp = runtime / "tmp"
+    for directory in (stale_home, fresh_tmp):
         directory.mkdir(parents=True)
-    stale_home.joinpath("cache.db").write_bytes(b"stale")
-    stale_wheels.joinpath("hol_guard.whl").write_bytes(b"stale")
-    fresh_tmp.joinpath("partial.tmp").write_bytes(b"fresh")
-    fresh_wheels.joinpath("hol_guard.whl").write_bytes(b"fresh")
-    for stale in (stale_home, stale_wheels):
-        _age(stale, age_seconds=8 * 24 * 60 * 60)
+    stale_home.joinpath("Library").mkdir()
+    stale_home.joinpath("Library").joinpath("cache.db").write_bytes(b"stale")
+    fresh_tmp.joinpath("in-flight.tmp").write_bytes(b"fresh")
+    _age(stale_home, age_seconds=8 * 24 * 60 * 60)
 
     prune_stale_update_staging(tmp_path / "guard-home")
 
     assert not stale_home.exists()
-    assert not stale_wheels.exists()
     # Recent staging — an update that is still running — is never touched.
-    assert fresh_tmp.joinpath("partial.tmp").read_bytes() == b"fresh"
-    assert fresh_wheels.joinpath("hol_guard.whl").read_bytes() == b"fresh"
+    assert fresh_tmp.joinpath("in-flight.tmp").read_bytes() == b"fresh"
+
+
+def test_fresh_update_activity_marker_blocks_the_staging_sweep(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    runtime = guard_home / "update-runtime"
+    stale_home = runtime / "home"
+    stale_home.mkdir(parents=True)
+    _age(stale_home, age_seconds=8 * 24 * 60 * 60)
+    marker = runtime / "active.json"
+    marker.write_text('{"staging": "active"}\n', encoding="utf-8")
+
+    prune_stale_update_staging(guard_home)
+
+    # Reused staging roots keep old mtimes while an update writes deep inside
+    # them; the fresh marker is what protects the tree.
+    assert stale_home.exists()
+
+    _age(marker, age_seconds=2 * 24 * 60 * 60)
+    prune_stale_update_staging(guard_home)
+
+    assert not stale_home.exists()
+    assert marker.exists()
 
 
 def test_stale_update_staging_prune_tolerates_missing_directories(tmp_path: Path) -> None:

--- a/tests/test_guard_store_quarantine_retention.py
+++ b/tests/test_guard_store_quarantine_retention.py
@@ -168,3 +168,15 @@ def test_staging_sweep_refuses_a_linked_runtime_tree(tmp_path: Path) -> None:
 
     # The sweep must not follow the link: the target tree stays untouched.
     assert stale.exists()
+
+
+def test_truncated_quarantine_stamp_is_ignored_without_raising(tmp_path: Path) -> None:
+    # A 21-character digit-led name (everything but the trailing Z) must not
+    # reach the stamp comparison and crash the sweep.
+    _write_snapshot(tmp_path, "guard.db.corrupt-20260101T00000000000", age_seconds=0)
+    _write_snapshot(tmp_path, "guard.db.corrupt-20260905T132908303335Z-real", age_seconds=99 * 24 * 60 * 60)
+
+    removed = prune_quarantined_store_snapshots(tmp_path, keep=1)
+
+    assert removed == 1
+    assert (tmp_path / "guard.db.corrupt-20260905T132908303335Z-real").exists()

--- a/tests/test_guard_store_quarantine_retention.py
+++ b/tests/test_guard_store_quarantine_retention.py
@@ -1,0 +1,95 @@
+"""Quarantined store snapshots must not accumulate for the life of the install."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from codex_plugin_scanner.guard.sqlite_recovery import prune_quarantined_store_snapshots
+from codex_plugin_scanner.guard.update_staging import prune_stale_update_staging
+
+
+def _write_snapshot(guard_home: Path, name: str, *, age_seconds: int = 0) -> None:
+    path = guard_home / name
+    path.write_bytes(b"snapshot")
+    stamp = path.stat().st_mtime - age_seconds
+    os.utime(path, (stamp, stamp))
+
+
+def test_prune_keeps_the_newest_two_quarantine_events(tmp_path: Path) -> None:
+    _write_snapshot(tmp_path, "guard.db.corrupt-a", age_seconds=500)
+    _write_snapshot(tmp_path, "guard.db.corrupt-a-wal", age_seconds=500)
+    _write_snapshot(tmp_path, "guard.db.corrupt-b", age_seconds=300)
+    _write_snapshot(tmp_path, "guard.db.corrupt-c", age_seconds=100)
+    _write_snapshot(tmp_path, "guard.db.corrupt-c-shm", age_seconds=100)
+    _write_snapshot(tmp_path, "guard.db.corrupt-d", age_seconds=50)
+    (tmp_path / "guard.db").write_bytes(b"live")
+
+    removed = prune_quarantined_store_snapshots(tmp_path, keep=2)
+
+    # Event "a" removes its base plus -wal sidecar, event "b" its base.
+    assert removed == 3
+    assert not (tmp_path / "guard.db.corrupt-a").exists()
+    assert not (tmp_path / "guard.db.corrupt-a-wal").exists()
+    assert not (tmp_path / "guard.db.corrupt-b").exists()
+    # The two newest events survive with their sidecars, for support.
+    assert (tmp_path / "guard.db.corrupt-c").exists()
+    assert (tmp_path / "guard.db.corrupt-c-shm").exists()
+    assert (tmp_path / "guard.db.corrupt-d").exists()
+    # The live database is never touched.
+    assert (tmp_path / "guard.db").read_bytes() == b"live"
+
+
+def test_prune_is_a_noop_below_the_retention_count(tmp_path: Path) -> None:
+    _write_snapshot(tmp_path, "guard.db.corrupt-only")
+
+    assert prune_quarantined_store_snapshots(tmp_path, keep=2) == 0
+    assert (tmp_path / "guard.db.corrupt-only").exists()
+
+
+def test_prune_ignores_missing_directory_and_symlinks(tmp_path: Path) -> None:
+    assert prune_quarantined_store_snapshots(tmp_path / "does-not-exist") == 0
+
+    _write_snapshot(tmp_path, "guard.db.corrupt-real")
+    link = tmp_path / "guard.db.corrupt-link"
+    link.symlink_to(tmp_path / "guard.db.corrupt-real")
+    _write_snapshot(tmp_path, "guard.db.corrupt-new", age_seconds=1)
+
+    prune_quarantined_store_snapshots(tmp_path, keep=1)
+
+    # The symlink is never followed or deleted through the retention sweep.
+    assert link.is_symlink()
+
+
+def _age(path: Path, *, age_seconds: int) -> None:
+    stamp = path.stat().st_mtime - age_seconds
+    os.utime(path, (stamp, stamp))
+
+
+def test_stale_update_staging_is_pruned_but_recent_staging_stays(tmp_path: Path) -> None:
+    runtime = tmp_path / "guard-home" / "update-runtime"
+    stale_home = runtime / "home" / "Library"
+    fresh_tmp = runtime / "tmp" / "in-flight"
+    stale_wheels = runtime / "wheels" / "artifact-stale"
+    fresh_wheels = runtime / "wheels" / "artifact-fresh"
+    for directory in (stale_home, fresh_tmp, stale_wheels, fresh_wheels):
+        directory.mkdir(parents=True)
+    stale_home.joinpath("cache.db").write_bytes(b"stale")
+    stale_wheels.joinpath("hol_guard.whl").write_bytes(b"stale")
+    fresh_tmp.joinpath("partial.tmp").write_bytes(b"fresh")
+    fresh_wheels.joinpath("hol_guard.whl").write_bytes(b"fresh")
+    for stale in (stale_home, stale_wheels):
+        _age(stale, age_seconds=8 * 24 * 60 * 60)
+
+    prune_stale_update_staging(tmp_path / "guard-home")
+
+    assert not stale_home.exists()
+    assert not stale_wheels.exists()
+    # Recent staging — an update that is still running — is never touched.
+    assert fresh_tmp.joinpath("partial.tmp").read_bytes() == b"fresh"
+    assert fresh_wheels.joinpath("hol_guard.whl").read_bytes() == b"fresh"
+
+
+def test_stale_update_staging_prune_tolerates_missing_directories(tmp_path: Path) -> None:
+    prune_stale_update_staging(tmp_path / "guard-home")
+    assert not (tmp_path / "guard-home").exists()

--- a/tests/test_guard_store_quarantine_retention.py
+++ b/tests/test_guard_store_quarantine_retention.py
@@ -124,7 +124,7 @@ def test_fresh_update_activity_marker_blocks_the_staging_sweep(tmp_path: Path) -
     # them; the fresh marker is what protects the tree.
     assert stale_home.exists()
 
-    _age(marker, age_seconds=2 * 24 * 60 * 60)
+    _age(marker, age_seconds=8 * 24 * 60 * 60)
     prune_stale_update_staging(guard_home)
 
     assert not stale_home.exists()
@@ -134,3 +134,37 @@ def test_fresh_update_activity_marker_blocks_the_staging_sweep(tmp_path: Path) -
 def test_stale_update_staging_prune_tolerates_missing_directories(tmp_path: Path) -> None:
     prune_stale_update_staging(tmp_path / "guard-home")
     assert not (tmp_path / "guard-home").exists()
+
+
+def test_malformed_digit_led_quarantine_name_does_not_outrank_real_stamps(tmp_path: Path) -> None:
+    _write_snapshot(tmp_path, "guard.db.corrupt-9-legacy", age_seconds=0)
+    _write_snapshot(tmp_path, "guard.db.corrupt-20260905T132908303335Z-real", age_seconds=30 * 24 * 60 * 60)
+
+    prune_quarantined_store_snapshots(tmp_path, keep=1)
+
+    # The real quarantine event survives even with an older file mtime.
+    assert (tmp_path / "guard.db.corrupt-20260905T132908303335Z-real").exists()
+    assert not (tmp_path / "guard.db.corrupt-9-legacy").exists()
+
+
+def test_staging_sweep_refuses_a_linked_runtime_tree(tmp_path: Path) -> None:
+    import os
+
+    if os.name == "nt":
+        import pytest
+
+        pytest.skip("symlink creation may require elevated privileges on Windows")
+    guard_home = tmp_path / "guard-home"
+    target = tmp_path / "target-tree"
+    stale = target / "home"
+    stale.mkdir(parents=True)
+    _age(stale, age_seconds=30 * 24 * 60 * 60)
+    guard_home.mkdir()
+    (guard_home / "update-runtime").symlink_to(target, target_is_directory=True)
+
+    from codex_plugin_scanner.guard.update_staging import prune_stale_update_staging
+
+    prune_stale_update_staging(guard_home)
+
+    # The sweep must not follow the link: the target tree stays untouched.
+    assert stale.exists()


### PR DESCRIPTION
## Summary

Two unbounded accumulations were found growing a long-lived Guard home past 15 GB, and the embedded dashboard offered a second update action that raced the Desktop app's own updater. This PR bounds both accumulations and defers embedded updates to the app.

**What was found on a live machine:** the Guard home held ~8 GB of `guard.db.corrupt-*` snapshots (eight quarantine events, each a full copy of the database at the moment it became unusable — several GB apiece) plus 6.4 GB of never-cleaned updater staging under `update-runtime/`. The sheer home size slowed every daemon start, which pushed cold boots past the budgets Desktop holds for them and turned recovery into a loop.

## Changes

**Quarantine snapshot retention (`sqlite_recovery.py`, `store_storage_maintenance.py`)**

- New `prune_quarantined_store_snapshots(guard_home, keep=2)` groups `guard.db.corrupt-*` events (base plus `-wal`/`-shm` sidecars) and deletes everything older than the newest two events. The newest two stay for support diagnostics.
- The sweep runs in scheduled storage maintenance, so existing hoards are cleaned without waiting for the next corruption event.

**Stale update staging prune (`update_staging.py`, `store_storage_maintenance.py`)**

- New `prune_stale_update_staging(guard_home)` deletes entries under `update-runtime/{home,tmp,wheels}` older than seven days. The age gate means an update that started recently — including one running right now — is never touched.
- Runs alongside the quarantine sweep in storage maintenance.

**Embedded dashboard defers to the app updater (`dashboard/`)**

- New `desktop-embed.ts` detects the `desktop_embed=1` handoff parameter (query or fragment) that Desktop uses for its embedded dashboard session.
- `GuardUpdatePanel` no longer renders its own Update Guard / Reinstall buttons when embedded; it still shows the running version and the available version, with copy pointing at the app's menu-bar Check for Updates. Desktop owns the managed Core runtime and its updater, and the daemon-side runner cannot move that runtime — the button could only ever flicker and reappear.
- Non-embedded dashboards (a real browser) keep the existing behavior.

## Testing

- New `tests/test_guard_store_quarantine_retention.py`: keeps the newest two events with sidecars while deleting older ones, never touches the live database, no-op below the retention count, tolerates missing directories and symlinks, stale staging is pruned while recent staging survives, missing directories tolerated.
- Dashboard `guard-update.test.ts` extended: embedded render offers no Update Guard button, points at the app's menu-bar updater, and still shows the running version.
- `bun run pretest` (dashboard suite), targeted pytest subsets (45 tests), ruff format/check, and the code-quality ratchet all pass. The dashboard bundle is rebuilt and committed.

## Notes for reviewers

- The quarantine sweep is file-level and best-effort; it never opens a database and never raises into maintenance.
- The staging prune's seven-day age gate is deliberately conservative: it bounds growth without any coordination with a running updater.
- The embedded deferral intentionally does not change the update-status payload — non-embedded dashboards and the API behave exactly as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updates are managed through the HOL Guard menu-bar app when the dashboard is embedded in Desktop.
  * Old quarantined database snapshots and stale update files are automatically cleaned up after successful maintenance.
* **Bug Fixes**
  * Embedded dashboards no longer show update or reinstall controls unavailable in Desktop.
  * Storage cleanup now preserves active update files, orders quarantine history correctly, and avoids unsafe linked paths.
* **Tests**
  * Added coverage for Desktop update messaging and storage cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->