### PR TITLE
fix(guard): keep protection after trusted catalog updates

### DIFF
--- a/src/codex_plugin_scanner/guard/store_extension_control_authority.py
+++ b/src/codex_plugin_scanner/guard/store_extension_control_authority.py
@@ -747,16 +747,6 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
                     raise ExtensionControlAuthorityError("extension control catalog digest changed")
                 pending = self._pending_transition(revision + 1)
                 if pending is not None and _row_str(pending, "catalog_digest") == catalog_digest:
-                    pending_layers = layers_from_json(_row_str(pending, "layers_json"))
-                    previous_target_ids = {
-                        control.target.target_id
-                        for layer in layers_from_json(str(row["layers_json"]))
-                        for control in layer.controls
-                    }
-                    pending_target_ids = {
-                        control.target.target_id for layer in pending_layers for control in layer.controls
-                    }
-                    retired_targets = tuple(sorted(previous_target_ids - pending_target_ids))
                     with self._connect() as connection:
                         resumed = self._resume_idempotent_transition(
                             connection,
@@ -776,14 +766,6 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
                             key=key,
                         )
                     if resumed is not None and resumed.health is AuthorityHealth.PROTECTED:
-                        self._record_catalog_migrated_event_once(
-                            previous_revision=revision,
-                            revision=_row_int(pending, "revision"),
-                            previous_catalog_digest=stored_catalog_digest,
-                            catalog_digest=catalog_digest,
-                            layers=pending_layers,
-                            retired_targets=retired_targets,
-                        )
                         return resumed
                 previous = self._read_extension_control_authority_locked(stored_catalog_digest)
                 if previous.health is not AuthorityHealth.PROTECTED:
@@ -831,6 +813,11 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
                 revision,
                 current_snapshot_digest=_row_str(row, "snapshot_digest"),
                 key=key,
+            )
+            self._ensure_catalog_migrated_event(
+                revision=revision,
+                catalog_digest=catalog_digest,
+                layers=layers,
             )
             return ExtensionControlAuthorityView(AuthorityHealth.PROTECTED, revision, catalog_digest, layers)
         except ExtensionControlAuthorityError:
@@ -966,6 +953,48 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
             raise ExtensionControlAuthorityError("invalid extension control catalog manifest")
         return value
 
+    def _ensure_catalog_migrated_event(
+        self,
+        *,
+        revision: int,
+        catalog_digest: str,
+        layers: tuple[ExtensionControlLayer, ...],
+    ) -> None:
+        if revision < 1:
+            return
+        with self._connect() as connection:
+            current = connection.execute(
+                "select previous_revision, catalog_digest, layers_json from extension_control_authority_transition "
+                "where revision = ?",
+                (revision,),
+            ).fetchone()
+            if current is None or _row_str(current, "catalog_digest") != catalog_digest:
+                return
+            previous_revision = _row_int(current, "previous_revision")
+            previous = connection.execute(
+                "select catalog_digest, layers_json from extension_control_authority_transition where revision = ?",
+                (previous_revision,),
+            ).fetchone()
+            if previous is None:
+                return
+            previous_catalog_digest = _row_str(previous, "catalog_digest")
+            if previous_catalog_digest == catalog_digest:
+                return
+            previous_target_ids = {
+                control.target.target_id
+                for layer in layers_from_json(_row_str(previous, "layers_json"))
+                for control in layer.controls
+            }
+        current_target_ids = {control.target.target_id for layer in layers for control in layer.controls}
+        self._record_catalog_migrated_event_once(
+            previous_revision=previous_revision,
+            revision=revision,
+            previous_catalog_digest=previous_catalog_digest,
+            catalog_digest=catalog_digest,
+            layers=layers,
+            retired_targets=tuple(sorted(previous_target_ids - current_target_ids)),
+        )
+
     def _record_catalog_migrated_event_once(
         self,
         *,
@@ -995,8 +1024,13 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
                 "select payload_json from guard_events where event_name = ?",
                 ("extension_control_authority_catalog_migrated",),
             ).fetchall()
