### PR TITLE
feat: add TermCoder Guard adapter

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/__init__.py
+++ b/src/codex_plugin_scanner/guard/adapters/__init__.py
@@ -23,6 +23,7 @@ _ADAPTER_SPECS: tuple[tuple[str, str], ...] = (
     (".openclaw", "OpenClawHarnessAdapter"),
     (".opencode", "OpenCodeHarnessAdapter"),
     (".zcode", "ZCodeHarnessAdapter"),
+    (".termcoder", "TermCoderHarnessAdapter"),
 )
 
 

--- a/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
@@ -340,7 +340,7 @@ def _should_exit_block(harness: str, event_name: str, policy_action: str) -> boo
     """Mirror _should_emit_native_hook_exit_block."""
     canonical = harness.strip().lower().replace("_", "-")
     compact = event_name.replace("_", "").replace("-", "").lower()
-    if canonical in {"kimi", "grok", "hermes", "pi", "omp", "zcode"} and compact in {
+    if canonical in {"kimi", "grok", "hermes", "pi", "omp", "zcode", "termcoder"} and compact in {
         "pretooluse",
         "userpromptsubmit",
         "pretoolcall",

--- a/src/codex_plugin_scanner/guard/adapters/contracts.py
+++ b/src/codex_plugin_scanner/guard/adapters/contracts.py
@@ -143,6 +143,7 @@ _DISPLAY_NAMES = {
     "pi": "Pi",
     "omp": "Oh My Pi",
     "zcode": "ZCode",
+    "termcoder": "TermCoder",
 }
 
 
@@ -423,6 +424,20 @@ HARNESS_CONTRACTS: tuple[HarnessProtectionContract, ...] = (
             "and background sessions that run without an active terminal do not surface hook events."
         ),
         smoke_command="hol-guard install zcode --dry-run",
+    ),
+    HarnessProtectionContract(
+        harness="termcoder",
+        install_aliases=("termcoder", "term-code"),
+        config_paths=("~/.config/termcoder/config.json", "~/.config/termcoder/guard.json"),
+        event_surfaces=("shell",),
+        native_approval=False,
+        browser_fallback=True,
+        resume_support=False,
+        known_blind_spots=(
+            "Guard observes only pre-exec shell commands from /run, BUILD/CHAT, /install, and /uninstall. "
+            "Read-only /doctor, /packages, and /git operations are intentionally outside the hook."
+        ),
+        smoke_command="hol-guard install termcoder --dry-run",
     ),
 )
 

