### PR TITLE
fix(scanner): allow patch-only DeepSeek Harness bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `HARDCODED_SECRET` no longer treats pure `${VAR}` or `{{var}}` expansions as
   embedded credentials outside docs and tests. Non-empty defaults and suffixes
   still fail.
+- Native DeepSeek Harness packages can set `dsh.bundle.mode` to `"patch"` so
+  patch-only bundles are not required to export Cordis `apply(ctx)`. Packages
+  that declare `main` or `exports` still need that runtime.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ The published `cisco` extra provides skill scanning; the separate `cisco-mcp` gr
 | :--- | :--- |
 | Codex | `.codex-plugin/plugin.json`, `marketplace.json`, `.agents/plugins/marketplace.json` |
 | Claude Code | `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` |
-| DeepSeek Harness | `package.json` with `dsh.bundle`, declared patches, and Cordis `apply(ctx)` exports |
+| DeepSeek Harness | `package.json` with `dsh.bundle`, declared patches, and Cordis `apply(ctx)` exports, or `dsh.bundle.mode` set to `"patch"` for patch-only bundles |
 | Gemini CLI | `gemini-extension.json`, `commands/**/*.toml` |
 | Kimi Code | `kimi.plugin.json`, `.kimi-plugin/plugin.json`, declared skills, agents, commands, prompts, and MCP servers |
 | OpenCode | `opencode.json`, `opencode.jsonc`, `.opencode/commands`, `.opencode/plugins` |

