### PR TITLE
feat(extensions): notify accepted publishers after merge

### DIFF
--- a/.github/workflows/extension-builder-ci.yml
+++ b/.github/workflows/extension-builder-ci.yml
@@ -17,7 +17,9 @@ on:
       - docs/guard/extensions/**
       - scripts/export_extension_directory.py
       - scripts/render_command_extension_directory.py
+      - scripts/notify_merged_extension_claimants.py
       - tests/test_guard_extension_directory*.py
+      - tests/test_guard_extension_claim_notice.py
       - tests/fixtures/extension-listings/**
       - docs/guard/extension-builder/**
       - tests/*extension_builder*.py
@@ -30,6 +32,7 @@ on:
       - scripts/ci/verify_extension_builder_install.py
       - scripts/release/stage_guard_cloud_review_artifacts.py
       - .github/workflows/extension-builder-ci.yml
+      - .github/workflows/extension-claim-notice.yml
       - pyproject.toml
       - uv.lock
   workflow_dispatch:
@@ -82,6 +85,7 @@ jobs:
           mkdir -p builder-evidence
           uv run --no-sync pytest tests/test_guard_extension_builder_*.py \
             tests/test_guard_extension_directory*.py \
+            tests/test_guard_extension_claim_notice.py \
             tests/test_guard_extension_contribution.py \
             tests/test_guard_extension_trust.py \
             tests/test_guard_mcp_server_contribution.py \
@@ -135,12 +139,16 @@ jobs:
             src/codex_plugin_scanner/guard/extension_builder \
             src/codex_plugin_scanner/guard/cli/extension_builder_commands.py \
             src/codex_plugin_scanner/guard/runtime/command_reviewed_literal_matcher.py \
-            scripts/ci/verify_extension_builder_install.py
+            scripts/ci/verify_extension_builder_install.py \
+            scripts/notify_merged_extension_claimants.py \
+            tests/test_guard_extension_claim_notice.py
           uv run --no-sync ruff format --check \
             src/codex_plugin_scanner/guard/extension_builder \
             src/codex_plugin_scanner/guard/cli/extension_builder_commands.py \
             src/codex_plugin_scanner/guard/runtime/command_reviewed_literal_matcher.py \
-            scripts/ci/verify_extension_builder_install.py
+            scripts/ci/verify_extension_builder_install.py \
+            scripts/notify_merged_extension_claimants.py \
+            tests/test_guard_extension_claim_notice.py
       - name: Preserve authoring verification evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/.github/workflows/extension-builder-ci.yml
+++ b/.github/workflows/extension-builder-ci.yml
@@ -142,11 +142,10 @@ jobs:
             scripts/ci/verify_extension_builder_install.py \
             scripts/notify_merged_extension_claimants.py \
             tests/test_guard_extension_claim_notice.py
-          uv run --no-sync ruff format --check \
-            src/codex_plugin_scanner/guard/extension_builder \
-            src/codex_plugin_scanner/guard/cli/extension_builder_commands.py \
-            src/codex_plugin_scanner/guard/runtime/command_reviewed_literal_matcher.py \
-            scripts/ci/verify_extension_builder_install.py \
+          uv run --no-sync ruff format \
+            scripts/notify_merged_extension_claimants.py \
+            tests/test_guard_extension_claim_notice.py
+          git diff --exit-code -- \
             scripts/notify_merged_extension_claimants.py \
             tests/test_guard_extension_claim_notice.py
       - name: Preserve authoring verification evidence

--- a/.github/workflows/extension-builder-ci.yml
+++ b/.github/workflows/extension-builder-ci.yml
@@ -142,13 +142,8 @@ jobs:
             scripts/ci/verify_extension_builder_install.py \
             scripts/notify_merged_extension_claimants.py \
             tests/test_guard_extension_claim_notice.py
-          uv run --no-sync ruff format --check \
-            src/codex_plugin_scanner/guard/extension_builder \
-            src/codex_plugin_scanner/guard/cli/extension_builder_commands.py \
-            src/codex_plugin_scanner/guard/runtime/command_reviewed_literal_matcher.py \
-            scripts/ci/verify_extension_builder_install.py \
-            scripts/notify_merged_extension_claimants.py \
-            tests/test_guard_extension_claim_notice.py
+          uv run --no-sync ruff format scripts/notify_merged_extension_claimants.py
+          git diff -- scripts/notify_merged_extension_claimants.py
       - name: Preserve authoring verification evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/.github/workflows/extension-builder-ci.yml
+++ b/.github/workflows/extension-builder-ci.yml
@@ -142,10 +142,11 @@ jobs:
             scripts/ci/verify_extension_builder_install.py \
             scripts/notify_merged_extension_claimants.py \
             tests/test_guard_extension_claim_notice.py
-          uv run --no-sync ruff format \
-            scripts/notify_merged_extension_claimants.py \
-            tests/test_guard_extension_claim_notice.py
-          git diff --exit-code -- \
+          uv run --no-sync ruff format --check \
+            src/codex_plugin_scanner/guard/extension_builder \
+            src/codex_plugin_scanner/guard/cli/extension_builder_commands.py \
+            src/codex_plugin_scanner/guard/runtime/command_reviewed_literal_matcher.py \
+            scripts/ci/verify_extension_builder_install.py \
             scripts/notify_merged_extension_claimants.py \
             tests/test_guard_extension_claim_notice.py
       - name: Preserve authoring verification evidence

--- a/.github/workflows/extension-builder-ci.yml
+++ b/.github/workflows/extension-builder-ci.yml
@@ -142,8 +142,13 @@ jobs:
             scripts/ci/verify_extension_builder_install.py \
             scripts/notify_merged_extension_claimants.py \
             tests/test_guard_extension_claim_notice.py
-          uv run --no-sync ruff format scripts/notify_merged_extension_claimants.py
-          git diff -- scripts/notify_merged_extension_claimants.py
+          uv run --no-sync ruff format --check \
+            src/codex_plugin_scanner/guard/extension_builder \
+            src/codex_plugin_scanner/guard/cli/extension_builder_commands.py \
+            src/codex_plugin_scanner/guard/runtime/command_reviewed_literal_matcher.py \
+            scripts/ci/verify_extension_builder_install.py \
+            scripts/notify_merged_extension_claimants.py \
+            tests/test_guard_extension_claim_notice.py
       - name: Preserve authoring verification evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/.github/workflows/extension-claim-notice.yml
+++ b/.github/workflows/extension-claim-notice.yml
@@ -1,0 +1,47 @@
+name: Extension Claim Notice
+
+on:
+  pull_request_target:
+    types: [closed]
+    paths:
+      - "contributions/extensions/**"
+      - "contributions/mcp-servers/**"
+      - "contributions/extension-listings/**"
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Merged PR number to backfill"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: extension-claim-notice-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  notify:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out trusted workflow source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Post Extension Studio claim notice
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+          GUARD_EXTENSION_STUDIO_URL: https://hol.org/guard/extension-studio
+        run: >-
+          python3 scripts/notify_merged_extension_claimants.py
+          --repo "$GITHUB_REPOSITORY"
+          --pr-number "$PR_NUMBER"

--- a/docs/guard/extensions/publisher-metadata.md
+++ b/docs/guard/extensions/publisher-metadata.md
@@ -129,8 +129,21 @@ availability, publisher authority, or enabled protection on a device.
 
 ## Cloud availability
 
-The directory and metadata contract can be used independently of Guard Cloud.
-Extension Studio is a separate rollout. This helper deliberately includes no
-sign-in instruction or claim notification. The Cloud entry point must be deployed
-and verified before contributor invitations are enabled. A maintainer profile is
-not a security certification or an upstream endorsement.
+Extension Studio is available at `https://hol.org/guard/extension-studio`. A deep
+link may select an extension with `?extension=<contribution-id>`. Signing in or
+opening that link never grants authority by itself; Cloud re-reads canonical source
+and verifies the current numeric GitHub ID before accepting a claim.
+
+The post-merge `Extension Claim Notice` workflow runs only after a pull request is
+merged into the repository's default branch and only for native contribution or
+publisher-listing changes. It compares the canonical merge commit with its first
+parent, reads the accepted sidecar at the merge SHA, and notifies only newly
+accepted `maintainerGithubIds`. For a newly introduced native contribution, all
+accepted IDs in its merged sidecar are eligible for the notice. Pull-request
+authorship is never substituted for missing authority.
+
+Notices are idempotent on each merged PR and can be backfilled with the workflow's
+manual `pr_number` input. A removed, non-canonical, malformed, or authority-free
+listing produces no claim invitation. The notice is only an onboarding link; the
+publisher profile remains separate from runtime trust, activation, security
+certification, and upstream ownership.

--- a/scripts/notify_merged_extension_claimants.py
+++ b/scripts/notify_merged_extension_claimants.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import ipaddress
 import json
 import os
 import re
@@ -23,8 +24,26 @@ CONTRIBUTION_PREFIXES = (
     "contributions/mcp-servers/",
 )
 EXTENSION_ID_RE = re.compile(r"^(?:command|mcp)\.[a-z0-9]+(?:[.-][a-z0-9]+)*$")
+TAG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+GITHUB_ID_RE = re.compile(r"^[1-9][0-9]{0,19}$")
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+TRUSTED_NOTICE_ACTOR_ID = 41898282
+MAX_LISTING_BYTES = 16_384
+LISTING_REQUIRED_KEYS = frozenset({"schemaVersion", "extensionId", "tagline", "category", "limitations"})
+LISTING_ALLOWED_KEYS = LISTING_REQUIRED_KEYS | frozenset({"documentationUrl", "tags", "maintainerGithubIds"})
+LISTING_CATEGORIES = frozenset(
+    {
+        "core-safety",
+        "cloud-infrastructure",
+        "data-resilience",
+        "delivery-remote",
+        "managed-services",
+        "package-supply-chain",
+        "specialized-tools",
+        "other",
+    }
+)
 
 
 class ClaimNoticeError(RuntimeError):
@@ -98,12 +117,6 @@ class GitHubApi:
             if len(data) < 100:
                 return files
         raise ClaimNoticeError("pull request changes exceed the supported 3000-file bound")
-
-    def commit(self, sha: str) -> dict[str, Any]:
-        data = self._request(f"{self.base_url}/commits/{sha}")
-        if not isinstance(data, dict):
-            raise ClaimNoticeError("commit response is invalid")
-        return data
 
     def compare(self, base: str, head: str) -> dict[str, Any]:
         data = self._request(f"{self.base_url}/compare/{base}...{head}")
@@ -191,22 +204,98 @@ def changed_extension_ids(files: list[dict[str, Any]]) -> tuple[set[str], set[st
     return contributions, listings
 
 
+def _plain_text(value: object, *, minimum: int, maximum: int, field: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not minimum <= len(value) <= maximum
+        or value != value.strip()
+        or any(ord(char) < 32 or ord(char) == 127 for char in value)
+    ):
+        raise ClaimNoticeError(f"listing {field} does not match the canonical plain-text contract")
+    return value
+
+
+def _public_https(value: object) -> None:
+    value = _plain_text(value, minimum=10, maximum=1024, field="documentationUrl")
+    try:
+        parsed = urllib.parse.urlsplit(value)
+        host = parsed.hostname
+        if (
+            parsed.scheme != "https"
+            or not host
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.port not in (None, 443)
+            or host.lower() in {"localhost", "localhost.localdomain"}
+            or host.lower().endswith((".localhost", ".local", ".internal"))
+            or "\\" in value
+        ):
+            raise ValueError("non-public reference")
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
+            if "." not in host or host.endswith("."):
+                raise ValueError("non-public host") from None
+        else:
+            raise ValueError("literal IP")
+    except ValueError as error:
+        raise ClaimNoticeError("listing documentationUrl must use public HTTPS without credentials") from error
+
+
 def accepted_github_ids(listing: dict[str, Any], extension_id: str) -> tuple[str, ...]:
-    """Read the authority-bearing numeric IDs from a canonical listing sidecar."""
+    """Validate the complete listing contract, then return its reviewed claimant IDs."""
+    keys = frozenset(listing)
+    if not LISTING_REQUIRED_KEYS <= keys or not keys <= LISTING_ALLOWED_KEYS:
+        raise ClaimNoticeError(f"{extension_id}: listing fields do not match the canonical schema")
     if listing.get("schemaVersion") != "guard.extension-listing.v1":
         raise ClaimNoticeError(f"{extension_id}: unsupported extension listing schema")
-    if listing.get("extensionId") != extension_id:
+    listed_id = listing.get("extensionId")
+    if (
+        listed_id != extension_id
+        or not isinstance(listed_id, str)
+        or len(listed_id) > 256
+        or not EXTENSION_ID_RE.fullmatch(listed_id)
+    ):
         raise ClaimNoticeError(f"{extension_id}: listing identity does not match its path")
+    _plain_text(listing.get("tagline"), minimum=10, maximum=140, field="tagline")
+    if listing.get("category") not in LISTING_CATEGORIES:
+        raise ClaimNoticeError(f"{extension_id}: listing category is invalid")
+
+    limitations = listing.get("limitations")
+    if not isinstance(limitations, list) or not 1 <= len(limitations) <= 8:
+        raise ClaimNoticeError(f"{extension_id}: listing limitations are invalid")
+    checked_limitations = [
+        _plain_text(value, minimum=10, maximum=400, field="limitations") for value in limitations
+    ]
+    if len(set(checked_limitations)) != len(checked_limitations):
+        raise ClaimNoticeError(f"{extension_id}: listing limitations must be unique")
+
+    if "documentationUrl" in listing:
+        _public_https(listing["documentationUrl"])
+    if "tags" in listing:
+        tags = listing["tags"]
+        if not isinstance(tags, list) or len(tags) > 8:
+            raise ClaimNoticeError(f"{extension_id}: listing tags are invalid")
+        if any(not isinstance(tag, str) or not 2 <= len(tag) <= 30 or not TAG_RE.fullmatch(tag) for tag in tags):
+            raise ClaimNoticeError(f"{extension_id}: listing tags are invalid")
+        if len(set(tags)) != len(tags):
+            raise ClaimNoticeError(f"{extension_id}: listing tags must be unique")
+
     values = listing.get("maintainerGithubIds", [])
     if not isinstance(values, list) or len(values) > 8:
         raise ClaimNoticeError(f"{extension_id}: maintainerGithubIds must be an array of at most eight IDs")
-    result: list[str] = []
-    for value in values:
-        if not isinstance(value, str) or not value.isdecimal() or int(value) <= 0:
-            raise ClaimNoticeError(f"{extension_id}: maintainerGithubIds contains an invalid numeric GitHub ID")
-        if value not in result:
-            result.append(value)
-    return tuple(result)
+    if any(not isinstance(value, str) or not GITHUB_ID_RE.fullmatch(value) for value in values):
+        raise ClaimNoticeError(f"{extension_id}: maintainerGithubIds contains an invalid numeric GitHub ID")
+    if len(set(values)) != len(values):
+        raise ClaimNoticeError(f"{extension_id}: maintainerGithubIds must be unique")
+
+    try:
+        encoded = json.dumps(listing, ensure_ascii=False, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()
+    except (TypeError, ValueError) as error:
+        raise ClaimNoticeError(f"{extension_id}: listing cannot be canonically serialized") from error
+    if len(encoded) > MAX_LISTING_BYTES:
+        raise ClaimNoticeError(f"{extension_id}: listing exceeds the canonical byte budget")
+    return tuple(values)
 
 
 def contribution_path(extension_id: str) -> str:
@@ -248,6 +337,17 @@ def _resolve_identities(client: GitHubApi, github_ids: tuple[str, ...]) -> tuple
     return tuple((account_id, client.user_login(account_id)) for account_id in github_ids)
 
 
+def has_trusted_notice(comments: list[dict[str, Any]]) -> bool:
+    """Return whether the trusted GitHub Actions identity already posted this notice."""
+    for comment in comments:
+        if MARKER not in str(comment.get("body") or ""):
+            continue
+        user = comment.get("user")
+        if isinstance(user, dict) and user.get("id") == TRUSTED_NOTICE_ACTOR_ID and user.get("type") == "Bot":
+            return True
+    return False
+
+
 def collect_notice_items(client: GitHubApi, pr_number: int) -> list[NoticeItem]:
     repo = client.repo_metadata()
     default_branch = repo.get("default_branch")
@@ -263,22 +363,20 @@ def collect_notice_items(client: GitHubApi, pr_number: int) -> list[NoticeItem]:
     if base_ref != default_branch:
         print(f"PR #{pr_number}: merged into {base_ref!r}, not canonical {default_branch!r}; skipping")
         return []
+    before_sha = base.get("sha") if isinstance(base, dict) else None
+    if not isinstance(before_sha, str) or not SHA_RE.fullmatch(before_sha):
+        raise ClaimNoticeError("merged pull request is missing its pre-merge base SHA")
     merge_sha = pr.get("merge_commit_sha")
     if not isinstance(merge_sha, str) or not SHA_RE.fullmatch(merge_sha):
         raise ClaimNoticeError("merged pull request is missing a canonical merge commit SHA")
 
+    baseline_relation = client.compare(before_sha, merge_sha).get("status")
+    if baseline_relation not in {"ahead", "identical"}:
+        raise ClaimNoticeError("pull request base SHA is not an ancestor of the merged source")
     ancestry = client.compare(merge_sha, default_branch).get("status")
     if ancestry not in {"ahead", "identical"}:
         print(f"PR #{pr_number}: merge commit is no longer on canonical {default_branch}; skipping")
         return []
-
-    commit = client.commit(merge_sha)
-    parents = commit.get("parents")
-    if not isinstance(parents, list) or not parents or not isinstance(parents[0], dict):
-        raise ClaimNoticeError("merged commit has no first parent for authority comparison")
-    before_sha = parents[0].get("sha")
-    if not isinstance(before_sha, str) or not SHA_RE.fullmatch(before_sha):
-        raise ClaimNoticeError("merged commit first parent is invalid")
 
     contribution_changes, listing_changes = changed_extension_ids(client.pull_request_files(pr_number))
     candidates = sorted(contribution_changes | listing_changes)
@@ -322,8 +420,8 @@ def collect_notice_items(client: GitHubApi, pr_number: int) -> list[NoticeItem]:
 
 
 def process(client: GitHubApi, pr_number: int, studio_url: str, *, dry_run: bool = False) -> int:
-    if any(MARKER in str(comment.get("body") or "") for comment in client.comments(pr_number)):
-        print(f"PR #{pr_number}: extension claim notice already exists; skipping")
+    if has_trusted_notice(client.comments(pr_number)):
+        print(f"PR #{pr_number}: trusted extension claim notice already exists; skipping")
         return 0
     items = collect_notice_items(client, pr_number)
     if not items:

--- a/scripts/notify_merged_extension_claimants.py
+++ b/scripts/notify_merged_extension_claimants.py
@@ -277,9 +277,7 @@ def accepted_github_ids(listing: dict[str, Any], extension_id: str) -> tuple[str
     limitations = listing.get("limitations")
     if not isinstance(limitations, list) or not 1 <= len(limitations) <= 8:
         raise ClaimNoticeError(f"{extension_id}: listing limitations are invalid")
-    checked_limitations = [
-        _plain_text(value, minimum=10, maximum=400, field="limitations") for value in limitations
-    ]
+    checked_limitations = [_plain_text(value, minimum=10, maximum=400, field="limitations") for value in limitations]
     if len(set(checked_limitations)) != len(checked_limitations):
         raise ClaimNoticeError(f"{extension_id}: listing limitations must be unique")
 

--- a/scripts/notify_merged_extension_claimants.py
+++ b/scripts/notify_merged_extension_claimants.py
@@ -228,10 +228,7 @@ def build_comment(items: list[NoticeItem], studio_url: str) -> str:
     ]
     for item in items:
         link = f"{studio_url}?{urllib.parse.urlencode({'extension': item.extension_id})}"
-        identities = [
-            f"@{login}" if login else f"GitHub ID `{account_id}`"
-            for account_id, login in item.identities
-        ]
+        identities = [f"@{login}" if login else f"GitHub ID `{account_id}`" for account_id, login in item.identities]
         identity_text = ", ".join(identities) if identities else "accepted maintainer identity"
         lines.append(f"- `{item.extension_id}`: {identity_text} · [Open Extension Studio]({link})")
     lines.extend(
@@ -247,9 +244,7 @@ def build_comment(items: list[NoticeItem], studio_url: str) -> str:
     return "\n".join(lines)
 
 
-def _resolve_identities(
-    client: GitHubApi, github_ids: tuple[str, ...]
-) -> tuple[tuple[str, str | None], ...]:
+def _resolve_identities(client: GitHubApi, github_ids: tuple[str, ...]) -> tuple[tuple[str, str | None], ...]:
     return tuple((account_id, client.user_login(account_id)) for account_id in github_ids)
 
 

--- a/scripts/notify_merged_extension_claimants.py
+++ b/scripts/notify_merged_extension_claimants.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Notify newly authorized HOL Guard extension publishers after a merged PR."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+
+MARKER = "<!-- hol-extension-claim-notice:v1 -->"
+DEFAULT_STUDIO_URL = "https://hol.org/guard/extension-studio"
+LISTING_PREFIX = "contributions/extension-listings/"
+CONTRIBUTION_PREFIXES = (
+    "contributions/extensions/",
+    "contributions/mcp-servers/",
+)
+EXTENSION_ID_RE = re.compile(r"^(?:command|mcp)\.[a-z0-9]+(?:[.-][a-z0-9]+)*$")
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+
+class ClaimNoticeError(RuntimeError):
+    """Raised when claim-notice provenance cannot be established safely."""
+
+
+@dataclass(frozen=True)
+class NoticeItem:
+    extension_id: str
+    identities: tuple[tuple[str, str | None], ...]
+
+
+class GitHubApi:
+    """Small GitHub REST client used by the post-merge workflow."""
+
+    def __init__(self, token: str, repo: str) -> None:
+        if not token:
+            raise ClaimNoticeError("GitHub token is required")
+        if not REPO_RE.fullmatch(repo):
+            raise ClaimNoticeError("repository must use owner/name form")
+        self.token = token
+        self.repo = repo
+        self.base_url = f"https://api.github.com/repos/{repo}"
+
+    def _request(self, url: str, *, method: str = "GET", payload: Any | None = None) -> Any:
+        body = None
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {self.token}",
+            "User-Agent": "hol-guard-extension-claim-notice/1.0",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if payload is not None:
+            body = json.dumps(payload).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        request = urllib.request.Request(url, headers=headers, method=method, data=body)
+        try:
+            with urllib.request.urlopen(request, timeout=20) as response:
+                raw = response.read()
+        except urllib.error.HTTPError as error:
+            detail = error.read().decode("utf-8", errors="replace")
+            raise ClaimNoticeError(f"GitHub API {error.code} for {url}: {detail[:300]}") from error
+        except OSError as error:
+            raise ClaimNoticeError(f"GitHub API request failed for {url}: {error}") from error
+        if not raw:
+            return None
+        try:
+            return json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise ClaimNoticeError(f"GitHub API returned invalid JSON for {url}") from error
+
+    def repo_metadata(self) -> dict[str, Any]:
+        data = self._request(self.base_url)
+        if not isinstance(data, dict):
+            raise ClaimNoticeError("repository metadata response is invalid")
+        return data
+
+    def pull_request(self, number: int) -> dict[str, Any]:
+        data = self._request(f"{self.base_url}/pulls/{number}")
+        if not isinstance(data, dict):
+            raise ClaimNoticeError("pull request response is invalid")
+        return data
+
+    def pull_request_files(self, number: int) -> list[dict[str, Any]]:
+        files: list[dict[str, Any]] = []
+        for page in range(1, 31):
+            data = self._request(f"{self.base_url}/pulls/{number}/files?per_page=100&page={page}")
+            if not isinstance(data, list):
+                raise ClaimNoticeError("pull request files response is invalid")
+            files.extend(item for item in data if isinstance(item, dict))
+            if len(data) < 100:
+                return files
+        raise ClaimNoticeError("pull request changes exceed the supported 3000-file bound")
+
+    def commit(self, sha: str) -> dict[str, Any]:
+        data = self._request(f"{self.base_url}/commits/{sha}")
+        if not isinstance(data, dict):
+            raise ClaimNoticeError("commit response is invalid")
+        return data
+
+    def compare(self, base: str, head: str) -> dict[str, Any]:
+        data = self._request(f"{self.base_url}/compare/{base}...{head}")
+        if not isinstance(data, dict):
+            raise ClaimNoticeError("compare response is invalid")
+        return data
+
+    def file_json(self, path: str, ref: str, *, missing_ok: bool = False) -> dict[str, Any] | None:
+        encoded_path = urllib.parse.quote(path, safe="/")
+        url = f"{self.base_url}/contents/{encoded_path}?ref={urllib.parse.quote(ref, safe='')}"
+        try:
+            data = self._request(url)
+        except ClaimNoticeError as error:
+            if missing_ok and "GitHub API 404" in str(error):
+                return None
+            raise
+        if not isinstance(data, dict) or data.get("encoding") != "base64" or not isinstance(data.get("content"), str):
+            raise ClaimNoticeError(f"repository file response is invalid for {path}@{ref}")
+        try:
+            decoded = base64.b64decode(data["content"], validate=False).decode("utf-8")
+            parsed = json.loads(decoded)
+        except (ValueError, UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise ClaimNoticeError(f"repository file is not valid UTF-8 JSON: {path}@{ref}") from error
+        if not isinstance(parsed, dict):
+            raise ClaimNoticeError(f"repository file must contain a JSON object: {path}@{ref}")
+        return parsed
+
+    def file_exists(self, path: str, ref: str) -> bool:
+        return self.file_json(path, ref, missing_ok=True) is not None
+
+    def comments(self, number: int) -> list[dict[str, Any]]:
+        comments: list[dict[str, Any]] = []
+        for page in range(1, 11):
+            data = self._request(f"{self.base_url}/issues/{number}/comments?per_page=100&page={page}")
+            if not isinstance(data, list):
+                raise ClaimNoticeError("pull request comments response is invalid")
+            comments.extend(item for item in data if isinstance(item, dict))
+            if len(data) < 100:
+                return comments
+        raise ClaimNoticeError("pull request comments exceed the supported 1000-comment bound")
+
+    def user_login(self, account_id: str) -> str | None:
+        url = f"https://api.github.com/user/{urllib.parse.quote(account_id, safe='')}"
+        try:
+            data = self._request(url)
+        except ClaimNoticeError as error:
+            if "GitHub API 404" in str(error):
+                return None
+            raise
+        login = data.get("login") if isinstance(data, dict) else None
+        return login if isinstance(login, str) and login else None
+
+    def post_comment(self, number: int, body: str) -> None:
+        self._request(f"{self.base_url}/issues/{number}/comments", method="POST", payload={"body": body})
+
+
+def _extension_id_from_path(path: str, prefix: str) -> str | None:
+    if not path.startswith(prefix) or not path.endswith(".json"):
+        return None
+    name = path[len(prefix) : -5]
+    if "/" in name or not EXTENSION_ID_RE.fullmatch(name):
+        return None
+    return name
+
+
+def changed_extension_ids(files: list[dict[str, Any]]) -> tuple[set[str], set[str]]:
+    """Return contribution-changed and listing-changed extension IDs."""
+    contributions: set[str] = set()
+    listings: set[str] = set()
+    for item in files:
+        if item.get("status") == "removed":
+            continue
+        path = item.get("filename")
+        if not isinstance(path, str):
+            continue
+        listing_id = _extension_id_from_path(path, LISTING_PREFIX)
+        if listing_id:
+            listings.add(listing_id)
+            continue
+        for prefix in CONTRIBUTION_PREFIXES:
+            contribution_id = _extension_id_from_path(path, prefix)
+            if contribution_id:
+                contributions.add(contribution_id)
+                break
+    return contributions, listings
+
+
+def accepted_github_ids(listing: dict[str, Any], extension_id: str) -> tuple[str, ...]:
+    """Read the authority-bearing numeric IDs from a canonical listing sidecar."""
+    if listing.get("schemaVersion") != "guard.extension-listing.v1":
+        raise ClaimNoticeError(f"{extension_id}: unsupported extension listing schema")
+    if listing.get("extensionId") != extension_id:
+        raise ClaimNoticeError(f"{extension_id}: listing identity does not match its path")
+    values = listing.get("maintainerGithubIds", [])
+    if not isinstance(values, list) or len(values) > 8:
+        raise ClaimNoticeError(f"{extension_id}: maintainerGithubIds must be an array of at most eight IDs")
+    result: list[str] = []
+    for value in values:
+        if not isinstance(value, str) or not value.isdecimal() or int(value) <= 0:
+            raise ClaimNoticeError(f"{extension_id}: maintainerGithubIds contains an invalid numeric GitHub ID")
+        if value not in result:
+            result.append(value)
+    return tuple(result)
+
+
+def contribution_path(extension_id: str) -> str:
+    if extension_id.startswith("command."):
+        return f"contributions/extensions/{extension_id}.json"
+    if extension_id.startswith("mcp."):
+        return f"contributions/mcp-servers/{extension_id}.json"
+    raise ClaimNoticeError(f"unsupported extension ID: {extension_id}")
+
+
+def build_comment(items: list[NoticeItem], studio_url: str) -> str:
+    lines = [
+        MARKER,
+        (
+            "The merged extension metadata now authorizes the GitHub account(s) below "
+            "to manage publisher profiles in HOL Guard Extension Studio."
+        ),
+        "",
+    ]
+    for item in items:
+        link = f"{studio_url}?{urllib.parse.urlencode({'extension': item.extension_id})}"
+        identities = [
+            f"@{login}" if login else f"GitHub ID `{account_id}`"
+            for account_id, login in item.identities
+        ]
+        identity_text = ", ".join(identities) if identities else "accepted maintainer identity"
+        lines.append(f"- `{item.extension_id}`: {identity_text} · [Open Extension Studio]({link})")
+    lines.extend(
+        [
+            "",
+            (
+                "Claim verification re-reads canonical `main` and checks the accepted numeric GitHub ID "
+                "before granting publisher access. The publisher profile is separate from runtime trust, "
+                "activation, or upstream ownership."
+            ),
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _resolve_identities(
+    client: GitHubApi, github_ids: tuple[str, ...]
+) -> tuple[tuple[str, str | None], ...]:
+    return tuple((account_id, client.user_login(account_id)) for account_id in github_ids)
+
+
+def collect_notice_items(client: GitHubApi, pr_number: int) -> list[NoticeItem]:
+    repo = client.repo_metadata()
+    default_branch = repo.get("default_branch")
+    if not isinstance(default_branch, str) or not default_branch:
+        raise ClaimNoticeError("repository default branch is unavailable")
+
+    pr = client.pull_request(pr_number)
+    if not pr.get("merged_at"):
+        print(f"PR #{pr_number}: not merged; skipping")
+        return []
+    base = pr.get("base")
+    base_ref = base.get("ref") if isinstance(base, dict) else None
+    if base_ref != default_branch:
+        print(f"PR #{pr_number}: merged into {base_ref!r}, not canonical {default_branch!r}; skipping")
+        return []
+    merge_sha = pr.get("merge_commit_sha")
+    if not isinstance(merge_sha, str) or not SHA_RE.fullmatch(merge_sha):
+        raise ClaimNoticeError("merged pull request is missing a canonical merge commit SHA")
+
+    ancestry = client.compare(merge_sha, default_branch).get("status")
+    if ancestry not in {"ahead", "identical"}:
+        print(f"PR #{pr_number}: merge commit is no longer on canonical {default_branch}; skipping")
+        return []
+
+    commit = client.commit(merge_sha)
+    parents = commit.get("parents")
+    if not isinstance(parents, list) or not parents or not isinstance(parents[0], dict):
+        raise ClaimNoticeError("merged commit has no first parent for authority comparison")
+    before_sha = parents[0].get("sha")
+    if not isinstance(before_sha, str) or not SHA_RE.fullmatch(before_sha):
+        raise ClaimNoticeError("merged commit first parent is invalid")
+
+    contribution_changes, listing_changes = changed_extension_ids(client.pull_request_files(pr_number))
+    candidates = sorted(contribution_changes | listing_changes)
+    if not candidates:
+        print(f"PR #{pr_number}: no extension contribution or listing changes; skipping")
+        return []
+
+    items: list[NoticeItem] = []
+    for extension_id in candidates:
+        listing_path = f"{LISTING_PREFIX}{extension_id}.json"
+        current_listing = client.file_json(listing_path, merge_sha, missing_ok=True)
+        if current_listing is None:
+            continue
+        current_ids = accepted_github_ids(current_listing, extension_id)
+        if not current_ids:
+            continue
+
+        native_path = contribution_path(extension_id)
+        if not client.file_exists(native_path, merge_sha):
+            raise ClaimNoticeError(f"{extension_id}: authority sidecar exists without a canonical native contribution")
+        contribution_existed = client.file_exists(native_path, before_sha)
+
+        if not contribution_existed:
+            notify_ids = current_ids
+        elif extension_id in listing_changes:
+            previous_listing = client.file_json(listing_path, before_sha, missing_ok=True)
+            previous_ids = accepted_github_ids(previous_listing, extension_id) if previous_listing else ()
+            notify_ids = tuple(account_id for account_id in current_ids if account_id not in previous_ids)
+        else:
+            notify_ids = ()
+        if not notify_ids:
+            continue
+
+        items.append(
+            NoticeItem(
+                extension_id=extension_id,
+                identities=_resolve_identities(client, notify_ids),
+            )
+        )
+    return items
+
+
+def process(client: GitHubApi, pr_number: int, studio_url: str, *, dry_run: bool = False) -> int:
+    if any(MARKER in str(comment.get("body") or "") for comment in client.comments(pr_number)):
+        print(f"PR #{pr_number}: extension claim notice already exists; skipping")
+        return 0
+    items = collect_notice_items(client, pr_number)
+    if not items:
+        return 0
+    body = build_comment(items, studio_url.rstrip("/"))
+    if dry_run:
+        print(body)
+        return 0
+    client.post_comment(pr_number, body)
+    print(f"PR #{pr_number}: posted Extension Studio claim notice for {len(items)} extension(s)")
+    return 0
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--pr-number", type=int, required=True)
+    parser.add_argument("--studio-url", default=os.environ.get("GUARD_EXTENSION_STUDIO_URL", DEFAULT_STUDIO_URL))
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or ""
+    try:
+        return process(GitHubApi(token, args.repo), args.pr_number, args.studio_url, dry_run=args.dry_run)
+    except ClaimNoticeError as error:
+        print(f"extension claim notice failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_guard_extension_claim_notice.py
+++ b/tests/test_guard_extension_claim_notice.py
@@ -243,10 +243,14 @@ def test_non_ascii_and_duplicate_github_ids_fail_closed() -> None:
 
 def test_worker_authority_constants_match_public_schema() -> None:
     schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
-    assert MODULE.LISTING_REQUIRED_KEYS == frozenset(schema["required"])
-    assert MODULE.LISTING_ALLOWED_KEYS == frozenset(schema["properties"])
-    assert MODULE.LISTING_CATEGORIES == frozenset(schema["properties"]["category"]["enum"])
-    assert MODULE.GITHUB_ID_RE.pattern == schema["properties"]["maintainerGithubIds"]["items"]["pattern"]
+    required = frozenset(schema["required"])
+    allowed = frozenset(schema["properties"])
+    categories = frozenset(schema["properties"]["category"]["enum"])
+    github_id_pattern = schema["properties"]["maintainerGithubIds"]["items"]["pattern"]
+    assert required == MODULE.LISTING_REQUIRED_KEYS
+    assert allowed == MODULE.LISTING_ALLOWED_KEYS
+    assert categories == MODULE.LISTING_CATEGORIES
+    assert github_id_pattern == MODULE.GITHUB_ID_RE.pattern
 
 
 def test_unresolved_numeric_id_stays_visible_without_guessing_a_username() -> None:

--- a/tests/test_guard_extension_claim_notice.py
+++ b/tests/test_guard_extension_claim_notice.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/notify_merged_extension_claimants.py"
+WORKFLOW = ROOT / ".github/workflows/extension-claim-notice.yml"
+SPEC = importlib.util.spec_from_file_location("guard_extension_claim_notice", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+MERGE_SHA = "a" * 40
+BEFORE_SHA = "b" * 40
+
+
+def listing(extension_id: str, ids: list[str]) -> dict[str, Any]:
+    return {
+        "schemaVersion": "guard.extension-listing.v1",
+        "extensionId": extension_id,
+        "maintainerGithubIds": ids,
+    }
+
+
+class FakeGitHub:
+    def __init__(self) -> None:
+        self.default_branch = "main"
+        self.merged = True
+        self.base_ref = "main"
+        self.compare_status = "ahead"
+        self.files: list[dict[str, Any]] = []
+        self.file_payloads: dict[tuple[str, str], dict[str, Any] | None] = {}
+        self.comment_rows: list[dict[str, Any]] = []
+        self.logins: dict[str, str | None] = {}
+        self.posted: list[tuple[int, str]] = []
+
+    def repo_metadata(self) -> dict[str, Any]:
+        return {"default_branch": self.default_branch}
+
+    def pull_request(self, number: int) -> dict[str, Any]:
+        return {
+            "merged_at": "2026-09-08T00:00:00Z" if self.merged else None,
+            "base": {"ref": self.base_ref},
+            "merge_commit_sha": MERGE_SHA,
+        }
+
+    def compare(self, base: str, head: str) -> dict[str, Any]:
+        assert base == MERGE_SHA
+        assert head == self.default_branch
+        return {"status": self.compare_status}
+
+    def commit(self, sha: str) -> dict[str, Any]:
+        assert sha == MERGE_SHA
+        return {"parents": [{"sha": BEFORE_SHA}]}
+
+    def pull_request_files(self, number: int) -> list[dict[str, Any]]:
+        return self.files
+
+    def file_json(self, path: str, ref: str, *, missing_ok: bool = False) -> dict[str, Any] | None:
+        value = self.file_payloads.get((ref, path))
+        if value is None and not missing_ok:
+            raise AssertionError(f"unexpected missing file: {path}@{ref}")
+        return value
+
+    def file_exists(self, path: str, ref: str) -> bool:
+        return self.file_payloads.get((ref, path)) is not None
+
+    def comments(self, number: int) -> list[dict[str, Any]]:
+        return self.comment_rows
+
+    def user_login(self, account_id: str) -> str | None:
+        return self.logins.get(account_id)
+
+    def post_comment(self, number: int, body: str) -> None:
+        self.posted.append((number, body))
+
+
+def test_new_contribution_notifies_only_reviewed_numeric_ids() -> None:
+    client = FakeGitHub()
+    extension_id = "command.example"
+    client.files = [
+        {"status": "added", "filename": f"contributions/extensions/{extension_id}.json"},
+        {"status": "added", "filename": f"contributions/extension-listings/{extension_id}.json"},
+    ]
+    client.file_payloads[(MERGE_SHA, f"contributions/extensions/{extension_id}.json")] = {
+        "schemaVersion": "v1"
+    }
+    client.file_payloads[(MERGE_SHA, f"contributions/extension-listings/{extension_id}.json")] = listing(
+        extension_id, ["200", "100"]
+    )
+    client.logins = {"200": "second-maintainer", "100": "first-maintainer"}
+
+    assert MODULE.process(client, 42, MODULE.DEFAULT_STUDIO_URL) == 0
+
+    assert len(client.posted) == 1
+    body = client.posted[0][1]
+    assert MODULE.MARKER in body
+    assert "@second-maintainer" in body
+    assert "@first-maintainer" in body
+    assert "extension=command.example" in body
+    assert "PR author" not in body
+    assert "runtime trust" in body
+
+
+def test_pr_authorship_never_creates_claim_authority() -> None:
+    client = FakeGitHub()
+    extension_id = "command.no-authority"
+    client.files = [{"status": "added", "filename": f"contributions/extensions/{extension_id}.json"}]
+    client.file_payloads[(MERGE_SHA, f"contributions/extensions/{extension_id}.json")] = {
+        "schemaVersion": "v1"
+    }
+
+    assert MODULE.process(client, 7, MODULE.DEFAULT_STUDIO_URL) == 0
+    assert client.posted == []
+
+
+def test_listing_change_notifies_only_newly_accepted_ids() -> None:
+    client = FakeGitHub()
+    extension_id = "command.existing"
+    listing_path = f"contributions/extension-listings/{extension_id}.json"
+    contribution_path = f"contributions/extensions/{extension_id}.json"
+    client.files = [{"status": "modified", "filename": listing_path}]
+    client.file_payloads[(MERGE_SHA, contribution_path)] = {"schemaVersion": "v1"}
+    client.file_payloads[(BEFORE_SHA, contribution_path)] = {"schemaVersion": "v1"}
+    client.file_payloads[(MERGE_SHA, listing_path)] = listing(extension_id, ["100", "200"])
+    client.file_payloads[(BEFORE_SHA, listing_path)] = listing(extension_id, ["100"])
+    client.logins = {"100": "old-maintainer", "200": "new-maintainer"}
+
+    assert MODULE.process(client, 8, MODULE.DEFAULT_STUDIO_URL) == 0
+
+    body = client.posted[0][1]
+    assert "@new-maintainer" in body
+    assert "@old-maintainer" not in body
+
+
+def test_existing_marker_makes_manual_backfill_idempotent() -> None:
+    client = FakeGitHub()
+    client.comment_rows = [{"body": f"{MODULE.MARKER}\nAlready posted"}]
+
+    assert MODULE.process(client, 9, MODULE.DEFAULT_STUDIO_URL) == 0
+    assert client.posted == []
+
+
+def test_noncanonical_or_removed_merge_is_not_actionable() -> None:
+    client = FakeGitHub()
+    client.base_ref = "release/3.2"
+    assert MODULE.process(client, 10, MODULE.DEFAULT_STUDIO_URL) == 0
+
+    client.base_ref = "main"
+    client.compare_status = "diverged"
+    assert MODULE.process(client, 10, MODULE.DEFAULT_STUDIO_URL) == 0
+    assert client.posted == []
+
+
+def test_invalid_authority_metadata_fails_closed() -> None:
+    client = FakeGitHub()
+    extension_id = "command.invalid-authority"
+    listing_path = f"contributions/extension-listings/{extension_id}.json"
+    contribution_path = f"contributions/extensions/{extension_id}.json"
+    client.files = [
+        {"status": "added", "filename": contribution_path},
+        {"status": "added", "filename": listing_path},
+    ]
+    client.file_payloads[(MERGE_SHA, contribution_path)] = {"schemaVersion": "v1"}
+    client.file_payloads[(MERGE_SHA, listing_path)] = listing(extension_id, ["not-a-number"])
+
+    with pytest.raises(MODULE.ClaimNoticeError, match="invalid numeric GitHub ID"):
+        MODULE.collect_notice_items(client, 11)
+
+
+def test_unresolved_numeric_id_stays_visible_without_guessing_a_username() -> None:
+    item = MODULE.NoticeItem(
+        extension_id="command.unresolved",
+        identities=(("100", "resolved-user"), ("200", None)),
+    )
+    body = MODULE.build_comment([item], MODULE.DEFAULT_STUDIO_URL)
+    assert "@resolved-user" in body
+    assert "GitHub ID `200`" in body
+    assert "GitHub ID `100`" not in body
+
+
+def test_changed_extension_ids_ignore_removed_or_unrelated_files() -> None:
+    contributions, listings = MODULE.changed_extension_ids(
+        [
+            {"status": "added", "filename": "contributions/extensions/command.one.json"},
+            {
+                "status": "modified",
+                "filename": "contributions/extension-listings/mcp.two.json",
+            },
+            {"status": "removed", "filename": "contributions/extensions/command.gone.json"},
+            {"status": "modified", "filename": "README.md"},
+        ]
+    )
+    assert contributions == {"command.one"}
+    assert listings == {"mcp.two"}
+
+
+def test_workflow_is_merge_only_and_supports_idempotent_backfill() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "pull_request_target:" in text
+    assert "types: [closed]" in text
+    assert "github.event.pull_request.merged == true" in text
+    assert "workflow_dispatch:" in text
+    assert "pr_number:" in text
+    assert "contributions/extension-listings/**" in text
+    assert "pull-requests: write" in text
+    assert "issues: write" in text
+    assert "persist-credentials: false" in text
+    assert "notify_merged_extension_claimants.py" in text
+    assert "https://hol.org/guard/extension-studio" in text

--- a/tests/test_guard_extension_claim_notice.py
+++ b/tests/test_guard_extension_claim_notice.py
@@ -88,9 +88,7 @@ def test_new_contribution_notifies_only_reviewed_numeric_ids() -> None:
         {"status": "added", "filename": f"contributions/extensions/{extension_id}.json"},
         {"status": "added", "filename": f"contributions/extension-listings/{extension_id}.json"},
     ]
-    client.file_payloads[(MERGE_SHA, f"contributions/extensions/{extension_id}.json")] = {
-        "schemaVersion": "v1"
-    }
+    client.file_payloads[(MERGE_SHA, f"contributions/extensions/{extension_id}.json")] = {"schemaVersion": "v1"}
     client.file_payloads[(MERGE_SHA, f"contributions/extension-listings/{extension_id}.json")] = listing(
         extension_id, ["200", "100"]
     )
@@ -112,9 +110,7 @@ def test_pr_authorship_never_creates_claim_authority() -> None:
     client = FakeGitHub()
     extension_id = "command.no-authority"
     client.files = [{"status": "added", "filename": f"contributions/extensions/{extension_id}.json"}]
-    client.file_payloads[(MERGE_SHA, f"contributions/extensions/{extension_id}.json")] = {
-        "schemaVersion": "v1"
-    }
+    client.file_payloads[(MERGE_SHA, f"contributions/extensions/{extension_id}.json")] = {"schemaVersion": "v1"}
 
     assert MODULE.process(client, 7, MODULE.DEFAULT_STUDIO_URL) == 0
     assert client.posted == []

--- a/tests/test_guard_extension_claim_notice.py
+++ b/tests/test_guard_extension_claim_notice.py
@@ -24,6 +24,9 @@ def listing(extension_id: str, ids: list[str]) -> dict[str, Any]:
     return {
         "schemaVersion": "guard.extension-listing.v1",
         "extensionId": extension_id,
+        "tagline": f"Reviewed operation coverage for {extension_id}.",
+        "category": "other",
+        "limitations": ["Coverage is limited to the reviewed operations and the surrounding Guard policy."],
         "maintainerGithubIds": ids,
     }
 
@@ -33,7 +36,9 @@ class FakeGitHub:
         self.default_branch = "main"
         self.merged = True
         self.base_ref = "main"
+        self.base_sha = BEFORE_SHA
         self.compare_status = "ahead"
+        self.baseline_status = "ahead"
         self.files: list[dict[str, Any]] = []
         self.file_payloads: dict[tuple[str, str], dict[str, Any] | None] = {}
         self.comment_rows: list[dict[str, Any]] = []
@@ -46,18 +51,16 @@ class FakeGitHub:
     def pull_request(self, number: int) -> dict[str, Any]:
         return {
             "merged_at": "2026-09-08T00:00:00Z" if self.merged else None,
-            "base": {"ref": self.base_ref},
+            "base": {"ref": self.base_ref, "sha": self.base_sha},
             "merge_commit_sha": MERGE_SHA,
         }
 
     def compare(self, base: str, head: str) -> dict[str, Any]:
-        assert base == MERGE_SHA
-        assert head == self.default_branch
-        return {"status": self.compare_status}
-
-    def commit(self, sha: str) -> dict[str, Any]:
-        assert sha == MERGE_SHA
-        return {"parents": [{"sha": BEFORE_SHA}]}
+        if base == self.base_sha and head == MERGE_SHA:
+            return {"status": self.baseline_status}
+        if base == MERGE_SHA and head == self.default_branch:
+            return {"status": self.compare_status}
+        raise AssertionError(f"unexpected comparison: {base}...{head}")
 
     def pull_request_files(self, number: int) -> list[dict[str, Any]]:
         return self.files
@@ -81,17 +84,20 @@ class FakeGitHub:
         self.posted.append((number, body))
 
 
+def configure_new_contribution(client: FakeGitHub, extension_id: str, ids: list[str]) -> None:
+    contribution_path = f"contributions/extensions/{extension_id}.json"
+    listing_path = f"contributions/extension-listings/{extension_id}.json"
+    client.files = [
+        {"status": "added", "filename": contribution_path},
+        {"status": "added", "filename": listing_path},
+    ]
+    client.file_payloads[(MERGE_SHA, contribution_path)] = {"schemaVersion": "v1"}
+    client.file_payloads[(MERGE_SHA, listing_path)] = listing(extension_id, ids)
+
+
 def test_new_contribution_notifies_only_reviewed_numeric_ids() -> None:
     client = FakeGitHub()
-    extension_id = "command.example"
-    client.files = [
-        {"status": "added", "filename": f"contributions/extensions/{extension_id}.json"},
-        {"status": "added", "filename": f"contributions/extension-listings/{extension_id}.json"},
-    ]
-    client.file_payloads[(MERGE_SHA, f"contributions/extensions/{extension_id}.json")] = {"schemaVersion": "v1"}
-    client.file_payloads[(MERGE_SHA, f"contributions/extension-listings/{extension_id}.json")] = listing(
-        extension_id, ["200", "100"]
-    )
+    configure_new_contribution(client, "command.example", ["200", "100"])
     client.logins = {"200": "second-maintainer", "100": "first-maintainer"}
 
     assert MODULE.process(client, 42, MODULE.DEFAULT_STUDIO_URL) == 0
@@ -135,12 +141,36 @@ def test_listing_change_notifies_only_newly_accepted_ids() -> None:
     assert "@old-maintainer" not in body
 
 
-def test_existing_marker_makes_manual_backfill_idempotent() -> None:
+def test_pre_pr_base_sha_supports_multi_commit_rebase_merges() -> None:
     client = FakeGitHub()
-    client.comment_rows = [{"body": f"{MODULE.MARKER}\nAlready posted"}]
+    configure_new_contribution(client, "command.rebased", ["300"])
+    client.logins = {"300": "rebased-maintainer"}
+
+    assert MODULE.process(client, 12, MODULE.DEFAULT_STUDIO_URL) == 0
+    assert "@rebased-maintainer" in client.posted[0][1]
+
+
+def test_existing_marker_from_trusted_actions_identity_is_idempotent() -> None:
+    client = FakeGitHub()
+    client.comment_rows = [
+        {
+            "body": f"{MODULE.MARKER}\nAlready posted",
+            "user": {"id": MODULE.TRUSTED_NOTICE_ACTOR_ID, "type": "Bot"},
+        }
+    ]
 
     assert MODULE.process(client, 9, MODULE.DEFAULT_STUDIO_URL) == 0
     assert client.posted == []
+
+
+def test_contributor_cannot_spoof_notice_marker() -> None:
+    client = FakeGitHub()
+    configure_new_contribution(client, "command.marker-spoof", ["400"])
+    client.logins = {"400": "real-maintainer"}
+    client.comment_rows = [{"body": MODULE.MARKER, "user": {"id": 1234, "type": "User"}}]
+
+    assert MODULE.process(client, 13, MODULE.DEFAULT_STUDIO_URL) == 0
+    assert len(client.posted) == 1
 
 
 def test_noncanonical_or_removed_merge_is_not_actionable() -> None:
@@ -157,17 +187,29 @@ def test_noncanonical_or_removed_merge_is_not_actionable() -> None:
 def test_invalid_authority_metadata_fails_closed() -> None:
     client = FakeGitHub()
     extension_id = "command.invalid-authority"
-    listing_path = f"contributions/extension-listings/{extension_id}.json"
-    contribution_path = f"contributions/extensions/{extension_id}.json"
-    client.files = [
-        {"status": "added", "filename": contribution_path},
-        {"status": "added", "filename": listing_path},
-    ]
-    client.file_payloads[(MERGE_SHA, contribution_path)] = {"schemaVersion": "v1"}
-    client.file_payloads[(MERGE_SHA, listing_path)] = listing(extension_id, ["not-a-number"])
+    configure_new_contribution(client, extension_id, ["not-a-number"])
 
     with pytest.raises(MODULE.ClaimNoticeError, match="invalid numeric GitHub ID"):
         MODULE.collect_notice_items(client, 11)
+
+
+def test_missing_required_listing_fields_fail_closed() -> None:
+    client = FakeGitHub()
+    extension_id = "command.invalid-listing"
+    configure_new_contribution(client, extension_id, ["500"])
+    listing_path = f"contributions/extension-listings/{extension_id}.json"
+    client.file_payloads[(MERGE_SHA, listing_path)].pop("tagline")
+
+    with pytest.raises(MODULE.ClaimNoticeError, match="canonical schema"):
+        MODULE.collect_notice_items(client, 14)
+
+
+def test_non_ascii_and_duplicate_github_ids_fail_closed() -> None:
+    extension_id = "command.invalid-ids"
+    with pytest.raises(MODULE.ClaimNoticeError, match="invalid numeric GitHub ID"):
+        MODULE.accepted_github_ids(listing(extension_id, ["１２３"]), extension_id)
+    with pytest.raises(MODULE.ClaimNoticeError, match="must be unique"):
+        MODULE.accepted_github_ids(listing(extension_id, ["600", "600"]), extension_id)
 
 
 def test_unresolved_numeric_id_stays_visible_without_guessing_a_username() -> None:


### PR DESCRIPTION
## Summary
- add a merge-only Extension Claim Notice workflow with manual PR backfill
- derive claim eligibility only from reviewed numeric `maintainerGithubIds` on canonical `main`
- notify all accepted IDs for a new native contribution and only newly accepted IDs for later listing changes
- deep-link authorized maintainers into HOL Guard Extension Studio without treating PR authorship or usernames as authority
- fail closed on malformed/non-canonical provenance and trust only the GitHub Actions bot marker for idempotency
- suppress rename-affected invitations unless a maintainer explicitly backfills with `allow_renames`

## Verification
- current `main` integrated; branch is 0 commits behind
- Extension Builder CI passed on Ubuntu Python 3.10/3.13, Windows Python 3.13, and macOS Python 3.13
- 449 focused builder, directory, claim-notice, contribution, trust, and MCP contribution tests passed per matrix job
- native public directory projections passed
- isolated wheel build/install verification passed on all four matrix jobs
- Ubuntu 3.13 coverage and source-bound decision evidence passed
- Ruff lint and strict formatting checks passed
- Security Gates, Fuzzing, PyPI validation, MCPB Distribution, Sonar findings, migration hygiene, and decision-critical I/O ownership passed on the exact head
- all review threads resolved