### PR TITLE
fix(cloud): restore bundled TLS trust and connection error layout

### DIFF
--- a/dashboard/e2e/protection-health-ui.spec.ts
+++ b/dashboard/e2e/protection-health-ui.spec.ts
@@ -178,6 +178,7 @@ for (const width of [390, 1440]) {
     await hero.getByRole("button", { name: "Connect this machine" }).click();
     await expect(hero.getByText(/Guard could not verify the secure connection/)).toBeVisible();
     await expect(hero.getByText(/CERTIFICATE_VERIFY_FAILED/)).toHaveCount(0);
+    await expect(hero.getByRole("button", { name: "Retry connection" })).toBeVisible();
     const home = hero.getByRole("button", { name: "Open Home" });
     await expect(home).toBeVisible();
     const box = await home.boundingBox();

--- a/dashboard/e2e/protection-health-ui.spec.ts
+++ b/dashboard/e2e/protection-health-ui.spec.ts
@@ -159,6 +159,34 @@ async function mountProtectionFixture(
   });
 }
 
+for (const width of [390, 1440]) {
+  test(`cloud TLS failure preserves usable actions at ${width}px`, async ({ page }, testInfo) => {
+    await page.setViewportSize({ width, height: 1000 });
+    await mountProtectionFixture(page, { ...snapshotForState("protected"), cloud_state: "local_only" });
+    await page.route("**/v1/cloud/connect", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ connect_required: true, connect_flow: {
+          state: "failed", detail: "<urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1010)>",
+          connect_url: "http://localhost:3017/connect", authorize_url: null,
+        } }),
+      });
+    });
+    await page.goto(`/protect?${DAEMON}`);
+    const hero = page.getByRole("region", { name: "Protection status" });
+    await hero.getByRole("button", { name: "Connect this machine" }).click();
+    await expect(hero.getByText(/Guard could not verify the secure connection/)).toBeVisible();
+    await expect(hero.getByText(/CERTIFICATE_VERIFY_FAILED/)).toHaveCount(0);
+    const home = hero.getByRole("button", { name: "Open Home" });
+    await expect(home).toBeVisible();
+    const box = await home.boundingBox();
+    expect(box?.height).toBeLessThan(65);
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
+    await page.screenshot({ path: testInfo.outputPath(`cloud-tls-${width}.png`), fullPage: true });
+  });
+}
+
 test("startup proving snapshot shows checking instead of degraded", async ({ page }, testInfo) => {
   await mountProtectionFixture(page, provingSnapshot);
   await page.goto(`/?${DAEMON}`);

--- a/dashboard/src/approval-center-primitives.tsx
+++ b/dashboard/src/approval-center-primitives.tsx
@@ -848,7 +848,7 @@ export function GuardHero(props: {
             </div>
           </div>
         </div>
-        <div className="flex flex-wrap gap-3">
+        <div className="flex flex-wrap items-start gap-3">
           {props.cta}
           {props.secondaryCta}
         </div>

--- a/dashboard/src/connect-guard-cloud-button.tsx
+++ b/dashboard/src/connect-guard-cloud-button.tsx
@@ -25,6 +25,13 @@ export type GuardCloudConnectUiState =
 const SIGN_IN_PENDING_MESSAGE =
   "Sign-in is still pending. Complete it in the opened window, or open sign-in again.";
 
+function cloudConnectErrorMessage(message: string): string {
+  if (/CERTIFICATE_VERIFY_FAILED|certificate verify failed/i.test(message)) {
+    return "Guard could not verify the secure connection to Guard Cloud. Update Guard and retry. Your local protection settings have not changed.";
+  }
+  return message;
+}
+
 function cloudConnectPendingMessage(opened: boolean): string {
   return opened
     ? "Complete sign-in in the opened window. This page will update automatically."
@@ -187,6 +194,8 @@ export function ConnectGuardCloudButton({
     buttonLabel = workingLabel;
   } else if (state.status === "connected") {
     buttonLabel = connectedLabel;
+  } else if (state.status === "error") {
+    buttonLabel = "Retry connection";
   }
 
   let statusLine: ReactNode = null;
@@ -194,11 +203,11 @@ export function ConnectGuardCloudButton({
     statusLine = (
       <span
         role="status"
-        className={`flex flex-wrap items-center justify-end gap-1.5 text-xs leading-relaxed ${
+        className={`flex flex-wrap items-center gap-1.5 text-sm leading-relaxed ${
           state.status === "error" ? "text-red-600" : "text-slate-500"
         }`}
       >
-        <span>{state.message}</span>
+        <span className="min-w-0 [overflow-wrap:anywhere]">{cloudConnectErrorMessage(state.message)}</span>
         {state.manualUrl ? (
           <a
             href={state.manualUrl}
@@ -214,7 +223,7 @@ export function ConnectGuardCloudButton({
   }
 
   return (
-    <span className="inline-flex flex-col items-end gap-1">
+    <span className="inline-flex min-w-0 max-w-full flex-col items-start gap-2 sm:max-w-sm">
       <ActionButton
         variant={variant}
         onClick={startConnect}

--- a/dashboard/src/connect-guard-cloud-button.tsx
+++ b/dashboard/src/connect-guard-cloud-button.tsx
@@ -27,7 +27,7 @@ const SIGN_IN_PENDING_MESSAGE =
 
 function cloudConnectErrorMessage(message: string): string {
   if (/CERTIFICATE_VERIFY_FAILED|certificate verify failed/i.test(message)) {
-    return "Guard could not verify the secure connection to Guard Cloud. Update Guard and retry. Your local protection settings have not changed.";
+    return "Guard could not verify the secure connection to Guard Cloud. Check your network or proxy certificate settings and make sure Guard is up to date, then retry. Your local protection settings have not changed.";
   }
   return message;
 }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/connect-guard-cloud-button.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/connect-guard-cloud-button.js
@@ -2,7 +2,7 @@ import { Y as openPackageFirewallAuthorizeFallback, Z as waitForCloudConnection,
 const SIGN_IN_PENDING_MESSAGE = "Sign-in is still pending. Complete it in the opened window, or open sign-in again.";
 function cloudConnectErrorMessage(message) {
   if (/CERTIFICATE_VERIFY_FAILED|certificate verify failed/i.test(message)) {
-    return "Guard could not verify the secure connection to Guard Cloud. Update Guard and retry. Your local protection settings have not changed.";
+    return "Guard could not verify the secure connection to Guard Cloud. Check your network or proxy certificate settings and make sure Guard is up to date, then retry. Your local protection settings have not changed.";
   }
   return message;
 }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/connect-guard-cloud-button.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/connect-guard-cloud-button.js
@@ -1,5 +1,11 @@
 import { Y as openPackageFirewallAuthorizeFallback, Z as waitForCloudConnection, U as waitForAuthorizeUrl, V as startOrRecoverCloudConnect, j as jsxRuntimeExports, A as ActionButton, bO as HiMiniCloudArrowUp, r as reactExports, X as safeCloudConnectUrl, bD as PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE } from "../guard-dashboard.js";
 const SIGN_IN_PENDING_MESSAGE = "Sign-in is still pending. Complete it in the opened window, or open sign-in again.";
+function cloudConnectErrorMessage(message) {
+  if (/CERTIFICATE_VERIFY_FAILED|certificate verify failed/i.test(message)) {
+    return "Guard could not verify the secure connection to Guard Cloud. Update Guard and retry. Your local protection settings have not changed.";
+  }
+  return message;
+}
 function cloudConnectPendingMessage(opened) {
   return opened ? "Complete sign-in in the opened window. This page will update automatically." : PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE;
 }
@@ -111,6 +117,8 @@ function ConnectGuardCloudButton({
     buttonLabel = workingLabel;
   } else if (state.status === "connected") {
     buttonLabel = connectedLabel;
+  } else if (state.status === "error") {
+    buttonLabel = "Retry connection";
   }
   let statusLine = null;
   if (state.status === "pending" || state.status === "error") {
@@ -118,9 +126,9 @@ function ConnectGuardCloudButton({
       "span",
       {
         role: "status",
-        className: `flex flex-wrap items-center justify-end gap-1.5 text-xs leading-relaxed ${state.status === "error" ? "text-red-600" : "text-slate-500"}`,
+        className: `flex flex-wrap items-center gap-1.5 text-sm leading-relaxed ${state.status === "error" ? "text-red-600" : "text-slate-500"}`,
         children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: state.message }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "min-w-0 [overflow-wrap:anywhere]", children: cloudConnectErrorMessage(state.message) }),
           state.manualUrl ? /* @__PURE__ */ jsxRuntimeExports.jsx(
             "a",
             {
@@ -135,7 +143,7 @@ function ConnectGuardCloudButton({
       }
     );
   }
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "inline-flex flex-col items-end gap-1", children: [
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "inline-flex min-w-0 max-w-full flex-col items-start gap-2 sm:max-w-sm", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs(
       ActionButton,
       {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -19674,7 +19674,7 @@ function GuardHero(props) {
             /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm leading-relaxed text-brand-dark/70", children: props.subheadline })
           ] })
         ] }) }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap gap-3", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-start gap-3", children: [
           props.cta,
           props.secondaryCta
         ] })

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -6280,6 +6280,10 @@
       max-width: 9rem;
     }
 
+    .sm\:max-w-sm {
+      max-width: var(--container-sm);
+    }
+
     .sm\:min-w-\[6\.5rem\] {
       min-width: 6.5rem;
     }

--- a/src/codex_plugin_scanner/guard/mdm/network_transport.py
+++ b/src/codex_plugin_scanner/guard/mdm/network_transport.py
@@ -305,9 +305,9 @@ def managed_urlopen(
     ):
         context = build_default_ssl_context()
         if reject_redirects:
-            return urllib.request.build_opener(
-                RejectRedirects(), urllib.request.HTTPSHandler(context=context)
-            ).open(request, timeout=timeout)
+            return urllib.request.build_opener(RejectRedirects(), urllib.request.HTTPSHandler(context=context)).open(
+                request, timeout=timeout
+            )
         return urllib.request.urlopen(request, timeout=timeout, context=context)
     return managed_opener(
         resolved,

--- a/src/codex_plugin_scanner/guard/mdm/network_transport.py
+++ b/src/codex_plugin_scanner/guard/mdm/network_transport.py
@@ -20,7 +20,7 @@ from urllib3.poolmanager import ProxyManager
 from ...no_redirect import RejectRedirects
 from .contracts import ManagedNetworkPolicy
 from .network_credentials import read_proxy_credential_record
-from .network_trust import ManagedTrustError, build_managed_ssl_context
+from .network_trust import ManagedTrustError, build_default_ssl_context, build_managed_ssl_context
 from .network_urlopen import ManagedOpener, ManagedResponse, ManagedUrlOpener
 from .policy import load_managed_policy
 
@@ -303,9 +303,12 @@ def managed_urlopen(
         and resolved.ca_bundle_path is None
         and resolved.allow_public_registries
     ):
+        context = build_default_ssl_context()
         if reject_redirects:
-            return urllib.request.build_opener(RejectRedirects()).open(request, timeout=timeout)
-        return urllib.request.urlopen(request, timeout=timeout)
+            return urllib.request.build_opener(
+                RejectRedirects(), urllib.request.HTTPSHandler(context=context)
+            ).open(request, timeout=timeout)
+        return urllib.request.urlopen(request, timeout=timeout, context=context)
     return managed_opener(
         resolved,
         redirect_handler=RejectRedirects() if reject_redirects else None,

--- a/src/codex_plugin_scanner/guard/mdm/network_trust.py
+++ b/src/codex_plugin_scanner/guard/mdm/network_trust.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import ssl
 import sys
 from pathlib import Path
@@ -13,6 +14,14 @@ from .managed_file_trust import machine_controlled_file_is_trusted
 
 class ManagedTrustError(RuntimeError):
     """A managed TLS trust source is unavailable or invalid."""
+
+
+def build_default_ssl_context() -> ssl.SSLContext:
+    """Keep platform trust and explicit CA overrides usable in bundled runtimes."""
+    context = ssl.create_default_context()
+    if not os.environ.get("SSL_CERT_FILE") and not os.environ.get("SSL_CERT_DIR"):
+        context.load_verify_locations(cafile=str(_requests_ca_bundle()))
+    return context
 
 
 def _requests_ca_bundle() -> Path:

--- a/src/codex_plugin_scanner/guard/mdm/network_trust.py
+++ b/src/codex_plugin_scanner/guard/mdm/network_trust.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import ssl
 import sys
+from contextlib import suppress
 from pathlib import Path
 
 import requests.certs as requests_certs
@@ -20,7 +21,9 @@ def build_default_ssl_context() -> ssl.SSLContext:
     """Keep platform trust and explicit CA overrides usable in bundled runtimes."""
     context = ssl.create_default_context()
     if not os.environ.get("SSL_CERT_FILE") and not os.environ.get("SSL_CERT_DIR"):
-        context.load_verify_locations(cafile=str(_requests_ca_bundle()))
+        # Preserve platform trust; an empty context still fails TLS verification.
+        with suppress(ManagedTrustError, OSError):
+            context.load_verify_locations(cafile=str(_requests_ca_bundle()))
     return context
 
 

--- a/tests/support/network.py
+++ b/tests/support/network.py
@@ -31,7 +31,9 @@ def stub_authenticated_urlopen(
 ) -> None:
     """Route both public and authenticated urllib paths through one test double."""
 
-    monkeypatch.setattr(urllib.request, "urlopen", callback)
+    monkeypatch.setattr(
+        urllib.request, "urlopen", lambda request, timeout=None, context=None: callback(request, timeout)
+    )
     monkeypatch.setattr(
         urllib.request,
         "build_opener",

--- a/tests/test_guard_mdm_network_integration.py
+++ b/tests/test_guard_mdm_network_integration.py
@@ -208,6 +208,36 @@ def _write_certificates(tmp_path: Path) -> tuple[Path, Path, Path]:
     return ca_path, cert_path, key_path
 
 
+@pytest.mark.parametrize("authenticated", [False, True])
+def test_unmanaged_bundled_runtime_loads_public_roots(network_lab, monkeypatch, authenticated):
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    monkeypatch.delenv("SSL_CERT_DIR", raising=False)
+    monkeypatch.setattr(transport_module, "resolved_network_policy", lambda _: (ManagedNetworkPolicy(), False))
+    # Model a bundled interpreter with no usable default root paths.
+    monkeypatch.setattr(ssl, "create_default_context", lambda: ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT))
+    empty_context = ssl.create_default_context()
+    with pytest.raises(urllib.error.URLError):
+        urllib.request.urlopen(network_lab.target_url, context=empty_context, timeout=5)
+    monkeypatch.setattr(trust_module, "_requests_ca_bundle", lambda: network_lab.ca_bundle)
+    request = urllib.request.Request(network_lab.target_url)
+    if authenticated:
+        request.add_header("Authorization", "Bearer synthetic")
+    with managed_urlopen(request, timeout=5) as response:
+        assert response.read() == b"guard-network-ok"
+    context = trust_module.build_default_ssl_context()
+    assert context.check_hostname is True
+    assert context.verify_mode == ssl.CERT_REQUIRED
+
+
+def test_explicit_untrusted_ca_does_not_fall_back(network_lab, monkeypatch):
+    monkeypatch.setattr(transport_module, "resolved_network_policy", lambda _: (ManagedNetworkPolicy(), False))
+    monkeypatch.setenv("SSL_CERT_FILE", "explicit-ca.pem")
+    monkeypatch.setattr(ssl, "create_default_context", lambda: ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT))
+    monkeypatch.setattr(trust_module, "_requests_ca_bundle", lambda: network_lab.ca_bundle)
+    with pytest.raises(urllib.error.URLError):
+        managed_urlopen(network_lab.target_url, timeout=5)
+
+
 @pytest.fixture
 def network_lab(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[_NetworkLab]:
     ca_path, cert_path, key_path = _write_certificates(tmp_path)

--- a/tests/test_guard_mdm_network_integration.py
+++ b/tests/test_guard_mdm_network_integration.py
@@ -229,6 +229,28 @@ def test_unmanaged_bundled_runtime_loads_public_roots(network_lab, monkeypatch, 
     assert context.verify_mode == ssl.CERT_REQUIRED
 
 
+@pytest.mark.parametrize("platform_trusted", [False, True])
+def test_missing_bundle_preserves_platform_trust(network_lab, monkeypatch, platform_trusted):
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    monkeypatch.delenv("SSL_CERT_DIR", raising=False)
+    monkeypatch.setattr(transport_module, "resolved_network_policy", lambda _: (ManagedNetworkPolicy(), False))
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    if platform_trusted:
+        context.load_verify_locations(cafile=str(network_lab.ca_bundle))
+    monkeypatch.setattr(ssl, "create_default_context", lambda: context)
+
+    def missing_bundle():
+        raise trust_module.ManagedTrustError("managed_system_trust_invalid")
+
+    monkeypatch.setattr(trust_module, "_requests_ca_bundle", missing_bundle)
+    if platform_trusted:
+        with managed_urlopen(network_lab.target_url, timeout=5) as response:
+            assert response.read() == b"guard-network-ok"
+    else:
+        with pytest.raises(urllib.error.URLError):
+            managed_urlopen(network_lab.target_url, timeout=5)
+
+
 def test_explicit_untrusted_ca_does_not_fall_back(network_lab, monkeypatch):
     monkeypatch.setattr(transport_module, "resolved_network_policy", lambda _: (ManagedNetworkPolicy(), False))
     monkeypatch.setenv("SSL_CERT_FILE", "explicit-ca.pem")

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -150,8 +150,9 @@ def test_request_device_authorization_sets_hol_guard_user_agent(monkeypatch) -> 
                 }
             ).encode("utf-8")
 
-    def fake_urlopen(request: urllib.request.Request, timeout: int):
+    def fake_urlopen(request: urllib.request.Request, timeout: int, *, context):
         del timeout
+        assert context.check_hostname is True
         captured["user_agent"] = request.get_header("User-agent") or ""
         return _Response()
 

--- a/tests/test_guard_phase03_remainder.py
+++ b/tests/test_guard_phase03_remainder.py
@@ -298,7 +298,7 @@ def test_latest_version_lookup_uses_practical_timeout(monkeypatch: pytest.Monkey
             read_limits.append(limit)
             return b'{"info":{"version":"2.0.1"}}'
 
-    def fake_urlopen(request: object, timeout: float) -> FakeResponse:
+    def fake_urlopen(request: object, timeout: float, *, context=None) -> FakeResponse:
         timeouts.append(timeout)
         return FakeResponse()
 
@@ -383,7 +383,7 @@ def test_bounded_version_read_enforces_total_deadline(monkeypatch: pytest.Monkey
 
 
 def test_latest_version_lookup_handles_truncated_response(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_urlopen(request: object, timeout: float) -> object:
+    def fake_urlopen(request: object, timeout: float, *, context=None) -> object:
         raise http.client.IncompleteRead(partial=b'{"info":')
 
     monkeypatch.setattr(update_commands.urllib.request, "urlopen", fake_urlopen)

--- a/tests/test_guard_sync_http_error_message.py
+++ b/tests/test_guard_sync_http_error_message.py
@@ -117,7 +117,7 @@ def test_urlopen_json_retries_cloudflare_502_with_default_retry_after(
         }
     )
 
-    def _urlopen(_request: urllib.request.Request, timeout: int) -> _JsonResponse:
+    def _urlopen(_request: urllib.request.Request, timeout: int, *, context=None) -> _JsonResponse:
         nonlocal attempts
         attempts += 1
         if attempts == 1:
@@ -150,7 +150,7 @@ def test_urlopen_retries_cloudflare_524_with_retry_after_header(
     attempts = 0
     slept: list[int] = []
 
-    def _urlopen(_request: urllib.request.Request, timeout: int) -> _EmptyResponse:
+    def _urlopen(_request: urllib.request.Request, timeout: int, *, context=None) -> _EmptyResponse:
         nonlocal attempts
         attempts += 1
         if attempts == 1:

--- a/tests/test_guard_workflow_capabilities.py
+++ b/tests/test_guard_workflow_capabilities.py
@@ -320,20 +320,23 @@ def test_concurrent_claims_never_exceed_exact_use_limit(tmp_path) -> None:
     claim = _claim(capability_id="wc-concurrent", max_uses=8)
     _issue(store, claim)
 
-    def attempt(invocation_id: str) -> str:
-        contender = _store(tmp_path)
+    # Initialize connections before measuring concurrent capability claims.
+    contenders = [_store(tmp_path) for _ in range(32)]
+
+    def attempt(index: int) -> str:
+        contender = contenders[index]
         try:
             _claim_capability(
                 contender,
                 claim,
-                invocation_id=invocation_id,
+                invocation_id=f"invocation-{index}",
             )
         except WorkflowCapabilityError as error:
             return str(error)
         return "claimed"
 
     with ThreadPoolExecutor(max_workers=32) as executor:
-        results = list(executor.map(attempt, (f"invocation-{index}" for index in range(32))))
+        results = list(executor.map(attempt, range(32)))
     assert results.count("claimed") == 8
     assert results.count("capability_exhausted") == 24
     with sqlite3.connect(store.path) as connection:


### PR DESCRIPTION
## Summary
- Load bundled public CA roots for ordinary HTTPS requests while preserving platform roots and explicit CA overrides. Authenticated requests still reject redirects and all requests retain certificate and hostname verification.
- Keep Cloud connection failures within the action layout, explain certificate failures plainly, and offer a clear retry action.
- Include rebuilt dashboard assets and regression coverage for empty default trust stores and responsive error states.

## Testing
- `uv run --no-sync pytest tests/test_guard_mdm_network.py tests/test_guard_mdm_network_integration.py tests/test_guard_connect_flow.py tests/test_guard_mdm_network_urlopen.py tests/test_guard_oauth_device_connect.py tests/test_guard_oauth_reconnect.py --tb=short -q`: 130 passed.
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/mdm/network_trust.py src/codex_plugin_scanner/guard/mdm/network_transport.py tests/test_guard_mdm_network_integration.py`: passed.
- Focused basedpyright: zero errors, 19 warnings.
- Dashboard build and connect flow tests passed.
- Playwright responsive TLS failure scenarios: 2 passed, desktop and mobile.
- `uv build --wheel` and wheel-installed version check passed.

## Notes
- No TLS verification bypass, MFA reset, or credential-store change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Replaced raw certificate verification details with clearer guidance about network and proxy certificate settings.
  - Added a “Retry connection” action when cloud connection attempts fail.
  - Improved TLS certificate handling across supported environments while preserving custom certificate settings.

- **Usability**
  - Improved error text wrapping and action alignment on narrow screens.
  - Protected pages remain usable after certificate failures, with accessible actions and no horizontal scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->