### PR TITLE
feat(extensions): add publisher metadata and public catalog

### DIFF
--- a/.github/workflows/extension-builder-ci.yml
+++ b/.github/workflows/extension-builder-ci.yml
@@ -13,6 +13,12 @@ on:
       - contracts/mcp-servers/**
       - contributions/extensions/**
       - contributions/mcp-servers/**
+      - contributions/extension-listings/**
+      - docs/guard/extensions/**
+      - scripts/export_extension_directory.py
+      - scripts/render_command_extension_directory.py
+      - tests/test_guard_extension_directory_export.py
+      - tests/fixtures/extension-listings/**
       - docs/guard/extension-builder/**
       - tests/*extension_builder*.py
       - tests/test_guard_extension_contribution.py
@@ -75,10 +81,15 @@ jobs:
         run: |
           mkdir -p builder-evidence
           uv run --no-sync pytest tests/test_guard_extension_builder_*.py \
+            tests/test_guard_extension_directory_export.py \
             tests/test_guard_extension_contribution.py \
             tests/test_guard_extension_trust.py \
             tests/test_guard_mcp_server_contribution.py \
             --junitxml=builder-evidence/tests.xml --tb=short
+      - name: Verify native public directory projections
+        run: |
+          uv run --no-sync python scripts/export_extension_directory.py --check
+          uv run --no-sync python scripts/render_command_extension_directory.py --check
       - name: Build and install a wheel outside the checkout
         run: |
           uv build --wheel --out-dir "$RUNNER_TEMP/extension-builder-dist"

--- a/contracts/extensions/directory.v1.schema.json
+++ b/contracts/extensions/directory.v1.schema.json
@@ -1,0 +1,228 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hol.org/guard/contracts/extension-directory.v1.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "entries"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "guard.extension-directory.v1"
+    },
+    "entries": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 512,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "runtimeExtensionId",
+          "kind",
+          "version",
+          "name",
+          "description",
+          "tagline",
+          "category",
+          "tags",
+          "limitations",
+          "documentationUrl",
+          "protectionModel",
+          "trustClass",
+          "claimPolicy",
+          "maintainerGithubIds",
+          "sourcePath",
+          "contributionDigest",
+          "executables",
+          "actionClasses",
+          "ruleCount",
+          "permissionCount",
+          "toolStates"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "maxLength": 128,
+            "pattern": "^(command|mcp)\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$"
+          },
+          "runtimeExtensionId": {
+            "type": "string",
+            "pattern": "^command\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$",
+            "maxLength": 128
+          },
+          "kind": {
+            "enum": [
+              "command",
+              "mcp"
+            ]
+          },
+          "version": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 2048
+          },
+          "tagline": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 140
+          },
+          "category": {
+            "enum": [
+              "core-safety",
+              "cloud-infrastructure",
+              "data-resilience",
+              "delivery-remote",
+              "managed-services",
+              "package-supply-chain",
+              "specialized-tools",
+              "other"
+            ]
+          },
+          "tags": {
+            "type": "array",
+            "maxItems": 8,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 30,
+              "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+            }
+          },
+          "limitations": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 8,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 10,
+              "maxLength": 400
+            }
+          },
+          "documentationUrl": {
+            "type": "string",
+            "minLength": 10,
+            "maxLength": 1024,
+            "pattern": "^https://",
+            "format": "uri"
+          },
+          "protectionModel": {
+            "enum": [
+              "required",
+              "built-in",
+              "package-firewall",
+              "external-opt-in"
+            ]
+          },
+          "trustClass": {
+            "enum": [
+              "first-party",
+              "trusted-library",
+              "external"
+            ]
+          },
+          "claimPolicy": {
+            "enum": [
+              "project",
+              "provenance"
+            ]
+          },
+          "maintainerGithubIds": {
+            "description": "Reviewed profile delegation only; never runtime or upstream ownership. Omit for automatic introducing-PR author eligibility.",
+            "type": "array",
+            "maxItems": 8,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "pattern": "^[1-9][0-9]{0,19}$"
+            }
+          },
+          "sourcePath": {
+            "type": "string",
+            "maxLength": 256,
+            "pattern": "^(contributions/(extensions|mcp-servers)/(command|mcp)\\.[a-z0-9.-]+\\.json|src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry\\.py)$"
+          },
+          "contributionDigest": {
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "string",
+                "pattern": "^sha256:[a-f0-9]{64}$"
+              }
+            ]
+          },
+          "executables": {
+            "type": "array",
+            "maxItems": 256,
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128
+            }
+          },
+          "actionClasses": {
+            "type": "array",
+            "maxItems": 256,
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256
+            }
+          },
+          "ruleCount": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 10000
+          },
+          "permissionCount": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 10000
+          },
+          "toolStates": {
+            "type": "array",
+            "maxItems": 256,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "name",
+                "state"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 128
+                },
+                "state": {
+                  "enum": [
+                    "inherit",
+                    "allow",
+                    "block"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/contracts/extensions/listing.v1.schema.json
+++ b/contracts/extensions/listing.v1.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hol.org/guard/contracts/extension-listing.v1.schema.json",
+  "title": "HOL Guard extension listing (presentation only)",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "extensionId",
+    "tagline",
+    "category",
+    "limitations"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "guard.extension-listing.v1"
+    },
+    "extensionId": {
+      "type": "string",
+      "maxLength": 128,
+      "pattern": "^(command|mcp)\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$"
+    },
+    "tagline": {
+      "type": "string",
+      "minLength": 10,
+      "maxLength": 140
+    },
+    "category": {
+      "enum": [
+        "core-safety",
+        "cloud-infrastructure",
+        "data-resilience",
+        "delivery-remote",
+        "managed-services",
+        "package-supply-chain",
+        "specialized-tools",
+        "other"
+      ]
+    },
+    "limitations": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 8,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 10,
+        "maxLength": 400
+      }
+    },
+    "documentationUrl": {
+      "type": "string",
+      "minLength": 10,
+      "maxLength": 1024,
+      "pattern": "^https://",
+      "format": "uri"
+    },
+    "tags": {
+      "type": "array",
+      "maxItems": 8,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 2,
+        "maxLength": 30,
+        "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+      }
+    },
+    "maintainerGithubIds": {
+      "description": "Reviewed profile delegation only; never runtime or upstream ownership. Omit for automatic introducing-PR author eligibility.",
+      "type": "array",
+      "maxItems": 8,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[1-9][0-9]{0,19}$"
+      }
+    }
+  }
+}

--- a/docs/guard/extensions/catalog.v1.json
+++ b/docs/guard/extensions/catalog.v1.json
@@ -1,0 +1,2042 @@
+{
+  "entries": [
+    {
+      "actionClasses": [
+        "API gateway destructive command"
+      ],
+      "category": "cloud-infrastructure",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews API and gateway deletion through supported cloud CLIs.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.api-gateway",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "API gateway command protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.api-gateway",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews API and gateway deletion through supported cloud CLIs.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Borg destructive command"
+      ],
+      "category": "data-resilience",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews Borg operations that delete, prune, or recreate archives.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.backup.borg",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Borg command protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.backup.borg",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews Borg operations that delete, prune, or recreate archives.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Rclone destructive command"
+      ],
+      "category": "data-resilience",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews rclone operations that delete, move, purge, or synchronize data.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.backup.rclone",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Rclone command protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.backup.rclone",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews rclone operations that delete, move, purge, or synchronize data.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Restic destructive command"
+      ],
+      "category": "data-resilience",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews restic operations that remove snapshots or repository data.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.backup.restic",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Restic command protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.backup.restic",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews restic operations that remove snapshots or repository data.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Velero destructive command"
+      ],
+      "category": "data-resilience",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews Velero operations that delete backup data or recovery records.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.backup.velero",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Velero command protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.backup.velero",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews Velero operations that delete backup data or recovery records.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Blitcp remote destination command",
+        "Blitcp privilege escalation command",
+        "Blitcp self-update command",
+        "Blitcp unverified copy command"
+      ],
+      "category": "other",
+      "claimPolicy": "provenance",
+      "contributionDigest": "sha256:76de69d39c41801514ad4c4bcb8137d15d5d0d3dece8068548f1d6adf00a29c1",
+      "description": "Reviews blitcp copies that leave the host, elevate privileges, or skip verification.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.blitcp",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Blitcp",
+      "permissionCount": 4,
+      "protectionModel": "external-opt-in",
+      "ruleCount": 4,
+      "runtimeExtensionId": "command.blitcp",
+      "sourcePath": "contributions/extensions/command.blitcp.json",
+      "tagline": "Reviews blitcp copies that leave the host, elevate privileges, or skip verification.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "external",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "CDN destructive command"
+      ],
+      "category": "cloud-infrastructure",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews distribution, profile, and endpoint deletion through supported cloud CLIs.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.cdn",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "CDN command protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.cdn",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews distribution, profile, and endpoint deletion through supported cloud CLIs.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "CircleCI pipeline execution command"
+      ],
+      "category": "delivery-remote",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews remote pipeline execution through CircleCI CLI.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.cicd.circleci",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "CircleCI command protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.cicd.circleci",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews remote pipeline execution through CircleCI CLI.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "GitHub Actions administrative command"
+      ],
+      "category": "delivery-remote",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews workflow-run cancellation, deletion, and workflow disabling through GitHub CLI.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.cicd.github",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "GitHub Actions command protection",
+      "permissionCount": 2,
+      "protectionModel": "built-in",
+      "ruleCount": 2,
+      "runtimeExtensionId": "command.cicd.github",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews workflow-run cancellation, deletion, and workflow disabling through GitHub CLI.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "GitLab pipeline administrative command"
+      ],
+      "category": "delivery-remote",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews remote pipeline cancellation through GitLab CLI.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.cicd.gitlab",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "GitLab CI/CD command protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.cicd.gitlab",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews remote pipeline cancellation through GitLab CLI.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "AWS destructive command"
+      ],
+      "category": "cloud-infrastructure",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews a validated AWS CLI operation matrix for permanent resource deletion and service termination.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.cloud.aws",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "AWS command protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.cloud.aws",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews a validated AWS CLI operation matrix for permanent resource deletion and service termination.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Azure destructive command"
+      ],
+      "category": "cloud-infrastructure",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews a validated Azure CLI operation matrix for permanent resource deletion across subscription, identity, network, compute, application, data, messaging, and AI services.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.cloud.azure",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Azure command protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.cloud.azure",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews a validated Azure CLI operation matrix for permanent resource deletion across subscription, identity, network, compute, application,",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Google Cloud destructive command"
+      ],
+      "category": "cloud-infrastructure",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews a validated gcloud operation matrix for permanent resource deletion across stable and supported release tracks.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.cloud.gcp",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Google Cloud command protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.cloud.gcp",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews a validated gcloud operation matrix for permanent resource deletion across stable and supported release tracks.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "docker-sensitive command",
+        "Docker client config access"
+      ],
+      "category": "core-safety",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews container lifecycle, cleanup, execution, network, and persistent-data operations that can expose credentials or mutate host state.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.container-runtime",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Container runtime protection",
+      "permissionCount": 21,
+      "protectionModel": "built-in",
+      "ruleCount": 21,
+      "runtimeExtensionId": "command.container-runtime",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews container lifecycle, cleanup, execution, network, and persistent-data operations that can expose credentials or mutate host state.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "first-party",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "credential exfiltration shell command",
+        "shell file upload command"
+      ],
+      "category": "core-safety",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Detects shell flows that can send credentials or local file contents to a network destination.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.data-protection",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Command data protection",
+      "permissionCount": 2,
+      "protectionModel": "built-in",
+      "ruleCount": 2,
+      "runtimeExtensionId": "command.data-protection",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Detects shell flows that can send credentials or local file contents to a network destination.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "first-party",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "MongoDB destructive command"
+      ],
+      "category": "data-resilience",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews restore operations that drop and replace collections.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.database.mongodb",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "MongoDB command protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.database.mongodb",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews restore operations that drop and replace collections.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "MySQL destructive command"
+      ],
+      "category": "data-resilience",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews mysqladmin database removal operations.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.database.mysql",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "MySQL command protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.database.mysql",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews mysqladmin database removal operations.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "PostgreSQL destructive command"
+      ],
+      "category": "data-resilience",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews explicit PostgreSQL database removal commands.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.database.postgresql",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "PostgreSQL command protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.database.postgresql",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews explicit PostgreSQL database removal commands.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Redis destructive command"
+      ],
+      "category": "data-resilience",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews Redis key deletion and database flush commands.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.database.redis",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Redis command protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.database.redis",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews Redis key deletion and database flush commands.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "SQLite destructive command"
+      ],
+      "category": "data-resilience",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews SQLite restore operations that replace database content.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.database.sqlite",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "SQLite command protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.database.sqlite",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews SQLite restore operations that replace database content.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Supabase destructive command"
+      ],
+      "category": "data-resilience",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews database reset and migration rollback commands.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.database.supabase",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Supabase command protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.database.supabase",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews database reset and migration rollback commands.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "DNS destructive command"
+      ],
+      "category": "cloud-infrastructure",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews hosted-zone deletion through supported cloud CLIs.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.dns",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "DNS command protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.dns",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews hosted-zone deletion through supported cloud CLIs.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Email destructive command"
+      ],
+      "category": "managed-services",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews email identity and contact-list deletion through AWS CLI.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.email",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Email service command protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.email",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews email identity and contact-list deletion through AWS CLI.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "encoded or encrypted shell command"
+      ],
+      "category": "core-safety",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews decode-and-execute flows whose effective program is hidden from normal command inspection.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.encoded-execution",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Encoded execution protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.encoded-execution",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews decode-and-execute flows whose effective program is hidden from normal command inspection.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "first-party",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Feature flag destructive command"
+      ],
+      "category": "managed-services",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews permanent feature-flag deletion through LaunchDarkly CLI.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.feature-flags",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Feature flag command protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.feature-flags",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews permanent feature-flag deletion through LaunchDarkly CLI.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "filesystem destructive command"
+      ],
+      "category": "core-safety",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews recursive deletion and access-control changes across filesystem trees.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.filesystem",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Filesystem protection",
+      "permissionCount": 2,
+      "protectionModel": "required",
+      "ruleCount": 2,
+      "runtimeExtensionId": "command.filesystem",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews recursive deletion and access-control changes across filesystem trees.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "first-party",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Laravel database wipe command",
+        "Laravel destructive rebuild command",
+        "Laravel migration reset command",
+        "Laravel migration rollback command",
+        "Laravel queue purge command"
+      ],
+      "category": "other",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews destructive Artisan database wipes, migration resets, and queue purges.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.framework.laravel",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Laravel command protection",
+      "permissionCount": 5,
+      "protectionModel": "built-in",
+      "ruleCount": 5,
+      "runtimeExtensionId": "command.framework.laravel",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews destructive Artisan database wipes, migration resets, and queue purges.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "git destructive command",
+        "git origin refresh",
+        "git index inspection",
+        "git workspace command",
+        "git read command"
+      ],
+      "category": "core-safety",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews everyday Git porcelain plus local and remote operations that can discard work, replace history, refresh a remote Guard cannot verify, or read a staged index Guard cannot bound.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.git",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Git protection",
+      "permissionCount": 39,
+      "protectionModel": "required",
+      "ruleCount": 39,
+      "runtimeExtensionId": "command.git",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews everyday Git porcelain plus local and remote operations that can discard work, replace history, refresh a remote Guard cannot verify",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "first-party",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "GitHub routine pull-request merge command",
+        "GitHub workflow rerun",
+        "GitHub local configuration write",
+        "GitHub bounded maintenance command",
+        "GitHub content mutation command",
+        "GitHub merge command",
+        "GitHub administrator pull-request merge command",
+        "GitHub release publication command",
+        "GitHub workflow mutation command",
+        "GitHub force mutation command",
+        "GitHub delete command",
+        "GitHub secret mutation command",
+        "GitHub access mutation command",
+        "GitHub remote mutation command",
+        "Unverified GitHub command capability"
+      ],
+      "category": "delivery-remote",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews distinct GitHub maintenance, content, merge, publication, workflow, and control effects.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.github",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "GitHub capability protection",
+      "permissionCount": 19,
+      "protectionModel": "built-in",
+      "ruleCount": 15,
+      "runtimeExtensionId": "command.github",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews distinct GitHub maintenance, content, merge, publication, workflow, and control effects.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Guard approval self-authorization command"
+      ],
+      "category": "core-safety",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Prevents commands from authorizing their own Guard approval or weakening protected Guard state.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.guard-self-protection",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Guard self-protection",
+      "permissionCount": 1,
+      "protectionModel": "required",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.guard-self-protection",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Prevents commands from authorizing their own Guard approval or weakening protected Guard state.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "first-party",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "infrastructure destructive command"
+      ],
+      "category": "cloud-infrastructure",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews infrastructure teardown through Terraform, OpenTofu, and Pulumi.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.infrastructure-as-code",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Infrastructure-as-code protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.infrastructure-as-code",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews infrastructure teardown through Terraform, OpenTofu, and Pulumi.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Kubernetes destructive command",
+        "Kubernetes remote execution command",
+        "Kubernetes network tunnel command",
+        "Kubernetes remote file transfer command",
+        "Kubernetes security administration command"
+      ],
+      "category": "cloud-infrastructure",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews cluster mutations, remote execution, file transfer, tunnels, certificate decisions, and Helm lifecycle operations.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.kubernetes-operations",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Kubernetes operation protection",
+      "permissionCount": 28,
+      "protectionModel": "built-in",
+      "ruleCount": 28,
+      "runtimeExtensionId": "command.kubernetes-operations",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews cluster mutations, remote execution, file transfer, tunnels, certificate decisions, and Helm lifecycle operations.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Kubernetes secret read command"
+      ],
+      "category": "core-safety",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews Kubernetes CLI operations that can reveal cluster or application secrets.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.kubernetes-secrets",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Kubernetes secret protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.kubernetes-secrets",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews Kubernetes CLI operations that can reveal cluster or application secrets.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "first-party",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Load balancer destructive command"
+      ],
+      "category": "cloud-infrastructure",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews load-balancer and forwarding-rule deletion through supported cloud CLIs.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.load-balancer",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Load balancer command protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.load-balancer",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews load-balancer and forwarding-rule deletion through supported cloud CLIs.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Kafka destructive command"
+      ],
+      "category": "managed-services",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews Kafka topic, group, offset, and record deletion operations.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.messaging.kafka",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Kafka command protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.messaging.kafka",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews Kafka topic, group, offset, and record deletion operations.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "NATS destructive command"
+      ],
+      "category": "managed-services",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews NATS stream, consumer, key-value, and object-store removal operations.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.messaging.nats",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "NATS command protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.messaging.nats",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews NATS stream, consumer, key-value, and object-store removal operations.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "RabbitMQ destructive command"
+      ],
+      "category": "managed-services",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews RabbitMQ deletion and broker reset operations.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.messaging.rabbitmq",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "RabbitMQ command protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.messaging.rabbitmq",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews RabbitMQ deletion and broker reset operations.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Monitoring destructive command"
+      ],
+      "category": "managed-services",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews alarm and alert deletion through supported cloud CLIs.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.monitoring",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Monitoring command protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.monitoring",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews alarm and alert deletion through supported cloud CLIs.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Noodle request execution command"
+      ],
+      "category": "other",
+      "claimPolicy": "provenance",
+      "contributionDigest": "sha256:ddca522461de9e0244be95c4acee3d50e9e2d8cc07a17c788eb5f604dd5d3fa6",
+      "description": "Reviews Noodle terminal REST client request and collection runs.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.noodle",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Noodle",
+      "permissionCount": 1,
+      "protectionModel": "external-opt-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.noodle",
+      "sourcePath": "contributions/extensions/command.noodle.json",
+      "tagline": "Reviews Noodle terminal REST client request and collection runs.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "external",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [],
+      "category": "package-supply-chain",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Routes Go module and tool installation requests through Guard's package firewall.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [
+        "go"
+      ],
+      "id": "command.package.go",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Go package protection",
+      "permissionCount": 1,
+      "protectionModel": "package-firewall",
+      "ruleCount": 0,
+      "runtimeExtensionId": "command.package.go",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Routes Go module and tool installation requests through Guard's package firewall.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "first-party",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [],
+      "category": "package-supply-chain",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Routes Maven and Gradle dependency operations through Guard's package firewall.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [
+        "mvn",
+        "mvnw",
+        "gradle",
+        "gradlew"
+      ],
+      "id": "command.package.jvm",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "JVM package protection",
+      "permissionCount": 1,
+      "protectionModel": "package-firewall",
+      "ruleCount": 0,
+      "runtimeExtensionId": "command.package.jvm",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Routes Maven and Gradle dependency operations through Guard's package firewall.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "first-party",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [],
+      "category": "package-supply-chain",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Routes Node package installs and one-shot execution through Guard's package firewall.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [
+        "npm",
+        "npx",
+        "pnpm",
+        "yarn",
+        "bun",
+        "bunx"
+      ],
+      "id": "command.package.node",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Node package protection",
+      "permissionCount": 1,
+      "protectionModel": "package-firewall",
+      "ruleCount": 0,
+      "runtimeExtensionId": "command.package.node",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Routes Node package installs and one-shot execution through Guard's package firewall.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "first-party",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [],
+      "category": "package-supply-chain",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Routes Composer dependency operations through Guard's package firewall.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [
+        "composer"
+      ],
+      "id": "command.package.php",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "PHP package protection",
+      "permissionCount": 1,
+      "protectionModel": "package-firewall",
+      "ruleCount": 0,
+      "runtimeExtensionId": "command.package.php",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Routes Composer dependency operations through Guard's package firewall.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "first-party",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [],
+      "category": "package-supply-chain",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Routes Python dependency installs and isolated package execution through Guard's package firewall.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [
+        "pip",
+        "pip3",
+        "pipx",
+        "uv",
+        "uvx",
+        "poetry",
+        "pipenv"
+      ],
+      "id": "command.package.python",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Python package protection",
+      "permissionCount": 1,
+      "protectionModel": "package-firewall",
+      "ruleCount": 0,
+      "runtimeExtensionId": "command.package.python",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Routes Python dependency installs and isolated package execution through Guard's package firewall.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "first-party",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [],
+      "category": "package-supply-chain",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Routes RubyGem and Bundler dependency operations through Guard's package firewall.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [
+        "gem",
+        "bundle",
+        "bundler"
+      ],
+      "id": "command.package.ruby",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Ruby package protection",
+      "permissionCount": 1,
+      "protectionModel": "package-firewall",
+      "ruleCount": 0,
+      "runtimeExtensionId": "command.package.ruby",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Routes RubyGem and Bundler dependency operations through Guard's package firewall.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "first-party",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [],
+      "category": "package-supply-chain",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Routes Cargo dependency and binary installation requests through Guard's package firewall.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [
+        "cargo"
+      ],
+      "id": "command.package.rust",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Rust package protection",
+      "permissionCount": 1,
+      "protectionModel": "package-firewall",
+      "ruleCount": 0,
+      "runtimeExtensionId": "command.package.rust",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Routes Cargo dependency and binary installation requests through Guard's package firewall.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "first-party",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [],
+      "category": "package-supply-chain",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Routes operating-system package installation requests through Guard's package firewall.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [
+        "apt",
+        "apt-get",
+        "yum",
+        "dnf",
+        "apk",
+        "pacman",
+        "zypper",
+        "brew"
+      ],
+      "id": "command.package.system",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "System package protection",
+      "permissionCount": 1,
+      "protectionModel": "package-firewall",
+      "ruleCount": 0,
+      "runtimeExtensionId": "command.package.system",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Routes operating-system package installation requests through Guard's package firewall.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "first-party",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Payment destructive command"
+      ],
+      "category": "managed-services",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews product, coupon, customer, and webhook endpoint deletion through Stripe CLI.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.payment",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Payment service command protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.payment",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews product, coupon, customer, and webhook endpoint deletion through Stripe CLI.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Heroku destructive command",
+        "Heroku release command"
+      ],
+      "category": "delivery-remote",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews app destruction, pipeline promotion, and release rollback.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.platform.heroku",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Heroku command protection",
+      "permissionCount": 2,
+      "protectionModel": "built-in",
+      "ruleCount": 2,
+      "runtimeExtensionId": "command.platform.heroku",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews app destruction, pipeline promotion, and release rollback.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Netlify destructive command",
+        "Netlify production command"
+      ],
+      "category": "delivery-remote",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews site deletion and production deployments.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.platform.netlify",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Netlify command protection",
+      "permissionCount": 2,
+      "protectionModel": "built-in",
+      "ruleCount": 2,
+      "runtimeExtensionId": "command.platform.netlify",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews site deletion and production deployments.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Vercel destructive command",
+        "Vercel production command"
+      ],
+      "category": "delivery-remote",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews deployment and project deletion plus production deployment, promotion, and rollback.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.platform.vercel",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Vercel command protection",
+      "permissionCount": 2,
+      "protectionModel": "built-in",
+      "ruleCount": 2,
+      "runtimeExtensionId": "command.platform.vercel",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews deployment and project deletion plus production deployment, promotion, and rollback.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Probe request execution command",
+        "Probe workspace mutation command",
+        "Probe destructive command"
+      ],
+      "category": "other",
+      "claimPolicy": "provenance",
+      "contributionDigest": "sha256:52d5017ac9ab2a3d824196f5885272ffe1cd7cf80f5f78019458ba5360811e9b",
+      "description": "Reviews HTTP execution and OpenCollection workspace mutations through the Probe CLI.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.probe",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Probe",
+      "permissionCount": 8,
+      "protectionModel": "external-opt-in",
+      "ruleCount": 8,
+      "runtimeExtensionId": "command.probe",
+      "sourcePath": "contributions/extensions/command.probe.json",
+      "tagline": "Reviews HTTP execution and OpenCollection workspace mutations through the Probe CLI.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "external",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "essh group execution command",
+        "essh cache removal command"
+      ],
+      "category": "delivery-remote",
+      "claimPolicy": "provenance",
+      "contributionDigest": "sha256:e7cea64f5372fcc2eac66470d2159e7d52d5572300e415897e89a97236225d7b",
+      "description": "Reviews essh host group execution and removal of cached hosts, keys, and workspaces.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.remote.essh",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "essh",
+      "permissionCount": 2,
+      "protectionModel": "external-opt-in",
+      "ruleCount": 2,
+      "runtimeExtensionId": "command.remote.essh",
+      "sourcePath": "contributions/extensions/command.remote.essh.json",
+      "tagline": "Reviews essh host group execution and removal of cached hosts, keys, and workspaces.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "external",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Rsync destructive command",
+        "Rsync remote shell command"
+      ],
+      "category": "delivery-remote",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews rsync options that delete destination data or remove synchronized source files.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.remote.rsync",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Rsync deletion protection",
+      "permissionCount": 2,
+      "protectionModel": "built-in",
+      "ruleCount": 2,
+      "runtimeExtensionId": "command.remote.rsync",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews rsync options that delete destination data or remove synchronized source files.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "SCP overwrite command"
+      ],
+      "category": "delivery-remote",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews SCP transfers that can overwrite local or remote destination files.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.remote.scp",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "SCP transfer protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.remote.scp",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews SCP transfers that can overwrite local or remote destination files.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "SSH remote execution command",
+        "SSH configured execution command"
+      ],
+      "category": "delivery-remote",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews SSH invocations that explicitly execute a remote command.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.remote.ssh",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "SSH remote execution protection",
+      "permissionCount": 2,
+      "protectionModel": "built-in",
+      "ruleCount": 2,
+      "runtimeExtensionId": "command.remote.ssh",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews SSH invocations that explicitly execute a remote command.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "repo2nb forced directory overwrite command",
+        "repo2nb notebook sync command"
+      ],
+      "category": "other",
+      "claimPolicy": "provenance",
+      "contributionDigest": "sha256:27ea5b9d3bc2e4786c8526afc75d0d9efa129023949e5d49b594b0b820a300d3",
+      "description": "Reviews repo2nb commands that can overwrite a destination directory or drop untracked notebook cells.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.repo2nb",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "repo2nb",
+      "permissionCount": 2,
+      "protectionModel": "external-opt-in",
+      "ruleCount": 2,
+      "runtimeExtensionId": "command.repo2nb",
+      "sourcePath": "contributions/extensions/command.repo2nb.json",
+      "tagline": "Reviews repo2nb commands that can overwrite a destination directory or drop untracked notebook cells.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "external",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Elasticsearch destructive command"
+      ],
+      "category": "managed-services",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews explicit DELETE requests to recognizable Elasticsearch API targets.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.search.elasticsearch",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Elasticsearch command protection",
+      "permissionCount": 1,
+      "protectionModel": "built-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.search.elasticsearch",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews explicit DELETE requests to recognizable Elasticsearch API targets.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "destructive shell command",
+        "guard-managed config write",
+        "sensitive local file write",
+        "GitHub PR body shell substitution",
+        "process environment secret read"
+      ],
+      "category": "core-safety",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews destructive shell, Git, filesystem, redirection, and protected configuration mutations.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.shell-mutations",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Shell, Git, and filesystem protection",
+      "permissionCount": 5,
+      "protectionModel": "built-in",
+      "ruleCount": 5,
+      "runtimeExtensionId": "command.shell-mutations",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews destructive shell, Git, filesystem, redirection, and protected configuration mutations.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "first-party",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Skill Sunset configuration audit command"
+      ],
+      "category": "specialized-tools",
+      "claimPolicy": "provenance",
+      "contributionDigest": "sha256:fcd38eacd06e48f50c905ea417cafa9bb5eab761c4c1f102887d0b48b2ea9ae8",
+      "description": "Reviews the Skill Sunset audit surface and its local report and viewer side effects.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.skill-sunset",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Skill Sunset",
+      "permissionCount": 1,
+      "protectionModel": "external-opt-in",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.skill-sunset",
+      "sourcePath": "contributions/extensions/command.skill-sunset.json",
+      "tagline": "Reviews the Skill Sunset audit surface and its local report and viewer side effects.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "external",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "AWS storage destructive command"
+      ],
+      "category": "data-resilience",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews AWS CLI S3 commands including copy, list, sync, website, and deletion.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.storage.aws-s3",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Amazon S3 command protection",
+      "permissionCount": 8,
+      "protectionModel": "built-in",
+      "ruleCount": 8,
+      "runtimeExtensionId": "command.storage.aws-s3",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews AWS CLI S3 commands including copy, list, sync, website, and deletion.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Azure storage destructive command"
+      ],
+      "category": "data-resilience",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews Azure CLI storage commands including upload, list, copy, and deletion.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.storage.azure-blob",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Azure Blob Storage command protection",
+      "permissionCount": 6,
+      "protectionModel": "built-in",
+      "ruleCount": 6,
+      "runtimeExtensionId": "command.storage.azure-blob",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews Azure CLI storage commands including upload, list, copy, and deletion.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "Google storage destructive command"
+      ],
+      "category": "data-resilience",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews Google CLI storage commands including copy, list, sync, and deletion.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.storage.google-cloud",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Google Cloud Storage command protection",
+      "permissionCount": 7,
+      "protectionModel": "built-in",
+      "ruleCount": 7,
+      "runtimeExtensionId": "command.storage.google-cloud",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews Google CLI storage commands including copy, list, sync, and deletion.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "MinIO storage destructive command"
+      ],
+      "category": "data-resilience",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews MinIO Client commands including copy, list, mirror, and deletion.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.storage.minio",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "MinIO command protection",
+      "permissionCount": 7,
+      "protectionModel": "built-in",
+      "ruleCount": 7,
+      "runtimeExtensionId": "command.storage.minio",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews MinIO Client commands including copy, list, mirror, and deletion.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "trusted-library",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "system destructive command"
+      ],
+      "category": "core-safety",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews storage formatting and operating-system power-state mutations.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.system",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "System protection",
+      "permissionCount": 1,
+      "protectionModel": "required",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.system",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews storage formatting and operating-system power-state mutations.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "first-party",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "windows destructive command"
+      ],
+      "category": "core-safety",
+      "claimPolicy": "project",
+      "contributionDigest": null,
+      "description": "Reviews destructive Windows storage and operating-system commands.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [],
+      "id": "command.windows",
+      "kind": "command",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Windows protection",
+      "permissionCount": 1,
+      "protectionModel": "required",
+      "ruleCount": 1,
+      "runtimeExtensionId": "command.windows",
+      "sourcePath": "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+      "tagline": "Reviews destructive Windows storage and operating-system commands.",
+      "tags": [],
+      "toolStates": [],
+      "trustClass": "first-party",
+      "version": "1.0.0"
+    },
+    {
+      "actionClasses": [
+        "mcp filesystem tool"
+      ],
+      "category": "specialized-tools",
+      "claimPolicy": "provenance",
+      "contributionDigest": "sha256:76029271d274eeff26ffb4b4dbca0029dfc3d1ac1ff2d98a5d6b5d5968ed2027",
+      "description": "Reviews official filesystem MCP tools. Off until you turn it on.",
+      "documentationUrl": "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+      "executables": [
+        "npx"
+      ],
+      "id": "mcp.filesystem",
+      "kind": "mcp",
+      "limitations": [
+        "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+        "A maintainer profile is not a security certification or an official upstream endorsement."
+      ],
+      "maintainerGithubIds": [],
+      "name": "Filesystem MCP",
+      "permissionCount": 1,
+      "protectionModel": "external-opt-in",
+      "ruleCount": 0,
+      "runtimeExtensionId": "command.mcp-filesystem",
+      "sourcePath": "contributions/mcp-servers/mcp.filesystem.json",
+      "tagline": "Reviews official filesystem MCP tools. Off until you turn it on.",
+      "tags": [],
+      "toolStates": [
+        {
+          "name": "read_file",
+          "state": "inherit"
+        },
+        {
+          "name": "write_file",
+          "state": "block"
+        },
+        {
+          "name": "edit_file",
+          "state": "block"
+        },
+        {
+          "name": "move_file",
+          "state": "block"
+        },
+        {
+          "name": "create_directory",
+          "state": "inherit"
+        },
+        {
+          "name": "other",
+          "state": "inherit"
+        }
+      ],
+      "trustClass": "external",
+      "version": "1.0.0"
+    }
+  ],
+  "schemaVersion": "guard.extension-directory.v1"
+}

--- a/docs/guard/extensions/contributing.md
+++ b/docs/guard/extensions/contributing.md
@@ -105,3 +105,11 @@ Maintainers evaluate Extension changes against these merge gates:
 - **Operability**: clear safer alternatives, authoritative references, directory entry, and focused tests.
 
 A change is complete only when code, catalog, documentation, and tests describe the same protection boundary.
+
+## Public profile and presentation metadata
+
+A merged external contribution can also have a public publisher profile. See
+[publisher metadata](publisher-metadata.md) for optional listing fields, numeric
+GitHub attribution, generated directory validation, and the boundary between a
+profile claim and runtime security authority. This does not change the contribution
+review or runtime activation requirements above.

--- a/docs/guard/extensions/publisher-metadata.md
+++ b/docs/guard/extensions/publisher-metadata.md
@@ -1,0 +1,106 @@
+# Extension publisher metadata
+
+HOL Guard Extensions separates a contributor's public profile from an extension's
+security behavior. Claiming a profile must never enable an extension, change its
+trust class, approve a command, or imply that the contributor owns the upstream tool.
+
+## Identity and eligibility
+
+The stable contribution ID is the public identity. For example, `command.blitcp`
+uses `contributions/extensions/command.blitcp.json`. An MCP contribution such as
+`mcp.filesystem` keeps that identity even though its runtime catalog entry is
+`command.mcp-filesystem`.
+
+The publisher workflow verifies the numeric GitHub account that authored the
+merged pull request introducing that specific file. A profile URL, username,
+repository membership, or authorship of an unrelated change is not sufficient.
+The contribution must still exist on the canonical `main` history. Ambiguous
+history, renames, direct pushes, or disputed attribution require maintainer review.
+An ordinary later edit does not replace the original contributor's claim.
+
+First-party and trusted-library coverage is project-maintained, not automatically
+claimable by the last person who edited its source.
+
+## Optional presentation file
+
+Existing contributors do not need a new metadata file merely to establish the
+introducing-PR relationship. Optional presentation metadata belongs in:
+
+```text
+contributions/extension-listings/<contribution-id>.json
+```
+
+For example, this is a valid presentation file for `command.blitcp`:
+
+```json
+{
+  "schemaVersion": "guard.extension-listing.v1",
+  "extensionId": "command.blitcp",
+  "tagline": "Reviewed file-transfer operation coverage for blitcp.",
+  "category": "delivery-remote",
+  "limitations": [
+    "Coverage is limited to the reviewed operations and the surrounding Guard policy."
+  ],
+  "documentationUrl": "https://github.com/hashgraph-online/hol-guard",
+  "tags": ["file-transfer"]
+}
+```
+
+The schema is [`listing.v1.schema.json`](../../../contracts/extensions/listing.v1.schema.json).
+It rejects unknown fields, control characters, unbounded prose, duplicate values,
+unsafe links, identity mismatches, and symlinked files. URLs are references only;
+validation never fetches them. Use a public HTTPS hostname, not a literal IP address,
+local host, credential-bearing URL, or nonstandard port.
+
+Do not add `activation`, `trustClass`, policy decisions, executable code, email
+addresses, secrets, or commands to presentation metadata. Runtime contribution
+contracts remain separate and strict.
+
+### Reviewed delegation
+
+`maintainerGithubIds` may contain up to eight numeric GitHub user IDs represented
+as decimal strings. Omit it unless maintainers have reviewed the delegation. This
+field can establish an additional eligible profile claimant; it does not create
+runtime trust or establish ownership of an upstream product. Once claimed,
+additional roles and transfers require the existing publisher's explicit
+invitation and the named account's acceptance. Renaming a GitHub account must not
+change ownership.
+
+## Builder compatibility
+
+Builder 1.1 creates an inert `listing-template.json` beside its README. Review it
+before copying it into the optional presentation directory. The template does not
+infer a GitHub identity and is not installed as a runtime artifact.
+
+Builder 1.0 kits remain byte-reproducible and verifiable. Updating an old kit to
+1.1 adds presentation guidance without changing its native artifacts or native
+revision digest. Existing ownership-file and local-edit protections still apply.
+
+## Public catalog projection
+
+Generate and verify the catalog from the canonical native registry:
+
+```bash
+uv run python scripts/export_extension_directory.py
+uv run python scripts/export_extension_directory.py --check
+uv run python scripts/render_command_extension_directory.py --check
+```
+
+The generated [`catalog.v1.json`](catalog.v1.json) follows
+[`directory.v1.schema.json`](../../../contracts/extensions/directory.v1.schema.json).
+It carries source IDs, exact contribution digests, runtime IDs, coverage counts,
+MCP inheritance, trust classes, and presentation fields. It does not contain
+activation decisions, install counts, ratings, certification claims, or secrets.
+An entry being present in this catalog does not mean it is enabled on any device.
+
+Consumers should pin an immutable source commit, verify provenance independently,
+and distinguish merged source from an actually published release. A public
+maintainer profile is not a security certification or an upstream endorsement.
+
+## Publisher workflow availability
+
+The catalog and metadata contract are independently useful to directory consumers.
+The companion Guard Cloud Extension Studio rollout is tracked separately. Do not
+send claim reminders until the deployed claim route has passed its production
+canary. The planned entry point is `/guard/extension-studio?extension=<id>`;
+possession of that link grants no authority.

--- a/scripts/export_extension_directory.py
+++ b/scripts/export_extension_directory.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Export the public extension directory from trusted canonical source, without network I/O."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+from codex_plugin_scanner.guard.extension_builder.errors import BuilderError
+from codex_plugin_scanner.guard.extension_builder.io import checked_path
+from codex_plugin_scanner.guard.extension_builder.listing import (
+    DEFAULT_LIMITATIONS,
+    category_for_extension,
+    load_listing,
+)
+from codex_plugin_scanner.guard.runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
+from codex_plugin_scanner.guard.runtime.extension_contribution import validate_contribution_file
+from codex_plugin_scanner.guard.runtime.extension_trust import trust_class_for
+from codex_plugin_scanner.guard.runtime.mcp_server_contribution import (
+    catalog_id_for_mcp_id,
+    validate_mcp_contribution_file,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+OUTPUT = ROOT / "docs/guard/extensions/catalog.v1.json"
+MAX_ENTRIES = 512
+MAX_SOURCE_BYTES = 1_048_576
+
+
+def _sources(root: Path) -> dict[str, tuple[str, dict[str, object], str]]:
+    result: dict[str, tuple[str, dict[str, object], str]] = {}
+    for directory, validate in (
+        ("extensions", validate_contribution_file),
+        ("mcp-servers", validate_mcp_contribution_file),
+    ):
+        parent = checked_path(root / "contributions" / directory)
+        for path in sorted(parent.glob("*.json")):
+            checked_path(path)
+            if not path.is_file() or path.stat().st_size > MAX_SOURCE_BYTES:
+                raise ValueError("Contribution is not a bounded regular source file")
+            payload = validate(path)
+            extension_id = str(payload["id"])
+            if path.name != f"{extension_id}.json" or extension_id in result:
+                raise ValueError("Contribution identity is duplicated or does not match its filename")
+            result[extension_id] = (
+                path.relative_to(root).as_posix(),
+                payload,
+                "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest(),
+            )
+            if len(result) > MAX_ENTRIES:
+                raise ValueError("Public directory source count exceeds its budget")
+    return result
+
+
+def export_directory(root: Path = ROOT) -> dict[str, object]:
+    sources = _sources(root)
+    listings: dict[str, dict[str, object]] = {}
+    parent = checked_path(root / "contributions/extension-listings")
+    if parent.exists():
+        paths = sorted(parent.glob("*.json"))
+        if len(paths) > MAX_ENTRIES:
+            raise ValueError("Listing count exceeds its budget")
+        for path in paths:
+            extension_id = path.stem
+            if extension_id not in sources:
+                raise ValueError("A listing must belong to an existing external native contribution")
+            listings[extension_id] = load_listing(path, expected_id=extension_id)
+    mcp_ids = {catalog_id_for_mcp_id(key): key for key in sources if key.startswith("mcp.")}
+    entries: list[dict[str, object]] = []
+    seen: set[str] = set()
+    for native in BUILT_IN_COMMAND_EXTENSION_REGISTRY.extensions:
+        extension_id = mcp_ids.get(native.extension_id, native.extension_id)
+        source = sources.get(extension_id)
+        payload: dict[str, object] = source[1] if source else {}
+        listing = listings.get(extension_id, {})
+        external = trust_class_for(native.extension_id) == "external"
+        if external and source is None:
+            raise ValueError("An external native extension must have a canonical contribution source")
+        if native.required:
+            model = "required"
+        elif native.delegated_protection == "package-firewall":
+            model = "package-firewall"
+        elif external:
+            model = "external-opt-in"
+        else:
+            model = "built-in"
+        tools = payload.get("tools", [])
+        entries.append(
+            {
+                "id": extension_id,
+                "runtimeExtensionId": native.extension_id,
+                "kind": "mcp" if extension_id.startswith("mcp.") else "command",
+                "version": native.version,
+                "name": str(payload.get("name", native.name)),
+                "description": str(payload.get("description", native.description)),
+                "tagline": listing.get("tagline", str(payload.get("description", native.description))[:140]),
+                "category": listing.get("category", category_for_extension(extension_id)),
+                "tags": listing.get("tags", []),
+                "limitations": listing.get("limitations", list(DEFAULT_LIMITATIONS)),
+                "documentationUrl": listing.get(
+                    "documentationUrl",
+                    "https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/extensions/README.md",
+                ),
+                "protectionModel": model,
+                "trustClass": trust_class_for(native.extension_id),
+                "claimPolicy": "provenance" if external else "project",
+                "maintainerGithubIds": listing.get("maintainerGithubIds", []),
+                "sourcePath": source[0]
+                if source
+                else "src/codex_plugin_scanner/guard/runtime/command_builtin_extension_registry.py",
+                "contributionDigest": source[2] if source else None,
+                "executables": list(native.executables),
+                "actionClasses": list(native.action_classes),
+                "ruleCount": len(native.rules),
+                "permissionCount": len(native.permissions),
+                "toolStates": tools,
+            }
+        )
+        seen.add(extension_id)
+    if set(sources) - seen:
+        raise ValueError("A source contribution is absent from the canonical native registry")
+    if len(entries) > MAX_ENTRIES or len(seen) != len(entries):
+        raise ValueError("Public directory has duplicate or excessive entries")
+    return {
+        "schemaVersion": "guard.extension-directory.v1",
+        "entries": sorted(entries, key=lambda item: str(item["id"])),
+    }
+
+
+def render_directory(root: Path = ROOT) -> str:
+    return json.dumps(export_directory(root), indent=2, ensure_ascii=True, sort_keys=True) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args(argv)
+    try:
+        rendered = render_directory()
+    except (BuilderError, OSError, ValueError) as error:
+        parser.error(str(error))
+    if args.check:
+        if not OUTPUT.is_file() or OUTPUT.read_text(encoding="utf-8") != rendered:
+            parser.error("Extension catalog is stale; run python scripts/export_extension_directory.py")
+    else:
+        OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+        OUTPUT.write_text(rendered, encoding="utf-8", newline="\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_command_extension_directory.py
+++ b/scripts/render_command_extension_directory.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+from codex_plugin_scanner.guard.extension_builder.listing import CATEGORY_LABELS, category_for_extension
 from codex_plugin_scanner.guard.runtime.command_extensions import (
     BUILT_IN_COMMAND_EXTENSION_REGISTRY,
     CommandSafetyExtension,
@@ -45,35 +46,7 @@ CORE_EXTENSION_IDS = frozenset(
 
 
 def _category(extension_id: str) -> str:
-    if extension_id in CORE_EXTENSION_IDS:
-        return "Core safety"
-    if extension_id in {
-        "command.api-gateway",
-        "command.cdn",
-        "command.dns",
-        "command.infrastructure-as-code",
-        "command.kubernetes-operations",
-        "command.load-balancer",
-    } or extension_id.startswith("command.cloud."):
-        return "Cloud and infrastructure"
-    if extension_id.startswith(("command.backup.", "command.database.", "command.storage.")):
-        return "Data and resilience"
-    if extension_id == "command.github" or extension_id.startswith(
-        ("command.cicd.", "command.platform.", "command.remote.")
-    ):
-        return "Delivery and remote operations"
-    if extension_id in {
-        "command.email",
-        "command.feature-flags",
-        "command.monitoring",
-        "command.payment",
-    } or extension_id.startswith(("command.messaging.", "command.search.")):
-        return "Managed services"
-    if extension_id.startswith("command.package."):
-        return "Package supply chain"
-    if extension_id == "command.skill-sunset" or extension_id.startswith("command.mcp-"):
-        return "Specialized tools"
-    return "Other extensions"
+    return CATEGORY_LABELS[category_for_extension(extension_id)]
 
 
 def _escape_cell(value: str) -> str:

--- a/src/codex_plugin_scanner/guard/extension_builder/__init__.py
+++ b/src/codex_plugin_scanner/guard/extension_builder/__init__.py
@@ -1,3 +1,4 @@
 """Offline, deterministic authoring for reviewed Guard contributions."""
 
-BUILDER_VERSION = "1.0.0"
+BUILDER_VERSION = "1.1.0"
+SUPPORTED_BUILDER_VERSIONS = frozenset({"1.0.0", BUILDER_VERSION})

--- a/src/codex_plugin_scanner/guard/extension_builder/kit.py
+++ b/src/codex_plugin_scanner/guard/extension_builder/kit.py
@@ -9,9 +9,10 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
-from . import BUILDER_VERSION
+from . import BUILDER_VERSION, SUPPORTED_BUILDER_VERSIONS
 from .errors import BuilderError
 from .io import canonical_json, checked_path, parse_json, read_bytes, read_json, sha256
+from .listing import listing_template
 from .models import Discovery, load_discovery
 from .render_native import (
     contribution_path,
@@ -34,6 +35,7 @@ class Kit:
     discovery: Discovery
     review: Review
     files: tuple[tuple[str, str], ...]
+    builder_version: str = BUILDER_VERSION
 
     @property
     def revision(self) -> str:
@@ -44,7 +46,7 @@ class Kit:
         return {
             "ok": True,
             "schemaVersion": MANIFEST_SCHEMA,
-            "builderVersion": BUILDER_VERSION,
+            "builderVersion": self.builder_version,
             "contributionId": self.discovery.metadata.contribution_id,
             "discoveryDigest": self.discovery.binding,
             "revisionDigest": self.revision,
@@ -91,7 +93,7 @@ def _report(discovery: Discovery, review: Review) -> dict[str, object]:
     }
 
 
-def _readme(discovery: Discovery) -> str:
+def _readme_v1(discovery: Discovery) -> str:
     metadata = discovery.metadata
     safe_name = re.sub(r"([\\`*_{}\[\]()#+.!|<>~-])", r"\\\1", metadata.name)
     return f"""# {safe_name}: Guard contribution kit
@@ -147,7 +149,29 @@ crash-atomic filesystem transaction. After a crash, inspect Git status and the
 """
 
 
-def build_kit(discovery: Discovery, review: Review) -> Kit:
+def _claim_readme(discovery: Discovery) -> str:
+    extension_id = discovery.metadata.contribution_id
+    return f"""
+## After your contribution is merged
+
+HOL Guard Extensions gives contributors a public coverage page and an optional
+publisher profile. Sign in at https://hol.org/guard/extension-studio?extension={extension_id}
+with the GitHub account that authored the merged contribution. The portal verifies
+that specific contribution; a link or a GitHub username alone grants no ownership.
+Claiming is free, does not require marketing consent, and never changes protection.
+Maintainer verification is not an upstream endorsement or a security certificate.
+
+`listing-template.json` is inert presentation metadata, not a runtime artifact.
+After reviewing its description and limits, you may copy it to
+`contributions/extension-listings/{extension_id}.json` in a separate source change.
+Do not put secrets, executable code, or runtime policy in listing metadata.
+The template does not infer a GitHub identity or grant anyone claim authority.
+"""
+
+
+def build_kit(discovery: Discovery, review: Review, *, builder_version: str = BUILDER_VERSION) -> Kit:
+    if builder_version not in SUPPORTED_BUILDER_VERSIONS:
+        raise BuilderError("builder_version", "Unsupported contribution builder version.")
     # Normalization can expand a small source into a large document. Enforce the
     # same byte and structure budgets that subsequent on-disk replay will use.
     discovery = load_discovery(parse_json(canonical_json(discovery.to_dict()).encode("utf-8")))
@@ -157,17 +181,19 @@ def build_kit(discovery: Discovery, review: Review) -> Kit:
         "discovery.json": canonical_json(discovery.to_dict()),
         "review.json": canonical_json(review.to_dict()),
         "report.json": canonical_json(_report(discovery, review)),
-        "README.md": _readme(discovery),
+        "README.md": _readme_v1(discovery) + (_claim_readme(discovery) if builder_version != "1.0.0" else ""),
         f"artifacts/{contribution_path(metadata)}": render_contribution(discovery, review),
         f"artifacts/{test_path(metadata)}": (
             render_cli_tests(discovery, review) if metadata.kind == "cli" else render_mcp_tests(discovery, review)
         ),
     }
+    if builder_version != "1.0.0":
+        files["listing-template.json"] = listing_template(metadata)
     if metadata.kind == "cli":
         files[f"artifacts/{detector_path(metadata)}"] = render_detector(discovery, review)
     manifest = {
         "schemaVersion": MANIFEST_SCHEMA,
-        "builderVersion": BUILDER_VERSION,
+        "builderVersion": builder_version,
         "contributionId": metadata.contribution_id,
         "discoveryDigest": discovery.binding,
         "revisionDigest": revision_digest(discovery, review),
@@ -177,7 +203,7 @@ def build_kit(discovery: Discovery, review: Review) -> Kit:
     sizes = [len(content.encode("utf-8")) for content in files.values()]
     if max(sizes) > MAX_ARTIFACT_BYTES or sum(sizes) > MAX_KIT_BYTES:
         raise BuilderError("kit_limit", "Compiled kit exceeds the bounded artifact budget.")
-    return Kit(discovery, review, tuple(sorted(files.items())))
+    return Kit(discovery, review, tuple(sorted(files.items())), builder_version)
 
 
 def _listed_files(root: Path, expected: set[str]) -> set[str]:
@@ -213,7 +239,11 @@ def load_kit(path: Path) -> Kit:
         raise BuilderError("kit_directory", "A kit must be an existing regular directory.")
     discovery = load_discovery(read_json(root / "discovery.json"))
     review = load_review(read_json(root / "review.json"), discovery)
-    expected = build_kit(discovery, review)
+    manifest = read_json(root / "manifest.json")
+    version = manifest.get("builderVersion") if isinstance(manifest, dict) else None
+    if not isinstance(version, str) or version not in SUPPORTED_BUILDER_VERSIONS:
+        raise BuilderError("builder_version", "Unsupported contribution builder version.")
+    expected = build_kit(discovery, review, builder_version=version)
     expected_names = {name for name, _ in expected.files}
     if _listed_files(root, expected_names) != expected_names:
         raise BuilderError(
@@ -228,7 +258,7 @@ def load_kit(path: Path) -> Kit:
 
 
 def write_kit(kit: Kit, path: Path) -> None:
-    if build_kit(kit.discovery, kit.review).files != kit.files:
+    if build_kit(kit.discovery, kit.review, builder_version=kit.builder_version).files != kit.files:
         raise BuilderError("kit_changed", "Only a reproducible compiled kit can be written.")
     output = checked_path(path)
     if output.exists():

--- a/src/codex_plugin_scanner/guard/extension_builder/listing.py
+++ b/src/codex_plugin_scanner/guard/extension_builder/listing.py
@@ -1,0 +1,158 @@
+"""Inert, bounded presentation metadata. Never imported by runtime enforcement."""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+from functools import lru_cache
+from importlib.resources import files
+from pathlib import Path
+from typing import cast
+from urllib.parse import urlsplit
+
+from jsonschema import Draft202012Validator, FormatChecker
+from jsonschema.exceptions import ValidationError
+
+from .errors import BuilderError
+from .io import canonical_json, checked_path, parse_json, read_bytes
+from .models import Metadata
+
+LISTING_SCHEMA = "guard.extension-listing.v1"
+MAX_LISTING_BYTES = 16_384
+CATEGORY_LABELS = {
+    "core-safety": "Core safety",
+    "cloud-infrastructure": "Cloud and infrastructure",
+    "data-resilience": "Data and resilience",
+    "delivery-remote": "Delivery and remote operations",
+    "managed-services": "Managed services",
+    "package-supply-chain": "Package supply chain",
+    "specialized-tools": "Specialized tools",
+    "other": "Other extensions",
+}
+DEFAULT_LIMITATIONS = (
+    "Coverage is limited to the reviewed operations and the surrounding Guard policy.",
+    "A maintainer profile is not a security certification or an official upstream endorsement.",
+)
+
+
+@lru_cache(maxsize=1)
+def listing_schema() -> dict[str, object]:
+    payload = (
+        files("codex_plugin_scanner.guard.extension_builder")
+        .joinpath("listing.v1.schema.json")
+        .read_text(encoding="utf-8")
+    )
+    return cast(dict[str, object], json.loads(payload))
+
+
+def _public_https(value: str) -> None:
+    try:
+        parsed = urlsplit(value)
+        host = parsed.hostname
+        if (
+            parsed.scheme != "https"
+            or not host
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.port not in (None, 443)
+            or host.lower() in {"localhost", "localhost.localdomain"}
+            or host.lower().endswith((".localhost", ".local", ".internal"))
+            or any(ord(char) < 32 for char in value)
+            or "\\" in value
+        ):
+            raise ValueError("non-public reference")
+        try:
+            _ = ipaddress.ip_address(host)
+        except ValueError:
+            if "." not in host or host.endswith("."):
+                raise ValueError("non-public host") from None
+        else:
+            raise ValueError("Literal IP references are not supported")
+    except ValueError as exc:
+        raise BuilderError("listing_url", "Listing links must use public HTTPS without credentials.") from exc
+
+
+def validate_listing(payload: object, *, expected_id: str | None = None) -> dict[str, object]:
+    """Validate presentation data without resolving a URL or granting authority."""
+
+    validator = Draft202012Validator(listing_schema(), format_checker=FormatChecker())
+    try:
+        validator.validate(payload)
+    except (ValidationError, RecursionError) as exc:
+        raise BuilderError("listing_schema", "Listing does not match the bounded presentation contract.") from exc
+    row = cast(dict[str, object], payload)
+    if expected_id is not None and row["extensionId"] != expected_id:
+        raise BuilderError("listing_identity", "Listing identity must match its native contribution and filename.")
+    for value in [row["tagline"], *cast(list[str], row["limitations"])]:
+        if not isinstance(value, str) or value != value.strip() or any(ord(char) < 32 for char in value):
+            raise BuilderError("listing_text", "Listing text must be trimmed, single-line plain text.")
+    reference = row.get("documentationUrl")
+    if isinstance(reference, str):
+        _public_https(reference)
+    if len(canonical_json(row).encode("utf-8")) > MAX_LISTING_BYTES:
+        raise BuilderError("listing_limit", "Listing exceeds its byte budget.")
+    return row
+
+
+def load_listing(path: Path, *, expected_id: str) -> dict[str, object]:
+    path = checked_path(path)
+    if path.name != f"{expected_id}.json":
+        raise BuilderError("listing_identity", "Listing filename must match the native contribution ID.")
+    return validate_listing(parse_json(read_bytes(path, limit=MAX_LISTING_BYTES)), expected_id=expected_id)
+
+
+def listing_template(metadata: Metadata) -> str:
+    """Produce a reviewable template, with no inferred identity or execution."""
+
+    row: dict[str, object] = {
+        "schemaVersion": LISTING_SCHEMA,
+        "extensionId": metadata.contribution_id,
+        "tagline": f"Reviewed operation coverage for {metadata.name}."[:140],
+        "category": "specialized-tools" if metadata.kind == "mcp" else "other",
+        "limitations": list(DEFAULT_LIMITATIONS),
+        "documentationUrl": metadata.homepage,
+    }
+    return canonical_json(validate_listing(row, expected_id=metadata.contribution_id))
+
+
+def category_for_extension(extension_id: str) -> str:
+    if extension_id in {
+        "command.container-runtime",
+        "command.data-protection",
+        "command.encoded-execution",
+        "command.filesystem",
+        "command.git",
+        "command.guard-self-protection",
+        "command.kubernetes-secrets",
+        "command.shell-mutations",
+        "command.system",
+        "command.windows",
+    }:
+        return "core-safety"
+    if extension_id in {
+        "command.api-gateway",
+        "command.cdn",
+        "command.dns",
+        "command.infrastructure-as-code",
+        "command.kubernetes-operations",
+        "command.load-balancer",
+    } or extension_id.startswith("command.cloud."):
+        return "cloud-infrastructure"
+    if extension_id.startswith(("command.backup.", "command.database.", "command.storage.")):
+        return "data-resilience"
+    if extension_id == "command.github" or extension_id.startswith(
+        ("command.cicd.", "command.platform.", "command.remote.")
+    ):
+        return "delivery-remote"
+    if extension_id in {
+        "command.email",
+        "command.feature-flags",
+        "command.monitoring",
+        "command.payment",
+    } or extension_id.startswith(("command.messaging.", "command.search.")):
+        return "managed-services"
+    if extension_id.startswith("command.package."):
+        return "package-supply-chain"
+    if extension_id == "command.skill-sunset" or extension_id.startswith(("command.mcp-", "mcp.")):
+        return "specialized-tools"
+    return "other"

--- a/src/codex_plugin_scanner/guard/extension_builder/listing.v1.schema.json
+++ b/src/codex_plugin_scanner/guard/extension_builder/listing.v1.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hol.org/guard/contracts/extension-listing.v1.schema.json",
+  "title": "HOL Guard extension listing (presentation only)",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "extensionId",
+    "tagline",
+    "category",
+    "limitations"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "guard.extension-listing.v1"
+    },
+    "extensionId": {
+      "type": "string",
+      "maxLength": 128,
+      "pattern": "^(command|mcp)\\.[a-z0-9]+(?:[.-][a-z0-9]+)*$"
+    },
+    "tagline": {
+      "type": "string",
+      "minLength": 10,
+      "maxLength": 140
+    },
+    "category": {
+      "enum": [
+        "core-safety",
+        "cloud-infrastructure",
+        "data-resilience",
+        "delivery-remote",
+        "managed-services",
+        "package-supply-chain",
+        "specialized-tools",
+        "other"
+      ]
+    },
+    "limitations": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 8,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 10,
+        "maxLength": 400
+      }
+    },
+    "documentationUrl": {
+      "type": "string",
+      "minLength": 10,
+      "maxLength": 1024,
+      "pattern": "^https://",
+      "format": "uri"
+    },
+    "tags": {
+      "type": "array",
+      "maxItems": 8,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 2,
+        "maxLength": 30,
+        "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+      }
+    },
+    "maintainerGithubIds": {
+      "description": "Reviewed profile delegation only; never runtime or upstream ownership. Omit for automatic introducing-PR author eligibility.",
+      "type": "array",
+      "maxItems": 8,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[1-9][0-9]{0,19}$"
+      }
+    }
+  }
+}

--- a/src/codex_plugin_scanner/guard/extension_builder/repository_plan.py
+++ b/src/codex_plugin_scanner/guard/extension_builder/repository_plan.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
-from . import BUILDER_VERSION
+from . import SUPPORTED_BUILDER_VERSIONS
 from .errors import BuilderError
 from .io import canonical_json, checked_path, digest, object_value, read_bytes, read_json, sha256, text_from_bytes
 from .kit import MAX_ARTIFACT_BYTES, Kit, build_kit
@@ -75,7 +75,10 @@ def managed_files(kit: Kit) -> dict[str, bytes]:
     files = {path: content.encode("utf-8") for path, content in kit.native_files().items()}
     prefix = ownership_root(kit.discovery.metadata)
     kit_files = dict(kit.files)
-    for name in ("discovery.json", "review.json", "report.json", "README.md"):
+    names = ["discovery.json", "review.json", "report.json", "README.md"]
+    if kit.builder_version != "1.0.0":
+        names.append("listing-template.json")
+    for name in names:
         files[f"{prefix}/{name}"] = kit_files[name].encode("utf-8")
     return files
 
@@ -84,7 +87,7 @@ def ownership_record(kit: Kit) -> bytes:
     return canonical_json(
         {
             "schemaVersion": OWNERSHIP_SCHEMA,
-            "builderVersion": BUILDER_VERSION,
+            "builderVersion": kit.builder_version,
             "contributionId": kit.discovery.metadata.contribution_id,
             "revisionDigest": kit.revision,
             "managedFiles": {path: sha256(content) for path, content in sorted(managed_files(kit).items())},
@@ -103,13 +106,16 @@ def _previous_kit(root: Path, metadata: Metadata) -> Kit | None:
     if record is None:
         return None
     payload = object_value(read_json(prefix / "record.json"))
-    if payload.get("schemaVersion") != OWNERSHIP_SCHEMA or payload.get("builderVersion") != BUILDER_VERSION:
+    if (
+        payload.get("schemaVersion") != OWNERSHIP_SCHEMA
+        or payload.get("builderVersion") not in SUPPORTED_BUILDER_VERSIONS
+    ):
         raise conflict("The prior authoring record uses an unsupported builder contract; migrate it explicitly.")
     discovery = load_discovery(read_json(prefix / "discovery.json"))
     if discovery.metadata.contribution_id != metadata.contribution_id:
         raise conflict("The existing authoring record belongs to a different contribution.")
     review = load_review(read_json(prefix / "review.json"), discovery)
-    previous = build_kit(discovery, review)
+    previous = build_kit(discovery, review, builder_version=str(payload["builderVersion"]))
     if record != ownership_record(previous):
         raise conflict("The existing authoring ownership record does not match its reviewed source contracts.")
     for path, expected in managed_files(previous).items():
@@ -196,7 +202,7 @@ def plan_repository(kit: Kit, repository: Path) -> IntegrationPlan:
     root = checked_path(repository)
     if not root.is_dir():
         raise BuilderError("repository_directory", "The destination must be an existing HOL Guard checkout.")
-    verified = build_kit(kit.discovery, kit.review)
+    verified = build_kit(kit.discovery, kit.review, builder_version=kit.builder_version)
     if verified.files != kit.files:
         raise BuilderError("kit_changed", "Only a reproducible, validated kit can be integrated.")
     metadata = kit.discovery.metadata

--- a/tests/fixtures/extension-listings/legacy-kit-files.json
+++ b/tests/fixtures/extension-listings/legacy-kit-files.json
@@ -1,0 +1,10 @@
+{
+  "README.md": "23546e527dd5413eaab1c50fe614bd2c7153e5fc12da0433c8f00082f776d7df",
+  "artifacts/contributions/extensions/command.builder-demo.json": "8e173570dc8cb1d0b5c732cfe6d522ebac6f8f3230feb4b45d973ce68d60139d",
+  "artifacts/src/codex_plugin_scanner/guard/runtime/command_builder_demo_extensions.py": "92e58e180624a8f2ada38d15c475e5308093b8243366ceb2f7b275dbae4d5e64",
+  "artifacts/tests/test_generated_cli_builder_demo_extension.py": "bb9ad17d88410b87618af4f1cad985bf9ffd17eb9ce724df225a59eb3095916b",
+  "discovery.json": "cc44e3be97c0e23eddb24dec694c5f3a6cf63d051f3fc9f39c746a931ae9b2de",
+  "manifest.json": "0a5042d95f58b463c8c8463c11bd475fc5ec9206e181df0694a36d6ae86cabc3",
+  "report.json": "f991fd91ca157006905a54fd42284bcbb8c623d3d1ed77b192a11b5a1838f98f",
+  "review.json": "ec72e7abe596f2f61e50bb194405feed16f85febffd3cfaf07feda2ce4ea782c"
+}

--- a/tests/test_guard_extension_builder_listing.py
+++ b/tests/test_guard_extension_builder_listing.py
@@ -1,0 +1,216 @@
+"""Listing metadata must remain inert and old contribution kits must replay."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import socket
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from codex_plugin_scanner.guard.extension_builder.errors import BuilderError
+from codex_plugin_scanner.guard.extension_builder.kit import build_kit, load_kit, write_kit
+from codex_plugin_scanner.guard.extension_builder.listing import (
+    CATEGORY_LABELS,
+    category_for_extension,
+    listing_schema,
+    listing_template,
+    load_listing,
+    validate_listing,
+)
+from codex_plugin_scanner.guard.extension_builder.repository_plan import managed_files, ownership_record
+from tests.extension_builder_support import REPOSITORY, make_kit, metadata
+
+
+def listing() -> dict[str, object]:
+    return json.loads(listing_template(metadata()))
+
+
+def test_listing_contract_is_packaged_byte_for_byte() -> None:
+    source = REPOSITORY / "contracts/extensions/listing.v1.schema.json"
+    packaged = REPOSITORY / "src/codex_plugin_scanner/guard/extension_builder/listing.v1.schema.json"
+    assert source.read_bytes() == packaged.read_bytes()
+    assert Draft202012Validator(listing_schema()).is_valid(listing())
+
+
+@pytest.mark.parametrize("kind", ["cli", "mcp"])
+def test_template_has_no_inferred_claim_or_runtime_authority(kind: str) -> None:
+    row = json.loads(listing_template(metadata(kind)))  # type: ignore[arg-type]
+    assert validate_listing(row, expected_id=row["extensionId"]) == row
+    assert "maintainerGithubIds" not in row
+    assert "activation" not in row
+    assert "trustClass" not in row
+    assert row["limitations"]
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("activation", "default-on"),
+        ("trustClass", "first-party"),
+        ("detector", "evil.py"),
+        ("policy", {}),
+        ("email", "private@example.test"),
+        ("script", "alert(1)"),
+        ("tagline", "short"),
+        ("tagline", "x" * 141),
+        ("tagline", "  untrimmed line  "),
+        ("tagline", "a newline\nis invalid"),
+        ("limitations", []),
+        ("limitations", ["short"]),
+        ("limitations", ["x" * 401]),
+        ("limitations", ["a long limitation"] * 2),
+        ("category", "certified-safe"),
+        ("extensionId", "../../escape"),
+        ("extensionId", "command.UPPER"),
+        ("maintainerGithubIds", [123]),
+        ("maintainerGithubIds", ["0"]),
+        ("maintainerGithubIds", ["01"]),
+        ("maintainerGithubIds", ["123", "123"]),
+        ("maintainerGithubIds", ["9" * 21]),
+        ("tags", ["Some Tag"]),
+        ("tags", ["valid", "valid"]),
+    ],
+)
+def test_rejects_invalid_or_authoritative_metadata(field: str, value: object) -> None:
+    row = listing()
+    row[field] = value
+    with pytest.raises(BuilderError):
+        validate_listing(row)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://example.test",
+        "javascript:alert(1)",
+        "https://user:secret@example.test",
+        "https://localhost/path",
+        "https://127.0.0.1/",
+        "https://[::1]/",
+        "https://169.254.169.254/latest",
+        "https://example.internal/",
+        "https://example.test:8443/",
+        "https://example.test\\@attacker.test/",
+        "https://example.test/\nsecret",
+        "https://intranet/",
+    ],
+)
+def test_rejects_private_or_unsafe_links(url: str) -> None:
+    row = listing()
+    row["documentationUrl"] = url
+    with pytest.raises(BuilderError):
+        validate_listing(row)
+
+
+def test_numeric_maintainers_are_reviewed_data_not_implicit_authority() -> None:
+    row = listing()
+    row["maintainerGithubIds"] = ["123", "99999999999999999999"]
+    assert validate_listing(row)["maintainerGithubIds"] == row["maintainerGithubIds"]
+    with pytest.raises(BuilderError):
+        validate_listing(row, expected_id="command.someone-else")
+
+
+def test_rejects_duplicate_json_keys_and_filename_mismatch(tmp_path: Path) -> None:
+    path = tmp_path / "command.builder-demo.json"
+    path.write_text('{"schemaVersion":"guard.extension-listing.v1","schemaVersion":"other"}', encoding="utf-8")
+    with pytest.raises(BuilderError):
+        load_listing(path, expected_id="command.builder-demo")
+    path.write_text(json.dumps(listing()), encoding="utf-8")
+    with pytest.raises(BuilderError):
+        load_listing(path, expected_id="command.other")
+
+
+def test_rejects_symlink_and_excessive_bytes(tmp_path: Path) -> None:
+    path = tmp_path / "command.builder-demo.json"
+    path.write_text(" " * 16_385, encoding="utf-8")
+    with pytest.raises(BuilderError):
+        load_listing(path, expected_id="command.builder-demo")
+    path.unlink()
+    target = tmp_path / "target.json"
+    target.write_text(json.dumps(listing()), encoding="utf-8")
+    try:
+        path.symlink_to(target)
+    except OSError:
+        pytest.skip("This host does not permit unprivileged symlink creation")
+    with pytest.raises(BuilderError):
+        load_listing(path, expected_id="command.builder-demo")
+
+
+@pytest.mark.parametrize("kind", ["cli", "mcp"])
+def test_current_kits_include_inert_listing_and_claim_guidance(tmp_path: Path, kind: str) -> None:
+    kit = make_kit(tmp_path, kind)  # type: ignore[arg-type]
+    files = dict(kit.files)
+    assert kit.builder_version == "1.1.0"
+    assert "extension-studio?extension=" + kit.discovery.metadata.contribution_id in files["README.md"]
+    assert "listing-template.json" in files
+    assert not any("extension-listings/" in key for key in kit.native_files())
+    assert any(key.endswith("/listing-template.json") for key in managed_files(kit))
+    write_kit(kit, tmp_path / "kit")
+    assert load_kit(tmp_path / "kit").files == kit.files
+
+
+def test_legacy_kits_remain_byte_reproducible_and_upgrade_without_native_change(tmp_path: Path) -> None:
+    current = make_kit(tmp_path)
+    legacy = build_kit(current.discovery, current.review, builder_version="1.0.0")
+    assert legacy.builder_version == "1.0.0"
+    assert "listing-template.json" not in dict(legacy.files)
+    assert legacy.native_files() == current.native_files()
+    assert legacy.revision == current.revision
+    assert json.loads(ownership_record(legacy))["builderVersion"] == "1.0.0"
+    write_kit(legacy, tmp_path / "old-kit")
+    loaded = load_kit(tmp_path / "old-kit")
+    assert loaded.files == legacy.files
+    fixture = json.loads((REPOSITORY / "tests/fixtures/extension-listings/legacy-kit-files.json").read_text())
+    assert {key: hashlib.sha256(value.encode()).hexdigest() for key, value in legacy.files} == fixture
+
+
+def test_rejects_unknown_or_tampered_builder_versions(tmp_path: Path) -> None:
+    kit = make_kit(tmp_path)
+    with pytest.raises(BuilderError):
+        build_kit(kit.discovery, kit.review, builder_version="999.0.0")
+    write_kit(kit, tmp_path / "kit")
+    manifest = tmp_path / "kit/manifest.json"
+    row = json.loads(manifest.read_text())
+    row["builderVersion"] = "999.0.0"
+    manifest.write_text(json.dumps(row))
+    with pytest.raises(BuilderError):
+        load_kit(tmp_path / "kit")
+
+
+def test_category_labels_are_total_for_supported_ids() -> None:
+    for extension_id in [
+        "command.git",
+        "command.cloud.aws",
+        "command.database.postgresql",
+        "command.remote.essh",
+        "command.email",
+        "command.package.npm",
+        "mcp.filesystem",
+        "command.unknown",
+    ]:
+        assert category_for_extension(extension_id) in CATEGORY_LABELS
+
+
+def test_validation_does_not_access_network(monkeypatch: pytest.MonkeyPatch) -> None:
+    def forbidden(*args: object, **kwargs: object) -> None:
+        raise AssertionError("Listing validation must not access the network")
+
+    monkeypatch.setattr(socket, "create_connection", forbidden)
+    assert validate_listing(listing())["extensionId"] == "command.builder-demo"
+
+
+def test_installed_legacy_kit_upgrades_without_overwriting_native_edits(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.extension_builder.repository_write import apply_kit
+    from tests.extension_builder_support import repository_fixture
+
+    current = make_kit(tmp_path)
+    legacy = build_kit(current.discovery, current.review, builder_version="1.0.0")
+    repository = repository_fixture(tmp_path)
+    apply_kit(legacy, repository, write=True)
+    inspected = apply_kit(current, repository)
+    assert all(item["action"] == "unchanged" for item in inspected["files"] if item["path"] in current.native_files())
+    apply_kit(current, repository, write=True, expected_plan=inspected["planDigest"])
+    assert all(item["action"] == "unchanged" for item in apply_kit(current, repository)["files"])

--- a/tests/test_guard_extension_directory_export.py
+++ b/tests/test_guard_extension_directory_export.py
@@ -1,0 +1,96 @@
+"""The public artifact describes native source, never changes its authority."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.extension_builder.errors import BuilderError
+from codex_plugin_scanner.guard.runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
+from codex_plugin_scanner.guard.runtime.extension_trust import trust_class_for
+from tests.extension_builder_support import REPOSITORY
+
+spec = importlib.util.spec_from_file_location(
+    "guard_directory_export", REPOSITORY / "scripts/export_extension_directory.py"
+)
+assert spec and spec.loader
+exporter = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = exporter
+spec.loader.exec_module(exporter)
+
+
+def test_export_is_deterministic_and_current() -> None:
+    first = exporter.render_directory()
+    assert first == exporter.render_directory()
+    assert first == (REPOSITORY / "docs/guard/extensions/catalog.v1.json").read_text()
+    payload = json.loads(first)
+    assert payload["schemaVersion"] == "guard.extension-directory.v1"
+    ids = [row["id"] for row in payload["entries"]]
+    assert ids == sorted(set(ids))
+
+
+def test_every_native_extension_appears_once_with_unchanged_authority() -> None:
+    native = {row.extension_id: row for row in BUILT_IN_COMMAND_EXTENSION_REGISTRY.extensions}
+    entries = exporter.export_directory()["entries"]
+    assert {row["runtimeExtensionId"] for row in entries} == set(native)
+    for row in entries:
+        extension = native[row["runtimeExtensionId"]]
+        assert row["trustClass"] == trust_class_for(extension.extension_id)
+        assert row["ruleCount"] == len(extension.rules)
+        assert row["permissionCount"] == len(extension.permissions)
+        assert (row["claimPolicy"] == "provenance") == (row["trustClass"] == "external")
+        if row["claimPolicy"] == "provenance":
+            assert row["protectionModel"] == "external-opt-in"
+            assert row["sourcePath"].startswith("contributions/")
+            assert row["contributionDigest"].startswith("sha256:")
+        assert "enabled" not in row and "safe" not in row and "rating" not in row
+
+
+def test_mcp_entry_preserves_contribution_identity_and_inheritance() -> None:
+    entries = exporter.export_directory()["entries"]
+    row = next(row for row in entries if row["id"] == "mcp.filesystem")
+    assert row["runtimeExtensionId"] == "command.mcp-filesystem"
+    assert row["kind"] == "mcp"
+    assert row["toolStates"][-1] == {"name": "other", "state": "inherit"}
+    assert "command.mcp-filesystem" not in {entry["id"] for entry in entries}
+
+
+def copy_sources(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    for directory in ("extensions", "mcp-servers"):
+        shutil.copytree(REPOSITORY / "contributions" / directory, root / "contributions" / directory)
+    (root / "contributions/extension-listings").mkdir()
+    return root
+
+
+def test_orphan_or_authoritative_listing_is_rejected(tmp_path: Path) -> None:
+    root = copy_sources(tmp_path)
+    path = root / "contributions/extension-listings/command.orphan.json"
+    path.write_text("{}")
+    with pytest.raises(ValueError, match="existing external"):
+        exporter.export_directory(root)
+    path.unlink()
+    path = root / "contributions/extension-listings/command.blitcp.json"
+    path.write_text(json.dumps({"extensionId": "command.blitcp", "activation": "default-on"}))
+    with pytest.raises(BuilderError):
+        exporter.export_directory(root)
+
+
+def test_source_identity_mismatch_is_rejected(tmp_path: Path) -> None:
+    root = copy_sources(tmp_path)
+    source = root / "contributions/extensions/command.blitcp.json"
+    source.rename(source.with_name("command.wrong-name.json"))
+    with pytest.raises(ValueError):
+        exporter.export_directory(root)
+
+
+def test_public_directory_matches_cross_repository_contract() -> None:
+    from jsonschema import Draft202012Validator
+
+    schema = json.loads((REPOSITORY / "contracts/extensions/directory.v1.schema.json").read_text())
+    Draft202012Validator(schema).validate(exporter.export_directory())


### PR DESCRIPTION
Adds a public catalog generated from the native extension registry and optional presentation-only listing metadata. Claim eligibility stays tied to a specific contribution, not general access to this repo. Runtime trust, policy, and activation are unchanged.

Builder 1.1 adds an inert listing template and profile guidance. Existing 1.0 kits still replay byte-for-byte and upgrade without changing their native artifacts.

The existing cross-platform builder workflow now checks the exported directory too. Locally: 412 builder, contribution, trust, and directory tests passed; Ruff and both directory checks passed.

This is the Core portion of the extension contributor experience. The Cloud claim UI and reminder rollout are separate; no claim reminders are enabled by this PR.