### PR TITLE
fix: distinguish token generation and typed field maps from secrets

### DIFF
--- a/src/codex_plugin_scanner/checks/security.py
+++ b/src/codex_plugin_scanner/checks/security.py
@@ -8,7 +8,6 @@ import json
 import os
 import re
 import stat
-from dataclasses import dataclass
 from itertools import pairwise
 from pathlib import Path
 from urllib.parse import urlparse
@@ -16,49 +15,16 @@ from urllib.parse import urlparse
 from ..models import CheckResult, Finding, Severity
 from ..path_support import path_entry_exists, read_text_file_within_root, resolves_within_root
 from .security_failures import ScanInputUnreadableError, unreadable_scan_input_failure
-
-
-@dataclass(frozen=True, slots=True)
-class SecretPattern:
-    pattern: re.Pattern[str]
-    kind: str = "provider"
-    value_group: int = 0
-
-
-# Patterns for hardcoded secrets
-SECRET_PATTERNS: tuple[SecretPattern, ...] = (
-    SecretPattern(re.compile(r"AKIA[0-9A-Z]{16}")),
-    SecretPattern(re.compile(r"aws_secret_access_key\s*[=:]\s*[\"']?([A-Za-z0-9/+=]{40})", re.I), value_group=1),
-    SecretPattern(
-        re.compile(
-            r"-----BEGIN (?P<label>(?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY)-----"
-            r"[\s\S]{32,}?"
-            r"-----END (?P=label)-----"
-        ),
-        kind="private_key",
-    ),
-    SecretPattern(re.compile(r"password\s*[=:]\s*[\"']([^\s\"']{8,})", re.I), kind="generic", value_group=1),
-    SecretPattern(re.compile(r"secret\s*[=:]\s*[\"']([^\s\"']{8,})", re.I), kind="generic", value_group=1),
-    SecretPattern(re.compile(r"token\s*[=:]\s*[\"']([^\s\"']{8,})", re.I), kind="generic", value_group=1),
-    SecretPattern(re.compile(r"api_?key\s*[=:]\s*[\"']([^\s\"']{8,})", re.I), kind="generic", value_group=1),
-    SecretPattern(re.compile(r"API_KEY\s*[=:]\s*[\"']([^\s\"']{8,})"), kind="generic", value_group=1),
-    SecretPattern(re.compile(r"PRIVATE_KEY\s*[=:]\s*[\"']([^\s\"']{8,})"), kind="generic", value_group=1),
-    SecretPattern(re.compile(r"ghp_[A-Za-z0-9]{36}")),
-    SecretPattern(re.compile(r"gho_[A-Za-z0-9]{36}")),
-    SecretPattern(re.compile(r"ghu_[A-Za-z0-9]{36}")),
-    SecretPattern(re.compile(r"ghs_[A-Za-z0-9]{36}")),
-    SecretPattern(re.compile(r"github_pat_[A-Za-z0-9_]{20,}")),
-    SecretPattern(re.compile(r"glpat-[A-Za-z0-9\-]{20}")),
-    SecretPattern(re.compile(r"xox[bpas]-[A-Za-z0-9\-]{10,}")),
-    SecretPattern(re.compile(r"xoxe-[A-Za-z0-9\-]{10,}")),
-    SecretPattern(re.compile(r"xoxr-[A-Za-z0-9\-]{10,}")),
-    SecretPattern(re.compile(r"xapp-[A-Za-z0-9\-]{10,}")),
-    SecretPattern(re.compile(r"(?<![A-Za-z0-9])sk-(?:proj-|ant-)?[A-Za-z0-9_-]{20,}")),
+from .security_secret_patterns import (
+    DOCUMENTATION_EXTS,
+    SECRET_PATTERNS,
+    SecretPattern,
+    _field_name_map_spans,
+    _is_generated_token_expression,
 )
 
 EXCLUDED_DIRS = {"node_modules", ".git", "dist", ".next", "coverage", ".turbo", "__pycache__", ".venv", "venv"}
 
-DOCUMENTATION_EXTS = {".md", ".mdx", ".markdown", ".rst", ".adoc", ".asciidoc"}
 EXAMPLE_PATH_HINTS = {
     "docs",
     "doc",
@@ -122,54 +88,6 @@ MAX_SCAN_FILE_BYTES = 16 * 1024 * 1024
 MAX_SCAN_TOTAL_BYTES = 512 * 1024 * 1024
 MAX_SECRET_MATCHES_PER_FILE = 10_000
 MAX_SCAN_DEPTH = 64
-
-# A bounded TypeScript field-name dictionary is metadata, not credential values.
-# The safety invariant is that EVERY value is derivable from its key by case
-# conversion (or the inverse); the type/count checks only constrain scope.
-# Arbitrary uppercase strings and ordinary credential objects do not
-# qualify. Compute spans once per file rather than rescanning for every match.
-FIELD_NAME_MAP_RE = re.compile(
-    r"(?m)^[ \t]*const [A-Za-z_$][\w$]*[ \t]*:[ \t]*Record<[^;\n{}]{1,160}>"
-    r"[ \t]*=[ \t]*\{(?P<body>[^{}]{1,4096})\}[ \t]*;"
-)
-FIELD_NAME_ENTRY_RE = re.compile(r"""\s*([A-Za-z][A-Za-z0-9_]*)\s*:\s*(["'])([A-Za-z][A-Za-z0-9_]*)\2\s*""")
-GENERATED_TOKEN_RE = re.compile(r'\$\(openssl rand -(?:hex|base64) [1-9][0-9]{0,3}\)"(?=$|[\s;])')
-
-
-def _field_name_map_spans(relative_path: Path, content: str) -> tuple[tuple[int, int], ...]:
-    """Index bounded TS field maps only when every value is case-derived from its key."""
-    if relative_path.suffix.lower() not in {".ts", ".tsx"}:
-        return ()
-    spans = []
-    for mapping in FIELD_NAME_MAP_RE.finditer(content):
-        entries = mapping.group("body").strip().rstrip(",").split(",")
-        if len(entries) < 2:
-            continue
-        for entry in entries:
-            pair = FIELD_NAME_ENTRY_RE.fullmatch(entry)
-            if pair is None:
-                break
-            key, _, value = pair.groups()
-            if key[0].isupper():
-                key, value = value, key
-            snake_key = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", key).upper()
-            if not re.fullmatch(r"[a-z][A-Za-z0-9]*", key) or value != snake_key:
-                break
-        else:
-            spans.append(mapping.span("body"))
-    return tuple(spans)
-
-
-def _is_generated_token_expression(relative_path: Path, content: str, match: re.Match[str]) -> bool:
-    """Recognize a complete double-quoted OpenSSL token generator in shell or docs."""
-    if relative_path.suffix.lower() not in DOCUMENTATION_EXTS | {".sh", ".bash"}:
-        return False
-    start = match.start(1)
-    # Single-quoted shell values are literal; arbitrary substitutions may carry
-    # credentials. Accept only the complete double-quoted random generator.
-    generated = GENERATED_TOKEN_RE.match(content, start)
-    return start > 0 and content[start - 1] == '"' and generated is not None and match.end(1) <= generated.end()
-
 
 BINARY_EXTS = {
     ".png",

--- a/src/codex_plugin_scanner/checks/security.py
+++ b/src/codex_plugin_scanner/checks/security.py
@@ -124,8 +124,9 @@ MAX_SECRET_MATCHES_PER_FILE = 10_000
 MAX_SCAN_DEPTH = 64
 
 # A bounded TypeScript field-name dictionary is metadata, not credential values.
-# Require a typed, multi-entry map whose every value is the upper-snake spelling
-# of its key. Arbitrary uppercase strings and ordinary credential objects do not
+# The safety invariant is that EVERY value is derivable from its key by case
+# conversion (or the inverse); the type/count checks only constrain scope.
+# Arbitrary uppercase strings and ordinary credential objects do not
 # qualify. Compute spans once per file rather than rescanning for every match.
 FIELD_NAME_MAP_RE = re.compile(
     r"(?m)^[ \t]*const [A-Za-z_$][\w$]*[ \t]*:[ \t]*Record<[^;\n{}]{1,160}>"
@@ -164,7 +165,8 @@ def _is_generated_token_expression(relative_path: Path, content: str, match: re.
     start = match.start(1)
     # Single-quoted shell values are literal; arbitrary substitutions may carry
     # credentials. Accept only the complete double-quoted random generator.
-    return start > 0 and content[start - 1] == '"' and GENERATED_TOKEN_RE.match(content, start) is not None
+    generated = GENERATED_TOKEN_RE.match(content, start)
+    return start > 0 and content[start - 1] == '"' and generated is not None and match.end(1) <= generated.end()
 
 
 BINARY_EXTS = {
@@ -484,8 +486,11 @@ def _should_skip_secret_match(
     if detector.kind == "generic" and _provider_payload(candidate) is None:
         if _is_generated_token_expression(relative_path, content, match):
             return True
-        if any(start <= match.start() < end for start, end in field_name_spans):
-            return True
+        span_index = bisect.bisect_right(field_name_spans, (match.start(), len(content))) - 1
+        if span_index >= 0:
+            start, end = field_name_spans[span_index]
+            if start <= match.start() and match.end() <= end:
+                return True
     if not _is_example_surface(relative_path):
         return False
     if _looks_like_placeholder_secret(candidate):

--- a/src/codex_plugin_scanner/checks/security.py
+++ b/src/codex_plugin_scanner/checks/security.py
@@ -137,6 +137,7 @@ GENERATED_TOKEN_RE = re.compile(r'\$\(openssl rand -(?:hex|base64) [1-9][0-9]{0,
 
 
 def _field_name_map_spans(relative_path: Path, content: str) -> tuple[tuple[int, int], ...]:
+    """Index bounded TS field maps only when every value is case-derived from its key."""
     if relative_path.suffix.lower() not in {".ts", ".tsx"}:
         return ()
     spans = []
@@ -160,6 +161,7 @@ def _field_name_map_spans(relative_path: Path, content: str) -> tuple[tuple[int,
 
 
 def _is_generated_token_expression(relative_path: Path, content: str, match: re.Match[str]) -> bool:
+    """Recognize a complete double-quoted OpenSSL token generator in shell or docs."""
     if relative_path.suffix.lower() not in DOCUMENTATION_EXTS | {".sh", ".bash"}:
         return False
     start = match.start(1)
@@ -482,6 +484,7 @@ def _should_skip_secret_match(
     offsets: tuple[int, ...] | None = None,
     field_name_spans: tuple[tuple[int, int], ...] = (),
 ) -> bool:
+    """Decide whether a match qualifies for a scoped non-secret or example exemption."""
     candidate = _extract_secret_candidate(detector, match)
     if detector.kind == "generic" and _provider_payload(candidate) is None:
         if _is_generated_token_expression(relative_path, content, match):
@@ -510,6 +513,7 @@ def _should_skip_secret_match(
 
 
 def _first_hardcoded_secret_line(relative_path: Path, content: str) -> int | None:
+    """Find the first retained secret line while enforcing the per-file match budget."""
     offsets = _newline_offsets(content)
     lines = content.splitlines()
     field_name_spans = _field_name_map_spans(relative_path, content)

--- a/src/codex_plugin_scanner/checks/security.py
+++ b/src/codex_plugin_scanner/checks/security.py
@@ -123,6 +123,50 @@ MAX_SCAN_TOTAL_BYTES = 512 * 1024 * 1024
 MAX_SECRET_MATCHES_PER_FILE = 10_000
 MAX_SCAN_DEPTH = 64
 
+# A bounded TypeScript field-name dictionary is metadata, not credential values.
+# Require a typed, multi-entry map whose every value is the upper-snake spelling
+# of its key. Arbitrary uppercase strings and ordinary credential objects do not
+# qualify. Compute spans once per file rather than rescanning for every match.
+FIELD_NAME_MAP_RE = re.compile(
+    r"(?m)^[ \t]*const [A-Za-z_$][\w$]*[ \t]*:[ \t]*Record<[^;\n{}]{1,160}>"
+    r"[ \t]*=[ \t]*\{(?P<body>[^{}]{1,4096})\}[ \t]*;"
+)
+FIELD_NAME_ENTRY_RE = re.compile(r"""\s*([A-Za-z][A-Za-z0-9_]*)\s*:\s*(["'])([A-Za-z][A-Za-z0-9_]*)\2\s*""")
+GENERATED_TOKEN_RE = re.compile(r'\$\(openssl rand -(?:hex|base64) [1-9][0-9]{0,3}\)"(?=$|[\s;])')
+
+
+def _field_name_map_spans(relative_path: Path, content: str) -> tuple[tuple[int, int], ...]:
+    if relative_path.suffix.lower() not in {".ts", ".tsx"}:
+        return ()
+    spans = []
+    for mapping in FIELD_NAME_MAP_RE.finditer(content):
+        entries = mapping.group("body").strip().rstrip(",").split(",")
+        if len(entries) < 2:
+            continue
+        for entry in entries:
+            pair = FIELD_NAME_ENTRY_RE.fullmatch(entry)
+            if pair is None:
+                break
+            key, _, value = pair.groups()
+            if key[0].isupper():
+                key, value = value, key
+            snake_key = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", key).upper()
+            if not re.fullmatch(r"[a-z][A-Za-z0-9]*", key) or value != snake_key:
+                break
+        else:
+            spans.append(mapping.span("body"))
+    return tuple(spans)
+
+
+def _is_generated_token_expression(relative_path: Path, content: str, match: re.Match[str]) -> bool:
+    if relative_path.suffix.lower() not in DOCUMENTATION_EXTS | {".sh", ".bash"}:
+        return False
+    start = match.start(1)
+    # Single-quoted shell values are literal; arbitrary substitutions may carry
+    # credentials. Accept only the complete double-quoted random generator.
+    return start > 0 and content[start - 1] == '"' and GENERATED_TOKEN_RE.match(content, start) is not None
+
+
 BINARY_EXTS = {
     ".png",
     ".jpg",
@@ -434,8 +478,14 @@ def _should_skip_secret_match(
     *,
     lines: list[str] | None = None,
     offsets: tuple[int, ...] | None = None,
+    field_name_spans: tuple[tuple[int, int], ...] = (),
 ) -> bool:
     candidate = _extract_secret_candidate(detector, match)
+    if detector.kind == "generic" and _provider_payload(candidate) is None:
+        if _is_generated_token_expression(relative_path, content, match):
+            return True
+        if any(start <= match.start() < end for start, end in field_name_spans):
+            return True
     if not _is_example_surface(relative_path):
         return False
     if _looks_like_placeholder_secret(candidate):
@@ -457,6 +507,7 @@ def _should_skip_secret_match(
 def _first_hardcoded_secret_line(relative_path: Path, content: str) -> int | None:
     offsets = _newline_offsets(content)
     lines = content.splitlines()
+    field_name_spans = _field_name_map_spans(relative_path, content)
     first_line = _first_private_key_line(relative_path, content, lines=lines, offsets=offsets)
     first_offset: int | None = None
     matches_seen = 0
@@ -478,6 +529,7 @@ def _first_hardcoded_secret_line(relative_path: Path, content: str) -> int | Non
                 match,
                 lines=lines,
                 offsets=offsets,
+                field_name_spans=field_name_spans,
             ):
                 continue
             first_offset = match.start()

--- a/src/codex_plugin_scanner/checks/security_secret_patterns.py
+++ b/src/codex_plugin_scanner/checks/security_secret_patterns.py
@@ -1,0 +1,95 @@
+"""Secret detectors and bounded recognition of non-secret token expressions."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class SecretPattern:
+    pattern: re.Pattern[str]
+    kind: str = "provider"
+    value_group: int = 0
+
+
+# Patterns for hardcoded secrets
+SECRET_PATTERNS: tuple[SecretPattern, ...] = (
+    SecretPattern(re.compile(r"AKIA[0-9A-Z]{16}")),
+    SecretPattern(re.compile(r"aws_secret_access_key\s*[=:]\s*[\"']?([A-Za-z0-9/+=]{40})", re.I), value_group=1),
+    SecretPattern(
+        re.compile(
+            r"-----BEGIN (?P<label>(?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY)-----"
+            r"[\s\S]{32,}?"
+            r"-----END (?P=label)-----"
+        ),
+        kind="private_key",
+    ),
+    SecretPattern(re.compile(r"password\s*[=:]\s*[\"']([^\s\"']{8,})", re.I), kind="generic", value_group=1),
+    SecretPattern(re.compile(r"secret\s*[=:]\s*[\"']([^\s\"']{8,})", re.I), kind="generic", value_group=1),
+    SecretPattern(re.compile(r"token\s*[=:]\s*[\"']([^\s\"']{8,})", re.I), kind="generic", value_group=1),
+    SecretPattern(re.compile(r"api_?key\s*[=:]\s*[\"']([^\s\"']{8,})", re.I), kind="generic", value_group=1),
+    SecretPattern(re.compile(r"API_KEY\s*[=:]\s*[\"']([^\s\"']{8,})"), kind="generic", value_group=1),
+    SecretPattern(re.compile(r"PRIVATE_KEY\s*[=:]\s*[\"']([^\s\"']{8,})"), kind="generic", value_group=1),
+    SecretPattern(re.compile(r"ghp_[A-Za-z0-9]{36}")),
+    SecretPattern(re.compile(r"gho_[A-Za-z0-9]{36}")),
+    SecretPattern(re.compile(r"ghu_[A-Za-z0-9]{36}")),
+    SecretPattern(re.compile(r"ghs_[A-Za-z0-9]{36}")),
+    SecretPattern(re.compile(r"github_pat_[A-Za-z0-9_]{20,}")),
+    SecretPattern(re.compile(r"glpat-[A-Za-z0-9\-]{20}")),
+    SecretPattern(re.compile(r"xox[bpas]-[A-Za-z0-9\-]{10,}")),
+    SecretPattern(re.compile(r"xoxe-[A-Za-z0-9\-]{10,}")),
+    SecretPattern(re.compile(r"xoxr-[A-Za-z0-9\-]{10,}")),
+    SecretPattern(re.compile(r"xapp-[A-Za-z0-9\-]{10,}")),
+    SecretPattern(re.compile(r"(?<![A-Za-z0-9])sk-(?:proj-|ant-)?[A-Za-z0-9_-]{20,}")),
+)
+
+DOCUMENTATION_EXTS = {".md", ".mdx", ".markdown", ".rst", ".adoc", ".asciidoc"}
+
+# A bounded TypeScript field-name dictionary is metadata, not credential values.
+# The safety invariant is that EVERY value is derivable from its key by case
+# conversion (or the inverse); the type/count checks only constrain scope.
+# Arbitrary uppercase strings and ordinary credential objects do not
+# qualify. Compute spans once per file rather than rescanning for every match.
+FIELD_NAME_MAP_RE = re.compile(
+    r"(?m)^[ \t]*const [A-Za-z_$][\w$]*[ \t]*:[ \t]*Record<[^;\n{}]{1,160}>"
+    r"[ \t]*=[ \t]*\{(?P<body>[^{}]{1,4096})\}[ \t]*;"
+)
+FIELD_NAME_ENTRY_RE = re.compile(r"""\s*([A-Za-z][A-Za-z0-9_]*)\s*:\s*(["'])([A-Za-z][A-Za-z0-9_]*)\2\s*""")
+GENERATED_TOKEN_RE = re.compile(r'\$\(openssl rand -(?:hex|base64) [1-9][0-9]{0,3}\)"(?=$|[\s;])')
+
+
+def _field_name_map_spans(relative_path: Path, content: str) -> tuple[tuple[int, int], ...]:
+    """Index bounded TS field maps only when every value is case-derived from its key."""
+    if relative_path.suffix.lower() not in {".ts", ".tsx"}:
+        return ()
+    spans = []
+    for mapping in FIELD_NAME_MAP_RE.finditer(content):
+        entries = mapping.group("body").strip().rstrip(",").split(",")
+        if len(entries) < 2:
+            continue
+        for entry in entries:
+            pair = FIELD_NAME_ENTRY_RE.fullmatch(entry)
+            if pair is None:
+                break
+            key, _, value = pair.groups()
+            if key[0].isupper():
+                key, value = value, key
+            snake_key = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", key).upper()
+            if not re.fullmatch(r"[a-z][A-Za-z0-9]*", key) or value != snake_key:
+                break
+        else:
+            spans.append(mapping.span("body"))
+    return tuple(spans)
+
+
+def _is_generated_token_expression(relative_path: Path, content: str, match: re.Match[str]) -> bool:
+    """Recognize a complete double-quoted OpenSSL token generator in shell or docs."""
+    if relative_path.suffix.lower() not in DOCUMENTATION_EXTS | {".sh", ".bash"}:
+        return False
+    start = match.start(1)
+    # Single-quoted shell values are literal; arbitrary substitutions may carry
+    # credentials. Accept only the complete double-quoted random generator.
+    generated = GENERATED_TOKEN_RE.match(content, start)
+    return start > 0 and content[start - 1] == '"' and generated is not None and match.end(1) <= generated.end()

--- a/tests/test_security_nonsecret_values.py
+++ b/tests/test_security_nonsecret_values.py
@@ -22,6 +22,7 @@ FIELD_MAP = """const SUFFIX_BY_FIELD: Record<Field, string> = {
 @pytest.mark.parametrize("path", ["README.md", "examples/docker.md", "scripts/start.sh"])
 @pytest.mark.parametrize("encoding", ["hex", "base64"])
 def test_generated_token_expression_is_not_a_literal_secret(path, encoding):
+    """Both supported encodings generate values rather than embed literal credentials."""
     content = f'MCP_HTTP_TOKEN="$(openssl rand -{encoding} 32)"'
     assert _first_hardcoded_secret_line(Path(path), content) is None
 
@@ -39,25 +40,30 @@ def test_generated_token_expression_is_not_a_literal_secret(path, encoding):
     ],
 )
 def test_other_shell_values_and_adjacent_secrets_still_fire(content):
+    """Reject malformed or literal substitutions without hiding adjacent credentials."""
     assert _first_hardcoded_secret_line(Path("README.md"), content) is not None
 
 
 def test_generated_expression_in_non_shell_source_remains_a_literal():
+    """Do not interpret shell syntax as executable generation inside Python strings."""
     content = 'token="$(openssl rand -hex 32)"'
     assert _first_hardcoded_secret_line(Path("src/config.py"), content) == 1
 
 
 @pytest.mark.parametrize("path", ["src/config.ts", "src/config.tsx"])
 def test_typed_field_name_map_is_not_a_credential_assignment(path):
+    """Recognize complete field-name dictionaries in both TS and TSX source files."""
     assert _first_hardcoded_secret_line(Path(path), FIELD_MAP) is None
 
 
 @pytest.mark.parametrize("path", ["src/config.js", "README.md"])
 def test_field_name_maps_outside_typescript_still_fire(path):
+    """Keep the typed-map exemption confined to TypeScript file extensions."""
     assert _first_hardcoded_secret_line(Path(path), FIELD_MAP) is not None
 
 
 def test_reverse_field_name_map_is_not_a_credential_assignment():
+    """Accept the inverse mapping from uppercase suffixes to camel-case field names."""
     content = """const FIELD_BY_SUFFIX: Record<string, Field> = {
       PUBLICATION_URL: "publicationUrl",
       SESSION_TOKEN: "sessionToken",
@@ -77,10 +83,12 @@ def test_reverse_field_name_map_is_not_a_credential_assignment():
     ],
 )
 def test_non_mapping_values_and_adjacent_credentials_still_fire(content):
+    """Require every map entry to qualify and retain detection outside valid maps."""
     assert _first_hardcoded_secret_line(Path("src/config.ts"), content) is not None
 
 
 def test_provider_secret_is_not_exempted_by_a_generated_token_line():
+    """A generated generic token must not exempt a provider token on the same line."""
     # Synthetic regression payload, not a credential.
     provider_value = "ghp_" + "Q7vN2mL9rT5xB8cD1fG6hJ3kP4sW0zY2uA9b"
     content = f'MCP_HTTP_TOKEN="$(openssl rand -hex 32)" # {provider_value}'
@@ -95,6 +103,7 @@ def test_provider_secret_is_not_exempted_by_a_generated_token_line():
     ],
 )
 def test_future_broader_detector_cannot_cross_an_exempted_region(path, content, pattern):
+    """Require full containment even if a future generic detector spans multiple lines."""
     detector = SecretPattern(re.compile(pattern, re.DOTALL), kind="generic", value_group=1)
     match = detector.pattern.search(content)
     assert match is not None

--- a/tests/test_security_nonsecret_values.py
+++ b/tests/test_security_nonsecret_values.py
@@ -1,0 +1,75 @@
+"""Non-secret token expressions must not hide adjacent or embedded credentials."""
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.checks.security import _first_hardcoded_secret_line
+
+FIELD_MAP = """const SUFFIX_BY_FIELD: Record<Field, string> = {
+  publicationUrl: "PUBLICATION_URL",
+  sessionToken: "SESSION_TOKEN",
+  userId: "USER_ID",
+};"""
+
+
+@pytest.mark.parametrize("path", ["README.md", "examples/docker.md", "scripts/start.sh"])
+@pytest.mark.parametrize("encoding", ["hex", "base64"])
+def test_generated_token_expression_is_not_a_literal_secret(path, encoding):
+    content = f'MCP_HTTP_TOKEN="$(openssl rand -{encoding} 32)"'
+    assert _first_hardcoded_secret_line(Path(path), content) is None
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "MCP_HTTP_TOKEN='$(openssl rand -hex 32)'",
+        'MCP_HTTP_TOKEN="$(openssl rand -hex 32)-literal-suffix"',
+        'MCP_HTTP_TOKEN="$(openssl rand -hex 32)"literal-suffix',
+        'MCP_HTTP_TOKEN="$(openssl rand -hex 32; echo literal-value)"',
+        'MCP_HTTP_TOKEN="$(printf literal-value)"',
+        'MCP_HTTP_TOKEN="$(openssl rand -hex 32)',
+        'MCP_HTTP_TOKEN="$(openssl rand -hex 32)"\npassword="actual-pass-937"',
+    ],
+)
+def test_other_shell_values_and_adjacent_secrets_still_fire(content):
+    assert _first_hardcoded_secret_line(Path("README.md"), content) is not None
+
+
+def test_generated_expression_in_non_shell_source_remains_a_literal():
+    content = 'token="$(openssl rand -hex 32)"'
+    assert _first_hardcoded_secret_line(Path("src/config.py"), content) == 1
+
+
+def test_typed_field_name_map_is_not_a_credential_assignment():
+    assert _first_hardcoded_secret_line(Path("src/config.ts"), FIELD_MAP) is None
+
+
+def test_reverse_field_name_map_is_not_a_credential_assignment():
+    content = """const FIELD_BY_SUFFIX: Record<string, Field> = {
+      PUBLICATION_URL: "publicationUrl",
+      SESSION_TOKEN: "sessionToken",
+      USER_ID: "userId",
+    };"""
+    assert _first_hardcoded_secret_line(Path("src/config.ts"), content) is None
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        'const credentials = { sessionToken: "SESSION_TOKEN" };',
+        'const credentials: Record<string, string> = { sessionToken: "SESSION_TOKEN" };',
+        FIELD_MAP.replace('"SESSION_TOKEN"', '"actual-pass-937"'),
+        FIELD_MAP + '\nconst sessionToken = "actual-pass-937";',
+        FIELD_MAP.replace('"USER_ID"', '"literal-value"'),
+    ],
+)
+def test_non_mapping_values_and_adjacent_credentials_still_fire(content):
+    assert _first_hardcoded_secret_line(Path("src/config.ts"), content) is not None
+
+
+def test_provider_secret_is_not_exempted_by_a_generated_token_line():
+    # Synthetic regression payload, not a credential.
+    provider_value = "ghp_" + "Q7vN2mL9rT5xB8cD1fG6hJ3kP4sW0zY2uA9b"
+    content = f'MCP_HTTP_TOKEN="$(openssl rand -hex 32)" # {provider_value}'
+    assert _first_hardcoded_secret_line(Path("README.md"), content) == 1

--- a/tests/test_security_nonsecret_values.py
+++ b/tests/test_security_nonsecret_values.py
@@ -1,10 +1,16 @@
 """Non-secret token expressions must not hide adjacent or embedded credentials."""
 
+import re
 from pathlib import Path
 
 import pytest
 
-from codex_plugin_scanner.checks.security import _first_hardcoded_secret_line
+from codex_plugin_scanner.checks.security import (
+    SecretPattern,
+    _field_name_map_spans,
+    _first_hardcoded_secret_line,
+    _should_skip_secret_match,
+)
 
 FIELD_MAP = """const SUFFIX_BY_FIELD: Record<Field, string> = {
   publicationUrl: "PUBLICATION_URL",
@@ -41,8 +47,14 @@ def test_generated_expression_in_non_shell_source_remains_a_literal():
     assert _first_hardcoded_secret_line(Path("src/config.py"), content) == 1
 
 
-def test_typed_field_name_map_is_not_a_credential_assignment():
-    assert _first_hardcoded_secret_line(Path("src/config.ts"), FIELD_MAP) is None
+@pytest.mark.parametrize("path", ["src/config.ts", "src/config.tsx"])
+def test_typed_field_name_map_is_not_a_credential_assignment(path):
+    assert _first_hardcoded_secret_line(Path(path), FIELD_MAP) is None
+
+
+@pytest.mark.parametrize("path", ["src/config.js", "README.md"])
+def test_field_name_maps_outside_typescript_still_fire(path):
+    assert _first_hardcoded_secret_line(Path(path), FIELD_MAP) is not None
 
 
 def test_reverse_field_name_map_is_not_a_credential_assignment():
@@ -73,3 +85,19 @@ def test_provider_secret_is_not_exempted_by_a_generated_token_line():
     provider_value = "ghp_" + "Q7vN2mL9rT5xB8cD1fG6hJ3kP4sW0zY2uA9b"
     content = f'MCP_HTTP_TOKEN="$(openssl rand -hex 32)" # {provider_value}'
     assert _first_hardcoded_secret_line(Path("README.md"), content) == 1
+
+
+@pytest.mark.parametrize(
+    ("path", "content", "pattern"),
+    [
+        ("src/config.ts", FIELD_MAP + '\nconst password = "actual-pass-937";', r'Token: "(.+)"'),
+        ("README.md", 'TOKEN="$(openssl rand -hex 32)"\npassword="actual-pass-937"', r'TOKEN="(.+)"'),
+    ],
+)
+def test_future_broader_detector_cannot_cross_an_exempted_region(path, content, pattern):
+    detector = SecretPattern(re.compile(pattern, re.DOTALL), kind="generic", value_group=1)
+    match = detector.pattern.search(content)
+    assert match is not None
+    assert not _should_skip_secret_match(
+        Path(path), content, detector, match, field_name_spans=_field_name_map_spans(Path(path), content)
+    )


### PR DESCRIPTION
## Problem

The hardcoded-secret detector treats two non-secret values as credentials:

- A double-quoted shell substitution that generates a token with `openssl rand`.
- A TypeScript `Record` mapping field names to their uppercase environment-variable suffixes, such as `sessionToken: "SESSION_TOKEN"`.

These block the Substack MCP submission in hashgraph-online/awesome-ai-plugins#221. The catalog currently uses plugin-scanner 2.0.1116; this fix targets current hol-guard source. Merging it alone will not update the catalog's installed scanner.

## Change

Recognize a bounded subset of those expressions for generic-secret matches only. Shell generation is limited to documentation and shell files, a complete double-quoted substitution, and `openssl rand -hex` or `-base64` with a positive size. Typed field maps are limited to TS/TSX, a bare `const` with a `Record` annotation, at least two entries, and values fully derivable from their keys by case conversion. Other syntax remains subject to the existing detector.

The TS exception also applies to production source, and the shell exception to scripts—not only example files. Every candidate must be fully contained in the recognized expression. Provider-specific detection is unchanged. Field-map spans are computed once per file and searched with bisect. No rule disabling, path suppression, or severity changes.

Secret patterns and the bounded expression recognizers live in `security_secret_patterns.py`, reducing `security.py` from 985 to 903 lines against its 924-line structural baseline. The extraction preserves all eight moved definitions/constants exactly at the AST level.

## Validation

Current head: `5fd272b291fd40ae8ec300c52f7e0816f4928415`.

- Structural code-quality debt ratchet passes without a baseline change.
- CI production Ruff lint/format gates and basedpyright pass (0 errors/warnings).
- Targeted security suite: 69 passed, 6 skipped. Broader security run: 85 passed, 7 skipped, one existing Windows-specific failure asserting `/usr/lib/python3.13/site-packages` is an absolute safe path. The failing test and Cisco integration module are identical to upstream main.
- Wheel build passes and includes the extracted module.
- 27 regression cases cover adjacent credentials, malformed maps, literal suffixes, provider-token controls, and matches crossing an exemption boundary.
- Prior pre-extraction validation included 167 passing tests, 8 skips and a passing scan of the corrected Substack source.

Authenticated `claude-opus-5` and independent free `opencode/muse-spark-1.3-contributor-free` reviewed this exact SHA. Neither found current security false negatives or import regressions. Opus flagged a low-priority future-maintenance concern: the generated-expression helper assumes capture group 1. Every current generic detector uses group 1; this unchanged behavior is deferred from the extraction repair. Move fidelity and current detector definitions were verified against the source.

Fresh GitHub workflows require maintainer approval (`action_required`), including [CI](https://github.com/hashgraph-online/hol-guard/actions/runs/34156445661) and [Native wheel CI](https://github.com/hashgraph-online/hol-guard/actions/runs/34156445628). Previous-head Windows failure was native probe cleanup (`resident-stop` exit 2 and WinError 32); the identical probe passed on upstream main in job 101844313106. No shutdown changes or check suppressions were made; a fresh approved run is needed to confirm it does not recur.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced false positives in hardcoded-secret scanning for generated shell tokens, such as tokens created with OpenSSL.
  * TypeScript field-name maps whose values are derived from their keys are no longer incorrectly identified as credentials.
  * Genuine literal secrets, malformed expressions, and credentials near exempted code continue to be detected.
  * Detection remains limited to supported generated-token patterns and complete TypeScript field-name maps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->