--- a/src/codex_plugin_scanner/guard/adapters/termcoder.py
+++ b/src/codex_plugin_scanner/guard/adapters/termcoder.py
@@ -1,0 +1,190 @@
+"""TermCoder harness adapter.
+
+TermCoder keeps its own per-command confirmation prompt.  Guard is deliberately
+invoked beside that prompt with the command text exactly as it will be
+executed, plus the current working directory; it does not consume or reproduce
+TermCoder's risk classification.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from ..models import GuardArtifact, HarnessDetection
+from ..shims import install_guard_shim, remove_guard_shim
+from .base import (
+    HarnessAdapter,
+    HarnessContext,
+    _command_available,
+    _ensure_path_within_root,
+    _json_payload,
+    _shell_command,
+)
+from .bounded_cli_hook_bridge import bounded_cli_hook_command
+
+TERMCODER_CONFIG_DIR = ".config/termcoder"
+TERMCODER_CONFIG_FILE = "config.json"
+TERMCODER_GUARD_CONFIG_FILE = "guard.json"
+TERMCODER_GUARD_MARKER = "HOL Guard managed TermCoder pre-exec"
+_GUARD_HOOK_INTERNAL_TIMEOUT_SECONDS = 25
+
+
+def termcoder_hook_payload(*, command: str, cwd: str, operation: str = "run") -> dict[str, object]:
+    """Build the small, raw pre-exec payload TermCoder sends to Guard."""
+
+    return {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "shell",
+        "tool_input": {"command": command},
+        "cwd": cwd,
+        "termcoder_operation": operation,
+    }
+
+
+class TermCoderHarnessAdapter(HarnessAdapter):
+    """Connect TermCoder's execution surfaces to Guard's independent policy."""
+
+    harness = "termcoder"
+    aliases = ("termcoder", "term-code")
+    executable = "termcoder"
+    launcher_name = "termcoder"
+    approval_tier = "approval-center"
+    approval_summary = (
+        "Guard receives TermCoder's raw command and cwd before execution while TermCoder keeps its "
+        "existing per-command confirmation."
+    )
+    fallback_hint = "TermCoder keeps its confirmation prompt; use the Guard approval center for Guard decisions."
+
+    @staticmethod
+    def _config_dir(context: HarnessContext) -> Path:
+        return context.home_dir / TERMCODER_CONFIG_DIR
+
+    @classmethod
+    def _config_path(cls, context: HarnessContext) -> Path:
+        return cls._config_dir(context) / TERMCODER_CONFIG_FILE
+
+    @classmethod
+    def _guard_config_path(cls, context: HarnessContext) -> Path:
+        return cls._config_dir(context) / TERMCODER_GUARD_CONFIG_FILE
+
+    def policy_path(self, context: HarnessContext) -> Path:
+        return self._config_path(context)
+
+    def detect(self, context: HarnessContext) -> HarnessDetection:
+        config_path = self._config_path(context)
+        artifacts: list[GuardArtifact] = []
+        found_paths: list[str] = []
+        if config_path.is_file():
+            found_paths.append(str(config_path))
+            payload = _json_payload(config_path)
+            if payload:
+                artifacts.append(
+                    GuardArtifact(
+                        artifact_id="termcoder:global:config",
+                        name="TermCoder config",
+                        harness=self.harness,
+                        artifact_type="config",
+                        source_scope="global",
+                        config_path=str(config_path),
+                        metadata={"keys": sorted(payload)},
+                    )
+                )
+        guard_config = self._guard_config_path(context)
+        if guard_config.is_file():
+            found_paths.append(str(guard_config))
+        command_available = _command_available(self.executable)
+        return HarnessDetection(
+            harness=self.harness,
+            installed=bool(found_paths) or command_available,
+            command_available=command_available,
+            config_paths=tuple(found_paths),
+            artifacts=tuple(artifacts),
+            warnings=(),
+        )
+
+    @staticmethod
+    def _hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
+        args = [
+            "guard",
+            "hook",
+            "--guard-home",
+            str(context.guard_home),
+            "--harness",
+            "termcoder",
+        ]
+        if context.home_dir.resolve() != Path.home().resolve():
+            args.extend(["--home", str(context.home_dir)])
+        if context.workspace_dir is not None:
+            args.extend(["--workspace", str(context.workspace_dir)])
+        return bounded_cli_hook_command(
+            python_executable=sys.executable,
+            package_root=Path(__file__).resolve().parents[3],
+            guard_home=context.guard_home,
+            cli_args=args,
+            harness="termcoder",
+            timeout_seconds=_GUARD_HOOK_INTERNAL_TIMEOUT_SECONDS,
+        )
+
+    def install(self, context: HarnessContext) -> dict[str, object]:
+        shim_manifest = install_guard_shim(
+            self.harness,
+            context,
+            launcher_name=self.launcher_name,
+            display_name="TermCoder",
+        )
+        guard_config = self._guard_config_path(context)
+        _ensure_path_within_root(context.home_dir, guard_config, label="TermCoder")
+        guard_config.parent.mkdir(parents=True, exist_ok=True)
+        hook_command = _shell_command(self._hook_command_parts(context))
+        guard_config.write_text(
+            json.dumps(
+                {
+                    "marker": TERMCODER_GUARD_MARKER,
+                    "pre_exec": {
+                        "command": hook_command,
+                        "events": ["run", "build", "chat", "install", "uninstall"],
+                        "payload": "termcoder_hook_payload(command, cwd, operation)",
+                    },
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return {
+            "harness": self.harness,
+            "active": True,
+            "config_path": str(guard_config),
+            "managed_config_path": str(guard_config),
+            **shim_manifest,
+            "notes": [
+                "Guard receives the raw command and cwd immediately before TermCoder executes it",
+                "TermCoder's per-command confirmation remains enabled",
+                "Guard coverage includes /run, BUILD/CHAT commands, /install, and /uninstall",
+                "Read-only /doctor, /packages, and /git operations are outside this hook",
+            ],
+        }
+
+    def uninstall(self, context: HarnessContext) -> dict[str, object]:
+        shim_manifest = remove_guard_shim(
+            self.harness,
+            context,
+            launcher_name=self.launcher_name,
+            display_name="TermCoder",
+        )
+        guard_config = self._guard_config_path(context)
+        if guard_config.is_file():
+            payload = _json_payload(guard_config)
+            if payload.get("marker") == TERMCODER_GUARD_MARKER:
+                guard_config.unlink()
+        return {
+            "harness": self.harness,
+            "active": False,
+            "config_path": str(guard_config),
+            **shim_manifest,
+        }
+
+
+__all__ = ["TermCoderHarnessAdapter", "termcoder_hook_payload"]

--- a/tests/test_termcoder_adapter.py
+++ b/tests/test_termcoder_adapter.py
@@ -1,0 +1,91 @@
+"""Focused tests for the TermCoder harness adapter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_plugin_scanner.guard.adapters import get_adapter, list_adapters
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.contracts import contract_for
+from codex_plugin_scanner.guard.adapters.termcoder import (
+    TERMCODER_GUARD_MARKER,
+    TermCoderHarnessAdapter,
+    termcoder_hook_payload,
+)
+
+
+def _ctx(tmp_path: Path) -> HarnessContext:
+    return HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=tmp_path / "workspace",
+        guard_home=tmp_path / "guard-home",
+    )
+
+
+def test_termcoder_is_registered() -> None:
+    assert isinstance(get_adapter("termcoder"), TermCoderHarnessAdapter)
+    assert get_adapter("term-code").harness == "termcoder"
+    assert "termcoder" in {adapter.harness for adapter in list_adapters()}
+    assert contract_for("termcoder") is not None
+
+
+def test_detects_termcoder_config(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    config_path = ctx.home_dir / ".config" / "termcoder" / "config.json"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(json.dumps({"mode": "build"}), encoding="utf-8")
+
+    detection = TermCoderHarnessAdapter().detect(ctx)
+
+    assert detection.installed is True
+    assert str(config_path) in detection.config_paths
+    assert detection.artifacts[0].artifact_type == "config"
+
+
+def test_install_writes_independent_raw_pre_exec_contract(tmp_path: Path, monkeypatch) -> None:
+    ctx = _ctx(tmp_path)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.adapters.termcoder.install_guard_shim",
+        lambda *args, **kwargs: {"shim_path": str(ctx.guard_home / "bin" / "guard-termcoder"), "notes": []},
+    )
+
+    manifest = TermCoderHarnessAdapter().install(ctx)
+
+    guard_config = ctx.home_dir / ".config" / "termcoder" / "guard.json"
+    payload = json.loads(guard_config.read_text(encoding="utf-8"))
+    assert manifest["active"] is True
+    assert payload["marker"] == TERMCODER_GUARD_MARKER
+    assert payload["pre_exec"]["events"] == ["run", "build", "chat", "install", "uninstall"]
+    assert "bounded_cli_hook_bridge" in payload["pre_exec"]["command"]
+    assert "risk" not in json.dumps(payload).lower()
+
+
+def test_hook_payload_preserves_raw_command_and_cwd() -> None:
+    payload = termcoder_hook_payload(
+        command="git commit -m 'keep the exact shell text'",
+        cwd="/workspace/project",
+        operation="build",
+    )
+
+    assert payload["tool_input"] == {"command": "git commit -m 'keep the exact shell text'"}
+    assert payload["cwd"] == "/workspace/project"
+    assert payload["termcoder_operation"] == "build"
+
+
+def test_uninstall_removes_only_guard_config(tmp_path: Path, monkeypatch) -> None:
+    ctx = _ctx(tmp_path)
+    adapter = TermCoderHarnessAdapter()
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.adapters.termcoder.install_guard_shim",
+        lambda *args, **kwargs: {"shim_path": str(ctx.guard_home / "bin" / "guard-termcoder"), "notes": []},
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.adapters.termcoder.remove_guard_shim",
+        lambda *args, **kwargs: {"shim_path": str(ctx.guard_home / "bin" / "guard-termcoder"), "notes": []},
+    )
+
+    adapter.install(ctx)
+    adapter.uninstall(ctx)
+
+    assert not (ctx.home_dir / ".config" / "termcoder" / "guard.json").exists()


### PR DESCRIPTION
Adds a TermCoder pre-exec adapter that forwards the raw command and cwd to Guard while preserving TermCoder's per-command confirmation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for integrating with the TermCoder harness.
  * Guard can now detect TermCoder, install and remove its protection hooks, and monitor run, build, chat, install, and uninstall operations.
  * TermCoder’s existing command confirmation flow is preserved while policy checks are applied.
* **Bug Fixes**
  * TermCoder hooks now return the appropriate blocking exit code when review or blocking action is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->