### PR TITLE
fix(scanner): read Claude marketplace strict from plugin entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Claude marketplace scans treat `strict` as an optional boolean on each
+  `plugins[]` entry (default `true`) instead of requiring a root-level field
+  that Claude Code rejects.
+
 ### Changed
 
 - Added the HOL Guard 3.0 Managed Controls user, operator, migration, recovery,

--- a/src/codex_plugin_scanner/checks/claude.py
+++ b/src/codex_plugin_scanner/checks/claude.py
@@ -123,23 +123,6 @@ def check_marketplace_structure(package: NormalizedPackage) -> CheckResult:
             applicable=False,
         )
     plugins = package.raw_manifest.get("plugins")
-    if not isinstance(plugins, list):
-        return CheckResult(
-            name="Claude marketplace structure",
-            passed=False,
-            points=0,
-            max_points=4,
-            message='Claude marketplace must include a "plugins" array.',
-            findings=(
-                _finding(
-                    "CLAUDE_MARKETPLACE_PLUGINS_MISSING",
-                    "Claude marketplace plugins array missing",
-                    'The Claude marketplace manifest must include a top-level "plugins" array.',
-                    'Add "plugins": [] to .claude-plugin/marketplace.json.',
-                    file_path=".claude-plugin/marketplace.json",
-                ),
-            ),
-        )
     findings: list[Finding] = []
     if "strict" in package.raw_manifest:
         findings.append(
@@ -150,6 +133,25 @@ def check_marketplace_structure(package: NormalizedPackage) -> CheckResult:
                 'Remove root-level "strict". Set boolean "strict" on a plugin entry, or omit it to default to true.',
                 file_path=".claude-plugin/marketplace.json",
             )
+        )
+    if not isinstance(plugins, list):
+        findings.insert(
+            0,
+            _finding(
+                "CLAUDE_MARKETPLACE_PLUGINS_MISSING",
+                "Claude marketplace plugins array missing",
+                'The Claude marketplace manifest must include a top-level "plugins" array.',
+                'Add "plugins": [] to .claude-plugin/marketplace.json.',
+                file_path=".claude-plugin/marketplace.json",
+            ),
+        )
+        return CheckResult(
+            name="Claude marketplace structure",
+            passed=False,
+            points=0,
+            max_points=4,
+            message='Claude marketplace must include a "plugins" array.',
+            findings=tuple(findings),
         )
     for index, plugin in enumerate(plugins):
         if not isinstance(plugin, dict) or "strict" not in plugin:

--- a/src/codex_plugin_scanner/checks/claude.py
+++ b/src/codex_plugin_scanner/checks/claude.py
@@ -123,7 +123,6 @@ def check_marketplace_structure(package: NormalizedPackage) -> CheckResult:
             applicable=False,
         )
     plugins = package.raw_manifest.get("plugins")
-    strict = package.raw_manifest.get("strict")
     if not isinstance(plugins, list):
         return CheckResult(
             name="Claude marketplace structure",
@@ -141,22 +140,39 @@ def check_marketplace_structure(package: NormalizedPackage) -> CheckResult:
                 ),
             ),
         )