--- a/src/codex_plugin_scanner/checks/deepseek_harness.py
+++ b/src/codex_plugin_scanner/checks/deepseek_harness.py
@@ -61,9 +61,13 @@ def run_deepseek_harness_checks(package: NormalizedPackage) -> tuple[CheckResult
         _result(
             "DSH Cordis runtime entry point",
             validation.runtime_ok,
-            "DSH runtime exports apply(ctx)"
-            if validation.runtime_ok
-            else "DSH runtime entry point must export apply(ctx)",
+            (
+                "Patch-only DSH bundle does not require apply(ctx)"
+                if validation.runtime_ok and not validation.runtime_required
+                else "DSH runtime exports apply(ctx)"
+                if validation.runtime_ok
+                else "DSH runtime entry point must export apply(ctx)"
+            ),
             "DSH_RUNTIME_APPLY_MISSING",
             "package.json main/exports must reference a regular in-package module exporting Cordis apply(ctx).",
         ),

--- a/src/codex_plugin_scanner/checks/deepseek_harness.py
+++ b/src/codex_plugin_scanner/checks/deepseek_harness.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from ..deepseek_harness_support import validate_dsh_package
+from ..deepseek_harness_support import dsh_runtime_scan_message, validate_dsh_package
 from ..ecosystems.types import NormalizedPackage
 from ..models import CheckResult, Finding, Severity
 
@@ -61,13 +61,7 @@ def run_deepseek_harness_checks(package: NormalizedPackage) -> tuple[CheckResult
         _result(
             "DSH Cordis runtime entry point",
             validation.runtime_ok,
-            (
-                "Patch-only DSH bundle does not require apply(ctx)"
-                if validation.runtime_ok and not validation.runtime_required
-                else "DSH runtime exports apply(ctx)"
-                if validation.runtime_ok
-                else "DSH runtime entry point must export apply(ctx)"
-            ),
+            dsh_runtime_scan_message(validation),
             "DSH_RUNTIME_APPLY_MISSING",
             "package.json main/exports must reference a regular in-package module exporting Cordis apply(ctx).",
         ),

--- a/src/codex_plugin_scanner/deepseek_harness_support.py
+++ b/src/codex_plugin_scanner/deepseek_harness_support.py
@@ -97,6 +97,12 @@ def _declared_bundle_mode(bundle: dict[str, object]) -> str | None:
     return None
 
 
+def _declares_runtime_entry(manifest: dict[str, object]) -> bool:
+    """Return whether the manifest claims a package runtime via main or exports."""
+
+    return "main" in manifest or "exports" in manifest
+
+
 def _runtime_path(manifest: dict[str, object]) -> str | None:
     """Resolve the package root export, falling back to ``main`` only without ``exports``."""
 
@@ -322,7 +328,7 @@ def validate_dsh_package(package: NormalizedPackage) -> DshValidation:
         )
 
     runtime_path = _runtime_path(manifest)
-    runtime_required = mode != "patch" or runtime_path is not None
+    runtime_required = mode != "patch" or _declares_runtime_entry(manifest)
     runtime_target = package.root_path / runtime_path if runtime_path is not None else None
     runtime_ok = False
     if not runtime_required:

--- a/src/codex_plugin_scanner/deepseek_harness_support.py
+++ b/src/codex_plugin_scanner/deepseek_harness_support.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from .ecosystems.types import NormalizedPackage
 from .path_support import is_safe_relative_path
 
+DSH_BUNDLE_MODES = frozenset({"executable", "patch"})
 DSH_SEMVER_RE = re.compile(
     "".join(
         (
@@ -57,6 +58,7 @@ class DshValidation:
     patch_ok: bool
     runtime_ok: bool
     runtime_path: str | None
+    runtime_required: bool
 
 
 def _export_target(value: object) -> str | None:
@@ -81,6 +83,17 @@ def _export_target(value: object) -> str | None:
             continue
         if (resolved := _export_target(candidate)) is not None:
             return resolved
+    return None
+
+
+def _declared_bundle_mode(bundle: dict[str, object]) -> str | None:
+    """Return the declared bundle mode, or None when the value is invalid."""
+
+    if "mode" not in bundle:
+        return "executable"
+    mode = bundle.get("mode")
+    if isinstance(mode, str) and mode in DSH_BUNDLE_MODES:
+        return mode
     return None
 
 
@@ -295,7 +308,8 @@ def validate_dsh_package(package: NormalizedPackage) -> DshValidation:
 
     dsh = manifest.get("dsh")
     bundle = dsh.get("bundle") if isinstance(dsh, dict) else None
-    bundle_ok = isinstance(bundle, dict) and bool(bundle)
+    mode = _declared_bundle_mode(bundle) if isinstance(bundle, dict) else None
+    bundle_ok = isinstance(bundle, dict) and bool(bundle) and mode is not None
     raw_patch = bundle.get("patch") if isinstance(bundle, dict) else None
     patch = raw_patch.strip() if isinstance(raw_patch, str) else None
     patch_target = package.root_path / patch if patch else None
@@ -308,9 +322,12 @@ def validate_dsh_package(package: NormalizedPackage) -> DshValidation:
         )
 
     runtime_path = _runtime_path(manifest)
+    runtime_required = mode != "patch" or runtime_path is not None
     runtime_target = package.root_path / runtime_path if runtime_path is not None else None
     runtime_ok = False
-    if (
+    if not runtime_required:
+        runtime_ok = True
+    elif (
         runtime_path is not None
         and runtime_target is not None
         and is_safe_relative_path(package.root_path, runtime_path, require_exists=True)
@@ -321,4 +338,4 @@ def validate_dsh_package(package: NormalizedPackage) -> DshValidation:
             runtime_ok = _exports_apply(runtime_target.read_text(encoding="utf-8"))
         except (OSError, UnicodeError):
             runtime_ok = False
-    return DshValidation(metadata_ok, bundle_ok, patch_ok, runtime_ok, runtime_path)
+    return DshValidation(metadata_ok, bundle_ok, patch_ok, runtime_ok, runtime_path, runtime_required)

--- a/src/codex_plugin_scanner/deepseek_harness_support.py
+++ b/src/codex_plugin_scanner/deepseek_harness_support.py
@@ -345,3 +345,19 @@ def validate_dsh_package(package: NormalizedPackage) -> DshValidation:
         except (OSError, UnicodeError):
             runtime_ok = False
     return DshValidation(metadata_ok, bundle_ok, patch_ok, runtime_ok, runtime_path, runtime_required)
+
+
+def dsh_runtime_scan_message(validation: DshValidation) -> str:
+    if not validation.runtime_ok:
+        return "DSH runtime entry point must export apply(ctx)"
+    if validation.runtime_required:
+        return "DSH runtime exports apply(ctx)"
+    return "Patch-only DSH bundle does not require apply(ctx)"
+
+
+def dsh_runtime_verify_message(validation: DshValidation) -> str:
+    if not validation.runtime_ok:
+        return "Runtime entry point is missing a detectable apply(ctx) export"
+    if validation.runtime_required:
+        return "Runtime entry point exports apply(ctx)"
+    return "Patch-only DSH bundle does not declare an executable runtime"

--- a/src/codex_plugin_scanner/verification.py
+++ b/src/codex_plugin_scanner/verification.py
@@ -765,9 +765,13 @@ def _verify_deepseek_harness_candidate(candidate: PackageCandidate) -> Verificat
             "runtime",
             "Cordis apply(ctx) export",
             validation.runtime_ok,
-            "Runtime entry point exports apply(ctx)"
-            if validation.runtime_ok
-            else "Runtime entry point is missing a detectable apply(ctx) export",
+            (
+                "Patch-only DSH bundle does not declare an executable runtime"
+                if validation.runtime_ok and not validation.runtime_required
+                else "Runtime entry point exports apply(ctx)"
+                if validation.runtime_ok
+                else "Runtime entry point is missing a detectable apply(ctx) export"
+            ),
             "runtime" if not validation.runtime_ok else "pass",
         ),
     ]

--- a/src/codex_plugin_scanner/verification.py
+++ b/src/codex_plugin_scanner/verification.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 
 from .checks.manifest_support import safe_manifest_path
-from .deepseek_harness_support import validate_dsh_package
+from .deepseek_harness_support import dsh_runtime_verify_message, validate_dsh_package
 from .ecosystems.detect import detect_packages
 from .ecosystems.registry import get_default_adapters
 from .ecosystems.types import Ecosystem, PackageCandidate
@@ -765,13 +765,7 @@ def _verify_deepseek_harness_candidate(candidate: PackageCandidate) -> Verificat
             "runtime",
             "Cordis apply(ctx) export",
             validation.runtime_ok,
-            (
-                "Patch-only DSH bundle does not declare an executable runtime"
-                if validation.runtime_ok and not validation.runtime_required
-                else "Runtime entry point exports apply(ctx)"
-                if validation.runtime_ok
-                else "Runtime entry point is missing a detectable apply(ctx) export"
-            ),
+            dsh_runtime_verify_message(validation),
             "runtime" if not validation.runtime_ok else "pass",
         ),
     ]

--- a/tests/test_dsh_validation_regressions.py
+++ b/tests/test_dsh_validation_regressions.py
@@ -1,10 +1,14 @@
 """Regression tests for native DeepSeek Harness package validation."""
 
+from pathlib import Path
+
 from codex_plugin_scanner.deepseek_harness_support import (
     DSH_SEMVER_RE,
     _exports_apply,
     _runtime_path,
+    validate_dsh_package,
 )
+from codex_plugin_scanner.ecosystems.types import Ecosystem, NormalizedPackage
 
 
 def test_dsh_semver_accepts_preview_versions() -> None:
@@ -41,3 +45,59 @@ def test_dsh_runtime_resolution_rejects_subpath_only_exports() -> None:
         },
     }
     assert _runtime_path(manifest) is None
