### PR TITLE
refine(dashboard): compact the Local Guard update block

### DIFF
--- a/dashboard/src/guard-update-channel-summary.tsx
+++ b/dashboard/src/guard-update-channel-summary.tsx
@@ -8,34 +8,45 @@ export type GuardUpdateChannelSummaryProps = {
   onManage: () => void;
 };
 
+// Inline channel control for the Local Guard status row: the card's 11px
+// status typography with a 24px minimum hit target.
+export const GUARD_UPDATE_CHANNEL_CONTROL_CLASS =
+  "inline-flex min-h-6 shrink-0 items-center gap-1 rounded-sm px-0.5 text-[11px] font-semibold leading-4 text-brand-blue transition-opacity hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60";
+
+// Compact pill for panel-level actions (update, reinstall): 32px target that
+// sits inline beside the status line instead of filling the card width.
 export const GUARD_UPDATE_ACTION_BUTTON_CLASS =
-  "inline-flex min-h-11 w-full items-center justify-center gap-1.5 rounded-lg border border-brand-blue/30 bg-white px-3 py-2 text-sm font-semibold text-brand-blue transition-colors hover:bg-brand-blue/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60";
+  "inline-flex min-h-8 shrink-0 items-center justify-center gap-1 rounded-full border border-brand-blue/30 bg-white px-2.5 text-[11px] font-semibold text-brand-blue transition-colors hover:bg-brand-blue/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60";
 
 export function GuardUpdateChannelSummary(props: GuardUpdateChannelSummaryProps) {
-  let versionContent: ReactNode = null;
-  if (props.version) {
-    versionContent = (
-      <p
-        className="min-w-0 truncate font-mono text-[10px] leading-4 text-brand-dark/70"
-        aria-label={`Guard version ${props.version}`}
+  let channelStatus: ReactNode = null;
+  if (props.useAlpha) {
+    channelStatus = (
+      <span
+        className="inline-flex min-w-0 items-center gap-1 text-[11px] font-semibold leading-4 text-brand-blue"
+        role="status"
+        aria-label="Alpha updates enabled"
       >
-        v{props.version}
-      </p>
+        <HiMiniBeaker className="h-3 w-3 shrink-0" aria-hidden="true" />
+        <span className="truncate">Alpha updates</span>
+      </span>
     );
   }
 
-  let channelAction: ReactNode;
-  if (props.useAlpha) {
-    channelAction = (
-      <div className="flex min-w-0 items-center justify-between gap-2">
-        <div
-          className="inline-flex min-w-0 items-center gap-1.5"
-          role="status"
-          aria-label="Alpha updates enabled"
-        >
-          <HiMiniBeaker className="h-4 w-4 shrink-0 text-brand-blue" aria-hidden="true" />
-          <span className="text-sm font-semibold leading-5 text-brand-blue">Alpha updates</span>
-        </div>
+  return (
+    <div className="flex min-w-0 items-center justify-between gap-1.5">
+      <span className="inline-flex min-w-0 items-center gap-1">
+        {props.version ? (
+          <span
+            className="shrink-0 font-mono text-[10px] leading-4 text-brand-dark/70"
+            aria-label={`Guard version ${props.version}`}
+          >
+            v{props.version}
+          </span>
+        ) : null}
+        {channelStatus}
+      </span>
+      {props.useAlpha ? (
         <button
           type="button"
           onClick={props.onManage}
@@ -43,31 +54,22 @@ export function GuardUpdateChannelSummary(props: GuardUpdateChannelSummaryProps)
           aria-label="Manage alpha updates"
           title="Manage alpha updates"
           data-testid="guard-alpha-updates-control"
-          className="inline-flex min-h-11 shrink-0 items-center rounded-lg px-3 text-sm font-semibold text-brand-blue transition-colors hover:bg-brand-blue/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60"
+          className={GUARD_UPDATE_CHANNEL_CONTROL_CLASS}
         >
           Manage
         </button>
-      </div>
-    );
-  } else {
-    channelAction = (
-      <button
-        type="button"
-        onClick={props.onManage}
-        disabled={props.busy}
-        data-testid="guard-alpha-updates-control"
-        className={GUARD_UPDATE_ACTION_BUTTON_CLASS}
-      >
-        <HiMiniBeaker className="h-4 w-4 shrink-0" aria-hidden="true" />
-        Try alpha updates
-      </button>
-    );
-  }
-
-  return (
-    <div className="space-y-1.5">
-      {versionContent}
-      {channelAction}
+      ) : (
+        <button
+          type="button"
+          onClick={props.onManage}
+          disabled={props.busy}
+          data-testid="guard-alpha-updates-control"
+          className={GUARD_UPDATE_CHANNEL_CONTROL_CLASS}
+        >
+          <HiMiniBeaker className="h-3 w-3 shrink-0" aria-hidden="true" />
+          Try alpha updates
+        </button>
+      )}
     </div>
   );
 }

--- a/dashboard/src/guard-update-channel-summary.tsx
+++ b/dashboard/src/guard-update-channel-summary.tsx
@@ -9,9 +9,9 @@ export type GuardUpdateChannelSummaryProps = {
 };
 
 // Inline channel control for the Local Guard status row: the card's 11px
-// status typography with a 24px minimum hit target.
+// status typography on a 32px target that matches the panel's action pills.
 export const GUARD_UPDATE_CHANNEL_CONTROL_CLASS =
-  "inline-flex min-h-6 shrink-0 items-center gap-1 rounded-sm px-0.5 text-[11px] font-semibold leading-4 text-brand-blue transition-opacity hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60";
+  "inline-flex min-h-8 shrink-0 items-center gap-1 rounded-sm px-0.5 text-[11px] font-semibold leading-4 text-brand-blue transition-opacity hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60";
 
 // Compact pill for panel-level actions (update, reinstall): 32px target that
 // sits inline beside the status line instead of filling the card width.
@@ -38,7 +38,7 @@ export function GuardUpdateChannelSummary(props: GuardUpdateChannelSummaryProps)
       <span className="inline-flex min-w-0 items-center gap-1">
         {props.version ? (
           <span
-            className="shrink-0 font-mono text-[10px] leading-4 text-brand-dark/70"
+            className="min-w-0 font-mono text-[10px] leading-4 text-brand-dark/70 [overflow-wrap:anywhere]"
             aria-label={`Guard version ${props.version}`}
           >
             v{props.version}

--- a/dashboard/src/guard-update-copy.ts
+++ b/dashboard/src/guard-update-copy.ts
@@ -5,7 +5,7 @@ export function updateStatusLabel(status: GuardUpdateStatus | null | undefined):
     return "Checking version…";
   }
   if (status.update_available && status.latest_version) {
-    return `Version ${status.latest_version} is ready`;
+    return `${status.latest_version} is ready`;
   }
   return `Version ${status.current_version}`;
 }
@@ -66,7 +66,7 @@ export function updateHelpCopy(
     if (embeddedInDesktop) {
       return "Updates run through the HOL Guard app. Use Check for Updates in the HOL Guard menu-bar icon, and the app installs this version with its own progress screen.";
     }
-    return "This restarts Guard for a moment. Open approvals will stay saved.";
+    return "Restarts briefly. Approvals stay saved.";
   }
   if (status && !status.auto_updatable && status.recovery_reinstall_available) {
     if (embeddedInDesktop) {

--- a/dashboard/src/guard-update-panel.tsx
+++ b/dashboard/src/guard-update-panel.tsx
@@ -141,7 +141,7 @@ export function GuardUpdatePanel(props: GuardUpdatePanelProps) {
       {updateChannelSummary}
       {props.updateStatus?.update_available ? (
         <div className="flex items-center justify-between gap-2">
-          <p className="min-w-0 truncate text-[11px] leading-4 text-brand-dark/75">
+          <p className="min-w-0 text-[11px] leading-4 text-brand-dark/75 [overflow-wrap:anywhere]">
             {updateStatusLabel(props.updateStatus)}
           </p>
           {showUpdateButton && props.onUpdateGuard ? (

--- a/dashboard/src/guard-update-panel.tsx
+++ b/dashboard/src/guard-update-panel.tsx
@@ -137,23 +137,28 @@ export function GuardUpdatePanel(props: GuardUpdatePanelProps) {
   }
 
   return (
-    <div className={props.compact ? "space-y-1" : "space-y-2"}>
+    <div className={props.compact ? "space-y-1" : "space-y-1.5"}>
       {updateChannelSummary}
       {props.updateStatus?.update_available ? (
-        <p className="text-[11px] leading-relaxed text-brand-dark/75">{updateStatusLabel(props.updateStatus)}</p>
+        <div className="flex items-center justify-between gap-2">
+          <p className="min-w-0 truncate text-[11px] leading-4 text-brand-dark/75">
+            {updateStatusLabel(props.updateStatus)}
+          </p>
+          {showUpdateButton && props.onUpdateGuard ? (
+            <button
+              type="button"
+              onClick={props.onUpdateGuard}
+              aria-label="Update Guard to the latest version"
+              className={GUARD_UPDATE_ACTION_BUTTON_CLASS}
+            >
+              <HiMiniArrowPath className="h-3 w-3 shrink-0" aria-hidden="true" />
+              Update
+            </button>
+          ) : null}
+        </div>
       ) : null}
       {helpCopy ? (
-        <p className="text-[11px] leading-relaxed text-brand-dark/70">{helpCopy}</p>
-      ) : null}
-      {showUpdateButton && props.onUpdateGuard ? (
-        <button
-          type="button"
-          onClick={props.onUpdateGuard}
-          className={GUARD_UPDATE_ACTION_BUTTON_CLASS}
-        >
-          <HiMiniArrowPath className="h-4 w-4 shrink-0" aria-hidden="true" />
-          Update Guard
-        </button>
+        <p className="text-[10px] leading-4 text-brand-dark/70">{helpCopy}</p>
       ) : null}
       {showReinstallButton && props.onReinstallGuard ? (
         <button
@@ -161,13 +166,13 @@ export function GuardUpdatePanel(props: GuardUpdatePanelProps) {
           onClick={props.onReinstallGuard}
           className={GUARD_UPDATE_ACTION_BUTTON_CLASS}
         >
-          <HiMiniArrowPath className="h-4 w-4 shrink-0" aria-hidden="true" />
+          <HiMiniArrowPath className="h-3 w-3 shrink-0" aria-hidden="true" />
           Reinstall from PyPI
         </button>
       ) : null}
       {busy && (
-        <p className="inline-flex min-h-11 items-center gap-2 text-[11px] font-medium text-brand-blue" role="status">
-          <HiMiniArrowPath className="h-4 w-4 animate-spin" aria-hidden="true" />
+        <p className="inline-flex items-center gap-1.5 text-[11px] font-medium leading-4 text-brand-blue" role="status">
+          <HiMiniArrowPath className="h-3 w-3 animate-spin" aria-hidden="true" />
           {phase === "updating" ? "Updating Guard…" : "Reconnecting…"}
         </p>
       )}

--- a/dashboard/src/guard-update.test.ts
+++ b/dashboard/src/guard-update.test.ts
@@ -58,14 +58,8 @@ assert(alphaMarkup.includes('aria-label="Manage alpha updates"'), "sidebar shoul
 assert(alphaMarkup.includes('data-testid="guard-alpha-updates-control"'), "alpha settings should stay findable as a dedicated control");
 assert(!alphaMarkup.includes("Alpha updates enabled</button>"), "active alpha status should not render as a wide text button");
 assert(!alphaMarkup.includes('type="checkbox"'), "sidebar should open alpha confirmation instead of toggling immediately");
-assert(
-  alphaMarkup.includes("min-h-8") && !alphaMarkup.includes("min-h-11") && !alphaMarkup.includes("min-h-6") && !alphaMarkup.includes("w-full"),
-  "Local Guard update controls stay compact inline rows with uniform 32px targets, not full-width blocks",
-);
-assert(
-  alphaMarkup.includes("1.2.4a1 is ready") && alphaMarkup.includes("Restarts briefly. Approvals stay saved."),
-  "update-ready copy keeps the version line and reassurance together",
-);
+assert(alphaMarkup.includes("min-h-8") && !alphaMarkup.includes("min-h-11") && !alphaMarkup.includes("min-h-6") && !alphaMarkup.includes("w-full"), "Local Guard update controls stay compact inline rows with uniform 32px targets, not full-width blocks");
+assert(alphaMarkup.includes("1.2.4a1 is ready") && alphaMarkup.includes("Restarts briefly. Approvals stay saved."), "update-ready copy keeps the version line and reassurance together");
 
 const alphaUpdateMarkup = renderToStaticMarkup(
   createElement(GuardUpdatePanel, {
@@ -74,38 +68,19 @@ const alphaUpdateMarkup = renderToStaticMarkup(
     onSetUpdateChannel: () => undefined,
   }),
 );
-assert(
-  alphaUpdateMarkup.includes('aria-label="Update Guard to the latest version"') &&
-    alphaUpdateMarkup.includes(">Update</button>"),
-  "update-ready state pairs the version line with a compact inline Update action",
-);
-assert(
-  alphaUpdateMarkup.includes("[overflow-wrap:anywhere]") && !alphaUpdateMarkup.includes("min-w-0 truncate"),
-  "the ready-version label wraps long release strings instead of clipping them",
-);
+assert(alphaUpdateMarkup.includes('aria-label="Update Guard to the latest version"') && alphaUpdateMarkup.includes(">Update</button>"), "update-ready state pairs the version line with a compact inline Update action");
+assert(alphaUpdateMarkup.includes("[overflow-wrap:anywhere]") && !alphaUpdateMarkup.includes("min-w-0 truncate"), "the ready-version label wraps long release strings instead of clipping them");
 
 const longVersion = "3.0.111a1.dev456+g1a2b3c4d5e6";
 const longVersionMarkup = renderToStaticMarkup(
   createElement(GuardUpdatePanel, {
     guardVersion: "3.0.110",
-    updateStatus: normalizeGuardUpdateStatus({
-      current_version: "3.0.110",
-      latest_version: longVersion,
-      installer: "pip",
-      version_check: { source: "pypi", status: "stale", current_version: "3.0.110", latest_version: longVersion, update_available: true },
-      auto_updatable: true,
-      update_available: true,
-      blocked_reason: null,
-      release_channel: "alpha",
-    }),
+    updateStatus: normalizeGuardUpdateStatus({ ...alphaReadyStatus, current_version: "3.0.110", latest_version: longVersion, version_check: { source: "pypi", status: "stale", current_version: "3.0.110", latest_version: longVersion, update_available: true } }),
     onUpdateGuard: () => undefined,
     onSetUpdateChannel: () => undefined,
   }),
 );
-assert(
-  longVersionMarkup.includes(`v3.0.110`) && longVersionMarkup.includes(`${longVersion} is ready`),
-  "long release strings render in full on both the version and ready-version lines",
-);
+assert(longVersionMarkup.includes("v3.0.110") && longVersionMarkup.includes(`${longVersion} is ready`), "long release strings render in full on both the version and ready-version lines");
 
 const loadingMarkup = renderToStaticMarkup(
   createElement(GuardUpdatePanel, {

--- a/dashboard/src/guard-update.test.ts
+++ b/dashboard/src/guard-update.test.ts
@@ -79,6 +79,10 @@ assert(
     alphaUpdateMarkup.includes(">Update</button>"),
   "update-ready state pairs the version line with a compact inline Update action",
 );
+assert(
+  alphaUpdateMarkup.includes("[overflow-wrap:anywhere]") && !alphaUpdateMarkup.includes("min-w-0 truncate"),
+  "the ready-version label wraps long release strings instead of clipping them",
+);
 
 const loadingMarkup = renderToStaticMarkup(
   createElement(GuardUpdatePanel, {

--- a/dashboard/src/guard-update.test.ts
+++ b/dashboard/src/guard-update.test.ts
@@ -36,18 +36,20 @@ assert(normalized.version_check.update_available === true, "version_check should
 assert(normalized.update_in_progress === true, "update_in_progress should normalize");
 assert(normalized.release_channel === "stable", "missing update channel should default to stable");
 
+const alphaReadyStatus = normalizeGuardUpdateStatus({
+  current_version: "1.2.3",
+  latest_version: "1.2.4a1",
+  installer: "pip",
+  version_check: { source: "pypi", status: "stale", current_version: "1.2.3", latest_version: "1.2.4a1", update_available: true },
+  auto_updatable: true,
+  update_available: true,
+  blocked_reason: null,
+  release_channel: "alpha",
+});
+
 const alphaMarkup = renderToStaticMarkup(
   createElement(GuardUpdatePanel, {
-    updateStatus: normalizeGuardUpdateStatus({
-      current_version: "1.2.3",
-      latest_version: "1.2.4a1",
-      installer: "pip",
-      version_check: { source: "pypi", status: "stale", current_version: "1.2.3", latest_version: "1.2.4a1", update_available: true },
-      auto_updatable: true,
-      update_available: true,
-      blocked_reason: null,
-      release_channel: "alpha",
-    }),
+    updateStatus: alphaReadyStatus,
     onSetUpdateChannel: () => undefined,
   }),
 );
@@ -56,6 +58,27 @@ assert(alphaMarkup.includes('aria-label="Manage alpha updates"'), "sidebar shoul
 assert(alphaMarkup.includes('data-testid="guard-alpha-updates-control"'), "alpha settings should stay findable as a dedicated control");
 assert(!alphaMarkup.includes("Alpha updates enabled</button>"), "active alpha status should not render as a wide text button");
 assert(!alphaMarkup.includes('type="checkbox"'), "sidebar should open alpha confirmation instead of toggling immediately");
+assert(
+  alphaMarkup.includes("min-h-6") && !alphaMarkup.includes("min-h-11") && !alphaMarkup.includes("w-full"),
+  "Local Guard update controls stay compact inline rows, not full-width blocks",
+);
+assert(
+  alphaMarkup.includes("1.2.4a1 is ready") && alphaMarkup.includes("Restarts briefly. Approvals stay saved."),
+  "update-ready copy keeps the version line and reassurance together",
+);
+
+const alphaUpdateMarkup = renderToStaticMarkup(
+  createElement(GuardUpdatePanel, {
+    updateStatus: alphaReadyStatus,
+    onUpdateGuard: () => undefined,
+    onSetUpdateChannel: () => undefined,
+  }),
+);
+assert(
+  alphaUpdateMarkup.includes('aria-label="Update Guard to the latest version"') &&
+    alphaUpdateMarkup.includes(">Update</button>"),
+  "update-ready state pairs the version line with a compact inline Update action",
+);
 
 const loadingMarkup = renderToStaticMarkup(
   createElement(GuardUpdatePanel, {

--- a/dashboard/src/guard-update.test.ts
+++ b/dashboard/src/guard-update.test.ts
@@ -59,8 +59,8 @@ assert(alphaMarkup.includes('data-testid="guard-alpha-updates-control"'), "alpha
 assert(!alphaMarkup.includes("Alpha updates enabled</button>"), "active alpha status should not render as a wide text button");
 assert(!alphaMarkup.includes('type="checkbox"'), "sidebar should open alpha confirmation instead of toggling immediately");
 assert(
-  alphaMarkup.includes("min-h-6") && !alphaMarkup.includes("min-h-11") && !alphaMarkup.includes("w-full"),
-  "Local Guard update controls stay compact inline rows, not full-width blocks",
+  alphaMarkup.includes("min-h-8") && !alphaMarkup.includes("min-h-11") && !alphaMarkup.includes("min-h-6") && !alphaMarkup.includes("w-full"),
+  "Local Guard update controls stay compact inline rows with uniform 32px targets, not full-width blocks",
 );
 assert(
   alphaMarkup.includes("1.2.4a1 is ready") && alphaMarkup.includes("Restarts briefly. Approvals stay saved."),
@@ -82,6 +82,29 @@ assert(
 assert(
   alphaUpdateMarkup.includes("[overflow-wrap:anywhere]") && !alphaUpdateMarkup.includes("min-w-0 truncate"),
   "the ready-version label wraps long release strings instead of clipping them",
+);
+
+const longVersion = "3.0.111a1.dev456+g1a2b3c4d5e6";
+const longVersionMarkup = renderToStaticMarkup(
+  createElement(GuardUpdatePanel, {
+    guardVersion: "3.0.110",
+    updateStatus: normalizeGuardUpdateStatus({
+      current_version: "3.0.110",
+      latest_version: longVersion,
+      installer: "pip",
+      version_check: { source: "pypi", status: "stale", current_version: "3.0.110", latest_version: longVersion, update_available: true },
+      auto_updatable: true,
+      update_available: true,
+      blocked_reason: null,
+      release_channel: "alpha",
+    }),
+    onUpdateGuard: () => undefined,
+    onSetUpdateChannel: () => undefined,
+  }),
+);
+assert(
+  longVersionMarkup.includes(`v3.0.110`) && longVersionMarkup.includes(`${longVersion} is ready`),
+  "long release strings render in full on both the version and ready-version lines",
 );
 
 const loadingMarkup = renderToStaticMarkup(

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -19932,7 +19932,7 @@ function updateStatusLabel(status) {
     return "Checking version…";
   }
   if (status.update_available && status.latest_version) {
-    return `Version ${status.latest_version} is ready`;
+    return `${status.latest_version} is ready`;
   }
   return `Version ${status.current_version}`;
 }
@@ -19978,7 +19978,7 @@ function updateHelpCopy(status, phase, errorMessage, embeddedInDesktop = false) 
     if (embeddedInDesktop) {
       return "Updates run through the HOL Guard app. Use Check for Updates in the HOL Guard menu-bar icon, and the app installs this version with its own progress screen.";
     }
-    return "This restarts Guard for a moment. Open approvals will stay saved.";
+    return "Restarts briefly. Approvals stay saved.";
   }
   if (status && !status.auto_updatable && status.recovery_reinstall_available) {
     if (embeddedInDesktop) {
@@ -20142,70 +20142,65 @@ function GuardModalLayer({
     overlayRoot
   );
 }
-const GUARD_UPDATE_ACTION_BUTTON_CLASS = "inline-flex min-h-11 w-full items-center justify-center gap-1.5 rounded-lg border border-brand-blue/30 bg-white px-3 py-2 text-sm font-semibold text-brand-blue transition-colors hover:bg-brand-blue/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60";
+const GUARD_UPDATE_CHANNEL_CONTROL_CLASS = "inline-flex min-h-6 shrink-0 items-center gap-1 rounded-sm px-0.5 text-[11px] font-semibold leading-4 text-brand-blue transition-opacity hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60";
+const GUARD_UPDATE_ACTION_BUTTON_CLASS = "inline-flex min-h-8 shrink-0 items-center justify-center gap-1 rounded-full border border-brand-blue/30 bg-white px-2.5 text-[11px] font-semibold text-brand-blue transition-colors hover:bg-brand-blue/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60";
 function GuardUpdateChannelSummary(props) {
-  let versionContent = null;
-  if (props.version) {
-    versionContent = /* @__PURE__ */ jsxRuntimeExports.jsxs(
-      "p",
+  let channelStatus = null;
+  if (props.useAlpha) {
+    channelStatus = /* @__PURE__ */ jsxRuntimeExports.jsxs(
+      "span",
       {
-        className: "min-w-0 truncate font-mono text-[10px] leading-4 text-brand-dark/70",
-        "aria-label": `Guard version ${props.version}`,
+        className: "inline-flex min-w-0 items-center gap-1 text-[11px] font-semibold leading-4 text-brand-blue",
+        role: "status",
+        "aria-label": "Alpha updates enabled",
         children: [
-          "v",
-          props.version
+          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniBeaker, { className: "h-3 w-3 shrink-0", "aria-hidden": "true" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "truncate", children: "Alpha updates" })
         ]
       }
     );
   }
-  let channelAction;
-  if (props.useAlpha) {
-    channelAction = /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-w-0 items-center justify-between gap-2", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs(
-        "div",
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-w-0 items-center justify-between gap-1.5", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "inline-flex min-w-0 items-center gap-1", children: [
+      props.version ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
+        "span",
         {
-          className: "inline-flex min-w-0 items-center gap-1.5",
-          role: "status",
-          "aria-label": "Alpha updates enabled",
+          className: "shrink-0 font-mono text-[10px] leading-4 text-brand-dark/70",
+          "aria-label": `Guard version ${props.version}`,
           children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniBeaker, { className: "h-4 w-4 shrink-0 text-brand-blue", "aria-hidden": "true" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-semibold leading-5 text-brand-blue", children: "Alpha updates" })
+            "v",
+            props.version
           ]
         }
-      ),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(
-        "button",
-        {
-          type: "button",
-          onClick: props.onManage,
-          disabled: props.busy,
-          "aria-label": "Manage alpha updates",
-          title: "Manage alpha updates",
-          "data-testid": "guard-alpha-updates-control",
-          className: "inline-flex min-h-11 shrink-0 items-center rounded-lg px-3 text-sm font-semibold text-brand-blue transition-colors hover:bg-brand-blue/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60",
-          children: "Manage"
-        }
-      )
-    ] });
-  } else {
-    channelAction = /* @__PURE__ */ jsxRuntimeExports.jsxs(
+      ) : null,
+      channelStatus
+    ] }),
+    props.useAlpha ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "button",
+      {
+        type: "button",
+        onClick: props.onManage,
+        disabled: props.busy,
+        "aria-label": "Manage alpha updates",
+        title: "Manage alpha updates",
+        "data-testid": "guard-alpha-updates-control",
+        className: GUARD_UPDATE_CHANNEL_CONTROL_CLASS,
+        children: "Manage"
+      }
+    ) : /* @__PURE__ */ jsxRuntimeExports.jsxs(
       "button",
       {
         type: "button",
         onClick: props.onManage,
         disabled: props.busy,
         "data-testid": "guard-alpha-updates-control",
-        className: GUARD_UPDATE_ACTION_BUTTON_CLASS,
+        className: GUARD_UPDATE_CHANNEL_CONTROL_CLASS,
         children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniBeaker, { className: "h-4 w-4 shrink-0", "aria-hidden": "true" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniBeaker, { className: "h-3 w-3 shrink-0", "aria-hidden": "true" }),
           "Try alpha updates"
         ]
       }
-    );
-  }
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-1.5", children: [
-    versionContent,
-    channelAction
+    )
   ] });
 }
 const UPDATE_STATUS_POLL_MS = 6e4;
@@ -20284,22 +20279,25 @@ function GuardUpdatePanel(props) {
       version
     ] });
   }
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: props.compact ? "space-y-1" : "space-y-2", children: [
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: props.compact ? "space-y-1" : "space-y-1.5", children: [
     updateChannelSummary,
-    props.updateStatus?.update_available ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] leading-relaxed text-brand-dark/75", children: updateStatusLabel(props.updateStatus) }) : null,
-    helpCopy ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] leading-relaxed text-brand-dark/70", children: helpCopy }) : null,
-    showUpdateButton && props.onUpdateGuard ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
-      "button",
-      {
-        type: "button",
-        onClick: props.onUpdateGuard,
-        className: GUARD_UPDATE_ACTION_BUTTON_CLASS,
-        children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "h-4 w-4 shrink-0", "aria-hidden": "true" }),
-          "Update Guard"
-        ]
-      }
-    ) : null,
+    props.updateStatus?.update_available ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between gap-2", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "min-w-0 truncate text-[11px] leading-4 text-brand-dark/75", children: updateStatusLabel(props.updateStatus) }),
+      showUpdateButton && props.onUpdateGuard ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
+        "button",
+        {
+          type: "button",
+          onClick: props.onUpdateGuard,
+          "aria-label": "Update Guard to the latest version",
+          className: GUARD_UPDATE_ACTION_BUTTON_CLASS,
+          children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "h-3 w-3 shrink-0", "aria-hidden": "true" }),
+            "Update"
+          ]
+        }
+      ) : null
+    ] }) : null,
+    helpCopy ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[10px] leading-4 text-brand-dark/70", children: helpCopy }) : null,
     showReinstallButton && props.onReinstallGuard ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
       "button",
       {
@@ -20307,13 +20305,13 @@ function GuardUpdatePanel(props) {
         onClick: props.onReinstallGuard,
         className: GUARD_UPDATE_ACTION_BUTTON_CLASS,
         children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "h-4 w-4 shrink-0", "aria-hidden": "true" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "h-3 w-3 shrink-0", "aria-hidden": "true" }),
           "Reinstall from PyPI"
         ]
       }
     ) : null,
