### PR TITLE
fix(dashboard): restore inline font sizing on Local Guard controls

### DIFF
--- a/dashboard/src/guard-update-channel-summary.tsx
+++ b/dashboard/src/guard-update-channel-summary.tsx
@@ -1,4 +1,3 @@
-import type { ReactNode } from "react";
 import { HiMiniBeaker } from "react-icons/hi2";
 
 export type GuardUpdateChannelSummaryProps = {
@@ -8,34 +7,24 @@ export type GuardUpdateChannelSummaryProps = {
   onManage: () => void;
 };
 
-// Inline channel control for the Local Guard status row: the card's 11px
-// status typography on a 32px target that matches the panel's action pills.
+// The app-wide `button { font: inherit }` reset is unlayered CSS, so it
+// outranks Tailwind's layered text utilities on form controls. Buttons here
+// size their label through an inner span instead (same pattern as the card's
+// Open Inbox action).
+export const GUARD_UPDATE_CONTROL_TEXT_CLASS = "text-[11px] font-semibold leading-4";
+
 export const GUARD_UPDATE_CHANNEL_CONTROL_CLASS =
-  "inline-flex min-h-8 shrink-0 items-center gap-1 rounded-sm px-0.5 text-[11px] font-semibold leading-4 text-brand-blue transition-opacity hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60";
+  "inline-flex min-h-8 shrink-0 items-center rounded-sm px-0.5 text-brand-blue transition-opacity hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60";
 
 // Compact pill for panel-level actions (update, reinstall): 32px target that
 // sits inline beside the status line instead of filling the card width.
 export const GUARD_UPDATE_ACTION_BUTTON_CLASS =
-  "inline-flex min-h-8 shrink-0 items-center justify-center gap-1 rounded-full border border-brand-blue/30 bg-white px-2.5 text-[11px] font-semibold text-brand-blue transition-colors hover:bg-brand-blue/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60";
+  "inline-flex min-h-8 shrink-0 items-center justify-center gap-1 rounded-full border border-brand-blue/30 bg-white px-2.5 text-brand-blue transition-colors hover:bg-brand-blue/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60";
 
 export function GuardUpdateChannelSummary(props: GuardUpdateChannelSummaryProps) {
-  let channelStatus: ReactNode = null;
-  if (props.useAlpha) {
-    channelStatus = (
-      <span
-        className="inline-flex min-w-0 items-center gap-1 text-[11px] font-semibold leading-4 text-brand-blue"
-        role="status"
-        aria-label="Alpha updates enabled"
-      >
-        <HiMiniBeaker className="h-3 w-3 shrink-0" aria-hidden="true" />
-        <span className="truncate">Alpha updates</span>
-      </span>
-    );
-  }
-
   return (
     <div className="flex min-w-0 items-center justify-between gap-1.5">
-      <span className="inline-flex min-w-0 items-center gap-1">
+      <span className="inline-flex min-w-0 items-center gap-1.5">
         {props.version ? (
           <span
             className="min-w-0 font-mono text-[10px] leading-4 text-brand-dark/70 [overflow-wrap:anywhere]"
@@ -44,7 +33,16 @@ export function GuardUpdateChannelSummary(props: GuardUpdateChannelSummaryProps)
             v{props.version}
           </span>
         ) : null}
-        {channelStatus}
+        {props.useAlpha ? (
+          <span
+            className="inline-flex shrink-0 items-center gap-1 rounded-full bg-brand-blue/15 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider text-brand-blue"
+            role="status"
+            aria-label="Alpha updates enabled"
+          >
+            <HiMiniBeaker className="h-2.5 w-2.5" aria-hidden="true" />
+            Alpha
+          </span>
+        ) : null}
       </span>
       {props.useAlpha ? (
         <button
@@ -56,7 +54,7 @@ export function GuardUpdateChannelSummary(props: GuardUpdateChannelSummaryProps)
           data-testid="guard-alpha-updates-control"
           className={GUARD_UPDATE_CHANNEL_CONTROL_CLASS}
         >
-          Manage
+          <span className={GUARD_UPDATE_CONTROL_TEXT_CLASS}>Manage</span>
         </button>
       ) : (
         <button
@@ -66,8 +64,8 @@ export function GuardUpdateChannelSummary(props: GuardUpdateChannelSummaryProps)
           data-testid="guard-alpha-updates-control"
           className={GUARD_UPDATE_CHANNEL_CONTROL_CLASS}
         >
-          <HiMiniBeaker className="h-3 w-3 shrink-0" aria-hidden="true" />
-          Try alpha updates
+          <HiMiniBeaker className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          <span className={GUARD_UPDATE_CONTROL_TEXT_CLASS}>Try alpha updates</span>
         </button>
       )}
     </div>

--- a/dashboard/src/guard-update-channel-summary.tsx
+++ b/dashboard/src/guard-update-channel-summary.tsx
@@ -14,7 +14,7 @@ export type GuardUpdateChannelSummaryProps = {
 export const GUARD_UPDATE_CONTROL_TEXT_CLASS = "text-[11px] font-semibold leading-4";
 
 export const GUARD_UPDATE_CHANNEL_CONTROL_CLASS =
-  "inline-flex min-h-8 shrink-0 items-center rounded-sm px-0.5 text-brand-blue transition-opacity hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60";
+  "inline-flex min-h-8 shrink-0 items-center gap-1 rounded-sm px-0.5 text-brand-blue transition-opacity hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60";
 
 // Compact pill for panel-level actions (update, reinstall): 32px target that
 // sits inline beside the status line instead of filling the card width.

--- a/dashboard/src/guard-update-panel.tsx
+++ b/dashboard/src/guard-update-panel.tsx
@@ -26,6 +26,7 @@ import { GuardModalLayer } from "./guard-modal-layer";
 import {
   GuardUpdateChannelSummary,
   GUARD_UPDATE_ACTION_BUTTON_CLASS,
+  GUARD_UPDATE_CONTROL_TEXT_CLASS,
 } from "./guard-update-channel-summary";
 
 const UPDATE_STATUS_POLL_MS = 60_000;
@@ -137,7 +138,13 @@ export function GuardUpdatePanel(props: GuardUpdatePanelProps) {
   }
 
   return (
-    <div className={props.compact ? "space-y-1" : "space-y-1.5"}>
+    <div
+      className={
+        props.compact
+          ? "space-y-1 border-t border-brand-blue/10 pt-1.5"
+          : "space-y-1.5 border-t border-brand-blue/10 pt-2"
+      }
+    >
       {updateChannelSummary}
       {props.updateStatus?.update_available ? (
         <div className="flex items-center justify-between gap-2">
@@ -152,7 +159,7 @@ export function GuardUpdatePanel(props: GuardUpdatePanelProps) {
               className={GUARD_UPDATE_ACTION_BUTTON_CLASS}
             >
               <HiMiniArrowPath className="h-3 w-3 shrink-0" aria-hidden="true" />
-              Update
+              <span className={GUARD_UPDATE_CONTROL_TEXT_CLASS}>Update</span>
             </button>
           ) : null}
         </div>
@@ -167,7 +174,7 @@ export function GuardUpdatePanel(props: GuardUpdatePanelProps) {
           className={GUARD_UPDATE_ACTION_BUTTON_CLASS}
         >
           <HiMiniArrowPath className="h-3 w-3 shrink-0" aria-hidden="true" />
-          Reinstall from PyPI
+          <span className={GUARD_UPDATE_CONTROL_TEXT_CLASS}>Reinstall from PyPI</span>
         </button>
       ) : null}
       {busy && (

--- a/dashboard/src/guard-update.test.ts
+++ b/dashboard/src/guard-update.test.ts
@@ -60,6 +60,7 @@ assert(!alphaMarkup.includes("Alpha updates enabled</button>"), "active alpha st
 assert(!alphaMarkup.includes('type="checkbox"'), "sidebar should open alpha confirmation instead of toggling immediately");
 assert(alphaMarkup.includes("min-h-8") && !alphaMarkup.includes("min-h-11") && !alphaMarkup.includes("min-h-6") && !alphaMarkup.includes("w-full"), "Local Guard update controls stay compact inline rows with uniform 32px targets, not full-width blocks");
 assert(alphaMarkup.includes("1.2.4a1 is ready") && alphaMarkup.includes("Restarts briefly. Approvals stay saved."), "update-ready copy keeps the version line and reassurance together");
+assert(alphaMarkup.includes('<span class="text-[11px] font-semibold leading-4">Manage</span>'), "control labels carry font sizing on an inner span the button reset cannot override");
 
 const alphaUpdateMarkup = renderToStaticMarkup(
   createElement(GuardUpdatePanel, {
@@ -68,7 +69,7 @@ const alphaUpdateMarkup = renderToStaticMarkup(
     onSetUpdateChannel: () => undefined,
   }),
 );
-assert(alphaUpdateMarkup.includes('aria-label="Update Guard to the latest version"') && alphaUpdateMarkup.includes(">Update</button>"), "update-ready state pairs the version line with a compact inline Update action");
+assert(alphaUpdateMarkup.includes('aria-label="Update Guard to the latest version"') && alphaUpdateMarkup.includes(">Update</span></button>"), "update-ready state pairs the version line with a compact inline Update action");
 assert(alphaUpdateMarkup.includes("[overflow-wrap:anywhere]") && !alphaUpdateMarkup.includes("min-w-0 truncate"), "the ready-version label wraps long release strings instead of clipping them");
 
 const longVersion = "3.0.111a1.dev456+g1a2b3c4d5e6";

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -20143,7 +20143,7 @@ function GuardModalLayer({
   );
 }
 const GUARD_UPDATE_CONTROL_TEXT_CLASS = "text-[11px] font-semibold leading-4";
-const GUARD_UPDATE_CHANNEL_CONTROL_CLASS = "inline-flex min-h-8 shrink-0 items-center rounded-sm px-0.5 text-brand-blue transition-opacity hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60";
+const GUARD_UPDATE_CHANNEL_CONTROL_CLASS = "inline-flex min-h-8 shrink-0 items-center gap-1 rounded-sm px-0.5 text-brand-blue transition-opacity hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60";
 const GUARD_UPDATE_ACTION_BUTTON_CLASS = "inline-flex min-h-8 shrink-0 items-center justify-center gap-1 rounded-full border border-brand-blue/30 bg-white px-2.5 text-brand-blue transition-colors hover:bg-brand-blue/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60";
 function GuardUpdateChannelSummary(props) {
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-w-0 items-center justify-between gap-1.5", children: [

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -20142,26 +20142,12 @@ function GuardModalLayer({
     overlayRoot
   );
 }
-const GUARD_UPDATE_CHANNEL_CONTROL_CLASS = "inline-flex min-h-8 shrink-0 items-center gap-1 rounded-sm px-0.5 text-[11px] font-semibold leading-4 text-brand-blue transition-opacity hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60";
-const GUARD_UPDATE_ACTION_BUTTON_CLASS = "inline-flex min-h-8 shrink-0 items-center justify-center gap-1 rounded-full border border-brand-blue/30 bg-white px-2.5 text-[11px] font-semibold text-brand-blue transition-colors hover:bg-brand-blue/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60";
+const GUARD_UPDATE_CONTROL_TEXT_CLASS = "text-[11px] font-semibold leading-4";
+const GUARD_UPDATE_CHANNEL_CONTROL_CLASS = "inline-flex min-h-8 shrink-0 items-center rounded-sm px-0.5 text-brand-blue transition-opacity hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60";
+const GUARD_UPDATE_ACTION_BUTTON_CLASS = "inline-flex min-h-8 shrink-0 items-center justify-center gap-1 rounded-full border border-brand-blue/30 bg-white px-2.5 text-brand-blue transition-colors hover:bg-brand-blue/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 disabled:cursor-not-allowed disabled:opacity-60";
 function GuardUpdateChannelSummary(props) {
-  let channelStatus = null;
-  if (props.useAlpha) {
-    channelStatus = /* @__PURE__ */ jsxRuntimeExports.jsxs(
-      "span",
-      {
-        className: "inline-flex min-w-0 items-center gap-1 text-[11px] font-semibold leading-4 text-brand-blue",
-        role: "status",
-        "aria-label": "Alpha updates enabled",
-        children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniBeaker, { className: "h-3 w-3 shrink-0", "aria-hidden": "true" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "truncate", children: "Alpha updates" })
-        ]
-      }
-    );
-  }
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-w-0 items-center justify-between gap-1.5", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "inline-flex min-w-0 items-center gap-1", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "inline-flex min-w-0 items-center gap-1.5", children: [
       props.version ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
         "span",
         {
@@ -20173,7 +20159,18 @@ function GuardUpdateChannelSummary(props) {
           ]
         }
       ) : null,
-      channelStatus
+      props.useAlpha ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
+        "span",
+        {
+          className: "inline-flex shrink-0 items-center gap-1 rounded-full bg-brand-blue/15 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider text-brand-blue",
+          role: "status",
+          "aria-label": "Alpha updates enabled",
+          children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniBeaker, { className: "h-2.5 w-2.5", "aria-hidden": "true" }),
+            "Alpha"
+          ]
+        }
+      ) : null
     ] }),
     props.useAlpha ? /* @__PURE__ */ jsxRuntimeExports.jsx(
       "button",
@@ -20185,7 +20182,7 @@ function GuardUpdateChannelSummary(props) {
         title: "Manage alpha updates",
         "data-testid": "guard-alpha-updates-control",
         className: GUARD_UPDATE_CHANNEL_CONTROL_CLASS,
-        children: "Manage"
+        children: /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: GUARD_UPDATE_CONTROL_TEXT_CLASS, children: "Manage" })
       }
     ) : /* @__PURE__ */ jsxRuntimeExports.jsxs(
       "button",
@@ -20196,8 +20193,8 @@ function GuardUpdateChannelSummary(props) {
         "data-testid": "guard-alpha-updates-control",
         className: GUARD_UPDATE_CHANNEL_CONTROL_CLASS,
         children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniBeaker, { className: "h-3 w-3 shrink-0", "aria-hidden": "true" }),
-          "Try alpha updates"
+          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniBeaker, { className: "h-3.5 w-3.5 shrink-0", "aria-hidden": "true" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: GUARD_UPDATE_CONTROL_TEXT_CLASS, children: "Try alpha updates" })
         ]
       }
     )
