### PR TITLE
fix(guard): salvage custom extension grants after store recovery

### DIFF
--- a/src/codex_plugin_scanner/guard/sqlite_recovery.py
+++ b/src/codex_plugin_scanner/guard/sqlite_recovery.py
@@ -194,3 +194,79 @@ def restore_readable_sqlite_store(*, destination: Path, quarantined: Path) -> bo
         with suppress(OSError):
             destination.replace(quarantined)
         return False
+
+
+_LOCAL_CLI_SALVAGE_TABLES = (
+    "local_cli_schema_migration",
+    "local_cli_authority",
+    "local_cli_observation",
+    "local_cli_grant",
+    "local_cli_command",
+    "local_cli_command_grant",
+)
+
+
+def salvage_local_cli_state(*, source: Path, destination: Path) -> bool:
+    """Copy readable custom-extension tables from a quarantined store.
+
+    Full ``quick_check`` can fail after an interrupted update while
+    ``local_cli_*`` tables still SELECT. Empty reinit would drop those grants.
+    """
+
+    if source.is_symlink() or destination.is_symlink() or not destination.is_file():
+        return False
+    try:
+        source_uri = f"{source.resolve().as_uri()}?mode=ro&immutable=1"
+        with (
+            sqlite3.connect(source_uri, uri=True, timeout=1.0) as src,
+            sqlite3.connect(destination, timeout=1.0) as dst,
+        ):
+            from .store_local_cli_schema import ensure_local_cli_schema
+
+            ensure_local_cli_schema(dst)
+            copied = False
+            for table in _LOCAL_CLI_SALVAGE_TABLES:
+                if _copy_allowlisted_table(src, dst, table):
+                    copied = True
+            if copied:
+                dst.commit()
+            return copied
+    except sqlite3.Error:
+        return False
+
+
+def _copy_allowlisted_table(src: sqlite3.Connection, dst: sqlite3.Connection, table: str) -> bool:
+    if table not in _LOCAL_CLI_SALVAGE_TABLES:
+        return False
+    try:
+        source_columns = _table_columns(src, table)
+        dest_columns = _table_columns(dst, table)
+    except sqlite3.Error:
+        return False
+    shared = [column for column in dest_columns if column in source_columns]
+    if not shared:
+        return False
+    quoted = ",".join(f'"{column}"' for column in shared)
+    placeholders = ",".join("?" for _ in shared)
+    try:
+        rows = src.execute(f'select {quoted} from "{table}"').fetchall()
+        _ = dst.execute(f'delete from "{table}"')
+        if rows:
+            _ = dst.executemany(
+                f'insert or replace into "{table}" ({quoted}) values ({placeholders})',
+                rows,
+            )
+    except sqlite3.Error:
+        return False
+    return True
+
+
+def _table_columns(connection: sqlite3.Connection, table: str) -> list[str]:
+    if table not in _LOCAL_CLI_SALVAGE_TABLES:
+        return []
+    names: list[str] = []
+    for row in connection.execute(f'pragma table_info("{table}")'):
+        name = row[1] if isinstance(row, tuple) else row["name"]
+        if isinstance(name, str) and name:
+            names.append(name)
+    return names

