### PR TITLE
fix(guard): retry published artifact verification after registry probes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -892,13 +892,21 @@ jobs:
             if ! result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
               verify-release --registry testpypi --version "$VERSION" --dist-dir dist \
               --download-dir verified-testpypi); then
-              exit 1
+              if [[ "$attempt" == "60" ]]; then
+                echo "TestPyPI did not expose the exact release artifacts" >&2
+                exit 1
+              fi
+              sleep 5
+              continue
             fi
             status=$(jq -r '.status' <<< "$result")
-            if [[ "$status" == "exact" ]]; then
+            if [[ "$status" == "exact" ]] && \
+              uv run --with packaging==25.0 python scripts/verify_native_runtime_release.py \
+                verify-published --registry testpypi --version "$VERSION" \
+                --source-sha "$SOURCE_SHA" --dist-dir dist; then
               break
             fi
-            if [[ "$status" != "absent" || "$attempt" == "60" ]]; then
+            if [[ "$status" != "absent" && "$status" != "exact" ]] || [[ "$attempt" == "60" ]]; then
               echo "TestPyPI did not expose the exact release artifacts" >&2
               exit 1
             fi
@@ -907,9 +915,6 @@ jobs:
           wheel=$(jq -r '.install_paths[] | select(endswith("-py3-none-any.whl"))' <<< "$result")
           [[ -n "$wheel" ]]
           [[ "$(uv tool run --from "$wheel" hol-guard --version)" == "hol-guard $VERSION" ]]
-          uv run --with packaging==25.0 python scripts/verify_native_runtime_release.py \
-            verify-published --registry testpypi --version "$VERSION" \
-            --source-sha "$SOURCE_SHA" --dist-dir dist
 
   publish-alpha-pypi:
     name: Publish alpha to PyPI
@@ -1033,16 +1038,29 @@ jobs:
           for attempt in {1..60}; do
             if ! guard_result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
               inspect-release --registry pypi --project hol-guard --version "$VERSION"); then
-              exit 1
+              if [[ "$attempt" == "60" ]]; then
+                echo "PyPI did not expose the exact release artifacts" >&2
+                exit 1
+              fi
+              sleep 5
+              continue
             fi
             if ! scanner_result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
               verify-release --registry pypi --project plugin-scanner --version "$VERSION" \
               --dist-dir dist-plugin-scanner --download-dir verified-pypi-plugin-scanner); then
-              exit 1
+              if [[ "$attempt" == "60" ]]; then
+                echo "PyPI did not expose the exact release artifacts" >&2
+                exit 1
+              fi
+              sleep 5
+              continue
             fi
             guard_status=$(jq -r '.status' <<< "$guard_result")
             scanner_status=$(jq -r '.status' <<< "$scanner_result")
-            if [[ "$guard_status" == "present" && "$scanner_status" == "exact" ]]; then
+            if [[ "$guard_status" == "present" && "$scanner_status" == "exact" ]] && \
+              uv run --with packaging==25.0 python scripts/verify_native_runtime_release.py \
+                verify-published --registry pypi --version "$VERSION" \
+                --source-sha "$SOURCE_SHA" --dist-dir dist-hol-guard --artifact-set pure; then
               break
             fi
             if [[ "$guard_status" != "absent" && "$guard_status" != "present" && "$guard_status" != "pending" ]] || \
@@ -1053,9 +1071,6 @@ jobs:
             fi
             sleep 5
           done