@@ -20279,57 +20276,63 @@ function GuardUpdatePanel(props) {
       version
     ] });
   }
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: props.compact ? "space-y-1" : "space-y-1.5", children: [
-    updateChannelSummary,
-    props.updateStatus?.update_available ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between gap-2", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "min-w-0 text-[11px] leading-4 text-brand-dark/75 [overflow-wrap:anywhere]", children: updateStatusLabel(props.updateStatus) }),
-      showUpdateButton && props.onUpdateGuard ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
-        "button",
-        {
-          type: "button",
-          onClick: props.onUpdateGuard,
-          "aria-label": "Update Guard to the latest version",
-          className: GUARD_UPDATE_ACTION_BUTTON_CLASS,
-          children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "h-3 w-3 shrink-0", "aria-hidden": "true" }),
-            "Update"
-          ]
-        }
-      ) : null
-    ] }) : null,
-    helpCopy ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[10px] leading-4 text-brand-dark/70", children: helpCopy }) : null,
-    showReinstallButton && props.onReinstallGuard ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
-      "button",
-      {
-        type: "button",
-        onClick: props.onReinstallGuard,
-        className: GUARD_UPDATE_ACTION_BUTTON_CLASS,
-        children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "h-3 w-3 shrink-0", "aria-hidden": "true" }),
-          "Reinstall from PyPI"
-        ]
-      }
-    ) : null,
-    busy && /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "inline-flex items-center gap-1.5 text-[11px] font-medium leading-4 text-brand-blue", role: "status", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "h-3 w-3 animate-spin", "aria-hidden": "true" }),
-      phase === "updating" ? "Updating Guard…" : "Reconnecting…"
-    ] }),
-    alphaModalOpen ? /* @__PURE__ */ jsxRuntimeExports.jsx(GuardModalLayer, { ariaLabel: modalTitle, onClose: handleCloseAlphaModal, panelClassName: "w-full max-w-md", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
-      AlphaChannelDialog,
-      {
-        useAlpha,
-        pending: alphaSavePending,
-        error: alphaSaveError,
-        approvalGate: props.approvalGate ?? null,
-        approvalPassword: alphaApprovalPassword,
-        approvalTotpCode: alphaApprovalTotpCode,
-        onClose: handleCloseAlphaModal,
-        onConfirm: handleConfirmAlphaChannel,
-        onApprovalPasswordChange: handleApprovalPasswordChange,
-        onApprovalTotpCodeChange: handleApprovalTotpCodeChange
-      }
-    ) }) : null
-  ] });
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs(
+    "div",
+    {
+      className: props.compact ? "space-y-1 border-t border-brand-blue/10 pt-1.5" : "space-y-1.5 border-t border-brand-blue/10 pt-2",
+      children: [
+        updateChannelSummary,
+        props.updateStatus?.update_available ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between gap-2", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "min-w-0 text-[11px] leading-4 text-brand-dark/75 [overflow-wrap:anywhere]", children: updateStatusLabel(props.updateStatus) }),
+          showUpdateButton && props.onUpdateGuard ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
+            "button",
+            {
+              type: "button",
+              onClick: props.onUpdateGuard,
+              "aria-label": "Update Guard to the latest version",
+              className: GUARD_UPDATE_ACTION_BUTTON_CLASS,
+              children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "h-3 w-3 shrink-0", "aria-hidden": "true" }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: GUARD_UPDATE_CONTROL_TEXT_CLASS, children: "Update" })
+              ]
+            }
+          ) : null
+        ] }) : null,
+        helpCopy ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[10px] leading-4 text-brand-dark/70", children: helpCopy }) : null,
+        showReinstallButton && props.onReinstallGuard ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          "button",
+          {
+            type: "button",
+            onClick: props.onReinstallGuard,
+            className: GUARD_UPDATE_ACTION_BUTTON_CLASS,
+            children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "h-3 w-3 shrink-0", "aria-hidden": "true" }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: GUARD_UPDATE_CONTROL_TEXT_CLASS, children: "Reinstall from PyPI" })
+            ]
+          }
+        ) : null,
+        busy && /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "inline-flex items-center gap-1.5 text-[11px] font-medium leading-4 text-brand-blue", role: "status", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "h-3 w-3 animate-spin", "aria-hidden": "true" }),
+          phase === "updating" ? "Updating Guard…" : "Reconnecting…"
+        ] }),
+        alphaModalOpen ? /* @__PURE__ */ jsxRuntimeExports.jsx(GuardModalLayer, { ariaLabel: modalTitle, onClose: handleCloseAlphaModal, panelClassName: "w-full max-w-md", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
+          AlphaChannelDialog,
+          {
+            useAlpha,
+            pending: alphaSavePending,
+            error: alphaSaveError,
+            approvalGate: props.approvalGate ?? null,
+            approvalPassword: alphaApprovalPassword,
+            approvalTotpCode: alphaApprovalTotpCode,
+            onClose: handleCloseAlphaModal,
+            onConfirm: handleConfirmAlphaChannel,
+            onApprovalPasswordChange: handleApprovalPasswordChange,
+            onApprovalTotpCodeChange: handleApprovalTotpCodeChange
+          }
+        ) }) : null
+      ]
+    }
+  );
 }
 function useGuardUpdate(options) {
   const enabled = options?.enabled !== false;

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -4122,6 +4122,10 @@
     padding-top: var(--spacing);
   }
 
+  .pt-1\.5 {
+    padding-top: calc(var(--spacing) * 1.5);
+  }
+
   .pt-2 {
     padding-top: calc(var(--spacing) * 2);
   }


### PR DESCRIPTION
## Summary
- Fix Local Guard inline controls rendering at the inherited root font size: the unlayered button font reset outranks Tailwind's layered text utilities, so Manage and Update ignored their 11px sizing. Control labels now carry font styling on an inner span, the same pattern as the card's Open Inbox action.
- Regroup the update block identity row as version plus an Alpha channel badge (mirroring the Review pill), with Manage as a quiet inline control, and separate the self-update rows from the queue status with a hairline divider so narrow cards no longer truncate the channel label or wrap the version mid-number.
- Add regression coverage pinning the inner-span label pattern, the compact inline rows, and wrap-not-clip long release strings; rebuild the served dashboard assets.

## Testing
- `cd dashboard && bun run test`
- `cd dashboard && bun run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved Guard update controls with more consistent label sizing and spacing.
  - Displayed the alpha channel as an inline badge with a beaker icon.
  - Updated the alpha action icon for improved visibility.
  - Added clearer separation and responsive spacing to the update panel.
  - Refined Update and Reinstall controls for a more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->