-    if not isinstance(strict, bool):
+    findings: list[Finding] = []
+    if "strict" in package.raw_manifest:
+        findings.append(
+            _finding(
+                "CLAUDE_MARKETPLACE_STRICT_INVALID",
+                "Claude marketplace strict mode is not a root field",
+                'Claude Code defines "strict" on each plugins[] entry, not at the marketplace root.',
+                'Remove root-level "strict". Set boolean "strict" on a plugin entry, or omit it to default to true.',
+                file_path=".claude-plugin/marketplace.json",
+            )
+        )
+    for index, plugin in enumerate(plugins):
+        if not isinstance(plugin, dict) or "strict" not in plugin:
+            continue
+        if isinstance(plugin.get("strict"), bool):
+            continue
+        findings.append(
+            _finding(
+                "CLAUDE_MARKETPLACE_STRICT_INVALID",
+                "Claude marketplace plugin strict mode is invalid",
+                f'plugins[{index}] "strict" must be a boolean when present.',
+                'Set "strict": true or false on the plugin entry, or omit it to default to true.',
+                file_path=".claude-plugin/marketplace.json",
+            )
+        )
+    if findings:
         return CheckResult(
             name="Claude marketplace structure",
             passed=False,
             points=0,
             max_points=4,
-            message='Claude marketplace must define boolean "strict".',
-            findings=(
-                _finding(
-                    "CLAUDE_MARKETPLACE_STRICT_INVALID",
-                    "Claude marketplace strict mode missing",
-                    'The Claude marketplace manifest should declare a boolean "strict" mode.',
-                    'Set "strict": true or false in .claude-plugin/marketplace.json.',
-                    file_path=".claude-plugin/marketplace.json",
-                ),
-            ),
+            message='Claude marketplace "strict" must be a per-plugin boolean when present.',
+            findings=tuple(findings),
         )
     return CheckResult(
         name="Claude marketplace structure",

--- a/src/codex_plugin_scanner/ecosystems/claude.py
+++ b/src/codex_plugin_scanner/ecosystems/claude.py
@@ -80,17 +80,7 @@ class ClaudeAdapter:
             components["mcp_servers"] = (str(mcp_file.relative_to(root)),)
 
         policies: dict[str, str] = {}
-        if candidate.package_kind == "marketplace":
-            plugins = manifest.get("plugins")
-            if isinstance(plugins, list):
-                for plugin in plugins:
-                    if not isinstance(plugin, dict) or "strict" not in plugin:
-                        continue
-                    strict_mode = plugin.get("strict")
-                    if isinstance(strict_mode, bool):
-                        policies["strict"] = "true" if strict_mode else "false"
-                        break
-        else:
+        if candidate.package_kind != "marketplace":
             strict_mode = manifest.get("strict")
             if isinstance(strict_mode, bool):
                 policies["strict"] = "true" if strict_mode else "false"

--- a/src/codex_plugin_scanner/ecosystems/claude.py
+++ b/src/codex_plugin_scanner/ecosystems/claude.py
@@ -79,10 +79,21 @@ class ClaudeAdapter:
         ):
             components["mcp_servers"] = (str(mcp_file.relative_to(root)),)
 
-        strict_mode = manifest.get("strict")
         policies: dict[str, str] = {}
-        if isinstance(strict_mode, bool):
-            policies["strict"] = "true" if strict_mode else "false"
+        if candidate.package_kind == "marketplace":
+            plugins = manifest.get("plugins")
+            if isinstance(plugins, list):
+                for plugin in plugins:
+                    if not isinstance(plugin, dict) or "strict" not in plugin:
+                        continue
+                    strict_mode = plugin.get("strict")
+                    if isinstance(strict_mode, bool):
+                        policies["strict"] = "true" if strict_mode else "false"
+                        break
+        else:
+            strict_mode = manifest.get("strict")
+            if isinstance(strict_mode, bool):
+                policies["strict"] = "true" if strict_mode else "false"
         raw_name = manifest.get("name")
         raw_version = manifest.get("version")
 

--- a/tests/guard_cli_facade_isolation.py
+++ b/tests/guard_cli_facade_isolation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Callable
 from typing import Any
 
