### PR TITLE
fix(guard): refresh catalog fingerprints without fail-safe

### DIFF
--- a/src/codex_plugin_scanner/guard/store_extension_control_authority.py
+++ b/src/codex_plugin_scanner/guard/store_extension_control_authority.py
@@ -125,9 +125,7 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
                     authority_key = self._authority_key(required=True)
                     if authority_key is None:
                         raise ExtensionControlAuthorityError("extension-control authority key is unavailable")
-                    view, stale_manifest = self._sync_trusted_catalog_manifest(
-                        view, registry, key=authority_key
-                    )
+                    view, stale_manifest = self._sync_trusted_catalog_manifest(view, registry, key=authority_key)
                 if include_managed_controls:
                     composed = self._with_managed_controls_activation(
                         view,

--- a/src/codex_plugin_scanner/guard/store_extension_control_authority.py
+++ b/src/codex_plugin_scanner/guard/store_extension_control_authority.py
@@ -119,17 +119,33 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
             with self._extension_control_authority_lock():
                 self._require_compatible_extension_control_schema()
                 view = self._read_extension_control_authority_locked(catalog_digest, migration_registry=registry)
+                stale_manifest: dict[str, str] | None = None
+                authority_key: bytes | None = None
                 if view.health is AuthorityHealth.PROTECTED:
-                    key = self._authority_key(required=True)
-                    if key is None:
+                    authority_key = self._authority_key(required=True)
+                    if authority_key is None:
                         raise ExtensionControlAuthorityError("extension-control authority key is unavailable")
-                    view = self._sync_trusted_catalog_manifest(view, registry, key=key)
+                    view, stale_manifest = self._sync_trusted_catalog_manifest(
+                        view, registry, key=authority_key
+                    )
                 if include_managed_controls:
-                    return self._with_managed_controls_activation(
+                    composed = self._with_managed_controls_activation(
                         view,
                         current_manifest=self._catalog_target_manifest(registry),
+                        previous_manifest=stale_manifest,
                     )
-                return view
+                else:
+                    composed = view
+                if stale_manifest is not None:
+                    if authority_key is None:
+                        raise ExtensionControlAuthorityError("extension-control authority key is unavailable")
+                    self._write_catalog_manifest(
+                        registry,
+                        key=authority_key,
+                        manifest=self._catalog_target_manifest(registry),
+                        replace=True,
+                    )
+                return composed
         except ExtensionControlAuthorityError:
             return self._tampered_view(catalog_digest)
         except Exception:
@@ -140,6 +156,7 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
         view: ExtensionControlAuthorityView,
         *,
         current_manifest: Mapping[str, str] | None = None,
+        previous_manifest: Mapping[str, str] | None = None,
     ) -> ExtensionControlAuthorityView:
         with self._connect() as connection:
             rows = connection.execute(
@@ -190,14 +207,24 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
             catalog_digest=active_catalog_digest,
             authority_key=key,
         )
-        if active_catalog_digest != view.catalog_digest:
+        fingerprint_refresh = (
+            current_manifest is not None
+            and previous_manifest is not None
+            and previous_manifest != current_manifest
+            and active_catalog_digest == view.catalog_digest
+        )
+        if active_catalog_digest != view.catalog_digest or fingerprint_refresh:
             if any(layer.catalog_digest != active_catalog_digest for layer in managed_layers):
                 raise ExtensionControlAuthorityError("managed controls activation layer catalog mismatch")
             if current_manifest is None:
                 raise ExtensionControlAuthorityError("managed controls current catalog manifest is missing")
             # A missing prior manifest must not act as an implicit fingerprint
             # match: stale managed allows remain disabled until cloud refresh.
-            previous_manifest = self._load_catalog_manifest(active_catalog_digest, key=key) or {}
+            prior_manifest = (
+                previous_manifest
+                if fingerprint_refresh
+                else (self._load_catalog_manifest(active_catalog_digest, key=key) or {})
+            )
             managed_layers = tuple(
                 replace(
                     layer,
@@ -207,7 +234,7 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
                             control
                             if preserve_managed_extension_control(
                                 control,
-                                previous_manifest=previous_manifest,
+                                previous_manifest=prior_manifest,
                                 current_manifest=current_manifest,
                             )
                             else replace(control, state=ControlState.DISABLED)
@@ -910,7 +937,7 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
         registry: CommandSafetyExtensionRegistry,
         *,
         key: bytes,
-    ) -> ExtensionControlAuthorityView:
+    ) -> tuple[ExtensionControlAuthorityView, dict[str, str] | None]:
         current = self._catalog_target_manifest(registry)
         with self._connect() as connection:
             existing = connection.execute(
@@ -919,26 +946,34 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
             ).fetchone()
         if existing is None:
             self._write_catalog_manifest(registry, key=key, manifest=current)
-            return view
+            return view, None
         persisted = self._load_catalog_manifest(registry.catalog_digest, key=key)
         if persisted is None:
             raise ExtensionControlAuthorityError("extension control catalog manifest conflict")
         if persisted == current:
-            return view
+            return view, None
         # Same catalog digest can still carry a newer trusted contract fingerprint
-        # after a package update. Rebind controls, then replace the stored
-        # manifest. An unverifiable stored row stays fail-closed above.
-        if view.layers:
-            view = self._migrate_extension_control_catalog(view, registry=registry, key=key)
-        self._write_catalog_manifest(registry, key=key, manifest=current, replace=True)
-        return view
-
-    def _record_catalog_manifest(self, registry: CommandSafetyExtensionRegistry, *, key: bytes) -> None:
-        self._sync_trusted_catalog_manifest(
-            ExtensionControlAuthorityView(AuthorityHealth.PROTECTED, 0, registry.catalog_digest, ()),
-            registry,
-            key=key,
+        # after a package update. Rebind local controls when needed, then let the
+        # caller replace the stored manifest after managed layers are composed.
+        rebound = tuple(
+            replace(
+                layer,
+                catalog_digest=view.catalog_digest,
+                controls=tuple(
+                    control
+                    for control in layer.controls
+                    if preserve_migrated_extension_control(
+                        control,
+                        previous_manifest=persisted,
+                        current_manifest=current,
+                    )
+                ),
+            )
+            for layer in view.layers
         )
+        if rebound != view.layers:
+            view = self._migrate_extension_control_catalog(view, registry=registry, key=key)
+        return view, persisted
 
     def _write_catalog_manifest(
         self,

--- a/src/codex_plugin_scanner/guard/store_extension_control_authority.py
+++ b/src/codex_plugin_scanner/guard/store_extension_control_authority.py
@@ -218,11 +218,12 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
                 raise ExtensionControlAuthorityError("managed controls current catalog manifest is missing")
             # A missing prior manifest must not act as an implicit fingerprint
             # match: stale managed allows remain disabled until cloud refresh.
-            prior_manifest = (
-                previous_manifest
-                if fingerprint_refresh
-                else (self._load_catalog_manifest(active_catalog_digest, key=key) or {})
-            )
+            if fingerprint_refresh:
+                if previous_manifest is None:
+                    raise ExtensionControlAuthorityError("managed controls current catalog manifest is missing")
+                prior_manifest: Mapping[str, str] = previous_manifest
+            else:
+                prior_manifest = self._load_catalog_manifest(active_catalog_digest, key=key) or {}
             managed_layers = tuple(
                 replace(
                     layer,

--- a/src/codex_plugin_scanner/guard/store_extension_control_authority.py
+++ b/src/codex_plugin_scanner/guard/store_extension_control_authority.py
@@ -123,7 +123,7 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
                     key = self._authority_key(required=True)
                     if key is None:
                         raise ExtensionControlAuthorityError("extension-control authority key is unavailable")
-                    self._record_catalog_manifest(registry, key=key)
+                    view = self._sync_trusted_catalog_manifest(view, registry, key=key)
                 if include_managed_controls:
                     return self._with_managed_controls_activation(
                         view,
@@ -904,32 +904,81 @@ class StoreExtensionControlAuthorityMixin(_ExtensionControlAuthorityTransitionMi
                 ).hexdigest()
         return manifest
 
-    def _record_catalog_manifest(self, registry: CommandSafetyExtensionRegistry, *, key: bytes) -> None:
-        manifest_json = json.dumps(
-            self._catalog_target_manifest(registry),
-            sort_keys=True,
-            separators=(",", ":"),
-        )
+    def _sync_trusted_catalog_manifest(
+        self,
+        view: ExtensionControlAuthorityView,
+        registry: CommandSafetyExtensionRegistry,
+        *,
+        key: bytes,
+    ) -> ExtensionControlAuthorityView:
+        current = self._catalog_target_manifest(registry)
         with self._connect() as connection:
             existing = connection.execute(
-                "select manifest_json from extension_control_catalog_manifest where catalog_digest = ?",
+                "select 1 from extension_control_catalog_manifest where catalog_digest = ?",
                 (registry.catalog_digest,),
             ).fetchone()
-            if existing is not None:
-                persisted = self._load_catalog_manifest(registry.catalog_digest, key=key)
-                if persisted is None or persisted != self._catalog_target_manifest(registry):
+        if existing is None:
+            self._write_catalog_manifest(registry, key=key, manifest=current)
+            return view
+        persisted = self._load_catalog_manifest(registry.catalog_digest, key=key)
+        if persisted is None:
+            raise ExtensionControlAuthorityError("extension control catalog manifest conflict")
+        if persisted == current:
+            return view
+        # Same catalog digest can still carry a newer trusted contract fingerprint
+        # after a package update. Rebind controls, then replace the stored
+        # manifest. An unverifiable stored row stays fail-closed above.
+        if view.layers:
+            view = self._migrate_extension_control_catalog(view, registry=registry, key=key)
+        self._write_catalog_manifest(registry, key=key, manifest=current, replace=True)
+        return view
+
+    def _record_catalog_manifest(self, registry: CommandSafetyExtensionRegistry, *, key: bytes) -> None:
+        self._sync_trusted_catalog_manifest(
+            ExtensionControlAuthorityView(AuthorityHealth.PROTECTED, 0, registry.catalog_digest, ()),
+            registry,
+            key=key,
+        )
+
+    def _write_catalog_manifest(
+        self,
+        registry: CommandSafetyExtensionRegistry,
+        *,
+        key: bytes,
+        manifest: dict[str, str],
+        replace: bool = False,
+    ) -> None:
+        manifest_json = json.dumps(manifest, sort_keys=True, separators=(",", ":"))
+        recorded_at = _now()
+        record_json, record_digest, record_mac = authenticated_record(
+            {
+                "catalog_digest": registry.catalog_digest,
+                "manifest_json": manifest_json,
+                "recorded_at": recorded_at,
+            },
+            key=key,
+            purpose=self._catalog_manifest_purpose,
+        )
+        with self._connect() as connection:
+            if replace:
+                connection.execute(
+                    """
+                    update extension_control_catalog_manifest
+                    set manifest_json = ?, record_json = ?, record_digest = ?, record_mac = ?, recorded_at = ?
+                    where catalog_digest = ?
+                    """,
+                    (
+                        manifest_json,
+                        record_json,
+                        record_digest,
+                        record_mac,
+                        recorded_at,
+                        registry.catalog_digest,
+                    ),
+                )
+                if connection.execute("select changes()").fetchone()[0] != 1:
                     raise ExtensionControlAuthorityError("extension control catalog manifest conflict")
                 return
-            recorded_at = _now()
-            record_json, record_digest, record_mac = authenticated_record(
-                {
-                    "catalog_digest": registry.catalog_digest,
-                    "manifest_json": manifest_json,
-                    "recorded_at": recorded_at,
-                },
-                key=key,
-                purpose=self._catalog_manifest_purpose,
-            )
             connection.execute(
                 """
                 insert into extension_control_catalog_manifest (

--- a/tests/test_guard_extension_control_catalog_manifest_refresh.py
+++ b/tests/test_guard_extension_control_catalog_manifest_refresh.py
@@ -92,9 +92,52 @@ def test_same_digest_fingerprint_drift_retires_changed_enabled_control(tmp_path:
 
     assert refreshed.health is AuthorityHealth.PROTECTED
     remaining = [
-        control
-        for layer in refreshed.layers
-        for control in layer.controls
-        if control.target.target_id == permission_id
+        control for layer in refreshed.layers for control in layer.controls if control.target.target_id == permission_id
     ]
     assert remaining == [] or all(control.state is not ControlState.ENABLED for control in remaining)
+    again = store.read_extension_control_authority_for_registry(BUILT_IN_COMMAND_EXTENSION_REGISTRY)
+    assert again.health is AuthorityHealth.PROTECTED
+    assert again.revision == refreshed.revision
+
+
+def test_failed_manifest_replace_does_not_duplicate_migration(tmp_path: Path) -> None:
+    store = _store(tmp_path, MemorySecretStore())
+    store.read_extension_control_authority_for_registry(BUILT_IN_COMMAND_EXTENSION_REGISTRY)
+    permission_id = "command.container-runtime.permission.compose-destructive-cleanup"
+    _commit_enabled_permission(store, permission_id, key="enable-before-replace-failure")
+    original = store._catalog_target_manifest
+
+    @staticmethod
+    def drifted(registry):
+        manifest = dict(original(registry))
+        manifest[f"permission:{permission_id}"] = "0" * 64
+        return manifest
+
+    store._catalog_target_manifest = drifted
+    original_write = store._write_catalog_manifest
+    attempts = 0
+
+    def fail_first_replace(*args, replace: bool = False, **kwargs):
+        nonlocal attempts
+        if replace:
+            attempts += 1
+            if attempts == 1:
+                raise RuntimeError("injected catalog manifest replace failure")
+        return original_write(*args, replace=replace, **kwargs)
+
+    store._write_catalog_manifest = fail_first_replace
+    interrupted = store.read_extension_control_authority_for_registry(BUILT_IN_COMMAND_EXTENSION_REGISTRY)
+    assert interrupted.health is AuthorityHealth.DEGRADED_UNACKNOWLEDGED
+    with store._connect() as connection:
+        snapshot_revision = connection.execute(
+            "select revision from extension_control_authority_snapshot where singleton = 1"
+        ).fetchone()[0]
+    recovered = store.read_extension_control_authority_for_registry(BUILT_IN_COMMAND_EXTENSION_REGISTRY)
+    assert recovered.health is AuthorityHealth.PROTECTED
+    assert recovered.revision == snapshot_revision
+    with store._connect() as connection:
+        migrated = connection.execute(
+            "select count(*) from guard_events where event_name = ?",
+            ("extension_control_authority_catalog_migrated",),
+        ).fetchone()[0]
+    assert migrated == 1

--- a/tests/test_guard_extension_control_catalog_manifest_refresh.py
+++ b/tests/test_guard_extension_control_catalog_manifest_refresh.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
+from codex_plugin_scanner.guard.runtime.extension_control_authority import AuthorityHealth
+from codex_plugin_scanner.guard.runtime.extension_control_contract import ControlState
+from tests.test_guard_extension_control_authority import (
+    MemorySecretStore,
+    _commit_enabled_permission,
+    _store,
+)
+
+
+@pytest.fixture(autouse=True)
+def _allow_local_terminal_confirmation(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.runtime.extension_control_proof._require_local_terminal_confirmation",
+        lambda _enrollment: None,
+    )
+
+
+def _drift_container_runtime_fingerprint(store) -> None:
+    original = store._catalog_target_manifest
+
+    @staticmethod
+    def drifted(registry):
+        manifest = dict(original(registry))
+        target = "extension:command.container-runtime"
+        if target not in manifest:
+            target = next(iter(manifest))
+        manifest[target] = "0" * 64
+        return manifest
+
+    store._catalog_target_manifest = drifted
+
+
+def test_same_digest_fingerprint_drift_keeps_protection(tmp_path: Path) -> None:
+    store = _store(tmp_path, MemorySecretStore())
+    protected = store.read_extension_control_authority_for_registry(BUILT_IN_COMMAND_EXTENSION_REGISTRY)
+    assert protected.health is AuthorityHealth.PROTECTED
+    _drift_container_runtime_fingerprint(store)
+
+    refreshed = store.read_extension_control_authority_for_registry(BUILT_IN_COMMAND_EXTENSION_REGISTRY)
+
+    assert refreshed.health is AuthorityHealth.PROTECTED
+    persisted = store._load_catalog_manifest(
+        BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest,
+        key=store._authority_key(required=True),
+    )
+    assert persisted is not None
+    assert persisted["extension:command.container-runtime"] == "0" * 64
+
+
+def test_catalog_manifest_mac_tamper_still_fails_closed(tmp_path: Path) -> None:
+    store = _store(tmp_path, MemorySecretStore())
+    store.read_extension_control_authority_for_registry(BUILT_IN_COMMAND_EXTENSION_REGISTRY)
+    with store._connect() as connection:
+        connection.execute(
+            "update extension_control_catalog_manifest set record_mac = ? where catalog_digest = ?",
+            ("0" * 64, BUILT_IN_COMMAND_EXTENSION_REGISTRY.catalog_digest),
+        )
+
+    tampered = store.read_extension_control_authority_for_registry(BUILT_IN_COMMAND_EXTENSION_REGISTRY)
+
+    assert tampered.health is AuthorityHealth.TAMPERED
+
+
+def test_same_digest_fingerprint_drift_retires_changed_enabled_control(tmp_path: Path) -> None:
+    store = _store(tmp_path, MemorySecretStore())
+    store.read_extension_control_authority_for_registry(BUILT_IN_COMMAND_EXTENSION_REGISTRY)
+    permission_id = "command.container-runtime.permission.compose-destructive-cleanup"
+    _commit_enabled_permission(store, permission_id, key="enable-before-fingerprint-drift")
+    enabled = store.read_extension_control_authority_for_registry(BUILT_IN_COMMAND_EXTENSION_REGISTRY)
+    assert any(
+        control.target.target_id == permission_id and control.state is ControlState.ENABLED
+        for layer in enabled.layers
+        for control in layer.controls
+    )
+    original = store._catalog_target_manifest
+
+    @staticmethod
+    def drifted(registry):
+        manifest = dict(original(registry))
+        manifest[f"permission:{permission_id}"] = "0" * 64
+        return manifest
+
+    store._catalog_target_manifest = drifted
+    refreshed = store.read_extension_control_authority_for_registry(BUILT_IN_COMMAND_EXTENSION_REGISTRY)
+
+    assert refreshed.health is AuthorityHealth.PROTECTED
+    remaining = [
+        control
+        for layer in refreshed.layers
+        for control in layer.controls
+        if control.target.target_id == permission_id
+    ]
+    assert remaining == [] or all(control.state is not ControlState.ENABLED for control in remaining)


### PR DESCRIPTION
## Summary
- Keep local protection when a trusted catalog update changes contract fingerprints without changing the catalog digest
- Rebind or retire local controls against the new trusted fingerprints, then replace the stored catalog manifest
- Keep fail-closed behavior when a stored catalog manifest cannot be verified

## Testing
- `uv run --no-sync pytest tests/test_guard_extension_control_catalog_manifest_refresh.py tests/test_guard_extension_control_authority.py::test_catalog_manifest_tamper_is_detected_immediately tests/test_guard_extension_control_catalog_upgrade.py tests/test_guard_extension_control_catalog_update_repair.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/store_extension_control_authority.py tests/test_guard_extension_control_catalog_manifest_refresh.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of trusted catalog updates when runtime fingerprints change.
  - Existing protection remains active when catalog metadata changes without altering controls.
  - Changed fingerprints for enabled permissions now retire the affected controls.
  - Tampered catalog integrity data continues to fail closed and is reported as tampered.
- **Tests**
  - Added coverage for catalog refresh, integrity tampering, and enabled-control retirement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->