-            if any(str(row["payload_json"]) == payload for row in existing):
-                return
+            for row in existing:
+                try:
+                    recorded = json.loads(str(row["payload_json"]))
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(recorded, dict) and recorded.get("revision") == revision:
+                    return
             connection.execute(
                 "insert into guard_events (event_name, payload_json, occurred_at) values (?, ?, ?)",
                 ("extension_control_authority_catalog_migrated", payload, _now()),

--- a/src/codex_plugin_scanner/guard/store_extension_control_authority.py
+++ b/src/codex_plugin_scanner/guard/store_extension_control_authority.py
@@ -178,34 +178,6 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
             raise ExtensionControlAuthorityError("managed controls require protected local authority")
         if revision_state is None or revision_state == {}:
             raise ExtensionControlAuthorityError("managed controls revision state is missing")
-        if isinstance(active, dict) and active.get("catalogDigest") != view.catalog_digest:
-            key = self._authority_key(required=True)
-            assert key is not None
-            activation_digest = active.get("catalogDigest")
-            if not isinstance(activation_digest, str):
-                raise ExtensionControlAuthorityError("incomplete managed controls activation state")
-            # Authenticate the leftover activation against its own catalog. A
-            # trusted package update rebinds local controls first, so the stored
-            # Cloud snapshot is stale but still must verify. Invalid MACs stay
-            # fail-closed; only a catalog-bound mismatch drops Cloud layers.
-            _, managed_revision = managed_controls_layers_from_activation_state(
-                active,
-                catalog_digest=activation_digest,
-                authority_key=key,
-            )
-            durable_revision = managed_controls_revision_from_state(
-                revision_state,
-                authority_key=key,
-            )
-            if managed_revision != durable_revision:
-                raise ExtensionControlAuthorityError("managed controls activation revision mismatch")
-            return ExtensionControlAuthorityView(
-                view.health,
-                view.revision,
-                view.catalog_digest,
-                local_layers,
-                durable_revision,
-            )
         key = self._authority_key(required=True)
         assert key is not None
         if not isinstance(active, dict):

--- a/src/codex_plugin_scanner/guard/store_extension_control_authority.py
+++ b/src/codex_plugin_scanner/guard/store_extension_control_authority.py
@@ -177,21 +177,23 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
             # trusted package update rebinds local controls first, so the stored
             # Cloud snapshot is stale but still must verify. Invalid MACs stay
             # fail-closed; only a catalog-bound mismatch drops Cloud layers.
-            managed_controls_layers_from_activation_state(
+            _, managed_revision = managed_controls_layers_from_activation_state(
                 active,
                 catalog_digest=activation_digest,
                 authority_key=key,
             )
-            managed_revision = managed_controls_revision_from_state(
+            durable_revision = managed_controls_revision_from_state(
                 revision_state,
                 authority_key=key,
             )
+            if managed_revision != durable_revision:
+                raise ExtensionControlAuthorityError("managed controls activation revision mismatch")
             return ExtensionControlAuthorityView(
                 view.health,
                 view.revision,
                 view.catalog_digest,
                 local_layers,
-                managed_revision,
+                durable_revision,
             )
         key = self._authority_key(required=True)
         assert key is not None
@@ -745,6 +747,16 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
                     raise ExtensionControlAuthorityError("extension control catalog digest changed")
                 pending = self._pending_transition(revision + 1)
                 if pending is not None and _row_str(pending, "catalog_digest") == catalog_digest:
+                    pending_layers = layers_from_json(_row_str(pending, "layers_json"))
+                    previous_target_ids = {
+                        control.target.target_id
+                        for layer in layers_from_json(str(row["layers_json"]))
+                        for control in layer.controls
+                    }
+                    pending_target_ids = {
+                        control.target.target_id for layer in pending_layers for control in layer.controls
+                    }
+                    retired_targets = tuple(sorted(previous_target_ids - pending_target_ids))
                     with self._connect() as connection:
                         resumed = self._resume_idempotent_transition(
                             connection,
@@ -764,6 +776,14 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
                             key=key,
                         )
                     if resumed is not None and resumed.health is AuthorityHealth.PROTECTED:
+                        self._record_catalog_migrated_event_once(
+                            previous_revision=revision,
+                            revision=_row_int(pending, "revision"),
+                            previous_catalog_digest=stored_catalog_digest,
+                            catalog_digest=catalog_digest,
+                            layers=pending_layers,
+                            retired_targets=retired_targets,
+                        )
                         return resumed
                 previous = self._read_extension_control_authority_locked(stored_catalog_digest)
                 if previous.health is not AuthorityHealth.PROTECTED:
@@ -945,6 +965,42 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
         ):
             raise ExtensionControlAuthorityError("invalid extension control catalog manifest")
         return value
+
+    def _record_catalog_migrated_event_once(
+        self,
+        *,
+        previous_revision: int,
+        revision: int,
+        previous_catalog_digest: str,
+        catalog_digest: str,
+        layers: tuple[ExtensionControlLayer, ...],
+        retired_targets: tuple[str, ...],
+    ) -> None:
+        payload = json.dumps(
+            {
+                "previous_revision": previous_revision,
+                "revision": revision,
+                "previous_catalog_digest": previous_catalog_digest,
+                "catalog_digest": catalog_digest,
+                "layer_count": len(layers),
+                "control_count": sum(len(layer.controls) for layer in layers),
+                "retired_target_count": len(retired_targets),
+                "retired_target_ids": list(retired_targets),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        with self._connect() as connection:
+            existing = connection.execute(
+                "select payload_json from guard_events where event_name = ?",
+                ("extension_control_authority_catalog_migrated",),
+            ).fetchall()
+            if any(str(row["payload_json"]) == payload for row in existing):
+                return
+            connection.execute(
+                "insert into guard_events (event_name, payload_json, occurred_at) values (?, ?, ?)",
+                ("extension_control_authority_catalog_migrated", payload, _now()),
+            )
 
     def _migrate_extension_control_catalog(
         self,

--- a/src/codex_plugin_scanner/guard/store_extension_control_authority.py
+++ b/src/codex_plugin_scanner/guard/store_extension_control_authority.py
@@ -146,6 +146,7 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
                 raise ExtensionControlAuthorityError("invalid managed controls state") from exc
         active = managed_state.get(MANAGED_CONTROLS_ACTIVE_STATE_KEY)
         revision_state = managed_state.get(MANAGED_CONTROLS_REVISION_STATE_KEY)
+        local_layers = tuple(layer for layer in view.layers if layer.kind is ControlLayerKind.LOCAL_ADMIN)
         if active is None or active == {}:
             if revision_state is None or revision_state == {}:
                 return view
@@ -155,7 +156,6 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
                 revision_state,
                 authority_key=key,
             )
-            local_layers = tuple(layer for layer in view.layers if layer.kind is ControlLayerKind.LOCAL_ADMIN)
             return ExtensionControlAuthorityView(
                 view.health,
                 view.revision,
@@ -167,6 +167,32 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
             raise ExtensionControlAuthorityError("managed controls require protected local authority")
         if revision_state is None or revision_state == {}:
             raise ExtensionControlAuthorityError("managed controls revision state is missing")
+        if isinstance(active, dict) and active.get("catalogDigest") != view.catalog_digest:
+            key = self._authority_key(required=True)
+            assert key is not None
+            activation_digest = active.get("catalogDigest")
+            if not isinstance(activation_digest, str):
+                raise ExtensionControlAuthorityError("incomplete managed controls activation state")
+            # Authenticate the leftover activation against its own catalog. A
+            # trusted package update rebinds local controls first, so the stored
+            # Cloud snapshot is stale but still must verify. Invalid MACs stay
+            # fail-closed; only a catalog-bound mismatch drops Cloud layers.
+            managed_controls_layers_from_activation_state(
+                active,
+                catalog_digest=activation_digest,
+                authority_key=key,
+            )
+            managed_revision = managed_controls_revision_from_state(
+                revision_state,
+                authority_key=key,
+            )
+            return ExtensionControlAuthorityView(
+                view.health,
+                view.revision,
+                view.catalog_digest,
+                local_layers,
+                managed_revision,
+            )
         key = self._authority_key(required=True)
         assert key is not None
         managed_layers, managed_revision = managed_controls_layers_from_activation_state(
@@ -717,6 +743,28 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
             if stored_catalog_digest != catalog_digest:
                 if migration_registry is None or migration_registry.catalog_digest != catalog_digest:
                     raise ExtensionControlAuthorityError("extension control catalog digest changed")
+                pending = self._pending_transition(revision + 1)
+                if pending is not None and _row_str(pending, "catalog_digest") == catalog_digest:
+                    with self._connect() as connection:
+                        resumed = self._resume_idempotent_transition(
+                            connection,
+                            pending,
+                            current=ExtensionControlAuthorityView(
+                                AuthorityHealth.RECOVERY_REQUIRED,
+                                revision,
+                                stored_catalog_digest,
+                                (),
+                            ),
+                            catalog_digest=_row_str(pending, "catalog_digest"),
+                            layers_json=_row_str(pending, "layers_json"),
+                            actor_hash=_row_str(pending, "actor_id_hash"),
+                            idempotency_hash=_row_str(pending, "idempotency_key_hash"),
+                            nonce_hash=_row_str(pending, "nonce_hash"),
+                            expected_revision=_row_int(pending, "previous_revision"),
+                            key=key,
+                        )
+                    if resumed is not None and resumed.health is AuthorityHealth.PROTECTED:
+                        return resumed
                 previous = self._read_extension_control_authority_locked(stored_catalog_digest)
                 if previous.health is not AuthorityHealth.PROTECTED:
                     raise ExtensionControlAuthorityError("extension control catalog migration source unavailable")

--- a/tests/test_guard_extension_control_catalog_update_repair.py
+++ b/tests/test_guard_extension_control_catalog_update_repair.py
@@ -12,7 +12,11 @@ from codex_plugin_scanner.guard.managed_controls_policy_bundle import (
 )
 from codex_plugin_scanner.guard.runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
 from codex_plugin_scanner.guard.runtime.extension_control_authority import AuthorityHealth, AuthorityPhase
-from codex_plugin_scanner.guard.runtime.extension_control_contract import ControlLayerKind
+from codex_plugin_scanner.guard.runtime.extension_control_contract import (
+    ControlLayerKind,
+    ControlState,
+    ControlTargetKind,
+)
 from codex_plugin_scanner.guard.store import GuardStore
 from tests.test_extension_control_clear_catalog_migration import (
     _activate_under_catalog,
@@ -51,7 +55,17 @@ def test_catalog_upgrade_keeps_protection_when_managed_activation_is_stale(
     assert upgraded.health is AuthorityHealth.PROTECTED
     assert upgraded.catalog_digest == BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest
     assert upgraded.layers
-    assert any(layer.kind is ControlLayerKind.LOCAL_ADMIN for layer in upgraded.layers)
+    local_layers = tuple(layer for layer in upgraded.layers if layer.kind is ControlLayerKind.LOCAL_ADMIN)
+    assert local_layers
+    preserved = [
+        control
+        for layer in local_layers
+        for control in layer.controls
+        if control.target.kind is ControlTargetKind.EXTENSION
+        and control.target.target_id == legacy.extensions[0].extension_id
+    ]
+    assert preserved
+    assert all(control.state is ControlState.DISABLED for control in preserved)
     assert all(layer.catalog_digest == upgraded.catalog_digest for layer in upgraded.layers)
     leftover = store.get_sync_payload(MANAGED_CONTROLS_ACTIVE_STATE_KEY)
     assert isinstance(leftover, dict)

--- a/tests/test_guard_extension_control_catalog_update_repair.py
+++ b/tests/test_guard_extension_control_catalog_update_repair.py
@@ -51,7 +51,7 @@ def test_catalog_upgrade_keeps_protection_when_managed_activation_is_stale(
     assert upgraded.health is AuthorityHealth.PROTECTED
     assert upgraded.catalog_digest == BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest
     assert upgraded.layers
-    assert all(layer.kind is ControlLayerKind.LOCAL_ADMIN for layer in upgraded.layers)
+    assert any(layer.kind is ControlLayerKind.LOCAL_ADMIN for layer in upgraded.layers)
     assert all(layer.catalog_digest == upgraded.catalog_digest for layer in upgraded.layers)
     leftover = store.get_sync_payload(MANAGED_CONTROLS_ACTIVE_STATE_KEY)
     assert isinstance(leftover, dict)

--- a/tests/test_guard_extension_control_catalog_update_repair.py
+++ b/tests/test_guard_extension_control_catalog_update_repair.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.managed_controls_policy_bundle import MANAGED_CONTROLS_ACTIVE_STATE_KEY
+from codex_plugin_scanner.guard.runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
+from codex_plugin_scanner.guard.runtime.extension_control_authority import AuthorityHealth, AuthorityPhase
+from codex_plugin_scanner.guard.runtime.extension_control_contract import ControlLayerKind
+from codex_plugin_scanner.guard.store import GuardStore
+from tests.test_extension_control_clear_catalog_migration import (
+    _activate_under_catalog,
+    _description_only_catalog_variant,
+)
+from tests.test_guard_extension_control_authority import (
+    MemorySecretStore,
+    _commit,
+    _store,
+    _upgraded_registry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _allow_local_terminal_confirmation(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.runtime.extension_control_proof._require_local_terminal_confirmation",
+        lambda _enrollment: None,
+    )
+
+
+def test_catalog_upgrade_keeps_protection_when_managed_activation_is_stale(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    legacy = _description_only_catalog_variant()
+    assert legacy.catalog_digest != BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest
+    _activate_under_catalog(store, legacy, monkeypatch, preserve_local_controls=True)
+    active = store.get_sync_payload(MANAGED_CONTROLS_ACTIVE_STATE_KEY)
+    assert isinstance(active, dict)
+    assert active["catalogDigest"] == legacy.catalog_digest
+
+    upgraded = store.read_extension_control_authority_for_registry(BUILT_IN_COMMAND_EXTENSION_REGISTRY)
+
+    assert upgraded.health is AuthorityHealth.PROTECTED
+    assert upgraded.catalog_digest == BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest
+    assert upgraded.layers
+    assert all(layer.kind is ControlLayerKind.LOCAL_ADMIN for layer in upgraded.layers)
+    assert all(layer.catalog_digest == upgraded.catalog_digest for layer in upgraded.layers)
+    leftover = store.get_sync_payload(MANAGED_CONTROLS_ACTIVE_STATE_KEY)
+    assert isinstance(leftover, dict)
+    assert leftover["catalogDigest"] == legacy.catalog_digest
+
+
+def test_stale_managed_activation_with_invalid_mac_still_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    legacy = _description_only_catalog_variant()
+    _activate_under_catalog(store, legacy, monkeypatch, preserve_local_controls=True)
+    with store._connect() as connection:
+        row = connection.execute(
+            "select payload_json from sync_state where state_key = ?",
+            (MANAGED_CONTROLS_ACTIVE_STATE_KEY,),
+        ).fetchone()
+        assert row is not None
+        payload = json.loads(str(row["payload_json"]))
+        assert isinstance(payload, dict)
+        authentication = payload.get("authentication")
+        assert isinstance(authentication, dict)
+        authentication["mac"] = "0" * 64
+        connection.execute(
+            "update sync_state set payload_json = ? where state_key = ?",
+            (json.dumps(payload, allow_nan=False), MANAGED_CONTROLS_ACTIVE_STATE_KEY),
+        )
+
+    tampered = store.read_extension_control_authority_for_registry(BUILT_IN_COMMAND_EXTENSION_REGISTRY)
+
+    assert tampered.health is AuthorityHealth.TAMPERED
+
+
+def test_catalog_upgrade_resumes_anchored_pending_migration_without_repair(tmp_path: Path) -> None:
+    secrets = MemorySecretStore()
+    store = _store(tmp_path, secrets)
+    store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest)
+    _commit(store)
+    original = store._write_and_verify_anchor
+    interrupted = False
+
+    def interrupt_after_anchor(anchor, *, key):
+        nonlocal interrupted
+        original(anchor, key=key)
+        if not interrupted and anchor.phase is AuthorityPhase.ANCHORED:
+            interrupted = True
+            raise RuntimeError("injected catalog migration interrupt")
+
+    store._write_and_verify_anchor = interrupt_after_anchor  # pyright: ignore[reportAttributeAccessIssue]
+    upgraded_registry = _upgraded_registry()
+    first = store.read_extension_control_authority_for_registry(upgraded_registry)
+    assert first.health is AuthorityHealth.DEGRADED_UNACKNOWLEDGED
+    with store._connect() as connection:
+        pending = connection.execute(
+            "select phase, catalog_digest from extension_control_authority_transition order by revision desc limit 1"
+        ).fetchone()
+    assert pending is not None
+    assert pending["phase"] == AuthorityPhase.PREPARED.value
+    assert pending["catalog_digest"] == upgraded_registry.catalog_digest
+
+    resumed = store.read_extension_control_authority_for_registry(upgraded_registry)
+
+    assert resumed.health is AuthorityHealth.PROTECTED
+    assert resumed.catalog_digest == upgraded_registry.catalog_digest
+    assert resumed.revision == 2
+    with store._connect() as connection:
+        committed = connection.execute(
+            "select phase from extension_control_authority_transition where revision = 2"
+        ).fetchone()
+        snapshot = connection.execute(
+            "select catalog_digest from extension_control_authority_snapshot where singleton = 1"
+        ).fetchone()
+    assert committed["phase"] == AuthorityPhase.COMMITTED.value
+    assert snapshot["catalog_digest"] == upgraded_registry.catalog_digest

--- a/tests/test_guard_extension_control_catalog_update_repair.py
+++ b/tests/test_guard_extension_control_catalog_update_repair.py
@@ -158,3 +158,49 @@ def test_catalog_upgrade_resumes_anchored_pending_migration_without_repair(tmp_p
     assert payload["previous_revision"] == 1
     assert payload["revision"] == 2
     assert payload["catalog_digest"] == upgraded_registry.catalog_digest
+
+
+def test_catalog_upgrade_records_migrated_event_on_later_protected_read(tmp_path: Path) -> None:
+    secrets = MemorySecretStore()
+    store = _store(tmp_path, secrets)
+    store.read_extension_control_authority(catalog_digest=BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest)
+    _commit(store)
+    original_anchor = store._write_and_verify_anchor
+    interrupted = False
+
+    def interrupt_after_anchor(anchor, *, key):
+        nonlocal interrupted
+        original_anchor(anchor, key=key)
+        if not interrupted and anchor.phase is AuthorityPhase.ANCHORED:
+            interrupted = True
+            raise RuntimeError("injected catalog migration interrupt")
+
+    store._write_and_verify_anchor = interrupt_after_anchor  # pyright: ignore[reportAttributeAccessIssue]
+    upgraded_registry = _upgraded_registry()
+    first = store.read_extension_control_authority_for_registry(upgraded_registry)
+    assert first.health is AuthorityHealth.DEGRADED_UNACKNOWLEDGED
+
+    original_record = store._record_catalog_migrated_event_once
+    attempts = 0
+
+    def fail_first_record(*args, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("injected catalog event failure")
+        return original_record(*args, **kwargs)
+
+    store._record_catalog_migrated_event_once = fail_first_record  # pyright: ignore[reportAttributeAccessIssue]
+    second = store.read_extension_control_authority_for_registry(upgraded_registry)
+    assert second.health is AuthorityHealth.DEGRADED_UNACKNOWLEDGED
+
+    recovered = store.read_extension_control_authority_for_registry(upgraded_registry)
+    assert recovered.health is AuthorityHealth.PROTECTED
+    assert recovered.catalog_digest == upgraded_registry.catalog_digest
+    with store._connect() as connection:
+        events = connection.execute(
+            "select payload_json from guard_events where event_name = ?",
+            ("extension_control_authority_catalog_migrated",),
+        ).fetchall()
+    assert len(events) == 1
+    assert json.loads(events[0]["payload_json"])["revision"] == 2

--- a/tests/test_guard_extension_control_catalog_update_repair.py
+++ b/tests/test_guard_extension_control_catalog_update_repair.py
@@ -5,7 +5,11 @@ from pathlib import Path
 
 import pytest
 
-from codex_plugin_scanner.guard.managed_controls_policy_bundle import MANAGED_CONTROLS_ACTIVE_STATE_KEY
+from codex_plugin_scanner.guard.managed_controls_policy_bundle import (
+    MANAGED_CONTROLS_ACTIVE_STATE_KEY,
+    MANAGED_CONTROLS_REVISION_STATE_KEY,
+    build_managed_controls_revision_state,
+)
 from codex_plugin_scanner.guard.runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
 from codex_plugin_scanner.guard.runtime.extension_control_authority import AuthorityHealth, AuthorityPhase
 from codex_plugin_scanner.guard.runtime.extension_control_contract import ControlLayerKind
@@ -82,6 +86,27 @@ def test_stale_managed_activation_with_invalid_mac_still_fails_closed(
     assert tampered.health is AuthorityHealth.TAMPERED
 
 
+def test_stale_managed_activation_revision_mismatch_still_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    legacy = _description_only_catalog_variant()
+    _activate_under_catalog(store, legacy, monkeypatch, preserve_local_controls=True)
+    key = store._authority_key(required=True)
+    assert key is not None
+    mismatched = build_managed_controls_revision_state(99, authority_key=key)
+    with store._connect() as connection:
+        connection.execute(
+            "update sync_state set payload_json = ? where state_key = ?",
+            (json.dumps(mismatched, allow_nan=False), MANAGED_CONTROLS_REVISION_STATE_KEY),
+        )
+
+    tampered = store.read_extension_control_authority_for_registry(BUILT_IN_COMMAND_EXTENSION_REGISTRY)
+
+    assert tampered.health is AuthorityHealth.TAMPERED
+
+
 def test_catalog_upgrade_resumes_anchored_pending_migration_without_repair(tmp_path: Path) -> None:
     secrets = MemorySecretStore()
     store = _store(tmp_path, secrets)
@@ -123,3 +148,13 @@ def test_catalog_upgrade_resumes_anchored_pending_migration_without_repair(tmp_p
         ).fetchone()
     assert committed["phase"] == AuthorityPhase.COMMITTED.value
     assert snapshot["catalog_digest"] == upgraded_registry.catalog_digest
+    with store._connect() as connection:
+        event = connection.execute(
+            "select payload_json from guard_events where event_name = ? order by event_id desc limit 1",
+            ("extension_control_authority_catalog_migrated",),
+        ).fetchone()
+    assert event is not None
+    payload = json.loads(event["payload_json"])
+    assert payload["previous_revision"] == 1
+    assert payload["revision"] == 2
+    assert payload["catalog_digest"] == upgraded_registry.catalog_digest


### PR DESCRIPTION
## Summary
- Keep local protection in place after a trusted built-in catalog update instead of failing closed into repair
- Resume an already-anchored catalog migration on the next read so an interrupted update does not require recover-authority
- Continue failing closed for invalid activation MACs and catalog digest changes without a trusted registry

## Testing
- `uv run --no-sync pytest tests/test_guard_extension_control_catalog_update_repair.py tests/test_extension_control_clear_catalog_migration.py tests/test_guard_extension_control_authority.py::test_authenticated_catalog_upgrade_preserves_controls_and_records_provenance tests/test_guard_extension_control_authority.py::test_catalog_digest_change_requires_trusted_migration_boundary tests/test_guard_extension_control_authority.py::test_catalog_upgrade_provenance_survives_final_anchor_failure tests/test_guard_extension_control_authority.py::test_catalog_manifest_tamper_is_detected_immediately tests/test_guard_extension_control_authority.py::test_authenticated_snapshot_transition_and_anchor_detect_sqlite_tamper tests/test_guard_extension_control_authority.py::test_recovery_finalizes_database_commit_when_final_anchor_write_failed tests/test_guard_extension_control_authority.py::test_failed_anchor_write_leaves_recoverable_prepared_transition --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/store_extension_control_authority.py tests/test_guard_extension_control_catalog_update_repair.py`
- `uv build --wheel` and `uv tool run --from dist/hol_guard-*.whl hol-guard --version`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved managed-control activation handling during catalog updates.
  * Preserved protection when activation data references an older catalog.
  * Invalid authentication data and revision mismatches now fail safely.
  * Interrupted catalog migrations resume automatically to a protected state.
  * Catalog migration events now record relevant revision details, including retired targets.

* **Tests**
  * Added coverage for stale activations, invalid authentication data, revision mismatches, interrupted migrations, and delayed event recording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->