@@ -22,3 +23,26 @@ def isolate_terminal_block_patches(monkeypatch: Any, unexpected: Callable[..., o
         monkeypatch.setattr(module, "queue_blocked_approvals", unexpected)
         monkeypatch.setattr(module, "wait_for_approval_requests", unexpected)
     monkeypatch.setattr(interaction, "wait_for_approval_requests", unexpected)
+
+
+def restore_cli_facade_approval_hooks() -> None:
+    from codex_plugin_scanner.guard.approvals import queue_blocked_approvals, wait_for_approval_requests
+    from codex_plugin_scanner.guard.cli.commands_support import _sync_namespace
+    from codex_plugin_scanner.guard.daemon.manager import ensure_guard_daemon
+
+    restored = {
+        "ensure_guard_daemon": ensure_guard_daemon,
+        "queue_blocked_approvals": queue_blocked_approvals,
+        "wait_for_approval_requests": wait_for_approval_requests,
+    }
+    _sync_namespace(restored)
+    prefix = "codex_plugin_scanner.guard.cli."
+    for module in tuple(sys.modules.values()):
+        if module is None:
+            continue
+        module_name = getattr(module, "__name__", "")
+        if not module_name.startswith(prefix):
+            continue
+        for attr, value in restored.items():
+            if hasattr(module, attr):
+                setattr(module, attr, value)

--- a/tests/test_claude_marketplace_structure.py
+++ b/tests/test_claude_marketplace_structure.py
@@ -62,6 +62,25 @@ def test_marketplace_plugin_strict_boolean_passes(tmp_path: Path) -> None:
     assert result.findings == ()
 
 
+def test_marketplace_root_strict_without_plugins_still_reports_strict(tmp_path: Path) -> None:
+    result = check_marketplace_structure(
+        _marketplace(
+            {
+                "name": "my-plugins",
+                "owner": {"name": "Example"},
+                "strict": True,
+            },
+            tmp_path,
+        )
+    )
+
+    assert result.passed is False
+    assert [finding.rule_id for finding in result.findings] == [
+        "CLAUDE_MARKETPLACE_PLUGINS_MISSING",
+        "CLAUDE_MARKETPLACE_STRICT_INVALID",
+    ]
+
+
 def test_marketplace_root_strict_is_rejected(tmp_path: Path) -> None:
     result = check_marketplace_structure(
         _marketplace(
@@ -138,7 +157,7 @@ def test_scan_documented_marketplace_does_not_emit_strict_finding(tmp_path: Path
     assert structure.points == 4
 
 
-def test_claude_adapter_reads_plugin_strict_not_root(tmp_path: Path) -> None:
+def test_claude_adapter_does_not_collapse_marketplace_strict(tmp_path: Path) -> None:
     manifest_path = tmp_path / ".claude-plugin" / "marketplace.json"
     manifest_path.parent.mkdir(parents=True)
     manifest_path.write_text(
@@ -152,7 +171,12 @@ def test_claude_adapter_reads_plugin_strict_not_root(tmp_path: Path) -> None:
                         "name": "quality-review-plugin",
                         "source": "./plugins/quality-review-plugin",
                         "strict": False,
-                    }
+                    },
+                    {
+                        "name": "docs-plugin",
+                        "source": "./plugins/docs-plugin",
+                        "strict": True,
+                    },
                 ],
             }
         ),
@@ -162,4 +186,4 @@ def test_claude_adapter_reads_plugin_strict_not_root(tmp_path: Path) -> None:
     adapter = ClaudeAdapter()
     package = adapter.parse(adapter.detect(tmp_path)[0])
 
-    assert package.policies["strict"] == "false"
+    assert "strict" not in package.policies

--- a/tests/test_claude_marketplace_structure.py
+++ b/tests/test_claude_marketplace_structure.py
@@ -1,0 +1,165 @@
+"""Claude marketplace structure checks."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_plugin_scanner.checks.claude import check_marketplace_structure
+from codex_plugin_scanner.ecosystems.claude import ClaudeAdapter
+from codex_plugin_scanner.ecosystems.types import Ecosystem, NormalizedPackage
+from codex_plugin_scanner.models import ScanOptions
+from codex_plugin_scanner.scanner import scan_plugin
+
+
+def _marketplace(raw_manifest: dict[str, object], tmp_path: Path) -> NormalizedPackage:
+    return NormalizedPackage(
+        ecosystem=Ecosystem.CLAUDE,
+        package_kind="marketplace",
+        root_path=tmp_path,
+        manifest_path=tmp_path / ".claude-plugin" / "marketplace.json",
+        raw_manifest=raw_manifest,
+    )
+
+
+def test_marketplace_without_strict_passes(tmp_path: Path) -> None:
+    result = check_marketplace_structure(
+        _marketplace(
+            {
+                "name": "my-plugins",
+                "owner": {"name": "Example"},
+                "plugins": [{"name": "quality-review-plugin", "source": "./plugins/quality-review-plugin"}],
+            },
+            tmp_path,
+        )
+    )
+
+    assert result.passed is True
+    assert result.points == 4
+    assert result.findings == ()
+
+
+def test_marketplace_plugin_strict_boolean_passes(tmp_path: Path) -> None:
+    result = check_marketplace_structure(
+        _marketplace(
+            {
+                "name": "my-plugins",
+                "owner": {"name": "Example"},
+                "plugins": [
+                    {
+                        "name": "quality-review-plugin",
+                        "source": "./plugins/quality-review-plugin",
+                        "strict": True,
+                    }
+                ],
+            },
+            tmp_path,
+        )
+    )
+
+    assert result.passed is True
+    assert result.points == 4
+    assert result.findings == ()
+
+
+def test_marketplace_root_strict_is_rejected(tmp_path: Path) -> None:
+    result = check_marketplace_structure(
+        _marketplace(
+            {
+                "name": "my-plugins",
+                "owner": {"name": "Example"},
+                "strict": True,
+                "plugins": [{"name": "quality-review-plugin", "source": "./plugins/quality-review-plugin"}],
+            },
+            tmp_path,
+        )
+    )
+
+    assert result.passed is False
+    assert result.points == 0
+    assert [finding.rule_id for finding in result.findings] == ["CLAUDE_MARKETPLACE_STRICT_INVALID"]
+    assert "plugins[]" in result.findings[0].description
+
+
+def test_marketplace_non_boolean_plugin_strict_is_rejected(tmp_path: Path) -> None:
+    result = check_marketplace_structure(
+        _marketplace(
+            {
+                "name": "my-plugins",
+                "owner": {"name": "Example"},
+                "plugins": [
+                    {
+                        "name": "quality-review-plugin",
+                        "source": "./plugins/quality-review-plugin",
+                        "strict": "true",
+                    }
+                ],
+            },
+            tmp_path,
+        )
+    )
+
+    assert result.passed is False
+    assert result.points == 0
+    assert [finding.rule_id for finding in result.findings] == ["CLAUDE_MARKETPLACE_STRICT_INVALID"]
+    assert "plugins[0]" in result.findings[0].description
+
+
+def test_scan_documented_marketplace_does_not_emit_strict_finding(tmp_path: Path) -> None:
+    marketplace = tmp_path / "my-marketplace"
+    manifest_dir = marketplace / ".claude-plugin"
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / "marketplace.json").write_text(
+        json.dumps(
+            {
+                "name": "my-plugins",
+                "owner": {"name": "Example"},
+                "plugins": [
+                    {
+                        "name": "quality-review-plugin",
+                        "source": "./plugins/quality-review-plugin",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = scan_plugin(marketplace, ScanOptions(ecosystem="claude", cisco_skill_scan="off"))
+
+    assert all(finding.rule_id != "CLAUDE_MARKETPLACE_STRICT_INVALID" for finding in result.findings)
+    structure = next(
+        check
+        for category in result.categories
+        for check in category.checks
+        if check.name == "Claude marketplace structure"
+    )
+    assert structure.passed is True
+    assert structure.points == 4
+
+
+def test_claude_adapter_reads_plugin_strict_not_root(tmp_path: Path) -> None:
+    manifest_path = tmp_path / ".claude-plugin" / "marketplace.json"
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "name": "my-plugins",
+                "owner": {"name": "Example"},
+                "strict": True,
+                "plugins": [
+                    {
+                        "name": "quality-review-plugin",
+                        "source": "./plugins/quality-review-plugin",
+                        "strict": False,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    adapter = ClaudeAdapter()
+    package = adapter.parse(adapter.detect(tmp_path)[0])
+
+    assert package.policies["strict"] == "false"

--- a/tests/test_guard_codex_browser_authority.py
+++ b/tests/test_guard_codex_browser_authority.py
@@ -27,23 +27,13 @@ from codex_plugin_scanner.guard.receipts import build_receipt
 from codex_plugin_scanner.guard.runtime.actions import GuardActionEnvelope
 from codex_plugin_scanner.guard.runtime.approval_context import build_approval_context_token
 from codex_plugin_scanner.guard.store import GuardStore
-from tests.guard_cli_facade_isolation import isolate_terminal_block_patches
+from tests.guard_cli_facade_isolation import isolate_terminal_block_patches, restore_cli_facade_approval_hooks
 
 
 def teardown_module() -> None:
     """Reset facade overrides propagated into lazily imported CLI modules."""
 
-    from codex_plugin_scanner.guard.approvals import queue_blocked_approvals, wait_for_approval_requests
-    from codex_plugin_scanner.guard.cli.commands_support import _sync_namespace
-    from codex_plugin_scanner.guard.daemon.manager import ensure_guard_daemon
-
-    _sync_namespace(
-        {
-            "ensure_guard_daemon": ensure_guard_daemon,
-            "queue_blocked_approvals": queue_blocked_approvals,
-            "wait_for_approval_requests": wait_for_approval_requests,
-        }
-    )
+    restore_cli_facade_approval_hooks()
 
 
 def _context_token() -> str:

--- a/tests/test_guard_package_hook.py
+++ b/tests/test_guard_package_hook.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+from collections.abc import Iterator
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -22,6 +23,13 @@ from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import (
     SupplyChainUserCopy,
 )
 from codex_plugin_scanner.guard.store import GuardStore
+from tests.guard_cli_facade_isolation import isolate_terminal_block_patches, restore_cli_facade_approval_hooks
+
+
+@pytest.fixture(autouse=True)
+def _restore_cli_facade_approval_hooks() -> Iterator[None]:
+    yield
+    restore_cli_facade_approval_hooks()
 
 
 def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
@@ -264,9 +272,7 @@ def test_guard_hook_terminal_package_block_is_not_queued_for_browser_approval(
     def unexpected_browser_approval(*_args: object, **_kwargs: object) -> object:
         raise AssertionError("terminal package block must not queue or wait for browser approval")
 
-    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", unexpected_browser_approval)
-    monkeypatch.setattr(guard_commands_module, "queue_blocked_approvals", unexpected_browser_approval)
-    monkeypatch.setattr(guard_commands_module, "wait_for_approval_requests", unexpected_browser_approval)
+    isolate_terminal_block_patches(monkeypatch, unexpected_browser_approval)
 
     def fail_subprocess(*args: object, **kwargs: object) -> object:
         raise AssertionError("blocked package request must not launch a subprocess")


### PR DESCRIPTION
## Summary
- Treat Claude marketplace `strict` as an optional boolean on each `plugins[]` entry, defaulting to `true` when omitted.
- Fail `CLAUDE_MARKETPLACE_STRICT_INVALID` when `strict` is set at the marketplace root or when a plugin entry sets a non-boolean value.

## Testing
- `ruff check src/codex_plugin_scanner/checks/claude.py src/codex_plugin_scanner/ecosystems/claude.py tests/test_claude_marketplace_structure.py`
- `ruff format --check src/codex_plugin_scanner/checks/claude.py src/codex_plugin_scanner/ecosystems/claude.py tests/test_claude_marketplace_structure.py`
- `pytest tests/test_claude_marketplace_structure.py tests/test_ecosystems.py tests/test_claude_code_marketplace_plugin.py --tb=short`

## Notes
- Fixes #2830


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Claude marketplace scans now support an optional `strict` setting on individual plugins, defaulting to strict mode when omitted.
  - Invalid root-level `strict` settings and non-boolean plugin values are now reported clearly.
  - Marketplace-level strict settings are no longer incorrectly applied to package policies.
  - Non-marketplace Claude scans continue to recognize valid boolean `strict` settings.

- **Documentation**
  - Updated the unreleased changelog to document the corrected Claude marketplace strict-mode behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->