### PR TITLE
feat(guard): add tether memory MCP server contribution

### DIFF
--- a/contracts/extensions/trust-class-map.v1.json
+++ b/contracts/extensions/trust-class-map.v1.json
@@ -78,6 +78,7 @@
     "external": [
       "command.blitcp",
       "command.mcp-filesystem",
+      "command.mcp-tether",
       "command.noodle",
       "command.probe",
       "command.remote.essh",

--- a/contributions/mcp-servers/mcp.tether.json
+++ b/contributions/mcp-servers/mcp.tether.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": "guard.mcp-server-contribution.v1",
+  "id": "mcp.tether",
+  "version": "1.0.0",
+  "name": "tether memory MCP",
+  "description": "Reviews tether memory writes: remember, link, forget, and the association updates recall makes. Off until you turn it on.",
+  "trustClass": "external",
+  "activation": "opt-in",
+  "publisher": {
+    "id": "community.sidyellur",
+    "displayName": "sidyellur",
+    "url": "https://github.com/sidyellur/tether"
+  },
+  "icon": {
+    "kind": "react-icon",
+    "name": "HiMiniCube",
+    "background": "#0F766E"
+  },
+  "homepage": "https://github.com/sidyellur/tether",
+  "license": "MIT",
+  "launch": {
+    "kind": "package-launcher",
+    "command": "uvx",
+    "package": "tether-memory"
+  },
+  "riskClasses": ["external-filesystem-write", "remote-state-mutation"],
+  "tools": [
+    { "name": "remember", "state": "inherit" },
+    { "name": "recall", "state": "inherit" },
+    { "name": "link", "state": "inherit" },
+    { "name": "forget", "state": "inherit" },
+    { "name": "other", "state": "inherit" }
+  ],
+  "referenceUrls": [
+    "https://github.com/sidyellur/tether",
+    "https://pypi.org/project/tether-memory/"
+  ],
+  "saferAlternatives": [
+    "Keep remember, link, and forget on Recommended review; forget is a reversible soft delete, so Block is rarely needed.",
+    "Leave libSQL sync unset to keep memory writes on this device only."
+  ]
+}

--- a/docs/guard/extensions/README.md
+++ b/docs/guard/extensions/README.md
@@ -122,6 +122,7 @@ Protection model meanings:
 | Extension | What it protects | Rules | Protection model |
 | :--- | :--- | ---: | :--- |
 | `command.mcp-filesystem` | Reviews official filesystem MCP tools. Off until you turn it on. | 0 | External opt-in |
+| `command.mcp-tether` | Reviews tether memory writes: remember, link, forget, and the association updates recall makes. Off until you turn it on. | 0 | External opt-in |
 | `command.skill-sunset` | Reviews the canonical Skill Sunset audit surface and its local report and viewer side effects. Experiment execution and npm launcher policy remain outside this extension. | 1 | External opt-in |
 
 ### Other extensions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,7 @@ packages = ["src/codex_plugin_scanner"]
 "contributions/extensions/command.skill-sunset.json" = "codex_plugin_scanner/guard/contracts/data/extensions/contributions/command.skill-sunset.json"
 "contracts/mcp-servers/contribution.v1.schema.json" = "codex_plugin_scanner/guard/contracts/data/mcp_servers/contribution.v1.schema.json"
 "contributions/mcp-servers/mcp.filesystem.json" = "codex_plugin_scanner/guard/contracts/data/mcp_servers/contributions/mcp.filesystem.json"
+"contributions/mcp-servers/mcp.tether.json" = "codex_plugin_scanner/guard/contracts/data/mcp_servers/contributions/mcp.tether.json"
 
 [tool.hatch.build]
 artifacts = [

--- a/scripts/release/stage_guard_cloud_review_artifacts.py
+++ b/scripts/release/stage_guard_cloud_review_artifacts.py
@@ -20,6 +20,7 @@ _ARTIFACTS = {
     "contributions/extensions/command.skill-sunset.json": "extensions/contributions/command.skill-sunset.json",
     "contracts/mcp-servers/contribution.v1.schema.json": "mcp_servers/contribution.v1.schema.json",
     "contributions/mcp-servers/mcp.filesystem.json": "mcp_servers/contributions/mcp.filesystem.json",
+    "contributions/mcp-servers/mcp.tether.json": "mcp_servers/contributions/mcp.tether.json",
 }
 
 

--- a/tests/fixtures/extension-controls/catalog-baseline.v1.json
+++ b/tests/fixtures/extension-controls/catalog-baseline.v1.json
@@ -7,7 +7,7 @@
     "canonical_diff_digest",
     "effective"
   ],