--- a/src/codex_plugin_scanner/guard/sqlite_recovery.py
+++ b/src/codex_plugin_scanner/guard/sqlite_recovery.py
@@ -277,6 +277,8 @@ def _copy_allowlisted_table(src: sqlite3.Connection, dst: sqlite3.Connection, ta
                 _ = dst.execute(statement, row)
                 inserted = True
             except sqlite3.Error:
+                if table not in _PARTIAL_COPY_OK_TABLES:
+                    return False
                 continue
     except sqlite3.Error:
         # Partial command or command-grant copies can drop block rows and

--- a/src/codex_plugin_scanner/guard/sqlite_recovery.py
+++ b/src/codex_plugin_scanner/guard/sqlite_recovery.py
@@ -208,6 +208,13 @@ _REQUIRED_LOCAL_CLI_SALVAGE_TABLES = (
     "local_cli_command",
     "local_cli_command_grant",
 )
+_PARTIAL_COPY_OK_TABLES = frozenset(
+    {
+        "local_cli_authority",
+        "local_cli_observation",
+        "local_cli_grant",
+    }
+)
 
 
 def salvage_local_cli_state(*, source: Path, destination: Path) -> bool:
@@ -272,7 +279,9 @@ def _copy_allowlisted_table(src: sqlite3.Connection, dst: sqlite3.Connection, ta
             except sqlite3.Error:
                 continue
     except sqlite3.Error:
-        return inserted
+        # Partial command or command-grant copies can drop block rows and
+        # widen an allowed grant. Fail those tables closed.
+        return inserted if table in _PARTIAL_COPY_OK_TABLES else False
     return inserted or not saw_rows
 
 

--- a/src/codex_plugin_scanner/guard/sqlite_recovery.py
+++ b/src/codex_plugin_scanner/guard/sqlite_recovery.py
@@ -249,18 +249,23 @@ def _copy_allowlisted_table(src: sqlite3.Connection, dst: sqlite3.Connection, ta
     quoted = ",".join(f'"{column}"' for column in shared)
     placeholders = ",".join("?" for _ in shared)
     try:
-        rows = src.execute(f'select {quoted} from "{table}"').fetchall()
+        cursor = src.execute(f'select {quoted} from "{table}"')
     except sqlite3.Error:
         return False
     inserted = False
+    saw_rows = False
     statement = f'insert or replace into "{table}" ({quoted}) values ({placeholders})'
-    for row in rows:
-        try:
-            _ = dst.execute(statement, row)
-            inserted = True
-        except sqlite3.Error:
-            continue
-    return inserted or not rows
+    try:
+        for row in cursor:
+            saw_rows = True
+            try:
+                _ = dst.execute(statement, row)
+                inserted = True
+            except sqlite3.Error:
+                continue
+    except sqlite3.Error:
+        return inserted
+    return inserted or not saw_rows
 
 
 def _table_columns(connection: sqlite3.Connection, table: str) -> list[str]:

--- a/src/codex_plugin_scanner/guard/sqlite_recovery.py
+++ b/src/codex_plugin_scanner/guard/sqlite_recovery.py
@@ -223,13 +223,14 @@ def salvage_local_cli_state(*, source: Path, destination: Path) -> bool:
             from .store_local_cli_schema import ensure_local_cli_schema
 
             ensure_local_cli_schema(dst)
-            copied = False
+            copied: dict[str, bool] = {}
             for table in _LOCAL_CLI_SALVAGE_TABLES:
-                if _copy_allowlisted_table(src, dst, table):
-                    copied = True
-            if copied:
-                dst.commit()
-            return copied
+                copied[table] = _copy_allowlisted_table(src, dst, table)
+            if not copied.get("local_cli_grant"):
+                dst.rollback()
+                return False
+            dst.commit()
+            return True
     except sqlite3.Error:
         return False
 

--- a/src/codex_plugin_scanner/guard/sqlite_recovery.py
+++ b/src/codex_plugin_scanner/guard/sqlite_recovery.py
@@ -197,7 +197,6 @@ def restore_readable_sqlite_store(*, destination: Path, quarantined: Path) -> bo
 
 
 _LOCAL_CLI_SALVAGE_TABLES = (
-    "local_cli_schema_migration",
     "local_cli_authority",
     "local_cli_observation",
     "local_cli_grant",
@@ -216,7 +215,7 @@ def salvage_local_cli_state(*, source: Path, destination: Path) -> bool:
     if source.is_symlink() or destination.is_symlink() or not destination.is_file():
         return False
     try:
-        source_uri = f"{source.resolve().as_uri()}?mode=ro&immutable=1"
+        source_uri = f"{source.resolve().as_uri()}?mode=ro"
         with (
             sqlite3.connect(source_uri, uri=True, timeout=1.0) as src,
             sqlite3.connect(destination, timeout=1.0) as dst,
@@ -250,15 +249,17 @@ def _copy_allowlisted_table(src: sqlite3.Connection, dst: sqlite3.Connection, ta
     placeholders = ",".join("?" for _ in shared)
     try:
         rows = src.execute(f'select {quoted} from "{table}"').fetchall()
-        _ = dst.execute(f'delete from "{table}"')
-        if rows:
-            _ = dst.executemany(
-                f'insert or replace into "{table}" ({quoted}) values ({placeholders})',
-                rows,
-            )
     except sqlite3.Error:
         return False
-    return True
+    inserted = False
+    statement = f'insert or replace into "{table}" ({quoted}) values ({placeholders})'
+    for row in rows:
+        try:
+            _ = dst.execute(statement, row)
+            inserted = True
+        except sqlite3.Error:
+            continue
+    return inserted or not rows
 
 
 def _table_columns(connection: sqlite3.Connection, table: str) -> list[str]:

--- a/src/codex_plugin_scanner/guard/sqlite_recovery.py
+++ b/src/codex_plugin_scanner/guard/sqlite_recovery.py
@@ -203,6 +203,11 @@ _LOCAL_CLI_SALVAGE_TABLES = (
     "local_cli_command",
     "local_cli_command_grant",
 )
+_REQUIRED_LOCAL_CLI_SALVAGE_TABLES = (
+    "local_cli_grant",
+    "local_cli_command",
+    "local_cli_command_grant",
+)
 
 
 def salvage_local_cli_state(*, source: Path, destination: Path) -> bool:
@@ -210,6 +215,9 @@ def salvage_local_cli_state(*, source: Path, destination: Path) -> bool:
 
     Full ``quick_check`` can fail after an interrupted update while
     ``local_cli_*`` tables still SELECT. Empty reinit would drop those grants.
+    Grant, command catalog, and command-grant copies must all succeed
+    (empty tables still count) so an allowed grant cannot restore without
+    its scoped catalog.
     """
 
     if source.is_symlink() or destination.is_symlink() or not destination.is_file():
@@ -226,7 +234,7 @@ def salvage_local_cli_state(*, source: Path, destination: Path) -> bool:
             copied: dict[str, bool] = {}
             for table in _LOCAL_CLI_SALVAGE_TABLES:
                 copied[table] = _copy_allowlisted_table(src, dst, table)
-            if not copied.get("local_cli_grant"):
+            if not all(copied.get(table) for table in _REQUIRED_LOCAL_CLI_SALVAGE_TABLES):
                 dst.rollback()
                 return False
             dst.commit()

--- a/src/codex_plugin_scanner/guard/store_connection_schema.py
+++ b/src/codex_plugin_scanner/guard/store_connection_schema.py
@@ -23,6 +23,7 @@ from .sqlite_recovery import (
     FATAL_SQLITE_ERROR_MARKERS,
     SQLITE_IO_ERROR_MARKER,
     restore_readable_sqlite_store,
+    salvage_local_cli_state,
     sqlite_store_is_proven_unusable,
 )
 
@@ -315,7 +316,10 @@ class StoreConnectionSchemaMixin:
                     _store_logger.error("Guard restored the quarantined SQLite store after it still opened cleanly.")
                 else:
                     self._initialize_schema()
-                    self._last_sqlite_recovery = "reinitialized"
+                    if salvage_local_cli_state(source=quarantined, destination=self.path):
+                        self._last_sqlite_recovery = "reinitialized_salvaged"
+                    else:
+                        self._last_sqlite_recovery = "reinitialized"
             finally:
                 self._storage_recovery_local.owner = None
             return True

--- a/tests/test_guard_local_cli_sqlite_salvage.py
+++ b/tests/test_guard_local_cli_sqlite_salvage.py
@@ -69,6 +69,18 @@ def test_salvage_keeps_destination_schema_marker(tmp_path: Path) -> None:
     assert checksum != "stale"
 
 
+def test_salvage_rolls_back_when_grants_unreadable(tmp_path: Path) -> None:
+    source = _grant_store(tmp_path / "src")
+    with sqlite3.connect(source.path) as connection:
+        connection.execute("drop table local_cli_grant")
+        connection.commit()
+    destination = GuardStore(tmp_path / "dst", prime_policy_integrity=False)
+    assert salvage_local_cli_state(source=source.path, destination=destination.path) is False
+    assert destination.read_local_cli_grant(_identity().cli_id) is None
+    listed = destination.list_local_cli_items()
+    assert listed == []
+
+
 def test_salvage_ignores_unreadable_quarantine(tmp_path: Path) -> None:
     destination = GuardStore(tmp_path / "dst", prime_policy_integrity=False)
     junk = tmp_path / "junk.db"

--- a/tests/test_guard_local_cli_sqlite_salvage.py
+++ b/tests/test_guard_local_cli_sqlite_salvage.py
@@ -164,6 +164,25 @@ def test_copy_keeps_rows_read_before_source_failure(tmp_path: Path) -> None:
     assert granted["state"] == "allowed"
 
 
+def test_copy_rejects_command_grant_insert_error(tmp_path: Path) -> None:
+    source = _grant_store(tmp_path / "src", with_commands=True)
+    source.upsert_local_cli_command_states(_identity().cli_id, {"navigate": "block", "other": "block"})
+    destination = GuardStore(tmp_path / "dst", prime_policy_integrity=False)
+    with sqlite3.connect(source.path) as src, sqlite3.connect(destination.path) as dst:
+        original = dst.execute
+        inserts = {"count": 0}
+
+        class _Destination:
+            def execute(self, sql: str, parameters: object = ()) -> object:
+                if sql.strip().lower().startswith("insert"):
+                    inserts["count"] += 1
+                    if inserts["count"] >= 2:
+                        raise sqlite3.DatabaseError("constraint")
+                return original(sql, parameters)
+
+        assert _copy_allowlisted_table(src, _Destination(), "local_cli_command_grant") is False
+
+
 def test_copy_rejects_partial_command_grant_scan(tmp_path: Path) -> None:
     source = _grant_store(tmp_path / "src", with_commands=True)
     source.upsert_local_cli_command_states(_identity().cli_id, {"navigate": "block", "other": "block"})

--- a/tests/test_guard_local_cli_sqlite_salvage.py
+++ b/tests/test_guard_local_cli_sqlite_salvage.py
@@ -4,6 +4,7 @@ import sqlite3
 from pathlib import Path
 
 from codex_plugin_scanner.guard.local_cli_trust import utc_now
+from codex_plugin_scanner.guard.runtime.local_cli_commands import LocalCliCommand
 from codex_plugin_scanner.guard.runtime.local_cli_identity import UnlistedCliIdentity
 from codex_plugin_scanner.guard.sqlite_recovery import _copy_allowlisted_table, salvage_local_cli_state
 from codex_plugin_scanner.guard.store import GuardStore
@@ -19,7 +20,15 @@ def _identity() -> UnlistedCliIdentity:
     )
 
 
-def _grant_store(home: Path) -> GuardStore:
+def _commands() -> tuple[LocalCliCommand, ...]:
+    return (
+        LocalCliCommand("root", "chrome-devtools", "npx chrome-devtools", "root"),
+        LocalCliCommand("navigate", "navigate", "navigate", "Open a page", parent_id="root"),
+        LocalCliCommand("other", "Other commands", "npx chrome-devtools …", "other"),
+    )
+
+
+def _grant_store(home: Path, *, with_commands: bool = False) -> GuardStore:
     store = GuardStore(home, prime_policy_integrity=False)
     identity = _identity()
     store.record_local_cli_observation(
@@ -34,6 +43,9 @@ def _grant_store(home: Path) -> GuardStore:
         expected_revision=0,
         updated_at=utc_now(),
     )
+    if with_commands:
+        store.replace_local_cli_commands(identity.cli_id, _commands())
+        store.upsert_local_cli_command_states(identity.cli_id, {"navigate": "block"})
     return store
 
 
@@ -53,9 +65,7 @@ def test_salvage_copies_custom_extension_grant(tmp_path: Path) -> None:
 def test_salvage_keeps_destination_schema_marker(tmp_path: Path) -> None:
     source = _grant_store(tmp_path / "src")
     with sqlite3.connect(source.path) as connection:
-        connection.execute(
-            "update local_cli_schema_migration set version = 1, checksum = 'stale' where singleton = 1"
-        )
+        connection.execute("update local_cli_schema_migration set version = 1, checksum = 'stale' where singleton = 1")
         connection.commit()
     destination = GuardStore(tmp_path / "dst", prime_policy_integrity=False)
     assert salvage_local_cli_state(source=source.path, destination=destination.path) is True
@@ -79,6 +89,45 @@ def test_salvage_rolls_back_when_grants_unreadable(tmp_path: Path) -> None:
     assert destination.read_local_cli_grant(_identity().cli_id) is None
     listed = destination.list_local_cli_items()
     assert listed == []
+
+
+def test_salvage_rolls_back_when_commands_unreadable(tmp_path: Path) -> None:
+    source = _grant_store(tmp_path / "src", with_commands=True)
+    with sqlite3.connect(source.path) as connection:
+        connection.execute("drop table local_cli_command")
+        connection.commit()
+    destination = GuardStore(tmp_path / "dst", prime_policy_integrity=False)
+    assert salvage_local_cli_state(source=source.path, destination=destination.path) is False
+    assert destination.read_local_cli_grant(_identity().cli_id) is None
+    assert destination.read_local_cli_command_catalog(_identity().cli_id) == []
+    listed = destination.list_local_cli_items()
+    assert listed == []
+
+
+def test_salvage_rolls_back_when_command_grants_unreadable(tmp_path: Path) -> None:
+    source = _grant_store(tmp_path / "src", with_commands=True)
+    with sqlite3.connect(source.path) as connection:
+        connection.execute("drop table local_cli_command_grant")
+        connection.commit()
+    destination = GuardStore(tmp_path / "dst", prime_policy_integrity=False)
+    assert salvage_local_cli_state(source=source.path, destination=destination.path) is False
+    assert destination.read_local_cli_grant(_identity().cli_id) is None
+    assert destination.read_local_cli_command_catalog(_identity().cli_id) == []
+    assert destination.read_local_cli_command_states(_identity().cli_id) == {}
+    listed = destination.list_local_cli_items()
+    assert listed == []
+
+
+def test_salvage_copies_command_catalog_and_states(tmp_path: Path) -> None:
+    source = _grant_store(tmp_path / "src", with_commands=True)
+    destination = GuardStore(tmp_path / "dst", prime_policy_integrity=False)
+    assert salvage_local_cli_state(source=source.path, destination=destination.path) is True
+    granted = destination.read_local_cli_grant(_identity().cli_id)
+    assert granted is not None
+    assert granted["state"] == "allowed"
+    catalog = destination.read_local_cli_command_catalog(_identity().cli_id)
+    assert [item.command_id for item in catalog] == ["root", "navigate", "other"]
+    assert destination.read_local_cli_command_states(_identity().cli_id) == {"navigate": "block"}
 
 
 def test_copy_keeps_rows_read_before_source_failure(tmp_path: Path) -> None:

--- a/tests/test_guard_local_cli_sqlite_salvage.py
+++ b/tests/test_guard_local_cli_sqlite_salvage.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from codex_plugin_scanner.guard.local_cli_trust import utc_now
 from codex_plugin_scanner.guard.runtime.local_cli_identity import UnlistedCliIdentity
-from codex_plugin_scanner.guard.sqlite_recovery import salvage_local_cli_state
+from codex_plugin_scanner.guard.sqlite_recovery import _copy_allowlisted_table, salvage_local_cli_state
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -79,6 +79,35 @@ def test_salvage_rolls_back_when_grants_unreadable(tmp_path: Path) -> None:
     assert destination.read_local_cli_grant(_identity().cli_id) is None
     listed = destination.list_local_cli_items()
     assert listed == []
+
+
+def test_copy_keeps_rows_read_before_source_failure(tmp_path: Path) -> None:
+    source = _grant_store(tmp_path / "src")
+    destination = GuardStore(tmp_path / "dst", prime_policy_integrity=False)
+    with sqlite3.connect(source.path) as src, sqlite3.connect(destination.path) as dst:
+        original = src.execute
+
+        class _Source:
+            def execute(self, sql: str, parameters: object = ()) -> object:
+                cursor = original(sql, parameters)
+                if not sql.strip().lower().startswith("select "):
+                    return cursor
+                rows = list(cursor)
+                if not rows:
+                    return cursor
+
+                class _Cursor:
+                    def __iter__(self) -> object:
+                        yield rows[0]
+                        raise sqlite3.DatabaseError("btreeInitPage")
+
+                return _Cursor()
+
+        assert _copy_allowlisted_table(_Source(), dst, "local_cli_grant") is True
+        dst.commit()
+    granted = destination.read_local_cli_grant(_identity().cli_id)
+    assert granted is not None
+    assert granted["state"] == "allowed"
 
 
 def test_salvage_ignores_unreadable_quarantine(tmp_path: Path) -> None:

--- a/tests/test_guard_local_cli_sqlite_salvage.py
+++ b/tests/test_guard_local_cli_sqlite_salvage.py
@@ -50,6 +50,25 @@ def test_salvage_copies_custom_extension_grant(tmp_path: Path) -> None:
     assert any(item.get("cli_id") == _identity().cli_id and item.get("state") == "allowed" for item in listed)
 
 
+def test_salvage_keeps_destination_schema_marker(tmp_path: Path) -> None:
+    source = _grant_store(tmp_path / "src")
+    with sqlite3.connect(source.path) as connection:
+        connection.execute(
+            "update local_cli_schema_migration set version = 1, checksum = 'stale' where singleton = 1"
+        )
+        connection.commit()
+    destination = GuardStore(tmp_path / "dst", prime_policy_integrity=False)
+    assert salvage_local_cli_state(source=source.path, destination=destination.path) is True
+    granted = destination.read_local_cli_grant(_identity().cli_id)
+    assert granted is not None
+    with sqlite3.connect(destination.path) as connection:
+        version, checksum = connection.execute(
+            "select version, checksum from local_cli_schema_migration where singleton = 1"
+        ).fetchone()
+    assert version != 1
+    assert checksum != "stale"
+
+
 def test_salvage_ignores_unreadable_quarantine(tmp_path: Path) -> None:
     destination = GuardStore(tmp_path / "dst", prime_policy_integrity=False)
     junk = tmp_path / "junk.db"

--- a/tests/test_guard_local_cli_sqlite_salvage.py
+++ b/tests/test_guard_local_cli_sqlite_salvage.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from codex_plugin_scanner.guard.local_cli_trust import utc_now
+from codex_plugin_scanner.guard.runtime.local_cli_identity import UnlistedCliIdentity
+from codex_plugin_scanner.guard.sqlite_recovery import salvage_local_cli_state
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _identity() -> UnlistedCliIdentity:
+    return UnlistedCliIdentity(
+        cli_id="local-cli.mcp-abcdef12",
+        name="chrome-devtools",
+        kind="executable",
+        identity_hash="a" * 64,
+        example_label="npx -y chrome-devtools-mcp@latest",
+    )
+
+
+def _grant_store(home: Path) -> GuardStore:
+    store = GuardStore(home, prime_policy_integrity=False)
+    identity = _identity()
+    store.record_local_cli_observation(
+        identity,
+        seen_at=utc_now(),
+        help_status="ok",
+        surface="mcp",
+    )
+    store.upsert_local_cli_grant(
+        identity=identity,
+        state="allowed",
+        expected_revision=0,
+        updated_at=utc_now(),
+    )
+    return store
+
+
+def test_salvage_copies_custom_extension_grant(tmp_path: Path) -> None:
+    source = _grant_store(tmp_path / "src")
+    destination_home = tmp_path / "dst"
+    destination = GuardStore(destination_home, prime_policy_integrity=False)
+    assert destination.read_local_cli_grant(_identity().cli_id) is None
+    assert salvage_local_cli_state(source=source.path, destination=destination.path) is True
+    granted = destination.read_local_cli_grant(_identity().cli_id)
+    assert granted is not None
+    assert granted["state"] == "allowed"
+    listed = destination.list_local_cli_items()
+    assert any(item.get("cli_id") == _identity().cli_id and item.get("state") == "allowed" for item in listed)
+
+
+def test_salvage_ignores_unreadable_quarantine(tmp_path: Path) -> None:
+    destination = GuardStore(tmp_path / "dst", prime_policy_integrity=False)
+    junk = tmp_path / "junk.db"
+    junk.write_bytes(b"not-a-sqlite-database")
+    assert salvage_local_cli_state(source=junk, destination=destination.path) is False
+    assert destination.read_local_cli_grant(_identity().cli_id) is None
+
+
+def test_fatal_recovery_salvages_grants_when_full_restore_fails(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    store = _grant_store(tmp_path / "guard")
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.store_connection_schema.restore_readable_sqlite_store",
+        lambda **_kwargs: False,
+    )
+    monkeypatch.setattr(store, "_store_is_proven_unusable", lambda _error: True)
+    recovered = store._recover_fatal_sqlite_store(  # pyright: ignore[reportPrivateUsage]
+        sqlite3.DatabaseError("database disk image is malformed")
+    )
+    assert recovered is True
+    assert store._last_sqlite_recovery == "reinitialized_salvaged"
+    granted = store.read_local_cli_grant(_identity().cli_id)
+    assert granted is not None
+    assert granted["state"] == "allowed"

--- a/tests/test_guard_local_cli_sqlite_salvage.py
+++ b/tests/test_guard_local_cli_sqlite_salvage.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
+from codex_plugin_scanner.guard import sqlite_recovery
 from codex_plugin_scanner.guard.local_cli_trust import utc_now
 from codex_plugin_scanner.guard.runtime.local_cli_commands import LocalCliCommand
 from codex_plugin_scanner.guard.runtime.local_cli_identity import UnlistedCliIdentity
@@ -130,33 +131,75 @@ def test_salvage_copies_command_catalog_and_states(tmp_path: Path) -> None:
     assert destination.read_local_cli_command_states(_identity().cli_id) == {"navigate": "block"}
 
 
+def _source_that_fails_after_first_select_row(connection: sqlite3.Connection) -> object:
+    original = connection.execute
+
+    class _Source:
+        def execute(self, sql: str, parameters: object = ()) -> object:
+            cursor = original(sql, parameters)
+            if not sql.strip().lower().startswith("select "):
+                return cursor
+            rows = list(cursor)
+            if not rows:
+                return cursor
+
+            class _Cursor:
+                def __iter__(self) -> object:
+                    yield rows[0]
+                    raise sqlite3.DatabaseError("btreeInitPage")
+
+            return _Cursor()
+
+    return _Source()
+
+
 def test_copy_keeps_rows_read_before_source_failure(tmp_path: Path) -> None:
     source = _grant_store(tmp_path / "src")
     destination = GuardStore(tmp_path / "dst", prime_policy_integrity=False)
     with sqlite3.connect(source.path) as src, sqlite3.connect(destination.path) as dst:
-        original = src.execute
-
-        class _Source:
-            def execute(self, sql: str, parameters: object = ()) -> object:
-                cursor = original(sql, parameters)
-                if not sql.strip().lower().startswith("select "):
-                    return cursor
-                rows = list(cursor)
-                if not rows:
-                    return cursor
-
-                class _Cursor:
-                    def __iter__(self) -> object:
-                        yield rows[0]
-                        raise sqlite3.DatabaseError("btreeInitPage")
-
-                return _Cursor()
-
-        assert _copy_allowlisted_table(_Source(), dst, "local_cli_grant") is True
+        assert _copy_allowlisted_table(_source_that_fails_after_first_select_row(src), dst, "local_cli_grant") is True
         dst.commit()
     granted = destination.read_local_cli_grant(_identity().cli_id)
     assert granted is not None
     assert granted["state"] == "allowed"
+
+
+def test_copy_rejects_partial_command_grant_scan(tmp_path: Path) -> None:
+    source = _grant_store(tmp_path / "src", with_commands=True)
+    source.upsert_local_cli_command_states(_identity().cli_id, {"navigate": "block", "other": "block"})
+    destination = GuardStore(tmp_path / "dst", prime_policy_integrity=False)
+    with sqlite3.connect(source.path) as src, sqlite3.connect(destination.path) as dst:
+        assert (
+            _copy_allowlisted_table(
+                _source_that_fails_after_first_select_row(src),
+                dst,
+                "local_cli_command_grant",
+            )
+            is False
+        )
+
+
+def test_salvage_rolls_back_after_partial_command_grant_scan(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    source = _grant_store(tmp_path / "src", with_commands=True)
+    destination = GuardStore(tmp_path / "dst", prime_policy_integrity=False)
+    original = sqlite_recovery._copy_allowlisted_table
+
+    def wrapped(src: sqlite3.Connection, dst: sqlite3.Connection, table: str) -> bool:
+        copied = original(src, dst, table)
+        if table != "local_cli_command_grant":
+            return copied
+        assert copied is True
+        return False
+
+    monkeypatch.setattr(sqlite_recovery, "_copy_allowlisted_table", wrapped)
+    assert salvage_local_cli_state(source=source.path, destination=destination.path) is False
+    assert destination.read_local_cli_grant(_identity().cli_id) is None
+    assert destination.read_local_cli_command_states(_identity().cli_id) == {}
+    listed = destination.list_local_cli_items()
+    assert listed == []
 
 
 def test_salvage_ignores_unreadable_quarantine(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- After a fatal SQLite quarantine that cannot restore the full database, Guard copies readable custom-extension tables into the reinitialized store.
- Enrolled custom extensions stay listed instead of disappearing when an interrupted update leaves btree damage that still allows table reads.
- Salvage commits only when grant, command catalog, and command-grant copies succeed, so scoped allow/block decisions cannot widen.

## Testing
- `pytest tests/test_guard_local_cli_sqlite_salvage.py tests/test_guard_sqlite_failure_containment.py`

## Notes
- Full `quick_check` can fail while `local_cli_*` tables still SELECT. Empty reinit was dropping those grants.
- Empty command tables still count as copied; missing or unreadable catalog or command-grant tables roll back the whole salvage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery of local CLI data when a SQLite store is damaged or quarantined.
  * Preserves readable grants, command catalogs, and command states during recovery.
  * Safely rolls back recovery when required command data cannot be read, preventing incomplete restoration.
  * Retains successfully read rows when supported data recovery encounters a partial read.
  * Preserves the destination store’s current schema information during salvage.
  * Reports when a store is successfully reinitialized with salvaged data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->