-    busy && /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "inline-flex min-h-11 items-center gap-2 text-[11px] font-medium text-brand-blue", role: "status", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "h-4 w-4 animate-spin", "aria-hidden": "true" }),
+    busy && /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "inline-flex items-center gap-1.5 text-[11px] font-medium leading-4 text-brand-blue", role: "status", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "h-3 w-3 animate-spin", "aria-hidden": "true" }),
       phase === "updating" ? "Updating Guard…" : "Reconnecting…"
     ] }),
     alphaModalOpen ? /* @__PURE__ */ jsxRuntimeExports.jsx(GuardModalLayer, { ariaLabel: modalTitle, onClose: handleCloseAlphaModal, panelClassName: "w-full max-w-md", children: /* @__PURE__ */ jsxRuntimeExports.jsx(

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -20142,7 +20142,7 @@ function GuardModalLayer({
     overlayRoot
   );
 }
-const GUARD_UPDATE_CHANNEL_CONTROL_CLASS = "inline-flex min-h-6 shrink-0 items-center gap-1 rounded-sm px-0.5 text-[11px] font-semibold leading-4 text-brand-blue transition-opacity hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60";
+const GUARD_UPDATE_CHANNEL_CONTROL_CLASS = "inline-flex min-h-8 shrink-0 items-center gap-1 rounded-sm px-0.5 text-[11px] font-semibold leading-4 text-brand-blue transition-opacity hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60";
 const GUARD_UPDATE_ACTION_BUTTON_CLASS = "inline-flex min-h-8 shrink-0 items-center justify-center gap-1 rounded-full border border-brand-blue/30 bg-white px-2.5 text-[11px] font-semibold text-brand-blue transition-colors hover:bg-brand-blue/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60";
 function GuardUpdateChannelSummary(props) {
   let channelStatus = null;
@@ -20165,7 +20165,7 @@ function GuardUpdateChannelSummary(props) {
       props.version ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
         "span",
         {
-          className: "shrink-0 font-mono text-[10px] leading-4 text-brand-dark/70",
+          className: "min-w-0 font-mono text-[10px] leading-4 text-brand-dark/70 [overflow-wrap:anywhere]",
           "aria-label": `Guard version ${props.version}`,
           children: [
             "v",

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -20282,7 +20282,7 @@ function GuardUpdatePanel(props) {
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: props.compact ? "space-y-1" : "space-y-1.5", children: [
     updateChannelSummary,
     props.updateStatus?.update_available ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between gap-2", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "min-w-0 truncate text-[11px] leading-4 text-brand-dark/75", children: updateStatusLabel(props.updateStatus) }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "min-w-0 text-[11px] leading-4 text-brand-dark/75 [overflow-wrap:anywhere]", children: updateStatusLabel(props.updateStatus) }),
       showUpdateButton && props.onUpdateGuard ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
         "button",
         {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -1159,6 +1159,10 @@
     min-height: calc(var(--spacing) * 5);
   }
 
+  .min-h-6 {
+    min-height: calc(var(--spacing) * 6);
+  }
+
   .min-h-7 {
     min-height: calc(var(--spacing) * 7);
   }
@@ -4012,6 +4016,10 @@
 
   .p-8 {
     padding: calc(var(--spacing) * 8);
+  }
+
+  .px-0\.5 {
+    padding-inline: calc(var(--spacing) * .5);
   }
 
   .px-1 {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -4461,6 +4461,10 @@
     letter-spacing: var(--tracking-widest);
   }
 
+  .\[overflow-wrap\:anywhere\] {
+    overflow-wrap: anywhere;
+  }
+
   .break-words {
     overflow-wrap: break-word;
   }


### PR DESCRIPTION
## Summary
- Render the Local Guard update block as compact inline rows: version, alpha channel status, and Manage share one status line sized to the card's existing 11px status typography.
- Pair the ready-version line with a compact inline Update action, shorten the restart reassurance to a single muted line, and keep the PyPI recovery action and busy states on the same compact scale.
- Keep alpha enrollment, manage, update, and reinstall behavior and their accessibility labels (including the dedicated alpha control test id) unchanged; add regression assertions pinning the compact, non-full-width control layout and rebuilt the served dashboard assets.

## Testing
- `cd dashboard && bun run test`
- `cd dashboard && bun run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Update status, version details, and available actions now appear in a compact inline layout.
  * “Update,” “Manage,” and “Try alpha updates” controls use consistent, compact styling with improved hit targets.
  * Progress indicators and busy-state messaging are more compact.
  * Long update status and version labels now wrap instead of being truncated.
* **Copy Updates**
  * Simplified update-available and restart messaging for clearer scanning.
* **Bug Fixes**
  * Improved status display and actions for alpha-channel updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->