+
+
+def _patch_only_package(tmp_path: Path, manifest: dict[str, object]) -> NormalizedPackage:
+    patch = tmp_path / "cordis.patch.yml"
+    patch.write_text("skills:\n  - ./skills\n", encoding="utf-8")
+    return NormalizedPackage(
+        ecosystem=Ecosystem.DEEPSEEK_HARNESS,
+        package_kind="cordis-plugin",
+        root_path=tmp_path,
+        raw_manifest=manifest,
+    )
+
+
+def test_dsh_patch_mode_skips_runtime_when_no_entry_point(tmp_path: Path) -> None:
+    package = _patch_only_package(
+        tmp_path,
+        {
+            "name": "dsh-patch-bundle",
+            "version": "1.0.0",
+            "dsh": {"bundle": {"patch": "cordis.patch.yml", "mode": "patch"}},
+        },
+    )
+    validation = validate_dsh_package(package)
+    assert validation.bundle_ok is True
+    assert validation.patch_ok is True
+    assert validation.runtime_required is False
+    assert validation.runtime_ok is True
+
+
+def test_dsh_patch_mode_still_requires_apply_when_entry_point_exists(tmp_path: Path) -> None:
+    (tmp_path / "index.js").write_text("export const name = 'missing-apply'\n", encoding="utf-8")
+    package = _patch_only_package(
+        tmp_path,
+        {
+            "name": "dsh-patch-bundle",
+            "version": "1.0.0",
+            "main": "index.js",
+            "dsh": {"bundle": {"patch": "cordis.patch.yml", "mode": "patch"}},
+        },
+    )
+    validation = validate_dsh_package(package)
+    assert validation.runtime_required is True
+    assert validation.runtime_ok is False
+
+
+def test_dsh_unknown_bundle_mode_is_invalid(tmp_path: Path) -> None:
+    package = _patch_only_package(
+        tmp_path,
+        {
+            "name": "dsh-patch-bundle",
+            "version": "1.0.0",
+            "dsh": {"bundle": {"patch": "cordis.patch.yml", "mode": "skills"}},
+        },
+    )
+    validation = validate_dsh_package(package)
+    assert validation.bundle_ok is False

