### PR TITLE
fix(scanner): ignore env interpolations in HARDCODED_SECRET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Claude marketplace scans treat `strict` as an optional boolean on each
   `plugins[]` entry (default `true`) instead of requiring a root-level field
   that Claude Code rejects.
-- `HARDCODED_SECRET` no longer treats `${VAR}` or `{{var}}` expansions as
-  embedded credentials outside docs and tests.
+- `HARDCODED_SECRET` no longer treats pure `${VAR}` or `{{var}}` expansions as
+  embedded credentials outside docs and tests. Non-empty defaults and suffixes
+  still fail.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Claude marketplace scans treat `strict` as an optional boolean on each
   `plugins[]` entry (default `true`) instead of requiring a root-level field
   that Claude Code rejects.
+- `HARDCODED_SECRET` no longer treats `${VAR}` or `{{var}}` expansions as
+  embedded credentials outside docs and tests.
 
 ### Changed
 

--- a/src/codex_plugin_scanner/checks/security.py
+++ b/src/codex_plugin_scanner/checks/security.py
@@ -225,12 +225,18 @@ def _normalize_secret_candidate(value: str) -> str:
     return normalized
 
 
+def _looks_like_interpolated_secret(value: str) -> bool:
+    """Env and template expansions are references, not embedded credentials."""
+    normalized = _normalize_secret_candidate(value)
+    return normalized.startswith(("${", "{{"))
+
+
 def _looks_like_placeholder_secret(value: str) -> bool:
     normalized = _normalize_secret_candidate(value)
     lowered = normalized.lower()
     if not normalized:
         return True
-    if normalized.startswith(("${", "{{", "<", "[")):
+    if _looks_like_interpolated_secret(normalized) or normalized.startswith(("<", "[")):
         return True
     if "..." in normalized or "…" in normalized:
         return True
@@ -404,6 +410,8 @@ def _should_skip_secret_match(
 ) -> bool:
     """Decide whether a match qualifies for a scoped non-secret or example exemption."""
     candidate = _extract_secret_candidate(detector, match)
+    if _looks_like_interpolated_secret(candidate):
+        return True
     if detector.kind == "generic" and _provider_payload(candidate) is None:
         if _is_generated_token_expression(relative_path, content, match):
             return True

--- a/src/codex_plugin_scanner/checks/security.py
+++ b/src/codex_plugin_scanner/checks/security.py
@@ -225,10 +225,18 @@ def _normalize_secret_candidate(value: str) -> str:
     return normalized
 
 
+_PURE_SHELL_EXPANSION_RE = re.compile(
+    r"^\$\{[A-Za-z_][A-Za-z0-9_]*"
+    r"(?:(?::-|-|:=|=|:\?|\?|:\+|\+)(?:\$\{[A-Za-z_][A-Za-z0-9_]*\}|\$[A-Za-z_][A-Za-z0-9_]*)?)?"
+    r"\}$"
+)
+_PURE_TEMPLATE_EXPANSION_RE = re.compile(r"^\{\{[^}]+\}\}$")
+
+
 def _looks_like_interpolated_secret(value: str) -> bool:
-    """Env and template expansions are references, not embedded credentials."""
+    """True only for complete env/template references with no literal payload."""
     normalized = _normalize_secret_candidate(value)
-    return normalized.startswith(("${", "{{"))
+    return bool(_PURE_SHELL_EXPANSION_RE.fullmatch(normalized) or _PURE_TEMPLATE_EXPANSION_RE.fullmatch(normalized))
 
 
 def _looks_like_placeholder_secret(value: str) -> bool:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -230,6 +230,18 @@ class TestNoHardcodedSecrets:
             assert result.passed is False
             assert result.findings[0].file_path == "src/app.py"
 