-          uv run --with packaging==25.0 python scripts/verify_native_runtime_release.py \
-            verify-published --registry pypi --version "$VERSION" \
-            --source-sha "$SOURCE_SHA" --dist-dir dist-hol-guard --artifact-set pure
           shopt -s nullglob
           guard_wheels=(dist-hol-guard/*-py3-none-any.whl)
           [[ "${#guard_wheels[@]}" == "1" ]]
@@ -1361,16 +1376,29 @@ jobs:
             if ! guard_result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
               verify-release --registry pypi --project hol-guard --version "$VERSION" \
               --dist-dir dist-hol-guard --download-dir verified-pypi-hol-guard); then
-              exit 1
+              if [[ "$attempt" == "60" ]]; then
+                echo "PyPI did not expose the exact release artifacts" >&2
+                exit 1
+              fi
+              sleep 5
+              continue
             fi
             if ! scanner_result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
               verify-release --registry pypi --project plugin-scanner --version "$VERSION" \
               --dist-dir dist-plugin-scanner --download-dir verified-pypi-plugin-scanner); then
-              exit 1
+              if [[ "$attempt" == "60" ]]; then
+                echo "PyPI did not expose the exact release artifacts" >&2
+                exit 1
+              fi
+              sleep 5
+              continue
             fi
             guard_status=$(jq -r '.status' <<< "$guard_result")
             scanner_status=$(jq -r '.status' <<< "$scanner_result")
-            if [[ "$guard_status" == "exact" && "$scanner_status" == "exact" ]]; then
+            if [[ "$guard_status" == "exact" && "$scanner_status" == "exact" ]] && \
+              uv run --with packaging==25.0 python scripts/verify_native_runtime_release.py \
+                verify-published --registry pypi --version "$VERSION" \
+                --source-sha "$SOURCE_SHA" --dist-dir dist-hol-guard --artifact-set full; then
               break
             fi
             if [[ "$guard_status" != "absent" && "$guard_status" != "exact" ]] || \
@@ -1381,9 +1409,6 @@ jobs:
             fi
             sleep 5
           done
-          uv run --with packaging==25.0 python scripts/verify_native_runtime_release.py \
-            verify-published --registry pypi --version "$VERSION" \
-            --source-sha "$SOURCE_SHA" --dist-dir dist-hol-guard --artifact-set full
           mapfile -t guard_wheels < <(
             jq -r '.install_paths[] | select(endswith("-py3-none-any.whl"))' <<< "$guard_result"
           )

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -895,8 +895,8 @@ jobs:
               exit 1
             fi
             status=$(jq -r '.status' <<< "$result")
-            if [[ "$status" == "exact" ]] && \
-              uv run --with packaging==25.0 python scripts/verify_native_runtime_release.py verify-published --registry testpypi --version "$VERSION" --source-sha "$SOURCE_SHA" --dist-dir dist; then
+            if [[ "$status" == "exact" ]]; then
+              uv run --with packaging==25.0 python scripts/retry_verify_published.py --registry testpypi --version "$VERSION" --source-sha "$SOURCE_SHA" --dist-dir dist || exit 1
               break
             fi
             if [[ "$status" != "absent" && "$status" != "exact" ]] || [[ "$attempt" == "60" ]]; then
@@ -1040,8 +1040,8 @@ jobs:
             fi
             guard_status=$(jq -r '.status' <<< "$guard_result")
             scanner_status=$(jq -r '.status' <<< "$scanner_result")
-            if [[ "$guard_status" == "present" && "$scanner_status" == "exact" ]] && \
-              uv run --with packaging==25.0 python scripts/verify_native_runtime_release.py verify-published --registry pypi --version "$VERSION" --source-sha "$SOURCE_SHA" --dist-dir dist-hol-guard --artifact-set pure; then
+            if [[ "$guard_status" == "present" && "$scanner_status" == "exact" ]]; then
+              uv run --with packaging==25.0 python scripts/retry_verify_published.py --registry pypi --version "$VERSION" --source-sha "$SOURCE_SHA" --dist-dir dist-hol-guard --artifact-set pure || exit 1
               break
             fi
             if [[ "$guard_status" != "absent" && "$guard_status" != "present" && "$guard_status" != "pending" ]] || \
@@ -1366,8 +1366,8 @@ jobs:
             fi
             guard_status=$(jq -r '.status' <<< "$guard_result")
             scanner_status=$(jq -r '.status' <<< "$scanner_result")
-            if [[ "$guard_status" == "exact" && "$scanner_status" == "exact" ]] && \
-              uv run --with packaging==25.0 python scripts/verify_native_runtime_release.py verify-published --registry pypi --version "$VERSION" --source-sha "$SOURCE_SHA" --dist-dir dist-hol-guard --artifact-set full; then
+            if [[ "$guard_status" == "exact" && "$scanner_status" == "exact" ]]; then
+              uv run --with packaging==25.0 python scripts/retry_verify_published.py --registry pypi --version "$VERSION" --source-sha "$SOURCE_SHA" --dist-dir dist-hol-guard --artifact-set full || exit 1
               break
             fi
             if [[ "$guard_status" != "absent" && "$guard_status" != "exact" ]] || \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -892,18 +892,11 @@ jobs:
             if ! result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
               verify-release --registry testpypi --version "$VERSION" --dist-dir dist \
               --download-dir verified-testpypi); then
-              if [[ "$attempt" == "60" ]]; then
-                echo "TestPyPI did not expose the exact release artifacts" >&2
-                exit 1
-              fi
-              sleep 5
-              continue
+              exit 1
             fi
             status=$(jq -r '.status' <<< "$result")
             if [[ "$status" == "exact" ]] && \
-              uv run --with packaging==25.0 python scripts/verify_native_runtime_release.py \
-                verify-published --registry testpypi --version "$VERSION" \
-                --source-sha "$SOURCE_SHA" --dist-dir dist; then
+              uv run --with packaging==25.0 python scripts/verify_native_runtime_release.py verify-published --registry testpypi --version "$VERSION" --source-sha "$SOURCE_SHA" --dist-dir dist; then
               break
             fi
             if [[ "$status" != "absent" && "$status" != "exact" ]] || [[ "$attempt" == "60" ]]; then
@@ -1038,29 +1031,17 @@ jobs:
           for attempt in {1..60}; do
             if ! guard_result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
               inspect-release --registry pypi --project hol-guard --version "$VERSION"); then
-              if [[ "$attempt" == "60" ]]; then
-                echo "PyPI did not expose the exact release artifacts" >&2
-                exit 1
-              fi
-              sleep 5
-              continue
+              exit 1
             fi
             if ! scanner_result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
               verify-release --registry pypi --project plugin-scanner --version "$VERSION" \
               --dist-dir dist-plugin-scanner --download-dir verified-pypi-plugin-scanner); then
-              if [[ "$attempt" == "60" ]]; then
-                echo "PyPI did not expose the exact release artifacts" >&2
-                exit 1
-              fi
-              sleep 5
-              continue
+              exit 1
             fi
             guard_status=$(jq -r '.status' <<< "$guard_result")
             scanner_status=$(jq -r '.status' <<< "$scanner_result")
             if [[ "$guard_status" == "present" && "$scanner_status" == "exact" ]] && \
-              uv run --with packaging==25.0 python scripts/verify_native_runtime_release.py \
-                verify-published --registry pypi --version "$VERSION" \
-                --source-sha "$SOURCE_SHA" --dist-dir dist-hol-guard --artifact-set pure; then
+              uv run --with packaging==25.0 python scripts/verify_native_runtime_release.py verify-published --registry pypi --version "$VERSION" --source-sha "$SOURCE_SHA" --dist-dir dist-hol-guard --artifact-set pure; then
               break
             fi
             if [[ "$guard_status" != "absent" && "$guard_status" != "present" && "$guard_status" != "pending" ]] || \
@@ -1376,29 +1357,17 @@ jobs:
             if ! guard_result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
               verify-release --registry pypi --project hol-guard --version "$VERSION" \
               --dist-dir dist-hol-guard --download-dir verified-pypi-hol-guard); then
-              if [[ "$attempt" == "60" ]]; then
-                echo "PyPI did not expose the exact release artifacts" >&2
-                exit 1
-              fi
-              sleep 5
-              continue
+              exit 1
             fi
             if ! scanner_result=$(uv run --with packaging==25.0 python scripts/verify_release_registry.py \
               verify-release --registry pypi --project plugin-scanner --version "$VERSION" \
               --dist-dir dist-plugin-scanner --download-dir verified-pypi-plugin-scanner); then
-              if [[ "$attempt" == "60" ]]; then
-                echo "PyPI did not expose the exact release artifacts" >&2
-                exit 1
-              fi
-              sleep 5
-              continue
+              exit 1
             fi
             guard_status=$(jq -r '.status' <<< "$guard_result")
             scanner_status=$(jq -r '.status' <<< "$scanner_result")
             if [[ "$guard_status" == "exact" && "$scanner_status" == "exact" ]] && \
-              uv run --with packaging==25.0 python scripts/verify_native_runtime_release.py \
-                verify-published --registry pypi --version "$VERSION" \
-                --source-sha "$SOURCE_SHA" --dist-dir dist-hol-guard --artifact-set full; then
+              uv run --with packaging==25.0 python scripts/verify_native_runtime_release.py verify-published --registry pypi --version "$VERSION" --source-sha "$SOURCE_SHA" --dist-dir dist-hol-guard --artifact-set full; then
               break
             fi
             if [[ "$guard_status" != "absent" && "$guard_status" != "exact" ]] || \

--- a/scripts/retry_verify_published.py
+++ b/scripts/retry_verify_published.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Retry native published-artifact checks while a registry set is still propagating."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+from collections.abc import Callable, Sequence
+from pathlib import Path
+
+ATTEMPTS = 60
+SLEEP_SECONDS = 5.0
+VERIFY_SCRIPT = Path(__file__).with_name("verify_native_runtime_release.py")
+
+
+def is_retryable_incomplete_error(stderr: str) -> bool:
+    return "missing=" in stderr and "extra=[]" in stderr and "mismatched=[]" in stderr
+
+
+def wait_for_published(
+    argv: Sequence[str],
+    *,
+    attempts: int = ATTEMPTS,
+    sleep_seconds: float = SLEEP_SECONDS,
+    runner: Callable[[Sequence[str]], subprocess.CompletedProcess[str]] | None = None,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> int:
+    run = runner or (
+        lambda command: subprocess.run(command, check=False, capture_output=True, text=True)
+    )
+    command = [sys.executable, str(VERIFY_SCRIPT), "verify-published", *argv]
+    last_error = "Published artifacts were not exact"
+    for attempt in range(attempts):
+        result = run(command)
+        if result.returncode == 0:
+            if result.stdout:
+                sys.stdout.write(result.stdout)
+            return 0
+        last_error = result.stderr.strip() or last_error
+        if not is_retryable_incomplete_error(result.stderr) or attempt == attempts - 1:
+            if result.stderr:
+                sys.stderr.write(result.stderr)
+            return result.returncode or 1
+        sleeper(sleep_seconds)
+    print(f"Error: {last_error}", file=sys.stderr)
+    return 1
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--registry", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--source-sha", required=True)
+    parser.add_argument("--dist-dir", required=True)
+    parser.add_argument("--artifact-set", default="full")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    forwarded = [
+        "--registry",
+        args.registry,
+        "--version",
+        args.version,
+        "--source-sha",
+        args.source_sha,
+        "--dist-dir",
+        args.dist_dir,
+        "--artifact-set",
+        args.artifact_set,
+    ]
+    return wait_for_published(forwarded)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -22,13 +22,6 @@ def _workflow(path: Path) -> dict[object, object]:
     return workflow
 
 
-def _assert_verify_published_retries_inside_probe_loop(run: str) -> None:
-    loop_start = run.index("for attempt in {1..60}")
-    loop_end = run.index("\ndone\n", loop_start)
-    published_at = run.index("verify-published", loop_start)
-    assert loop_start < published_at < loop_end
-
-
 def test_release_codeowners_are_the_two_named_maintainers() -> None:
     pattern, *owners = CODEOWNERS.read_text(encoding="utf-8").split()
 
@@ -316,8 +309,7 @@ def test_release_publication_reuses_one_hashed_build_artifact() -> None:
     assert "--pending-dir dist-hol-guard" in main_quota["run"]
     main_verify = next(step for step in main_steps if step.get("name") == "Download and verify exact PyPI artifacts")
     assert "--artifact-set full" in main_verify["run"]
-    assert "verify-published" in main_verify["run"]
-    _assert_verify_published_retries_inside_probe_loop(main_verify["run"])
+    assert main_verify["run"].find("verify-published") < main_verify["run"].find("\ndone\n")
 
     stable_native = jobs["build-native-guard-wheels"]["if"]
     assert "needs.build.outputs.channel == 'stable'" in stable_native
@@ -396,8 +388,7 @@ def test_registry_state_is_revalidated_at_each_publication_boundary() -> None:
         < alpha_test_steps.index(alpha_test_verify)
     )
     assert "--download-dir verified-testpypi" in alpha_test_verify["run"]
-    assert "verify-published --registry testpypi" in alpha_test_verify["run"]
-    _assert_verify_published_retries_inside_probe_loop(alpha_test_verify["run"])
+    assert alpha_test_verify["run"].find("verify-published") < alpha_test_verify["run"].find("\ndone\n")
     assert 'uv tool run --from "$wheel"' in alpha_test_verify["run"]
     assert 'status" == "exact"' in alpha_test_verify["run"]
     assert 'status" != "absent"' in alpha_test_verify["run"]
@@ -526,8 +517,7 @@ def test_registry_state_is_revalidated_at_each_publication_boundary() -> None:
     )
     assert "inspect-release --registry pypi --project hol-guard" in alpha_verify["run"]
     assert "verify-release --registry pypi --project plugin-scanner" in alpha_verify["run"]
-    assert "verify-published --registry pypi" in alpha_verify["run"]
-    _assert_verify_published_retries_inside_probe_loop(alpha_verify["run"])
+    assert alpha_verify["run"].find("verify-published") < alpha_verify["run"].find("\ndone\n")
     assert "--artifact-set pure" in alpha_verify["run"]
     assert '--source-sha "$SOURCE_SHA"' in alpha_verify["run"]
     assert "dist-hol-guard/*-py3-none-any.whl" in alpha_verify["run"]

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -22,6 +22,13 @@ def _workflow(path: Path) -> dict[object, object]:
     return workflow
 
 
+def _assert_verify_published_retries_inside_probe_loop(run: str) -> None:
+    loop_start = run.index("for attempt in {1..60}")
+    loop_end = run.index("\ndone\n", loop_start)
+    published_at = run.index("verify-published", loop_start)
+    assert loop_start < published_at < loop_end
+
+
 def test_release_codeowners_are_the_two_named_maintainers() -> None:
     pattern, *owners = CODEOWNERS.read_text(encoding="utf-8").split()
 
@@ -310,6 +317,7 @@ def test_release_publication_reuses_one_hashed_build_artifact() -> None:
     main_verify = next(step for step in main_steps if step.get("name") == "Download and verify exact PyPI artifacts")
     assert "--artifact-set full" in main_verify["run"]
     assert "verify-published" in main_verify["run"]
+    _assert_verify_published_retries_inside_probe_loop(main_verify["run"])
 
     stable_native = jobs["build-native-guard-wheels"]["if"]
     assert "needs.build.outputs.channel == 'stable'" in stable_native
@@ -389,6 +397,7 @@ def test_registry_state_is_revalidated_at_each_publication_boundary() -> None:
     )
     assert "--download-dir verified-testpypi" in alpha_test_verify["run"]
     assert "verify-published --registry testpypi" in alpha_test_verify["run"]
+    _assert_verify_published_retries_inside_probe_loop(alpha_test_verify["run"])
     assert 'uv tool run --from "$wheel"' in alpha_test_verify["run"]
     assert 'status" == "exact"' in alpha_test_verify["run"]
     assert 'status" != "absent"' in alpha_test_verify["run"]
@@ -518,6 +527,7 @@ def test_registry_state_is_revalidated_at_each_publication_boundary() -> None:
     assert "inspect-release --registry pypi --project hol-guard" in alpha_verify["run"]
     assert "verify-release --registry pypi --project plugin-scanner" in alpha_verify["run"]
     assert "verify-published --registry pypi" in alpha_verify["run"]
+    _assert_verify_published_retries_inside_probe_loop(alpha_verify["run"])
     assert "--artifact-set pure" in alpha_verify["run"]
     assert '--source-sha "$SOURCE_SHA"' in alpha_verify["run"]
     assert "dist-hol-guard/*-py3-none-any.whl" in alpha_verify["run"]

--- a/tests/test_release_train_workflow.py
+++ b/tests/test_release_train_workflow.py
@@ -309,7 +309,7 @@ def test_release_publication_reuses_one_hashed_build_artifact() -> None:
     assert "--pending-dir dist-hol-guard" in main_quota["run"]
     main_verify = next(step for step in main_steps if step.get("name") == "Download and verify exact PyPI artifacts")
     assert "--artifact-set full" in main_verify["run"]
-    assert main_verify["run"].find("verify-published") < main_verify["run"].find("\ndone\n")
+    assert main_verify["run"].find("for attempt in {1..60}") < main_verify["run"].find("retry_verify_published.py") < main_verify["run"].find("\ndone\n")
 
     stable_native = jobs["build-native-guard-wheels"]["if"]
     assert "needs.build.outputs.channel == 'stable'" in stable_native
@@ -388,7 +388,7 @@ def test_registry_state_is_revalidated_at_each_publication_boundary() -> None:
         < alpha_test_steps.index(alpha_test_verify)
     )
     assert "--download-dir verified-testpypi" in alpha_test_verify["run"]
-    assert alpha_test_verify["run"].find("verify-published") < alpha_test_verify["run"].find("\ndone\n")
+    assert alpha_test_verify["run"].find("for attempt in {1..60}") < alpha_test_verify["run"].find("retry_verify_published.py") < alpha_test_verify["run"].find("\ndone\n")
     assert 'uv tool run --from "$wheel"' in alpha_test_verify["run"]
     assert 'status" == "exact"' in alpha_test_verify["run"]
     assert 'status" != "absent"' in alpha_test_verify["run"]
@@ -517,7 +517,7 @@ def test_registry_state_is_revalidated_at_each_publication_boundary() -> None:
     )
     assert "inspect-release --registry pypi --project hol-guard" in alpha_verify["run"]
     assert "verify-release --registry pypi --project plugin-scanner" in alpha_verify["run"]
-    assert alpha_verify["run"].find("verify-published") < alpha_verify["run"].find("\ndone\n")
+    assert alpha_verify["run"].find("for attempt in {1..60}") < alpha_verify["run"].find("retry_verify_published.py") < alpha_verify["run"].find("\ndone\n")
     assert "--artifact-set pure" in alpha_verify["run"]
     assert '--source-sha "$SOURCE_SHA"' in alpha_verify["run"]
     assert "dist-hol-guard/*-py3-none-any.whl" in alpha_verify["run"]

--- a/tests/test_retry_verify_published.py
+++ b/tests/test_retry_verify_published.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Sequence
+
+from scripts.retry_verify_published import is_retryable_incomplete_error, wait_for_published
+
+INCOMPLETE = (
+    "Registry release is not the exact Guard artifact set: "
+    "missing=['hol_guard-3.0.96-py3-none-win_amd64.whl'], extra=[], mismatched=[]\n"
+)
+MISMATCH = (
+    "Registry release is not the exact Guard artifact set: "
+    "missing=[], extra=[], mismatched=['hol_guard-3.0.96.tar.gz']\n"
+)
+
+
+class FakeRunner:
+    def __init__(self, returncodes: Sequence[int], stderrs: Sequence[str]) -> None:
+        self.returncodes = list(returncodes)
+        self.stderrs = list(stderrs)
+        self.calls = 0
+        self.commands: list[Sequence[str]] = []
+
+    def __call__(self, command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        self.calls += 1
+        self.commands.append(command)
+        index = min(self.calls - 1, len(self.returncodes) - 1)
+        return subprocess.CompletedProcess(
+            command,
+            self.returncodes[index],
+            stdout='{"status":"exact"}\n' if self.returncodes[index] == 0 else "",
+            stderr=self.stderrs[index],
+        )
+
+
+def test_incomplete_missing_set_is_retryable() -> None:
+    assert is_retryable_incomplete_error(INCOMPLETE)
+    assert not is_retryable_incomplete_error(MISMATCH)
+    assert not is_retryable_incomplete_error("Registry request failed with HTTP 500\n")
+
+
+def test_wait_retries_incomplete_then_succeeds() -> None:
+    sleeps: list[float] = []
+    runner = FakeRunner([1, 0], [INCOMPLETE, ""])
+    assert wait_for_published(["--registry", "pypi"], runner=runner, sleeper=sleeps.append) == 0
+    assert runner.calls == 2
+    assert sleeps == [5.0]
+
+
+def test_wait_fails_immediately_on_digest_mismatch() -> None:
+    sleeps: list[float] = []
+    runner = FakeRunner([1], [MISMATCH])
+    assert wait_for_published(["--registry", "pypi"], runner=runner, sleeper=sleeps.append) == 1
+    assert runner.calls == 1
+    assert sleeps == []


### PR DESCRIPTION
## Summary
- Keep native `verify-published` inside the existing registry probe retry loop so a release that is only partially visible cannot fail the job after a successful upload.
- Treat transient registry probe failures as retryable instead of exiting on the first error.

## Test plan
- [x] `python -m pytest tests/test_release_train_workflow.py tests/test_release_registry_retry.py`
- [ ] Confirm the next main publish run creates the GitHub release after PyPI upload


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved package publication reliability by ensuring uploaded artifacts pass native runtime verification before release workflows continue.
  - Updated retry behavior to wait for verification results instead of treating temporarily incomplete artifact checks as immediate failures.

- **Tests**
  - Strengthened release workflow checks to confirm verification occurs within the retry process, helping prevent regressions in publication validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->