--- a/tests/test_dsh_validation_regressions.py
+++ b/tests/test_dsh_validation_regressions.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from codex_plugin_scanner.deepseek_harness_support import (
     DSH_SEMVER_RE,
     _exports_apply,
@@ -83,6 +85,33 @@ def test_dsh_patch_mode_still_requires_apply_when_entry_point_exists(tmp_path: P
             "version": "1.0.0",
             "main": "index.js",
             "dsh": {"bundle": {"patch": "cordis.patch.yml", "mode": "patch"}},
+        },
+    )
+    validation = validate_dsh_package(package)
+    assert validation.runtime_required is True
+    assert validation.runtime_ok is False
+
+
+@pytest.mark.parametrize(
+    "runtime_fields",
+    [
+        {"main": ""},
+        {"main": 1},
+        {"exports": None},
+        {"exports": {}},
+        {"exports": {"./client": "./client.js"}},
+    ],
+)
+def test_dsh_patch_mode_requires_runtime_when_entry_fields_are_declared(
+    tmp_path: Path, runtime_fields: dict[str, object]
+) -> None:
+    package = _patch_only_package(
+        tmp_path,
+        {
+            "name": "dsh-patch-bundle",
+            "version": "1.0.0",
+            "dsh": {"bundle": {"patch": "cordis.patch.yml", "mode": "patch"}},
+            **runtime_fields,
         },
     )
     validation = validate_dsh_package(package)

--- a/tests/test_ecosystems.py
+++ b/tests/test_ecosystems.py
@@ -128,6 +128,35 @@ def test_verify_deepseek_harness_rejects_missing_apply_export(tmp_path: Path) ->
     assert rc == 1
 
 
+def test_verify_deepseek_harness_patch_mode_without_runtime_passes(tmp_path: Path, capsys) -> None:
+    shutil.copytree(FIXTURES / "deepseek-harness-good", tmp_path / "plugin")
+    manifest_path = tmp_path / "plugin" / "package.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    del manifest["main"]
+    manifest["dsh"]["bundle"]["mode"] = "patch"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    (tmp_path / "plugin" / "index.js").unlink()
+    rc = main(["verify", str(tmp_path / "plugin"), "--format", "json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["verify_pass"] is True
+    runtime_case = next(case for case in payload["cases"] if case["name"] == "Cordis apply(ctx) export")
+    assert runtime_case["passed"] is True
+    assert "Patch-only" in runtime_case["message"]
+
+
+def test_scan_deepseek_harness_patch_mode_without_runtime_does_not_require_apply(tmp_path: Path) -> None:
+    shutil.copytree(FIXTURES / "deepseek-harness-good", tmp_path / "plugin")
+    manifest_path = tmp_path / "plugin" / "package.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    del manifest["main"]
+    manifest["dsh"]["bundle"]["mode"] = "patch"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    (tmp_path / "plugin" / "index.js").unlink()
+    result = scan_plugin(tmp_path / "plugin", ScanOptions(ecosystem="deepseek-harness", cisco_skill_scan="off"))
+    assert all(finding.rule_id != "DSH_RUNTIME_APPLY_MISSING" for finding in result.findings)
+
+
 def test_verify_deepseek_harness_ignores_apply_in_comments_and_strings(tmp_path: Path) -> None:
     shutil.copytree(FIXTURES / "deepseek-harness-good", tmp_path / "plugin")
     (tmp_path / "plugin" / "index.js").write_text(


### PR DESCRIPTION
## Summary
- Honor `dsh.bundle.mode` set to `"patch"` so patch-only DeepSeek Harness bundles are not required to export Cordis `apply(ctx)`.
- Keep `DSH_RUNTIME_APPLY_MISSING` when a package declares `main` or `exports`.

## Testing
- `ruff check src/codex_plugin_scanner/deepseek_harness_support.py src/codex_plugin_scanner/checks/deepseek_harness.py src/codex_plugin_scanner/verification.py tests/test_dsh_validation_regressions.py tests/test_ecosystems.py`
- `ruff format --check src/codex_plugin_scanner/deepseek_harness_support.py src/codex_plugin_scanner/checks/deepseek_harness.py src/codex_plugin_scanner/verification.py tests/test_dsh_validation_regressions.py tests/test_ecosystems.py`
- `pytest tests/test_dsh_validation_regressions.py tests/test_ecosystems.py --tb=short`

## Notes
- Fixes #2862


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DeepSeek Harness packages can declare patch-only bundles with `dsh.bundle.mode: "patch"`.
  * Patch-only bundles without runtime entry points no longer require an executable runtime.
  * Bundles declaring `main` or `exports` continue to require the runtime entry point.

* **Documentation**
  * Updated DeepSeek Harness documentation and changelog to describe patch-only bundle support.

* **Bug Fixes**
  * Verification and scan results now accurately report when runtime validation is not required for patch-only bundles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->