+    def test_ignores_env_interpolations_in_scripts(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            scripts_dir = root / "scripts"
+            scripts_dir.mkdir()
+            (scripts_dir / "x.sh").write_text('API_KEY="${GEMINI_API_KEY:-}"\n', encoding="utf-8")
+
+            result = check_no_hardcoded_secrets(root)
+
+            assert result.passed is True
+            assert all(finding.rule_id != "HARDCODED_SECRET" for finding in result.findings)
+
     def test_detects_plain_provider_token_examples_without_illustrative_context(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/tests/test_security_nonsecret_values.py
+++ b/tests/test_security_nonsecret_values.py
@@ -19,6 +19,25 @@ FIELD_MAP = """const SUFFIX_BY_FIELD: Record<Field, string> = {
 };"""
 
 
+@pytest.mark.parametrize("path", ["scripts/start.sh", "src/config.py", "src/provider.ts"])
+@pytest.mark.parametrize(
+    "content",
+    [
+        'API_KEY="${GEMINI_API_KEY:-}"',
+        'api_key = "${GEMINI_API_KEY}"',
+        'token = "{{secrets.GEMINI_API_KEY}}"',
+    ],
+)
+def test_interpolated_secret_values_are_not_hardcoded(path, content):
+    """Variable expansions are references, including in production scripts."""
+    assert _first_hardcoded_secret_line(Path(path), content) is None
+
+
+def test_interpolated_assignment_does_not_hide_adjacent_secret():
+    content = 'API_KEY="${GEMINI_API_KEY:-}"\npassword="actual-pass-937"'
+    assert _first_hardcoded_secret_line(Path("scripts/start.sh"), content) == 2
+
+
 @pytest.mark.parametrize("path", ["README.md", "examples/docker.md", "scripts/start.sh"])
 @pytest.mark.parametrize("encoding", ["hex", "base64"])
 def test_generated_token_expression_is_not_a_literal_secret(path, encoding):

--- a/tests/test_security_nonsecret_values.py
+++ b/tests/test_security_nonsecret_values.py
@@ -26,11 +26,25 @@ FIELD_MAP = """const SUFFIX_BY_FIELD: Record<Field, string> = {
         'API_KEY="${GEMINI_API_KEY:-}"',
         'api_key = "${GEMINI_API_KEY}"',
         'token = "{{secrets.GEMINI_API_KEY}}"',
+        'API_KEY="${GEMINI_API_KEY:-$BACKUP_KEY}"',
     ],
 )
 def test_interpolated_secret_values_are_not_hardcoded(path, content):
     """Variable expansions are references, including in production scripts."""
     assert _first_hardcoded_secret_line(Path(path), content) is None
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        'password="${PASSWORD:-actual-pass-937}"',
+        'password="${PASSWORD}actual-pass-937"',
+        'API_KEY="${API_KEY:-actual-secret-937}"',
+    ],
+)
+def test_interpolations_with_literal_payloads_still_fire(content):
+    """A non-empty default or suffix is still embedded credential material."""
+    assert _first_hardcoded_secret_line(Path("scripts/start.sh"), content) == 1
 
 
 def test_interpolated_assignment_does_not_hide_adjacent_secret():


### PR DESCRIPTION
## Summary
- Skip `${VAR}` and `{{var}}` expansions in `HARDCODED_SECRET`, including in scripts and source.
- Keep other placeholder heuristics limited to docs, tests, and example paths.

## Testing
- `ruff check src/codex_plugin_scanner/checks/security.py tests/test_security_nonsecret_values.py tests/test_security.py`
- `ruff format --check src/codex_plugin_scanner/checks/security.py tests/test_security_nonsecret_values.py tests/test_security.py`
- `pytest tests/test_security_nonsecret_values.py tests/test_security.py::TestNoHardcodedSecrets --tb=short`

## Notes
- Fixes #2811


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Security scanning no longer incorrectly flags pure environment-variable or template interpolations, such as `${VAR}` and `{{var}}`, as hardcoded credentials.
  - Interpolations containing literal defaults or suffixes, as well as adjacent literal secrets, continue to be detected.

- **Documentation**
  - Updated the changelog to document the improved handling of interpolated secret references.

- **Tests**
  - Added coverage across shell, Python, and TypeScript-like files to verify accurate secret detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->