### PR TITLE
fix(approval): clarify local gate setup guidance

### DIFF
--- a/dashboard/e2e/extension-authority-recovery.spec.ts
+++ b/dashboard/e2e/extension-authority-recovery.spec.ts
@@ -79,7 +79,7 @@ for (const configured of [false, true]) {
     page.on("pageerror", (error) => runtimeErrors.push(error.message));
     await mountRecoveryFixture(page, { configured, enabled: false, failSettings: false });
     await page.goto(`/extensions?${DAEMON}`);
-    await expect(page.getByRole("heading", { name: "Set up approval before enrollment" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Set up local approval before enrollment" })).toBeVisible();
     await expect(page.getByText("hol-guard command controls enroll", { exact: true })).toHaveCount(0);
     await page.getByRole("button", { name: "Set up approval", exact: true }).click();
     await expect(page).toHaveURL(/\/settings\?.*section=approval/);

--- a/dashboard/src/extensions-workspace.test.ts
+++ b/dashboard/src/extensions-workspace.test.ts
@@ -98,7 +98,7 @@ assert.match(approvalSetupMarkup, /Set up approval/);
 assert.match(approvalSetupMarkup, /Guard Cloud sign-in and account MFA are separate and do not enable this gate/);
 assert.match(approvalSetupMarkup, /Settings &gt; Approval gate/);
 assert.match(approvalSetupMarkup, /Ask for proof on allow decisions/);
-assert.match(approvalSetupMarkup, /Optionally connect an Authenticator app for high-risk approvals/);
+assert.match(approvalSetupMarkup, /Optionally connect an Authenticator app; once enabled, its code replaces the Approval password for every protected action and disables cooldown/);
 assert.doesNotMatch(approvalSetupMarkup, /Authy/);
 assert.doesNotMatch(approvalSetupMarkup, /command controls enroll/);
 assert.doesNotMatch(approvalSetupMarkup, /Copy setup command/);

--- a/dashboard/src/extensions-workspace.test.ts
+++ b/dashboard/src/extensions-workspace.test.ts
@@ -93,8 +93,13 @@ const approvalSetupMarkup = renderToStaticMarkup(createElement(ProtectionAuthori
   onCheckAgain: () => undefined,
   onOpenApprovalSettings: () => undefined,
 }));
-assert.match(approvalSetupMarkup, /Set up approval before enrollment/);
+assert.match(approvalSetupMarkup, /Set up local approval before enrollment/);
 assert.match(approvalSetupMarkup, /Set up approval/);
+assert.match(approvalSetupMarkup, /Guard Cloud sign-in and account MFA are separate and do not enable this gate/);
+assert.match(approvalSetupMarkup, /Settings &gt; Approval gate/);
+assert.match(approvalSetupMarkup, /Ask for proof on allow decisions/);
+assert.match(approvalSetupMarkup, /Optionally connect an Authenticator app for high-risk approvals/);
+assert.doesNotMatch(approvalSetupMarkup, /Authy/);
 assert.doesNotMatch(approvalSetupMarkup, /command controls enroll/);
 assert.doesNotMatch(approvalSetupMarkup, /Copy setup command/);
 
@@ -105,7 +110,7 @@ const disabledApprovalMarkup = renderToStaticMarkup(createElement(ProtectionAuth
   onCheckAgain: () => undefined,
   onOpenApprovalSettings: () => undefined,
 }));
-assert.match(disabledApprovalMarkup, /Set up approval before enrollment/);
+assert.match(disabledApprovalMarkup, /Set up local approval before enrollment/);
 assert.doesNotMatch(disabledApprovalMarkup, /command controls enroll/);
 
 const pendingApprovalMarkup = renderToStaticMarkup(createElement(ProtectionAuthorityNotice, {

--- a/dashboard/src/protection-center/components/protection-authority-notice.tsx
+++ b/dashboard/src/protection-center/components/protection-authority-notice.tsx
@@ -92,8 +92,8 @@ function authorityNoticeView(
       if (!approvalGateReady) {
         return {
           tone: "info",
-          title: "Set up approval before enrollment",
-          body: "Extension controls require a local approval password or Authenticator before this device can create trusted protection settings. Set up approval first, then return here to enroll.",
+          title: "Set up local approval before enrollment",
+          body: "Extension controls require this device's local approval gate. Guard Cloud sign-in and account MFA are separate and do not enable this gate. In Settings > Approval gate, enable Ask for proof on allow decisions and set an Approval password, then return here to enroll. Optionally connect an Authenticator app for high-risk approvals.",
           action: { kind: "configure-approval" },
           actionLabel: "Set up approval",
           actionDetail: null,

--- a/dashboard/src/protection-center/components/protection-authority-notice.tsx
+++ b/dashboard/src/protection-center/components/protection-authority-notice.tsx
@@ -93,7 +93,7 @@ function authorityNoticeView(
         return {
           tone: "info",
           title: "Set up local approval before enrollment",
-          body: "Extension controls require this device's local approval gate. Guard Cloud sign-in and account MFA are separate and do not enable this gate. In Settings > Approval gate, enable Ask for proof on allow decisions and set an Approval password, then return here to enroll. Optionally connect an Authenticator app for high-risk approvals.",
+          body: "Extension controls require this device's local approval gate. Guard Cloud sign-in and account MFA are separate and do not enable this gate. In Settings > Approval gate, enable Ask for proof on allow decisions and set an Approval password, then return here to enroll. Optionally connect an Authenticator app; once enabled, its code replaces the Approval password for every protected action and disables cooldown.",
           action: { kind: "configure-approval" },
           actionLabel: "Set up approval",
           actionDetail: null,

--- a/src/codex_plugin_scanner/guard/cli/commands_lifecycle_gate.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_lifecycle_gate.py
@@ -16,8 +16,10 @@ from ..windows_paths import trusted_windows_user_profile
 from .approval_gate_prompt import consume_desktop_lifecycle_env, prompt_for_approval_gate
 
 _ENROLLMENT_NOTICE = (
-    "Security recommendation: protect Guard administration with an approval password or Authenticator. "
-    "Run `hol-guard dashboard`, then enable these controls in Settings."
+    "Local Guard approval protection is not enabled. Guard Cloud sign-in and account MFA are separate from this "
+    "local gate. Run `hol-guard dashboard`, then open Settings > Approval gate, enable `Ask for proof on allow "
+    "decisions`, and set an `Approval password`. Optionally connect an `Authenticator app` for high-risk "
+    "approvals. This notice is advisory and does not block the current command."
 )
 _CANONICAL_AUTHORITY_ACTION_PREFIXES = (
     "apps.",

--- a/src/codex_plugin_scanner/guard/cli/commands_lifecycle_gate.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_lifecycle_gate.py
@@ -18,8 +18,9 @@ from .approval_gate_prompt import consume_desktop_lifecycle_env, prompt_for_appr
 _ENROLLMENT_NOTICE = (
     "Local Guard approval protection is not enabled. Guard Cloud sign-in and account MFA are separate from this "
     "local gate. Run `hol-guard dashboard`, then open Settings > Approval gate, enable `Ask for proof on allow "
-    "decisions`, and set an `Approval password`. Optionally connect an `Authenticator app` for high-risk "
-    "approvals. This notice is advisory and does not block the current command."
+    "decisions`, and set an `Approval password`. Optionally connect an `Authenticator app`; once enabled, its "
+    "code replaces the `Approval password` for every protected action and disables cooldown. This notice is "
+    "advisory and does not block the current command."
 )
 _CANONICAL_AUTHORITY_ACTION_PREFIXES = (
     "apps.",

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
@@ -4147,7 +4147,7 @@ function authorityNoticeView(health, approvalGateReady) {
         return {
           tone: "info",
           title: "Set up local approval before enrollment",
-          body: "Extension controls require this device's local approval gate. Guard Cloud sign-in and account MFA are separate and do not enable this gate. In Settings > Approval gate, enable Ask for proof on allow decisions and set an Approval password, then return here to enroll. Optionally connect an Authenticator app for high-risk approvals.",
+          body: "Extension controls require this device's local approval gate. Guard Cloud sign-in and account MFA are separate and do not enable this gate. In Settings > Approval gate, enable Ask for proof on allow decisions and set an Approval password, then return here to enroll. Optionally connect an Authenticator app; once enabled, its code replaces the Approval password for every protected action and disables cooldown.",
           action: { kind: "configure-approval" },
           actionLabel: "Set up approval",
           actionDetail: null,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
@@ -4146,8 +4146,8 @@ function authorityNoticeView(health, approvalGateReady) {
       if (!approvalGateReady) {
         return {
           tone: "info",
-          title: "Set up approval before enrollment",
-          body: "Extension controls require a local approval password or Authenticator before this device can create trusted protection settings. Set up approval first, then return here to enroll.",
+          title: "Set up local approval before enrollment",
+          body: "Extension controls require this device's local approval gate. Guard Cloud sign-in and account MFA are separate and do not enable this gate. In Settings > Approval gate, enable Ask for proof on allow decisions and set an Approval password, then return here to enroll. Optionally connect an Authenticator app for high-risk approvals.",
           action: { kind: "configure-approval" },
           actionLabel: "Set up approval",
           actionDetail: null,

--- a/tests/test_guard_cli_lifecycle_gate.py
+++ b/tests/test_guard_cli_lifecycle_gate.py
@@ -91,7 +91,7 @@ def test_lifecycle_gate_warns_and_allows_when_protection_is_disabled(
     assert "Guard Cloud sign-in and account MFA are separate from this local gate." in warning
     assert "Settings > Approval gate" in warning
     assert "Ask for proof on allow decisions" in warning
-    assert "Optionally connect an `Authenticator app` for high-risk approvals." in warning
+    assert "Optionally connect an `Authenticator app`; once enabled, its code replaces the `Approval password` for every protected action and disables cooldown." in warning
     assert "Authy" not in warning
     assert "This notice is advisory and does not block the current command." in warning
 

--- a/tests/test_guard_cli_lifecycle_gate.py
+++ b/tests/test_guard_cli_lifecycle_gate.py
@@ -87,9 +87,13 @@ def test_lifecycle_gate_warns_and_allows_when_protection_is_disabled(
     )
 
     warning = error_stream.getvalue()
-    assert "Security recommendation" in warning
-    assert "approval password or Authenticator" in warning
-    assert "hol-guard dashboard" in warning
+    assert "Local Guard approval protection is not enabled." in warning
+    assert "Guard Cloud sign-in and account MFA are separate from this local gate." in warning
+    assert "Settings > Approval gate" in warning
+    assert "Ask for proof on allow decisions" in warning
+    assert "Optionally connect an `Authenticator app` for high-risk approvals." in warning
+    assert "Authy" not in warning
+    assert "This notice is advisory and does not block the current command." in warning
 
 
 def test_lifecycle_gate_requires_fresh_password_when_enabled(


### PR DESCRIPTION
## Summary
- Clarify that the local Guard approval gate is separate from Guard Cloud sign-in and account MFA.
- Point users to the exact Approval gate controls and keep the generated dashboard asset aligned with the source copy.

## Testing
- `python3 -m pytest tests/test_guard_cli_lifecycle_gate.py`
- `pnpm --dir dashboard exec tsx src/extensions-workspace.test.ts`
- `bun run build`
