### PR TITLE
fix(extensions): restore Add custom extension script auto-detect

### DIFF
--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -988,7 +988,7 @@ export async function fetchExtensionControlApi(input: RequestInfo, init?: Reques
 export async function fetchLocalCliApi(input: RequestInfo, init?: RequestInit): Promise<Response> {
   const approvedPath =
     typeof input === "string" &&
-    /^\/v1\/local-clis(?:\/(?:preview|apply|recognize))?$/.test(input);
+    /^\/v1\/local-clis(?:\/(?:preview|apply|recognize|discover))?$/.test(input);
   if (!approvedPath) {
     throw new Error("Invalid local CLI API path");
   }

--- a/dashboard/src/local-cli-api.ts
+++ b/dashboard/src/local-cli-api.ts
@@ -451,14 +451,6 @@ export async function fetchLocalCliList(): Promise<LocalCliListResponse> {
   return normalizeLocalCliList(await readJson(await fetchLocalCliApi("/v1/local-clis")));
 }
 
-export async function fetchLocalCliDiscover(): Promise<LocalCliListResponse> {
-  return normalizeLocalCliList(await readJson(await fetchLocalCliApi("/v1/local-clis/discover", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: "{}",
-  })));
-}
-
 export async function previewLocalCliMutation(payload: LocalCliMutationPayload): Promise<{ summary: string }> {
   const body = await readJson(await fetchLocalCliApi("/v1/local-clis/preview", {
     method: "POST",

--- a/dashboard/src/local-cli-api.ts
+++ b/dashboard/src/local-cli-api.ts
@@ -451,6 +451,14 @@ export async function fetchLocalCliList(): Promise<LocalCliListResponse> {
   return normalizeLocalCliList(await readJson(await fetchLocalCliApi("/v1/local-clis")));
 }
 
+export async function fetchLocalCliDiscover(): Promise<LocalCliListResponse> {
+  return normalizeLocalCliList(await readJson(await fetchLocalCliApi("/v1/local-clis/discover", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{}",
+  })));
+}
+
 export async function previewLocalCliMutation(payload: LocalCliMutationPayload): Promise<{ summary: string }> {
   const body = await readJson(await fetchLocalCliApi("/v1/local-clis/preview", {
     method: "POST",

--- a/dashboard/src/protection-center/add-custom-extension-dialog.tsx
+++ b/dashboard/src/protection-center/add-custom-extension-dialog.tsx
@@ -162,12 +162,24 @@ export function AddCustomExtensionWorkspace(props: {
     await runRecognize(command);
   }, [command, runRecognize]);
   useEffect(() => {
-    if (didAutoSelect.current || recognized !== null || command.trim() !== "") return;
+    if (props.discovering === true || command.trim() !== "") return;
     const preferred = preferredPackageScriptExtension(props.items);
     if (preferred === null) return;
+    if (recognized !== null) {
+      if (recognized.cli_id !== preferred.cli_id) return;
+      if (
+        recognized.identity_hash === preferred.identity_hash
+        && recognized.commands.length === preferred.commands.length
+      ) {
+        return;
+      }
+      markRecognized(preferred, suggestionSummary(preferred));
+      return;
+    }
+    if (didAutoSelect.current) return;
     didAutoSelect.current = true;
     selectSuggestion(preferred);
-  }, [command, props.items, recognized, selectSuggestion]);
+  }, [command, markRecognized, props.discovering, props.items, recognized, selectSuggestion]);
   useEffect(() => {
     const trimmed = command.trim();
     if (recognized !== null || !looksLikePackageScriptPaste(trimmed)) return;

--- a/dashboard/src/protection-center/add-custom-extension-dialog.tsx
+++ b/dashboard/src/protection-center/add-custom-extension-dialog.tsx
@@ -54,6 +54,7 @@ function randomToken(): string {
 export function AddCustomExtensionWorkspace(props: {
   items: LocalCliItem[];
   revision: number;
+  discovering?: boolean;
   onBack: () => void;
   onAdded: (cliId: string) => void;
 }) {
@@ -312,7 +313,11 @@ export function AddCustomExtensionWorkspace(props: {
           <header className="mt-3 max-w-2xl pb-4">
             <h1 id="add-custom-extension-title" className="text-2xl font-semibold tracking-tight text-brand-dark">Add a custom extension</h1>
             <p className="mt-2 text-sm leading-6 text-slate-500">
-              {dialogIntro(rememberedProjects.length > 0, recognized?.surface ?? null)}
+              {dialogIntro(
+                rememberedProjects.length > 0,
+                recognized?.surface ?? null,
+                props.discovering === true && recognized === null,
+              )}
             </p>
           </header>
           <label htmlFor="custom-extension-command" className="mt-4 block text-sm font-semibold text-brand-dark">
@@ -381,6 +386,7 @@ export function AddCustomExtensionWorkspace(props: {
           ) : (
             <SuggestionPanel
               query={command}
+              discovering={props.discovering === true}
               hasSuggestions={hasSuggestions}
               packageScriptSuggestions={packageScriptSuggestions}
               harnessSuggestions={harnessSuggestions}

--- a/dashboard/src/protection-center/add-custom-extension-dialog.tsx
+++ b/dashboard/src/protection-center/add-custom-extension-dialog.tsx
@@ -73,6 +73,7 @@ export function AddCustomExtensionWorkspace(props: {
   const recognizeGeneration = useRef(0);
   const autoRecognizedCommand = useRef("");
   const didAutoSelect = useRef(false);
+  const sawDiscovering = useRef(false);
   const rememberedProjects = suggestedPackageScriptExtensions(props.items);
   const packageScriptSuggestions = filterExtensionSuggestions(rememberedProjects, command).slice(0, 8);
   const harnessSuggestions = filterExtensionSuggestions(suggestedHarnessExtensions(props.items), command).slice(0, 8);
@@ -162,7 +163,8 @@ export function AddCustomExtensionWorkspace(props: {
     await runRecognize(command);
   }, [command, runRecognize]);
   useEffect(() => {
-    if (props.discovering === true || command.trim() !== "") return;
+    if (props.discovering === true) sawDiscovering.current = true;
+    if (!sawDiscovering.current || props.discovering === true || command.trim() !== "") return;
     const preferred = preferredPackageScriptExtension(props.items);
     if (preferred === null) return;
     if (recognized !== null) {

--- a/dashboard/src/protection-center/add-custom-extension-support.test.ts
+++ b/dashboard/src/protection-center/add-custom-extension-support.test.ts
@@ -43,6 +43,7 @@ const packageItem: LocalCliItem = {
 
 assert.match(dialogIntro(true, "package-scripts"), /Allow these scripts/);
 assert.match(dialogIntro(false, "mcp"), /Allow all/);
+assert.match(dialogIntro(false, null, true), /Looking for project scripts/);
 assert.match(filterCountCopy(1, 8), /1 of 8 scripts match/);
 assert.match(suggestionSummary(packageItem), /1 script from ads-app/);
 assert.equal(

--- a/dashboard/src/protection-center/add-custom-extension-support.test.ts
+++ b/dashboard/src/protection-center/add-custom-extension-support.test.ts
@@ -44,6 +44,7 @@ const packageItem: LocalCliItem = {
 assert.match(dialogIntro(true, "package-scripts"), /Allow these scripts/);
 assert.match(dialogIntro(false, "mcp"), /Allow all/);
 assert.match(dialogIntro(false, null, true), /Looking for project scripts/);
+assert.match(dialogIntro(true, null, true), /Looking for project scripts/);
 assert.match(filterCountCopy(1, 8), /1 of 8 scripts match/);
 assert.match(suggestionSummary(packageItem), /1 script from ads-app/);
 assert.equal(

--- a/dashboard/src/protection-center/add-custom-extension-support.tsx
+++ b/dashboard/src/protection-center/add-custom-extension-support.tsx
@@ -89,6 +89,7 @@ export function blockActionLabel(surface: LocalCliItem["surface"]): string {
 export function dialogIntro(
   hasProjects: boolean,
   surface: LocalCliItem["surface"] | null,
+  discovering = false,
 ): string {
   if (surface === "package-scripts") {
     return "Allow these scripts so Protect can stop asking about them. Type a nested name such as guard:audit to inspect one.";
@@ -98,6 +99,9 @@ export function dialogIntro(
   }
   if (hasProjects) {
     return "Guard already found project scripts on this device. Pick a project, or paste another folder.";
+  }
+  if (discovering) {
+    return "Looking for project scripts and app servers on this device.";
   }
   return "Paste a script, binary, MCP launch, or package scripts such as npm run. Everyday commands such as rg, grep, and whoami are not custom extensions.";
 }
@@ -131,6 +135,7 @@ export function suggestionSummary(item: LocalCliItem): string {
 
 export function SuggestionPanel(props: {
   query: string;
+  discovering?: boolean;
   hasSuggestions: boolean;
   packageScriptSuggestions: LocalCliItem[];
   harnessSuggestions: LocalCliItem[];
@@ -139,8 +144,8 @@ export function SuggestionPanel(props: {
 }) {
   if (!props.hasSuggestions) {
     return (
-      <p className="mt-5 text-sm leading-6 text-brand-dark/70">
-        {suggestionEmptyCopy(props.query)}
+      <p className="mt-5 text-sm leading-6 text-brand-dark/70" role="status" aria-live="polite">
+        {suggestionEmptyCopy(props.query, props.discovering === true)}
       </p>
     );
   }
@@ -188,9 +193,12 @@ export function ProjectSwitcher(props: {
   );
 }
 
-function suggestionEmptyCopy(query: string): string {
+function suggestionEmptyCopy(query: string, discovering: boolean): string {
   if (query.trim() !== "") {
     return "No matching tools. Try npm run, a project folder, or a nested script name. Everyday commands such as rg stay hidden.";
+  }
+  if (discovering) {
+    return "Scanning this device for package scripts and app servers.";
   }
   return "No extra tools yet. Paste npm run, a project folder, a script, or an MCP launch.";
 }

--- a/dashboard/src/protection-center/add-custom-extension-support.tsx
+++ b/dashboard/src/protection-center/add-custom-extension-support.tsx
@@ -97,11 +97,11 @@ export function dialogIntro(
   if (surface === "mcp") {
     return "Choose Recommended, Allow all, or Block all, then confirm this server.";
   }
-  if (hasProjects) {
-    return "Guard already found project scripts on this device. Pick a project, or paste another folder.";
-  }
   if (discovering) {
     return "Looking for project scripts and app servers on this device.";
+  }
+  if (hasProjects) {
+    return "Guard already found project scripts on this device. Pick a project, or paste another folder.";
   }
   return "Paste a script, binary, MCP launch, or package scripts such as npm run. Everyday commands such as rg, grep, and whoami are not custom extensions.";
 }
@@ -151,6 +151,11 @@ export function SuggestionPanel(props: {
   }
   return (
     <>
+      {props.discovering === true ? (
+        <p className="mt-5 text-sm leading-6 text-brand-dark/70" role="status" aria-live="polite">
+          Looking for more project scripts and app servers on this device.
+        </p>
+      ) : null}
       <SuggestionGroup
         heading="From this device"
         helper="Projects Guard has already seen, including nested names such as guard:audit."

--- a/dashboard/src/protection-center/local-clis-panel.tsx
+++ b/dashboard/src/protection-center/local-clis-panel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { ChangeEvent, FormEvent } from "react";
 import { HiMiniArrowLeft, HiMiniPlus } from "react-icons/hi2";
 
@@ -15,8 +15,6 @@ import {
   applyLocalCliMutation,
   bulkCommandState,
   enrollablePackageScriptCommands,
-  fetchLocalCliDiscover,
-  fetchLocalCliList,
   LocalCliApiError,
   previewLocalCliMutation,
   type LocalCliCommandState,
@@ -32,6 +30,7 @@ import { InlineError, ProtectionModuleRow } from "./components/protection-primit
 import { customExtensionContinuityView } from "../managed-controls/custom-extension-continuity";
 
 export { AddCustomExtensionWorkspace } from "./add-custom-extension-dialog";
+export { useLocalCliCatalog } from "./use-local-cli-catalog";
 
 function randomToken(): string {
   return crypto.randomUUID().replaceAll("-", "");
@@ -441,51 +440,4 @@ function CustomExtensionReviewModal(props: {
       </form>
     </div>
   );
-}
-
-export function useLocalCliCatalog() {
-  const [data, setData] = useState<LocalCliListResponse | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [discovering, setDiscovering] = useState(false);
-  const loadGeneration = useRef(0);
-  const load = useCallback(async () => {
-    const generation = loadGeneration.current + 1;
-    loadGeneration.current = generation;
-    try {
-      const next = await fetchLocalCliList();
-      if (loadGeneration.current !== generation) return;
-      setData(next);
-      setError(null);
-    } catch (caught) {
-      if (loadGeneration.current !== generation) return;
-      setError(caught instanceof Error ? caught.message : "Guard could not load custom extensions.");
-    }
-  }, []);
-  const discover = useCallback(async () => {
-    const generation = loadGeneration.current + 1;
-    loadGeneration.current = generation;
-    setDiscovering(true);
-    try {
-      const next = await fetchLocalCliDiscover();
-      if (loadGeneration.current !== generation) return;
-      setData(next);
-      setError(null);
-    } catch {
-      try {
-        const next = await fetchLocalCliList();
-        if (loadGeneration.current !== generation) return;
-        setData(next);
-        setError(null);
-      } catch (caught) {
-        if (loadGeneration.current !== generation) return;
-        setError(caught instanceof Error ? caught.message : "Guard could not load custom extensions.");
-      }
-    } finally {
-      if (loadGeneration.current === generation) setDiscovering(false);
-    }
-  }, []);
-  useEffect(() => {
-    void load();
-  }, [load]);
-  return { data, error, load, discover, discovering };
 }

--- a/dashboard/src/protection-center/local-clis-panel.tsx
+++ b/dashboard/src/protection-center/local-clis-panel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { ChangeEvent, FormEvent } from "react";
 import { HiMiniArrowLeft, HiMiniPlus } from "react-icons/hi2";
 
@@ -15,6 +15,7 @@ import {
   applyLocalCliMutation,
   bulkCommandState,
   enrollablePackageScriptCommands,
+  fetchLocalCliDiscover,
   fetchLocalCliList,
   LocalCliApiError,
   previewLocalCliMutation,
@@ -445,16 +446,46 @@ function CustomExtensionReviewModal(props: {
 export function useLocalCliCatalog() {
   const [data, setData] = useState<LocalCliListResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [discovering, setDiscovering] = useState(false);
+  const loadGeneration = useRef(0);
   const load = useCallback(async () => {
+    const generation = loadGeneration.current + 1;
+    loadGeneration.current = generation;
     try {
-      setData(await fetchLocalCliList());
+      const next = await fetchLocalCliList();
+      if (loadGeneration.current !== generation) return;
+      setData(next);
       setError(null);
     } catch (caught) {
+      if (loadGeneration.current !== generation) return;
       setError(caught instanceof Error ? caught.message : "Guard could not load custom extensions.");
+    }
+  }, []);
+  const discover = useCallback(async () => {
+    const generation = loadGeneration.current + 1;
+    loadGeneration.current = generation;
+    setDiscovering(true);
+    try {
+      const next = await fetchLocalCliDiscover();
+      if (loadGeneration.current !== generation) return;
+      setData(next);
+      setError(null);
+    } catch {
+      try {
+        const next = await fetchLocalCliList();
+        if (loadGeneration.current !== generation) return;
+        setData(next);
+        setError(null);
+      } catch (caught) {
+        if (loadGeneration.current !== generation) return;
+        setError(caught instanceof Error ? caught.message : "Guard could not load custom extensions.");
+      }
+    } finally {
+      if (loadGeneration.current === generation) setDiscovering(false);
     }
   }, []);
   useEffect(() => {
     void load();
   }, [load]);
-  return { data, error, load };
+  return { data, error, load, discover, discovering };
 }

--- a/dashboard/src/protection-center/protection-center-workspace.tsx
+++ b/dashboard/src/protection-center/protection-center-workspace.tsx
@@ -427,7 +427,7 @@ export function ProtectionCenterWorkspace(props: {
         <AddCustomExtensionWorkspace
           items={localClis.data?.items ?? []}
           revision={localClis.data?.revision ?? 0}
-          discovering={localClis.discovering}
+          discovering={localClis.discovering || !localClis.catalogReady}
           onBack={closeExtension}
           onAdded={handleCustomExtensionAdded}
         />

--- a/dashboard/src/protection-center/protection-center-workspace.tsx
+++ b/dashboard/src/protection-center/protection-center-workspace.tsx
@@ -176,6 +176,10 @@ export function ProtectionCenterWorkspace(props: {
     window.addEventListener("popstate", onPopState);
     return () => window.removeEventListener("popstate", onPopState);
   }, []);
+  useEffect(() => {
+    if (routeState.route.kind !== "add-custom") return;
+    void localClis.discover();
+  }, [localClis.discover, routeState.route.kind]);
 
   const catalogExtensions = useMemo(() => state.kind === "ready" ? [...state.catalog.extensions].sort((a, b) => a.name.localeCompare(b.name)) : [], [state]);
   const requestedExtensionId = routeState.route.kind === "detail" ? routeState.route.extensionId : null;
@@ -423,6 +427,7 @@ export function ProtectionCenterWorkspace(props: {
         <AddCustomExtensionWorkspace
           items={localClis.data?.items ?? []}
           revision={localClis.data?.revision ?? 0}
+          discovering={localClis.discovering}
           onBack={closeExtension}
           onAdded={handleCustomExtensionAdded}
         />

--- a/dashboard/src/protection-center/protection-center-workspace.tsx
+++ b/dashboard/src/protection-center/protection-center-workspace.tsx
@@ -172,10 +172,14 @@ export function ProtectionCenterWorkspace(props: {
 
   useEffect(() => { void load(); }, [load]);
   useEffect(() => {
-    const onPopState = () => setRouteState(currentExtensionRouteState());
+    const onPopState = () => {
+      const next = currentExtensionRouteState();
+      if (next.route.kind === "add-custom") void localClis.discover();
+      setRouteState(next);
+    };
     window.addEventListener("popstate", onPopState);
     return () => window.removeEventListener("popstate", onPopState);
-  }, []);
+  }, [localClis.discover]);
   useEffect(() => {
     if (routeState.route.kind !== "add-custom") return;
     void localClis.discover();
@@ -219,10 +223,11 @@ export function ProtectionCenterWorkspace(props: {
     window.scrollTo({ top: 0, behavior: "auto" });
   }, []);
   const openAddCustom = useCallback(() => {
+    void localClis.discover();
     pushExtensionHistory(addCustomExtensionHref());
     setRouteState({ route: { kind: "add-custom" }, detail: DEFAULT_EXTENSION_DETAIL_URL_STATE });
     window.scrollTo({ top: 0, behavior: "auto" });
-  }, []);
+  }, [localClis.discover]);
   const handleCustomExtensionAdded = useCallback((cliId: string) => {
     void localClis.load();
     openLocalCliDetail(cliId);

--- a/dashboard/src/protection-center/use-local-cli-catalog.ts
+++ b/dashboard/src/protection-center/use-local-cli-catalog.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { fetchLocalCliApi } from "../guard-api";
+import {
+  fetchLocalCliList,
+  LocalCliApiError,
+  normalizeLocalCliList,
+  type LocalCliListResponse,
+} from "../local-cli-api";
+
+async function fetchLocalCliDiscover(): Promise<LocalCliListResponse> {
+  const response = await fetchLocalCliApi("/v1/local-clis/discover", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{}",
+  });
+  const payload: unknown = await response.json().catch(() => null);
+  if (!response.ok) {
+    throw new LocalCliApiError("local_cli_request_failed", "Guard could not refresh custom extensions.");
+  }
+  return normalizeLocalCliList(payload);
+}
+
+export function useLocalCliCatalog() {
+  const [data, setData] = useState<LocalCliListResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [discovering, setDiscovering] = useState(false);
+  const [catalogReady, setCatalogReady] = useState(false);
+  const loadGeneration = useRef(0);
+  const load = useCallback(async () => {
+    const generation = loadGeneration.current + 1;
+    loadGeneration.current = generation;
+    try {
+      const next = await fetchLocalCliList();
+      if (loadGeneration.current !== generation) return;
+      setData(next);
+      setError(null);
+    } catch (caught) {
+      if (loadGeneration.current !== generation) return;
+      setError(caught instanceof Error ? caught.message : "Guard could not load custom extensions.");
+    }
+  }, []);
+  const discover = useCallback(async () => {
+    const generation = loadGeneration.current + 1;
+    loadGeneration.current = generation;
+    setDiscovering(true);
+    setCatalogReady(false);
+    try {
+      const next = await fetchLocalCliDiscover();
+      if (loadGeneration.current !== generation) return;
+      setData(next);
+      setError(null);
+    } catch {
+      try {
+        const next = await fetchLocalCliList();
+        if (loadGeneration.current !== generation) return;
+        setData(next);
+        setError(null);
+      } catch (caught) {
+        if (loadGeneration.current !== generation) return;
+        setError(caught instanceof Error ? caught.message : "Guard could not load custom extensions.");
+      }
+    } finally {
+      if (loadGeneration.current === generation) {
+        setDiscovering(false);
+        setCatalogReady(true);
+      }
+    }
+  }, []);
+  useEffect(() => {
+    void load();
+  }, [load]);
+  return { data, error, load, discover, discovering, catalogReady };
+}

--- a/docs/guard/local-cli-allowlist.md
+++ b/docs/guard/local-cli-allowlist.md
@@ -2,7 +2,7 @@
 
 Extensions already cover built-in tools such as Git, npm, and cloud CLIs. Agents also run tools that are not in that catalog: a local binary, or an interpreter launching a specific script.
 
-On the Extensions page, choose **Add custom extension** and paste the command for your tool. For a local script or binary, paste something like `python3 <skill-root>/scripts/cwv.py --by url`. Guard binds to that exact file, runs `--help`, and lists the commands it finds.
+On the Extensions page, choose **Add custom extension**. Guard scans remembered project `package.json` files and stdio MCP servers already configured in your apps, then lists them. You can still paste a command. For a local script or binary, paste something like `python3 <skill-root>/scripts/cwv.py --by url`. Guard binds to that exact file, runs `--help`, and lists the commands it finds.
 
 For package scripts, paste `npm run`, `pnpm run`, `yarn run`, `bun run`, a project folder, or `package.json`. Guard reads that file's `scripts` and lists nested names such as `guard:reddit-targeting:audit` as separate commands. `npm --prefix <dir> run` and a path to a directory with `package.json` both work. Lifecycle hooks such as `preinstall` stay hidden. Package launchers used as whole install/execute commands still stay in All tools.
 

--- a/src/codex_plugin_scanner/guard/daemon/local_cli_api.py
+++ b/src/codex_plugin_scanner/guard/daemon/local_cli_api.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 from ..adapters.harness_mcp_discovery import (
     DiscoveredHarnessMcpServer,
+    apply_source_labels,
     discover_harness_mcp_servers,
     discovered_server_for_observation,
     persist_discovered_harness_mcp_servers,
@@ -53,6 +54,7 @@ from ..runtime.package_json_script_memory import (
     operator_working_directory,
     public_local_cli_item,
     recognize_operator_package_scripts,
+    refresh_package_script_catalogs,
 )
 from ..runtime.package_json_scripts import looks_like_package_script_paste
 from .local_cli_continuity_api import decorate_local_cli_continuity
@@ -87,10 +89,29 @@ class LocalCliApiService:
         # when the daemon is under lock contention.
         stored = self._store.list_local_cli_items()
         items = [public_local_cli_item(item) for item in stored if _package_item_available(item)]
-        revision = self._store.read_local_cli_revision()
+        return self._list_payload(items)
+
+    def discover_items(self) -> dict[str, object]:
+        """Refresh package.json catalogs and app MCP servers, then return the list.
+
+        GET listing stays a store read. This write path is for Add custom
+        extension so project scripts reappear without blocking the overview.
+        """
+        stored = self._store.list_local_cli_items()
+        try:
+            labels = self._observe_harness_mcp_servers()
+            items = apply_source_labels(
+                refresh_package_script_catalogs(self._store, home_dir=Path.home()),
+                labels,
+            )
+        except (OSError, RuntimeError, TypeError, ValueError, KeyError, UnicodeError, sqlite3.Error):
+            items = [public_local_cli_item(item) for item in stored if _package_item_available(item)]
+        return self._list_payload(items)
+
+    def _list_payload(self, items: list[dict[str, object]]) -> dict[str, object]:
         return {
             "schema_version": _LOCAL_CLI_API_SCHEMA,
-            "revision": revision,
+            "revision": self._store.read_local_cli_revision(),
             "items": items,
             "cloud": decorate_local_cli_continuity(self._store, items),
         }

--- a/src/codex_plugin_scanner/guard/daemon/local_cli_api.py
+++ b/src/codex_plugin_scanner/guard/daemon/local_cli_api.py
@@ -87,9 +87,7 @@ class LocalCliApiService:
         # Listing must stay a read of persisted grants. Live MCP/package
         # discovery writes to the same store and can abort the HTTP response
         # when the daemon is under lock contention.
-        stored = self._store.list_local_cli_items()
-        items = [public_local_cli_item(item) for item in stored if _package_item_available(item)]
-        return self._list_payload(items)
+        return self._list_payload(self._listed_public_items())
 
     def discover_items(self) -> dict[str, object]:
         """Refresh package.json catalogs and app MCP servers, then return the list.
@@ -97,7 +95,6 @@ class LocalCliApiService:
         GET listing stays a store read. This write path is for Add custom
         extension so project scripts reappear without blocking the overview.
         """
-        stored = self._store.list_local_cli_items()
         try:
             labels = self._observe_harness_mcp_servers()
             items = apply_source_labels(
@@ -105,8 +102,12 @@ class LocalCliApiService:
                 labels,
             )
         except (OSError, RuntimeError, TypeError, ValueError, KeyError, UnicodeError, sqlite3.Error):
-            items = [public_local_cli_item(item) for item in stored if _package_item_available(item)]
+            items = self._listed_public_items()
         return self._list_payload(items)
+
+    def _listed_public_items(self) -> list[dict[str, object]]:
+        stored = self._store.list_local_cli_items()
+        return [public_local_cli_item(item) for item in stored if _package_item_available(item)]
 
     def _list_payload(self, items: list[dict[str, object]]) -> dict[str, object]:
         return {

--- a/src/codex_plugin_scanner/guard/daemon/local_cli_http.py
+++ b/src/codex_plugin_scanner/guard/daemon/local_cli_http.py
@@ -3,20 +3,24 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import Protocol
 
 
-def dispatch_local_cli_post(api: object, path: str, payload: dict[str, object]) -> dict[str, object]:
+class _LocalCliPostApi(Protocol):
+    def apply(self, payload: dict[str, object]) -> dict[str, object]: ...
+    def discover_items(self) -> dict[str, object]: ...
+    def preview(self, payload: dict[str, object]) -> dict[str, object]: ...
+    def recognize(self, payload: dict[str, object]) -> dict[str, object]: ...
+
+
+def dispatch_local_cli_post(api: _LocalCliPostApi, path: str, payload: dict[str, object]) -> dict[str, object]:
     if path.endswith("/preview"):
-        result = getattr(api, "preview")(payload)
-    elif path.endswith("/recognize"):
-        result = getattr(api, "recognize")(payload)
-    elif path.endswith("/discover"):
-        result = getattr(api, "discover_items")()
-    else:
-        result = getattr(api, "apply")(payload)
-    if not isinstance(result, dict):
-        raise TypeError("local_cli_post_dispatch")
-    return result
+        return api.preview(payload)
+    if path.endswith("/recognize"):
+        return api.recognize(payload)
+    if path.endswith("/discover"):
+        return api.discover_items()
+    return api.apply(payload)
 
 
 def handle_local_cli_list(handler: object) -> None:

--- a/src/codex_plugin_scanner/guard/daemon/local_cli_http.py
+++ b/src/codex_plugin_scanner/guard/daemon/local_cli_http.py
@@ -5,6 +5,16 @@ from __future__ import annotations
 from collections.abc import Callable
 
 
+def dispatch_local_cli_post(api: object, path: str, payload: dict[str, object]) -> dict[str, object]:
+    if path.endswith("/preview"):
+        return api.preview(payload)
+    if path.endswith("/recognize"):
+        return api.recognize(payload)
+    if path.endswith("/discover"):
+        return api.discover_items()
+    return api.apply(payload)
+
+
 def handle_local_cli_list(handler: object) -> None:
     daemon_server = getattr(handler, "_daemon_server", None)
     write_json = getattr(handler, "_write_json", None)

--- a/src/codex_plugin_scanner/guard/daemon/local_cli_http.py
+++ b/src/codex_plugin_scanner/guard/daemon/local_cli_http.py
@@ -7,12 +7,16 @@ from collections.abc import Callable
 
 def dispatch_local_cli_post(api: object, path: str, payload: dict[str, object]) -> dict[str, object]:
     if path.endswith("/preview"):
-        return api.preview(payload)
-    if path.endswith("/recognize"):
-        return api.recognize(payload)
-    if path.endswith("/discover"):
-        return api.discover_items()
-    return api.apply(payload)
+        result = getattr(api, "preview")(payload)
+    elif path.endswith("/recognize"):
+        result = getattr(api, "recognize")(payload)
+    elif path.endswith("/discover"):
+        result = getattr(api, "discover_items")()
+    else:
+        result = getattr(api, "apply")(payload)
+    if not isinstance(result, dict):
+        raise TypeError("local_cli_post_dispatch")
+    return result
 
 
 def handle_local_cli_list(handler: object) -> None:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -322,14 +322,9 @@ _EXTENSION_CONTROL_PATHS = frozenset(
         "/v1/extension-controls/acknowledge-degraded",
     }
 )
-_LOCAL_CLI_PATHS = frozenset(
-    {
-        "/v1/local-clis/preview",
-        "/v1/local-clis/apply",
-        "/v1/local-clis/recognize",
-        "/v1/local-clis/discover",
-    }
-)
+_LOCAL_CLI_PATHS = frozenset({
+    "/v1/local-clis/preview", "/v1/local-clis/apply", "/v1/local-clis/recognize", "/v1/local-clis/discover",
+})
 
 
 class _HookPathValidationError(ValueError):
@@ -6991,10 +6986,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/v1/extension-controls/recover-authority",
             "/v1/extension-controls/acknowledge-degraded",
             "/v1/local-clis",
-            "/v1/local-clis/preview",
-            "/v1/local-clis/apply",
-            "/v1/local-clis/recognize",
-            "/v1/local-clis/discover",
+            *_LOCAL_CLI_PATHS,
             "/v1/harnesses",
             "/v1/notifications/setup",
             "/v1/policy",

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -322,7 +322,14 @@ _EXTENSION_CONTROL_PATHS = frozenset(
         "/v1/extension-controls/acknowledge-degraded",
     }
 )
-_LOCAL_CLI_PATHS = frozenset({"/v1/local-clis/preview", "/v1/local-clis/apply", "/v1/local-clis/recognize"})
+_LOCAL_CLI_PATHS = frozenset(
+    {
+        "/v1/local-clis/preview",
+        "/v1/local-clis/apply",
+        "/v1/local-clis/recognize",
+        "/v1/local-clis/discover",
+    }
+)
 
 
 class _HookPathValidationError(ValueError):
@@ -2714,6 +2721,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     response = self._daemon_server().local_cli_api.preview(payload)
                 elif parsed.path.endswith("/recognize"):
                     response = self._daemon_server().local_cli_api.recognize(payload)
+                elif parsed.path.endswith("/discover"):
+                    response = self._daemon_server().local_cli_api.discover_items()
                 else:
                     response = self._daemon_server().local_cli_api.apply(payload)
             except LocalCliApiError as error:
@@ -6985,6 +6994,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/v1/local-clis/preview",
             "/v1/local-clis/apply",
             "/v1/local-clis/recognize",
+            "/v1/local-clis/discover",
             "/v1/harnesses",
             "/v1/notifications/setup",
             "/v1/policy",

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -261,7 +261,7 @@ from .hook_worker_responses import prepare_native_hook_policy
 from .lifecycle_journal import record_daemon_lifecycle_event
 from .local_approval_continuation import apply_local_approval_continuation
 from .local_cli_api import LocalCliApiError, LocalCliApiService
-from .local_cli_http import handle_local_cli_list
+from .local_cli_http import dispatch_local_cli_post, handle_local_cli_list
 from .managed_controls_api import managed_policy_rows
 from .managed_policy_delivery import daemon_managed_controls_candidate
 from .manager import (
@@ -322,9 +322,14 @@ _EXTENSION_CONTROL_PATHS = frozenset(
         "/v1/extension-controls/acknowledge-degraded",
     }
 )
-_LOCAL_CLI_PATHS = frozenset({
-    "/v1/local-clis/preview", "/v1/local-clis/apply", "/v1/local-clis/recognize", "/v1/local-clis/discover",
-})
+_LOCAL_CLI_PATHS = frozenset(
+    {
+        "/v1/local-clis/preview",
+        "/v1/local-clis/apply",
+        "/v1/local-clis/recognize",
+        "/v1/local-clis/discover",
+    }
+)
 
 
 class _HookPathValidationError(ValueError):
@@ -2712,14 +2717,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         if parsed.path in _LOCAL_CLI_PATHS:
             try:
-                if parsed.path.endswith("/preview"):
-                    response = self._daemon_server().local_cli_api.preview(payload)
-                elif parsed.path.endswith("/recognize"):
-                    response = self._daemon_server().local_cli_api.recognize(payload)
-                elif parsed.path.endswith("/discover"):
-                    response = self._daemon_server().local_cli_api.discover_items()
-                else:
-                    response = self._daemon_server().local_cli_api.apply(payload)
+                response = dispatch_local_cli_post(self._daemon_server().local_cli_api, parsed.path, payload)
             except LocalCliApiError as error:
                 self._write_json(error.to_payload(), status=error.status)
                 return

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/extensions-workspace.js
@@ -2432,12 +2432,15 @@ function blockActionLabel(surface) {
   if (surface === "package-scripts") return "Block these scripts";
   return "Block this tool";
 }
-function dialogIntro(hasProjects, surface) {
+function dialogIntro(hasProjects, surface, discovering = false) {
   if (surface === "package-scripts") {
     return "Allow these scripts so Protect can stop asking about them. Type a nested name such as guard:audit to inspect one.";
   }
   if (surface === "mcp") {
     return "Choose Recommended, Allow all, or Block all, then confirm this server.";
+  }
+  if (discovering) {
+    return "Looking for project scripts and app servers on this device.";
   }
   if (hasProjects) {
     return "Guard already found project scripts on this device. Pick a project, or paste another folder.";
@@ -2471,9 +2474,10 @@ function suggestionSummary(item) {
 }
 function SuggestionPanel(props) {
   if (!props.hasSuggestions) {
-    return /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-5 text-sm leading-6 text-brand-dark/70", children: suggestionEmptyCopy(props.query) });
+    return /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-5 text-sm leading-6 text-brand-dark/70", role: "status", "aria-live": "polite", children: suggestionEmptyCopy(props.query, props.discovering === true) });
   }
   return /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+    props.discovering === true ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-5 text-sm leading-6 text-brand-dark/70", role: "status", "aria-live": "polite", children: "Looking for more project scripts and app servers on this device." }) : null,
     /* @__PURE__ */ jsxRuntimeExports.jsx(
       SuggestionGroup,
       {
@@ -2515,9 +2519,12 @@ function ProjectSwitcher(props) {
     item.cli_id
   )) });
 }
-function suggestionEmptyCopy(query) {
+function suggestionEmptyCopy(query, discovering) {
   if (query.trim() !== "") {
     return "No matching tools. Try npm run, a project folder, or a nested script name. Everyday commands such as rg stay hidden.";
+  }
+  if (discovering) {
+    return "Scanning this device for package scripts and app servers.";
   }
   return "No extra tools yet. Paste npm run, a project folder, a script, or an MCP launch.";
 }
@@ -3432,6 +3439,7 @@ function AddCustomExtensionWorkspace(props) {
   const recognizeGeneration = reactExports.useRef(0);
   const autoRecognizedCommand = reactExports.useRef("");
   const didAutoSelect = reactExports.useRef(false);
+  const sawDiscovering = reactExports.useRef(false);
   const rememberedProjects = suggestedPackageScriptExtensions(props.items);
   const packageScriptSuggestions = filterExtensionSuggestions(rememberedProjects, command).slice(0, 8);
   const harnessSuggestions = filterExtensionSuggestions(suggestedHarnessExtensions(props.items), command).slice(0, 8);
@@ -3517,12 +3525,22 @@ function AddCustomExtensionWorkspace(props) {
     await runRecognize(command);
   }, [command, runRecognize]);
   reactExports.useEffect(() => {
-    if (didAutoSelect.current || recognized !== null || command.trim() !== "") return;
+    if (props.discovering === true) sawDiscovering.current = true;
+    if (!sawDiscovering.current || props.discovering === true || command.trim() !== "") return;
     const preferred = preferredPackageScriptExtension(props.items);
     if (preferred === null) return;
+    if (recognized !== null) {
+      if (recognized.cli_id !== preferred.cli_id) return;
+      if (recognized.identity_hash === preferred.identity_hash && recognized.commands.length === preferred.commands.length) {
+        return;
+      }
+      markRecognized(preferred, suggestionSummary(preferred));
+      return;
+    }
+    if (didAutoSelect.current) return;
     didAutoSelect.current = true;
     selectSuggestion(preferred);
-  }, [command, props.items, recognized, selectSuggestion]);
+  }, [command, markRecognized, props.discovering, props.items, recognized, selectSuggestion]);
   reactExports.useEffect(() => {
     const trimmed = command.trim();
     if (recognized !== null || !looksLikePackageScriptPaste(trimmed)) return;
@@ -3660,7 +3678,11 @@ function AddCustomExtensionWorkspace(props) {
         ] }) : /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
           /* @__PURE__ */ jsxRuntimeExports.jsxs("header", { className: "mt-3 max-w-2xl pb-4", children: [
             /* @__PURE__ */ jsxRuntimeExports.jsx("h1", { id: "add-custom-extension-title", className: "text-2xl font-semibold tracking-tight text-brand-dark", children: "Add a custom extension" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm leading-6 text-slate-500", children: dialogIntro(rememberedProjects.length > 0, recognized?.surface ?? null) })
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm leading-6 text-slate-500", children: dialogIntro(
+              rememberedProjects.length > 0,
+              recognized?.surface ?? null,
+              props.discovering === true && recognized === null
+            ) })
           ] }),
           /* @__PURE__ */ jsxRuntimeExports.jsx("label", { htmlFor: "custom-extension-command", className: "mt-4 block text-sm font-semibold text-brand-dark", children: commandFieldLabel(recognized?.surface ?? null) }),
           /* @__PURE__ */ jsxRuntimeExports.jsx(
@@ -3718,6 +3740,7 @@ function AddCustomExtensionWorkspace(props) {
             SuggestionPanel,
             {
               query: command,
+              discovering: props.discovering === true,
               hasSuggestions,
               packageScriptSuggestions,
               harnessSuggestions,
@@ -3735,6 +3758,69 @@ function AddCustomExtensionWorkspace(props) {
       ]
     }
   );
+}
+async function fetchLocalCliDiscover() {
+  const response = await fetchLocalCliApi("/v1/local-clis/discover", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{}"
+  });
+  const payload = await response.json().catch(() => null);
+  if (!response.ok) {
+    throw new LocalCliApiError("local_cli_request_failed", "Guard could not refresh custom extensions.");
+  }
+  return normalizeLocalCliList(payload);
+}
+function useLocalCliCatalog() {
+  const [data, setData] = reactExports.useState(null);
+  const [error, setError] = reactExports.useState(null);
+  const [discovering, setDiscovering] = reactExports.useState(false);
+  const [catalogReady, setCatalogReady] = reactExports.useState(false);
+  const loadGeneration = reactExports.useRef(0);
+  const load = reactExports.useCallback(async () => {
+    const generation = loadGeneration.current + 1;
+    loadGeneration.current = generation;
+    try {
+      const next = await fetchLocalCliList();
+      if (loadGeneration.current !== generation) return;
+      setData(next);
+      setError(null);
+    } catch (caught) {
+      if (loadGeneration.current !== generation) return;
+      setError(caught instanceof Error ? caught.message : "Guard could not load custom extensions.");
+    }
+  }, []);
+  const discover = reactExports.useCallback(async () => {
+    const generation = loadGeneration.current + 1;
+    loadGeneration.current = generation;
+    setDiscovering(true);
+    setCatalogReady(false);
+    try {
+      const next = await fetchLocalCliDiscover();
+      if (loadGeneration.current !== generation) return;
+      setData(next);
+      setError(null);
+    } catch {
+      try {
+        const next = await fetchLocalCliList();
+        if (loadGeneration.current !== generation) return;
+        setData(next);
+        setError(null);
+      } catch (caught) {
+        if (loadGeneration.current !== generation) return;
+        setError(caught instanceof Error ? caught.message : "Guard could not load custom extensions.");
+      }
+    } finally {
+      if (loadGeneration.current === generation) {
+        setDiscovering(false);
+        setCatalogReady(true);
+      }
+    }
+  }, []);
+  reactExports.useEffect(() => {
+    void load();
+  }, [load]);
+  return { data, error, load, discover, discovering, catalogReady };
 }
 function randomToken$1() {
   return crypto.randomUUID().replaceAll("-", "");
@@ -4049,22 +4135,6 @@ function CustomExtensionReviewModal(props) {
       /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "submit", disabled: submitDisabled, className: "min-h-11 rounded-xl bg-brand-blue px-5 text-sm font-semibold text-white disabled:opacity-60", children: props.busy ? "Saving…" : "Confirm" })
     ] })
   ] }) });
-}
-function useLocalCliCatalog() {
-  const [data, setData] = reactExports.useState(null);
-  const [error, setError] = reactExports.useState(null);
-  const load = reactExports.useCallback(async () => {
-    try {
-      setData(await fetchLocalCliList());
-      setError(null);
-    } catch (caught) {
-      setError(caught instanceof Error ? caught.message : "Guard could not load custom extensions.");
-    }
-  }, []);
-  reactExports.useEffect(() => {
-    void load();
-  }, [load]);
-  return { data, error, load };
 }
 const PROTECTION_TERMS = {
   pageTitle: "Extensions"
@@ -6342,10 +6412,18 @@ function ProtectionCenterWorkspace(props) {
     void load();
   }, [load]);
   reactExports.useEffect(() => {
-    const onPopState = () => setRouteState(currentExtensionRouteState());
+    const onPopState = () => {
+      const next = currentExtensionRouteState();
+      if (next.route.kind === "add-custom") void localClis.discover();
+      setRouteState(next);
+    };
     window.addEventListener("popstate", onPopState);
     return () => window.removeEventListener("popstate", onPopState);
-  }, []);
+  }, [localClis.discover]);
+  reactExports.useEffect(() => {
+    if (routeState.route.kind !== "add-custom") return;
+    void localClis.discover();
+  }, [localClis.discover, routeState.route.kind]);
   const catalogExtensions = reactExports.useMemo(() => state.kind === "ready" ? [...state.catalog.extensions].sort((a, b) => a.name.localeCompare(b.name)) : [], [state]);
   const requestedExtensionId = routeState.route.kind === "detail" ? routeState.route.extensionId : null;
   const canonicalSelected = reactExports.useMemo(() => canonicalExtensionId(catalogExtensions, requestedExtensionId), [catalogExtensions, requestedExtensionId]);
@@ -6380,10 +6458,11 @@ function ProtectionCenterWorkspace(props) {
     window.scrollTo({ top: 0, behavior: "auto" });
   }, []);
   const openAddCustom = reactExports.useCallback(() => {
+    void localClis.discover();
     pushExtensionHistory(addCustomExtensionHref());
     setRouteState({ route: { kind: "add-custom" }, detail: DEFAULT_EXTENSION_DETAIL_URL_STATE });
     window.scrollTo({ top: 0, behavior: "auto" });
-  }, []);
+  }, [localClis.discover]);
   const handleCustomExtensionAdded = reactExports.useCallback((cliId) => {
     void localClis.load();
     openLocalCliDetail(cliId);
@@ -6565,6 +6644,7 @@ function ProtectionCenterWorkspace(props) {
       {
         items: localClis.data?.items ?? [],
         revision: localClis.data?.revision ?? 0,
+        discovering: localClis.discovering || !localClis.catalogReady,
         onBack: closeExtension,
         onAdded: handleCustomExtensionAdded
       }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -16498,7 +16498,7 @@ async function fetchExtensionControlApi(input, init) {
   return fetchWithGuardAuth(input, init);
 }
 async function fetchLocalCliApi(input, init) {
-  const approvedPath = typeof input === "string" && /^\/v1\/local-clis(?:\/(?:preview|apply|recognize))?$/.test(input);
+  const approvedPath = typeof input === "string" && /^\/v1\/local-clis(?:\/(?:preview|apply|recognize|discover))?$/.test(input);
   if (!approvedPath) {
     throw new Error("Invalid local CLI API path");
   }

--- a/tests/test_guard_extension_control_dashboard_session_auth.py
+++ b/tests/test_guard_extension_control_dashboard_session_auth.py
@@ -124,6 +124,7 @@ def test_dashboard_session_authorizes_new_extension_control_routes(tmp_path: Pat
         "/v1/local-clis/preview",
         "/v1/local-clis/apply",
         "/v1/local-clis/recognize",
+        "/v1/local-clis/discover",
     ):
         assert daemon_server_module._GuardDaemonHandler._is_hosted_dashboard_api_path(
             path,

--- a/tests/test_guard_local_cli_api.py
+++ b/tests/test_guard_local_cli_api.py
@@ -158,11 +158,7 @@ def test_discover_items_refreshes_package_scripts_from_cwd(tmp_path: Path, monke
     assert listed == []
     discovered = service.discover_items()["items"]
     assert isinstance(discovered, list)
-    package_items = [
-        item
-        for item in discovered
-        if isinstance(item, dict) and item.get("surface") == "package-scripts"
-    ]
+    package_items = [item for item in discovered if isinstance(item, dict) and item.get("surface") == "package-scripts"]
     assert package_items
     names = {
         str(command.get("name"))

--- a/tests/test_guard_local_cli_api.py
+++ b/tests/test_guard_local_cli_api.py
@@ -214,6 +214,58 @@ def test_discover_items_falls_back_to_store_when_refresh_fails(tmp_path: Path, m
     assert listed["state"] == "allowed"
 
 
+def test_discover_items_rereads_store_after_partial_refresh_failure(tmp_path: Path, monkeypatch) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.local_cli_api.Path.home",
+        staticmethod(lambda: home),
+    )
+    existing = UnlistedCliIdentity(
+        cli_id="local-cli.ship-12345678",
+        name="ship",
+        kind="executable",
+        identity_hash="a" * 64,
+        example_label="ship",
+    )
+    persisted = UnlistedCliIdentity(
+        cli_id="local-cli.mcp-abcdef123456",
+        name="github",
+        kind="executable",
+        identity_hash="b" * 64,
+        example_label="npx -y @modelcontextprotocol/server-github",
+    )
+    store = GuardStore(home)
+    store.record_local_cli_observation(existing, seen_at="2026-08-25T16:00:00Z")
+    store.upsert_local_cli_grant(
+        identity=existing,
+        state="allowed",
+        expected_revision=0,
+        updated_at="2026-08-25T16:00:00Z",
+    )
+    service = LocalCliApiService(store=store)
+
+    def persist_then_fail_refresh(*_args: object, **_kwargs: object) -> list[dict[str, object]]:
+        store.record_local_cli_observation(
+            persisted,
+            seen_at="2026-08-25T16:05:00Z",
+            surface="mcp",
+        )
+        raise RuntimeError("refresh failed")
+
+    monkeypatch.setattr(service, "_observe_harness_mcp_servers", lambda: {})
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.local_cli_api.refresh_package_script_catalogs",
+        persist_then_fail_refresh,
+    )
+    payload = service.discover_items()
+    items = payload["items"]
+    assert isinstance(items, list)
+    ids = {item["cli_id"] for item in items if isinstance(item, dict)}
+    assert existing.cli_id in ids
+    assert persisted.cli_id in ids
+
+
 def test_list_items_fallback_hides_unset_package_scripts_without_a_project(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_guard_local_cli_api.py
+++ b/tests/test_guard_local_cli_api.py
@@ -137,6 +137,83 @@ def test_list_items_returns_stored_grants_when_discovery_fails(tmp_path: Path, m
     assert listed["state"] == "allowed"
 
 
+def test_discover_items_refreshes_package_scripts_from_cwd(tmp_path: Path, monkeypatch) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    project = home / "demo-app"
+    project.mkdir()
+    (project / "package.json").write_text(
+        '{"name":"demo-app","scripts":{"guard:audit":"echo audit","build":"echo build"}}\n',
+        encoding="utf-8",
+    )
+    (project / "pnpm-lock.yaml").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.local_cli_api.Path.home",
+        staticmethod(lambda: home),
+    )
+    monkeypatch.chdir(project)
+    service = LocalCliApiService(store=GuardStore(home))
+    listed = service.list_items()["items"]
+    assert isinstance(listed, list)
+    assert listed == []
+    discovered = service.discover_items()["items"]
+    assert isinstance(discovered, list)
+    package_items = [
+        item
+        for item in discovered
+        if isinstance(item, dict) and item.get("surface") == "package-scripts"
+    ]
+    assert package_items
+    names = {
+        str(command.get("name"))
+        for item in package_items
+        for command in item.get("commands", [])
+        if isinstance(command, dict)
+    }
+    assert "guard:audit" in names
+
+
+def test_discover_items_falls_back_to_store_when_refresh_fails(tmp_path: Path, monkeypatch) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.local_cli_api.Path.home",
+        staticmethod(lambda: home),
+    )
+    identity = UnlistedCliIdentity(
+        cli_id="local-cli.ship-12345678",
+        name="ship",
+        kind="executable",
+        identity_hash="a" * 64,
+        example_label="ship",
+    )
+    store = GuardStore(home)
+    store.record_local_cli_observation(identity, seen_at="2026-08-25T16:00:00Z")
+    store.upsert_local_cli_grant(
+        identity=identity,
+        state="allowed",
+        expected_revision=0,
+        updated_at="2026-08-25T16:00:00Z",
+    )
+    service = LocalCliApiService(store=store)
+
+    def fail_refresh(*_args: object, **_kwargs: object) -> list[dict[str, object]]:
+        raise RuntimeError("refresh failed")
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.local_cli_api.refresh_package_script_catalogs",
+        fail_refresh,
+    )
+    payload = service.discover_items()
+    items = payload["items"]
+    assert isinstance(items, list)
+    assert len(items) == 1
+    listed = items[0]
+    assert isinstance(listed, dict)
+    assert listed["cli_id"] == identity.cli_id
+    assert listed["state"] == "allowed"
+
+
 def test_list_items_fallback_hides_unset_package_scripts_without_a_project(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary
- Opening Add custom extension now refreshes project `package.json` scripts and app MCP servers again.
- GET listing stays a store read so the Extensions overview does not block on live discovery.
- The add page shows a scanning state until those catalogs are ready.

## Testing
- `python3 -m pytest tests/test_guard_local_cli_api.py tests/test_guard_package_json_scripts.py tests/test_guard_extension_control_dashboard_session_auth.py -q`
- `./node_modules/.bin/tsx src/protection-center/add-custom-extension-support.test.ts`
- `./node_modules/.bin/tsx src/local-cli-api.test.ts`
- `./node_modules/.bin/tsx src/protection-center/protection-center.test.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom extension setup now scans remembered projects and configured MCP servers for available extensions.
  * Added discovery status messaging, automatic selection of preferred discovered extensions, and manual command entry support.
  * Added support for discovering local CLI items through the dashboard.

* **Bug Fixes**
  * Improved discovery recovery so newly detected items remain available after partial refresh failures.
  * Prevented outdated discovery results from replacing newer catalog data.

* **Documentation**
  * Updated custom extension setup guidance to explain automatic discovery and manual commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->