-  "catalog_digest": "14dfe51da62093fc36240bd1deed75626c5931179b89b4e157c0530afb939b09",
+  "catalog_digest": "6a097a2e33553091e875457bdd7d2cbf5473648c5d306e8f2703d1f432948206",
   "control_schema_version": "1.0.0",
   "daemon_api_schema": "guard.daemon.extension-controls.v1",
   "effective_shape": [
@@ -21,7 +21,7 @@
     "failures",
     "projection"
   ],
-  "extension_count": 67,
+  "extension_count": 68,
   "extension_ids": [
     "command.api-gateway",
     "command.backup.borg",
@@ -58,6 +58,7 @@
     "command.kubernetes-secrets",
     "command.load-balancer",
     "command.mcp-filesystem",
+    "command.mcp-tether",
     "command.messaging.kafka",
     "command.messaging.nats",
     "command.messaging.rabbitmq",
@@ -94,7 +95,7 @@
   "extension_schema_version": 2,
   "installed_browser_config": "dashboard/playwright.installed.config.ts",
   "overview_route": "/extensions",
-  "permission_count": 222,
+  "permission_count": 223,
   "permission_examples": {
     "command.api-gateway.permission.delete": "aws apigateway delete-rest-api",
     "command.backup.borg.permission.mutation": "borg delete",
@@ -244,6 +245,7 @@
     "command.kubernetes-secrets.permission.secret-read": "kubectl get secret db-credentials -o yaml",
     "command.load-balancer.permission.delete": "aws elbv2 delete-load-balancer",
     "command.mcp-filesystem.permission.mcp-filesystem-tool": "npx -y @modelcontextprotocol/server-filesystem",
+    "command.mcp-tether.permission.mcp-tether-tool": "uvx -y tether-memory",
     "command.messaging.kafka.permission.delete": "kafka-topics --delete",
     "command.messaging.nats.permission.delete": "nats str rm ORDERS",
     "command.messaging.rabbitmq.permission.delete": "rabbitmqctl delete_queue jobs",
@@ -540,6 +542,7 @@
     "command.kubernetes-secrets.permission.secret-read",
     "command.load-balancer.permission.delete",
     "command.mcp-filesystem.permission.mcp-filesystem-tool",
+    "command.mcp-tether.permission.mcp-tether-tool",
     "command.messaging.kafka.permission.delete",
     "command.messaging.nats.permission.delete",
     "command.messaging.rabbitmq.permission.delete",

--- a/tests/test_guard_command_permission_catalog.py
+++ b/tests/test_guard_command_permission_catalog.py
@@ -187,7 +187,7 @@ def test_permission_catalog_serialization_and_digest_are_deterministic() -> None
     reversed_registry = CommandSafetyExtensionRegistry(tuple(reversed(registry.extensions)))
 
     assert reversed_registry.catalog_digest == registry.catalog_digest
-    assert registry.catalog_digest == "14dfe51da62093fc36240bd1deed75626c5931179b89b4e157c0530afb939b09"
+    assert registry.catalog_digest == "6a097a2e33553091e875457bdd7d2cbf5473648c5d306e8f2703d1f432948206"
     assert [permission.permission_id for permission in registry.permissions] == sorted(
         permission.permission_id for permission in registry.permissions
     )

--- a/tests/test_guard_extension_trust.py
+++ b/tests/test_guard_extension_trust.py
@@ -97,6 +97,7 @@ def test_trust_map_covers_every_builtin_extension() -> None:
     assert ids_for_class("external") == {
         "command.blitcp",
         "command.mcp-filesystem",
+        "command.mcp-tether",
         "command.noodle",
         "command.probe",
         "command.remote.essh",

--- a/tests/test_guard_mcp_server_contribution.py
+++ b/tests/test_guard_mcp_server_contribution.py
@@ -183,3 +183,35 @@ def test_frozen_mcp_payloads_fail_closed_without_package_data(tmp_path: Path, mo
     monkeypatch.setattr(mcp_module.resources, "files", missing_package)
     with pytest.raises(FileNotFoundError, match="contributions"):
         mcp_module._load_packaged_payloads()
+
+
+_TETHER = Path(__file__).resolve().parents[1] / "contributions/mcp-servers/mcp.tether.json"
+
+
+def _tether_payload() -> dict[str, object]:
+    payload = json.loads(_TETHER.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_tether_catalog_item_is_external_opt_in() -> None:
+    extension = BUILT_IN_COMMAND_EXTENSION_REGISTRY.get("command.mcp-tether")
+    assert extension is not None
+    payload = extension.to_dict()
+    assert payload["enabled"] is False
+    assert payload["trust_class"] == "external"
+    assert payload["activation"] == "opt-in"
+    assert payload["surface"] == "mcp"
+    assert payload["mcp_launch"]["command"] == "uvx"
+    assert payload["mcp_launch"]["package"] == "tether-memory"
+    assert payload["publisher"]["id"] == "community.sidyellur"
+    assert payload["icon"]["name"] == "HiMiniCube"
+    assert payload["permissions"][0]["configurable"] is False
+    assert trust_class_for("command.mcp-tether") == "external"
+    assert "command.mcp-tether" in mcp_catalog_ids()
+
+
+def test_tether_tool_defaults_keep_every_write_on_review() -> None:
+    payload = _tether_payload()
+    for tool_name in ("remember", "recall", "link", "forget", "unknown_tool"):
+        assert mcp_tool_state(payload, tool_name) == "inherit"

--- a/tests/test_guard_mcp_server_grants.py
+++ b/tests/test_guard_mcp_server_grants.py
@@ -230,3 +230,128 @@ def test_evaluate_write_file_stays_review_while_inert(tmp_path: Path) -> None:
     )
     assert decision.action == "review"
     assert decision.source != "catalog-mcp-extension"
+
+
+def _tether_identity():
+    return build_mcp_server_identity(
+        config_path="",
+        command="uvx",
+        args=("tether-memory",),
+        transport="stdio",
+    )
+
+
+def _tether_artifact(identity, tool_name: str):
+    return build_tool_call_artifact(
+        harness="codex",
+        server_name="tether",
+        tool_name=tool_name,
+        source_scope="project",
+        config_path=".mcp.json",
+        transport="stdio",
+        server_identity=identity,
+    )
+
+
+@pytest.mark.parametrize("tool_name", ["remember", "recall", "link", "forget"])
+def test_tether_mcp_stays_inert_until_enabled(tool_name: str) -> None:
+    artifact = _tether_artifact(_tether_identity(), tool_name)
+    assert apply_contributed_mcp_decision(_AuthorityStore(), artifact, "review") is None
+
+
+@pytest.mark.parametrize("tool_name", ["remember", "recall", "link", "forget"])
+def test_enabled_tether_keeps_every_tool_on_review(tool_name: str) -> None:
+    artifact = _tether_artifact(_tether_identity(), tool_name)
+    enabled = _AuthorityStore((_layer(ControlLayerKind.LOCAL_ADMIN, "command.mcp-tether", ControlState.ENABLED),))
+    assert apply_contributed_mcp_decision(enabled, artifact, "review") is None
+
+
+def test_signed_cloud_enable_does_not_activate_tether() -> None:
+    artifact = _tether_artifact(_tether_identity(), "forget")
+    cloud = _AuthorityStore((_layer(ControlLayerKind.SIGNED_CLOUD, "command.mcp-tether", ControlState.ENABLED),))
+    assert apply_contributed_mcp_decision(cloud, artifact, "review") is None
+
+
+def test_pipx_launch_matches_tether_package() -> None:
+    identity = build_mcp_server_identity(
+        config_path="",
+        command="pipx",
+        args=("run", "tether-memory"),
+        transport="stdio",
+    )
+    assert identity.package_name == "tether-memory"
+    artifact = _tether_artifact(identity, "remember")
+    assert apply_contributed_mcp_decision(_AuthorityStore(), artifact, "review") is None
+
+
+def test_custom_mcp_grant_overrides_tether_contribution(tmp_path: Path) -> None:
+    identity = _tether_identity()
+    store = GuardStore(tmp_path / "guard-home")
+    cli_identity = UnlistedCliIdentity(
+        cli_id=f"local-cli.mcp-{identity.identity_hash[:8]}",
+        name=identity.package_name or "mcp-server",
+        kind="executable",
+        identity_hash=identity.identity_hash,
+        example_label="uvx tether-memory",
+    )
+    store.record_local_cli_observation(
+        cli_identity,
+        seen_at=utc_now(),
+        surface="mcp",
+        server_identity_hash=identity.identity_hash,
+        server_command=identity.command,
+        server_args_hash=identity.args_hash,
+        help_status="ok",
+    )
+    store.replace_local_cli_commands(
+        cli_identity.cli_id,
+        (LocalCliCommand("forget", "forget", "forget", "Soft-delete a memory"),),
+    )
+    store.upsert_local_cli_grant(
+        identity=cli_identity,
+        state="allowed",
+        expected_revision=0,
+        updated_at=utc_now(),
+        command_states={"forget": "block"},
+    )
+    artifact = _tether_artifact(identity, "forget")
+    granted = apply_local_mcp_extension_decision(store, artifact, "review")
+    assert granted is not None
+    assert granted[0] == "block"
+    assert granted[1] == "local-mcp-extension"
+
+
+def _evaluate_tether_forget(tmp_path: Path, store: GuardStore):
+    artifact = _tether_artifact(_tether_identity(), "forget")
+    arguments = {"id": 42}
+    config = _config(tmp_path)
+    return evaluate_tool_call(
+        store=store,
+        config=config,
+        artifact=artifact,
+        artifact_hash=build_tool_call_hash(artifact, arguments, workspace=tmp_path, config=config),
+        arguments=arguments,
+        claim_saved_approval=False,
+    )
+
+
+def test_evaluate_tether_forget_unchanged_by_local_enable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every tether tool inherits, so enabling the catalog item must not change Guard's usual review."""
+
+    inert = _evaluate_tether_forget(tmp_path, GuardStore(tmp_path / "inert-home"))
+    assert inert.source != "catalog-mcp-extension"
+
+    store = GuardStore(tmp_path / "guard-home")
+    view = ExtensionControlAuthorityView(
+        health=AuthorityHealth.PROTECTED,
+        revision=1,
+        catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest,
+        layers=(_layer(ControlLayerKind.LOCAL_ADMIN, "command.mcp-tether", ControlState.ENABLED),),
+    )
+    monkeypatch.setattr(store, "read_extension_control_authority_for_registry", lambda _registry: view)
+    enabled = _evaluate_tether_forget(tmp_path, store)
+    assert enabled.action == inert.action
+    assert enabled.source != "catalog-mcp-extension"


### PR DESCRIPTION
## Summary

Adds [tether](https://github.com/sidyellur/tether) (`tether-memory` on PyPI) as an External, opt-in MCP server contribution, following the path in `docs/guard/mcp-server-contributions.md`. Discussed with @kantorcodes1 on r/mcp; this is the first memory server in the catalog.

tether is a local-first memory MCP server (SQLite + FTS5, optional libSQL sync). Its state-changing surface is `remember` (upsert), `link`, `forget` (soft delete via `valid_to`, reversible), and `recall`, which updates association weights as a side effect of reading.

## What changed

- `contributions/mcp-servers/mcp.tether.json`: new entry. `uvx` + package `tether-memory`; all four tools plus `other` are `inherit`, so enabling the item keeps Guard's usual review rather than hard-blocking anything. Risk classes: `external-filesystem-write` (the store lives outside the workspace) and `remote-state-mutation` (only when the operator opts into libSQL sync).
- `contracts/extensions/trust-class-map.v1.json`: `command.mcp-tether` added to `external`.
- `pyproject.toml` force-include and `scripts/release/stage_guard_cloud_review_artifacts.py`: package the new JSON.
- `docs/guard/extensions/README.md`: regenerated with `scripts/render_command_extension_directory.py`.
- `tests/fixtures/extension-controls/catalog-baseline.v1.json`: regenerated identity snapshot (catalog digest, 67 → 68 extensions, 222 → 223 permissions).

## Tests

- `tests/test_guard_mcp_server_contribution.py`: tether catalog item is external / opt-in / off by default, launches via `uvx tether-memory`, and every tool resolves to `inherit`.
- `tests/test_guard_mcp_server_grants.py`: tether stays inert until a local-admin enable; a signed-cloud enable does not activate it; a `pipx run tether-memory` launch matches the same package identity; a this-device custom grant still wins over the contribution; and enabling the item leaves `evaluate_tool_call` unchanged for `forget` (same action, source never `catalog-mcp-extension`).
- `tests/test_guard_extension_trust.py`: expected external id set updated.

Ran `ruff check` / `ruff format --check` on touched files, the focused test files, the full `pytest` suite, and `python -m build --wheel` (the wheel contains `mcp_servers/contributions/mcp.tether.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wyui2ch8btSWpCziWFMSvP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in Tether Memory integration with tools for remembering, recalling, linking, and forgetting information.
  * Tether Memory actions remain subject to review when enabled and are classified as external operations.
* **Documentation**
  * Added the integration to the specialized tools documentation, including its opt-in status and protection model.
* **Tests**
  * Added coverage for trust classification, enablement behavior, tool permissions, launch configuration, and custom permission overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->