### PR TITLE
fix(guard): reset overrides captured by lazily imported hook modules

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -74,15 +74,22 @@ def _support_overrides() -> Iterator[None]:
     # remain independent of the Python evaluator.
     compatibility_prefix = f"{__package__}.commands_hook_"
     known_targets = {id(module) for module, _ in targets}
-    for module in tuple(sys.modules.values()):
-        if module is None or id(module) in known_targets:
-            continue
-        module_name = getattr(module, "__name__", "")
-        if not module_name.startswith(compatibility_prefix):
-            continue
-        affected_names = {name for name in override_names if hasattr(module, name)}
-        if affected_names:
-            targets.append((module, affected_names))
+
+    def _compatibility_targets(skip: set[int]) -> list[tuple[ModuleType, set[str]]]:
+        found: list[tuple[ModuleType, set[str]]] = []
+        for module in tuple(sys.modules.values()):
+            if module is None or id(module) in skip:
+                continue
+            module_name = getattr(module, "__name__", "")
+            if not module_name.startswith(compatibility_prefix):
+                continue
+            affected_names = {name for name in override_names if hasattr(module, name)}
+            if affected_names:
+                found.append((module, affected_names))
+        return found
+
+    for module, affected_names in _compatibility_targets(known_targets):
+        targets.append((module, affected_names))
     snapshots = [
         (module, {name: getattr(module, name, missing) for name in affected_names})
         for module, affected_names in targets
@@ -105,6 +112,15 @@ def _support_overrides() -> Iterator[None]:
                         delattr(module, name)
                 else:
                     setattr(module, name, value)
+        # A compatibility module imported for the first time inside the scoped
+        # window bound the override values at import time and is absent from
+        # the entry snapshots, so its captured bindings would outlive the
+        # window. Reset only the names still bound to an override value.
+        snapshotted = {id(module) for module, _ in snapshots}
+        for module, affected_names in _compatibility_targets(snapshotted):
+            for name in affected_names:
+                if getattr(module, name, missing) is export_map[name]:
+                    setattr(module, name, getattr(_support, name))
 
 
 def _support_attr(name: str) -> Any:

--- a/tests/test_guard_cli_commands_facade.py
+++ b/tests/test_guard_cli_commands_facade.py
@@ -39,3 +39,28 @@ def test_commands_facade_restores_propagated_overrides(monkeypatch) -> None:
         assert generic_commands.schedule_guard_daemon_ensure is replacement
 
     assert generic_commands.schedule_guard_daemon_ensure is original
+
+
+def test_commands_facade_restores_overrides_captured_by_modules_imported_inside_window(monkeypatch) -> None:
+    import sys
+    from types import ModuleType
+
+    from codex_plugin_scanner.guard.cli import _commands_shared as shared_commands
+    from codex_plugin_scanner.guard.cli import commands_support as support_module
+
+    real_queue = support_module.queue_blocked_approvals
+
+    def replacement(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("override leaked past the scoped call")
+
+    monkeypatch.setattr(guard_commands_module, "queue_blocked_approvals", replacement)
+
+    probe_name = f"{guard_commands_module.__package__}.commands_hook_probe_leak"
+    probe = ModuleType(probe_name)
+    monkeypatch.setitem(sys.modules, probe_name, probe)
+
+    with guard_commands_module._support_overrides():
+        probe.queue_blocked_approvals = shared_commands.queue_blocked_approvals
+        assert probe.queue_blocked_approvals is replacement
+
+    assert probe.queue_blocked_approvals is real_queue


### PR DESCRIPTION
## Summary
- The scoped CLI facade override window snapshotted only compatibility `commands_hook_*` modules that were already loaded; a compatibility module imported for the first time inside the window bound the override values at import time and kept them after the window closed, leaking one invocation's stubs into every later invocation in the same process
- Reset those captured bindings when the window exits, so overrides can no longer leak across independent CLI invocations
- Add a regression test covering a compatibility module imported inside the override window

## Testing
- `uv run --no-sync pytest -q tests/test_guard_cli_commands_facade.py tests/test_guard_codex_browser_authority.py tests/test_guard_package_hook.py`
- `uv run --no-sync python -m ruff check src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_cli_commands_facade.py && uv run --no-sync python -m ruff format --check src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_cli_commands_facade.py`

## Notes
- This fixes ordering-dependent `test_guard_package_hook.py` failures where a hook run inherited another invocation's stub and aborted with "terminal package block must not queue or wait for browser approval".
