### PR TITLE
fix(grok): keep shared native runtime and wait for live approvals

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import sys
+import time
 import urllib.error
 import urllib.request
 from collections.abc import Mapping, Sequence
@@ -462,6 +463,7 @@ def _apply_grok_bridge_approval_wait(
     stdout: str,
     stderr: str,
     exit_code: int,
+    timeout_seconds: float | None = None,
 ) -> tuple[str, str, int]:
     """Wait for Grok review after a fast daemon decision, inside the hook budget."""
 
@@ -477,11 +479,15 @@ def _apply_grok_bridge_approval_wait(
         from ..store import GuardStore
         from .grok_approval_resume import apply_grok_pretool_approval_wait
 
+        configured = load_guard_config(guard_home).approval_wait_timeout_seconds
+        wait_seconds = configured
+        if timeout_seconds is not None:
+            wait_seconds = min(configured, max(0, int(timeout_seconds)))
         updated = apply_grok_pretool_approval_wait(
             payload,
             event_name="PreToolUse",
             store=GuardStore(guard_home),
-            timeout_seconds=load_guard_config(guard_home).approval_wait_timeout_seconds,
+            timeout_seconds=wait_seconds,
         )
     except (OSError, RuntimeError, TypeError, ValueError, KeyError, sqlite3.Error):
         return stdout, stderr, exit_code
@@ -601,6 +607,7 @@ def run_bounded_cli_hook(config: Mapping[str, object], *, input_text: str) -> in
             package_root,
             _cli_args_with_json(cli_args),
         )
+    deadline = time.monotonic() + float(timeout_seconds)
     daemon_result = _try_daemon_hook(
         guard_home=guard_home,
         harness=harness,
@@ -608,6 +615,7 @@ def run_bounded_cli_hook(config: Mapping[str, object], *, input_text: str) -> in
         timeout_seconds=float(timeout_seconds),
     )
     if daemon_result is not None:
+        remaining = max(0.0, deadline - time.monotonic())
         daemon_stdout, daemon_stderr, daemon_exit = _apply_grok_bridge_approval_wait(
             guard_home=guard_home,
             harness=harness,
@@ -615,6 +623,7 @@ def run_bounded_cli_hook(config: Mapping[str, object], *, input_text: str) -> in
             stdout=daemon_result[0],
             stderr=daemon_result[1],
             exit_code=daemon_result[2],
+            timeout_seconds=remaining,
         )
         if daemon_stdout:
             _ = sys.stdout.write(daemon_stdout)

--- a/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 import sys
 import urllib.error
 import urllib.request
@@ -468,7 +469,7 @@ def _apply_grok_bridge_approval_wait(
             store=GuardStore(guard_home),
             timeout_seconds=load_guard_config(guard_home).approval_wait_timeout_seconds,
         )
-    except (OSError, RuntimeError, ValueError):
+    except (OSError, RuntimeError, ValueError, sqlite3.Error):
         return stdout, stderr, exit_code
     rewritten = json.dumps(updated, ensure_ascii=True, separators=(",", ":")) + "\n"
     if updated.get("decision") == "allow":

--- a/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
@@ -428,11 +428,52 @@ def _daemon_response_to_native(
             if permission_decision != "allow" or "unreachable" in reason.lower():
                 hook_specific_output["permissionDecisionReason"] = reason or f"HOL Guard {policy_action} this action"
         payload["hookSpecificOutput"] = hook_specific_output
+        if canonical in {"grok", "openclaw"} and permission_decision is not None:
+            payload["decision"] = "allow" if permission_decision == "allow" else "deny"
+            if permission_decision != "allow" and reason:
+                payload["reason"] = reason
 
     stdout = json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
     exit_code = 2 if _should_exit_block(harness, event_name, policy_action) else 0
     stderr = reason if exit_code == 2 and canonical == "kimi" else ""
     return stdout, stderr, exit_code
+
+
+def _apply_grok_bridge_approval_wait(
+    *,
+    guard_home: Path,
+    harness: str,
+    input_text: str,
+    stdout: str,
+    stderr: str,
+    exit_code: int,
+) -> tuple[str, str, int]:
+    """Wait for Grok review after a fast daemon decision, inside the hook budget."""
+
+    if harness.strip().lower() != "grok" or _event_name(input_text) != "PreToolUse":
+        return stdout, stderr, exit_code
+    payload = _json_object(stdout)
+    if payload is None:
+        return stdout, stderr, exit_code
+    if str(payload.get("policy_action") or "") not in {"review", "require-reapproval"}:
+        return stdout, stderr, exit_code
+    try:
+        from ..config import load_guard_config
+        from ..store import GuardStore
+        from .grok_approval_resume import apply_grok_pretool_approval_wait
+
+        updated = apply_grok_pretool_approval_wait(
+            payload,
+            event_name="PreToolUse",
+            store=GuardStore(guard_home),
+            timeout_seconds=load_guard_config(guard_home).approval_wait_timeout_seconds,
+        )
+    except (OSError, RuntimeError, ValueError):
+        return stdout, stderr, exit_code
+    rewritten = json.dumps(updated, ensure_ascii=True, separators=(",", ":")) + "\n"
+    if updated.get("decision") == "allow":
+        return rewritten, stderr, 0
+    return rewritten, stderr, exit_code
 
 
 def _try_daemon_hook(
@@ -443,9 +484,6 @@ def _try_daemon_hook(
     timeout_seconds: float,
 ) -> tuple[str, str, int] | None:
     """POST the hook payload to the running daemon; return native stdout or None."""
-    if harness.strip().lower() == "grok" and _event_name(input_text) == "PreToolUse":
-        return None
-
     endpoint = _daemon_hook_endpoint(guard_home, harness)
     if endpoint is None:
         return None
@@ -555,7 +593,14 @@ def run_bounded_cli_hook(config: Mapping[str, object], *, input_text: str) -> in
         timeout_seconds=float(timeout_seconds),
     )
     if daemon_result is not None:
-        daemon_stdout, daemon_stderr, daemon_exit = daemon_result
+        daemon_stdout, daemon_stderr, daemon_exit = _apply_grok_bridge_approval_wait(
+            guard_home=guard_home,
+            harness=harness,
+            input_text=input_text,
+            stdout=daemon_result[0],
+            stderr=daemon_result[1],
+            exit_code=daemon_result[2],
+        )
         if daemon_stdout:
             _ = sys.stdout.write(daemon_stdout)
         if daemon_stderr:

--- a/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/bounded_cli_hook_bridge.py
@@ -431,8 +431,22 @@ def _daemon_response_to_native(
         payload["hookSpecificOutput"] = hook_specific_output
         if canonical in {"grok", "openclaw"} and permission_decision is not None:
             payload["decision"] = "allow" if permission_decision == "allow" else "deny"
+            payload["policy_action"] = policy_action
             if permission_decision != "allow" and reason:
                 payload["reason"] = reason
+            for key in (
+                "reason_code",
+                "approval_url",
+                "approval_request_id",
+                "primary_approval_request_id",
+                "primary_approval_url",
+                "guardApprovalRequestId",
+                "guardApprovalUrl",
+                "approval_requests",
+            ):
+                value = daemon_response.get(key)
+                if value is not None:
+                    payload[key] = value
 
     stdout = json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
     exit_code = 2 if _should_exit_block(harness, event_name, policy_action) else 0
@@ -469,7 +483,7 @@ def _apply_grok_bridge_approval_wait(
             store=GuardStore(guard_home),
             timeout_seconds=load_guard_config(guard_home).approval_wait_timeout_seconds,
         )
-    except (OSError, RuntimeError, ValueError, sqlite3.Error):
+    except (OSError, RuntimeError, TypeError, ValueError, KeyError, sqlite3.Error):
         return stdout, stderr, exit_code
     rewritten = json.dumps(updated, ensure_ascii=True, separators=(",", ":")) + "\n"
     if updated.get("decision") == "allow":

--- a/src/codex_plugin_scanner/guard/adapters/grok_approval_resume.py
+++ b/src/codex_plugin_scanner/guard/adapters/grok_approval_resume.py
@@ -91,7 +91,7 @@ def wait_for_grok_live_approval(
         return None
     wait_items = wait_result.get("items")
     resolved_items = [item for item in (wait_items if isinstance(wait_items, list) else []) if isinstance(item, dict)]
-    if any(str(item.get("resolution_action")) == "block" for item in resolved_items):
+    if not resolved_items or any(str(item.get("resolution_action")) != "allow" for item in resolved_items):
         response_payload["review_hint"] = "HOL Guard kept this Grok action blocked."
         return "block"
     response_payload["browser_resolution_request_id"] = request_ids[0]

--- a/src/codex_plugin_scanner/guard/adapters/grok_approval_resume.py
+++ b/src/codex_plugin_scanner/guard/adapters/grok_approval_resume.py
@@ -160,8 +160,11 @@ def _approval_request_ids(payload: Mapping[str, object]) -> list[str]:
                     ids.append(request_id)
     if ids:
         return ids
-    primary = _optional_string(payload.get("primary_approval_request_id"))
-    return [primary] if primary is not None else []
+    for key in ("primary_approval_request_id", "approval_request_id", "guardApprovalRequestId"):
+        request_id = _optional_string(payload.get(key))
+        if request_id is not None:
+            return [request_id]
+    return []
 
 
 def _existing_request_ids(operation: Mapping[str, object], request_id: str) -> list[str]:

--- a/src/codex_plugin_scanner/guard/adapters/grok_approval_resume.py
+++ b/src/codex_plugin_scanner/guard/adapters/grok_approval_resume.py
@@ -52,10 +52,15 @@ def wait_for_grok_live_approval(
     json_mode: bool,
     payload: Mapping[str, object] | None = None,
 ) -> str | None:
-    """Wait for the queued Grok approval and return allow, block, or None."""
+    """Wait for the queued Grok approval and return allow, block, or None.
 
+    ``json_mode`` is retained for callers. Compact JSON stdout still waits so
+    the original PreToolUse call can resume inside the hook deadline.
+    """
+
+    del json_mode
     canonical_event = event_name.replace("_", "").replace("-", "").lower()
-    if json_mode or canonical_event != "pretooluse":
+    if canonical_event != "pretooluse":
         return None
     if policy_action not in _GROK_WAITABLE_ACTIONS:
         return None
@@ -175,6 +180,50 @@ def _optional_string(value: object) -> str | None:
     return stripped or None
 
 
+def apply_grok_pretool_approval_wait(
+    response: dict[str, object],
+    *,
+    event_name: str,
+    store: GuardStore,
+    timeout_seconds: int,
+) -> dict[str, object]:
+    """Wait on a native or daemon Grok review and rewrite allow/deny JSON."""
+
+    policy_action = str(response.get("policy_action") or "")
+    decision = wait_for_grok_live_approval(
+        event_name=event_name,
+        policy_action=policy_action,
+        response_payload=response,
+        store=store,
+        timeout_seconds=timeout_seconds,
+        json_mode=False,
+        payload=response,
+    )
+    if decision == "allow":
+        allowed = dict(response)
+        allowed["decision"] = "allow"
+        allowed["policy_action"] = "allow"
+        allowed.pop("reason", None)
+        hook_specific = allowed.get("hookSpecificOutput")
+        if isinstance(hook_specific, Mapping):
+            rewritten = dict(hook_specific)
+            rewritten["permissionDecision"] = "allow"
+            rewritten.pop("permissionDecisionReason", None)
+            allowed["hookSpecificOutput"] = rewritten
+        return allowed
+    if decision == "block":
+        blocked = dict(response)
+        blocked["decision"] = "deny"
+        blocked["policy_action"] = "block"
+        hook_specific = blocked.get("hookSpecificOutput")
+        if isinstance(hook_specific, Mapping):
+            rewritten = dict(hook_specific)
+            rewritten["permissionDecision"] = "deny"
+            blocked["hookSpecificOutput"] = rewritten
+        return blocked
+    return response
+
+
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -183,6 +232,7 @@ __all__ = [
     "GROK_APPROVAL_WAIT_MAX_SECONDS",
     "GROK_HOOK_INTERNAL_TIMEOUT_SECONDS",
     "GROK_PRETOOL_HOOK_TIMEOUT_SECONDS",
+    "apply_grok_pretool_approval_wait",
     "grok_live_approval_wait_seconds",
     "grok_resume_metadata_from_guard_payload",
     "wait_for_grok_live_approval",

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_native_authority.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_native_authority.py
@@ -122,12 +122,15 @@ def try_native_or_source_ref_hook(
     )
     if native_result is not None:
         if str(args.harness).strip().lower().replace("_", "-") == "grok":
+            wait_config = config
+            if wait_config is None:
+                wait_config = load_guard_config(context.guard_home, workspace=runtime_workspace)
             with suppress(OSError, RuntimeError, TypeError, ValueError, KeyError, sqlite3.Error):
                 native_result = apply_grok_pretool_approval_wait(
                     native_result,
                     event_name=runtime_hook_event_name(payload),
                     store=store,
-                    timeout_seconds=load_guard_config(context.guard_home).approval_wait_timeout_seconds,
+                    timeout_seconds=wait_config.approval_wait_timeout_seconds,
                 )
         _emit("hook", native_result, getattr(args, "json", False))
         return 0

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_native_authority.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_native_authority.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import sqlite3
 from pathlib import Path
 from typing import Any
 
@@ -120,12 +121,15 @@ def try_native_or_source_ref_hook(
     )
     if native_result is not None:
         if str(args.harness).strip().lower().replace("_", "-") == "grok":
-            native_result = apply_grok_pretool_approval_wait(
-                native_result,
-                event_name=runtime_hook_event_name(payload),
-                store=store,
-                timeout_seconds=load_guard_config(context.guard_home).approval_wait_timeout_seconds,
-            )
+            try:
+                native_result = apply_grok_pretool_approval_wait(
+                    native_result,
+                    event_name=runtime_hook_event_name(payload),
+                    store=store,
+                    timeout_seconds=load_guard_config(context.guard_home).approval_wait_timeout_seconds,
+                )
+            except (OSError, RuntimeError, ValueError, sqlite3.Error):
+                pass
         _emit("hook", native_result, getattr(args, "json", False))
         return 0
     if _native_mode_requires_rust():

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_native_authority.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_native_authority.py
@@ -7,7 +7,8 @@ from pathlib import Path
 from typing import Any
 
 from ..adapters.base import HarnessContext
-from ..config import GuardConfig
+from ..adapters.grok_approval_resume import apply_grok_pretool_approval_wait
+from ..config import GuardConfig, load_guard_config
 from ..daemon.hook_availability_policy import availability_harness_response
 from ..daemon.hook_request_parsing import runtime_hook_event_name
 from ..daemon.hook_worker import HookWorker, HookWorkerUnsupported
@@ -118,6 +119,13 @@ def try_native_or_source_ref_hook(
         store=store,
     )
     if native_result is not None:
+        if str(args.harness).strip().lower().replace("_", "-") == "grok":
+            native_result = apply_grok_pretool_approval_wait(
+                native_result,
+                event_name=runtime_hook_event_name(payload),
+                store=store,
+                timeout_seconds=load_guard_config(context.guard_home).approval_wait_timeout_seconds,
+            )
         _emit("hook", native_result, getattr(args, "json", False))
         return 0
     if _native_mode_requires_rust():

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_native_authority.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_native_authority.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import sqlite3
+from contextlib import suppress
 from pathlib import Path
 from typing import Any
 
@@ -121,15 +122,13 @@ def try_native_or_source_ref_hook(
     )
     if native_result is not None:
         if str(args.harness).strip().lower().replace("_", "-") == "grok":
-            try:
+            with suppress(OSError, RuntimeError, TypeError, ValueError, KeyError, sqlite3.Error):
                 native_result = apply_grok_pretool_approval_wait(
                     native_result,
                     event_name=runtime_hook_event_name(payload),
                     store=store,
                     timeout_seconds=load_guard_config(context.guard_home).approval_wait_timeout_seconds,
                 )
-            except (OSError, RuntimeError, ValueError, sqlite3.Error):
-                pass
         _emit("hook", native_result, getattr(args, "json", False))
         return 0
     if _native_mode_requires_rust():

--- a/src/codex_plugin_scanner/guard/cli/commands_support_interaction.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_interaction.py
@@ -316,6 +316,8 @@ def _should_emit_native_hook_json_response(
     output_stream: TextIO | None,
 ) -> bool:
     harness = _canonical_harness_name(args.harness)
+    if harness == "grok" and getattr(args, "json", False):
+        return True
     if harness == "codex" and getattr(args, "json", False) and event_name == "UserPromptSubmit":
         return True
     return (

--- a/src/codex_plugin_scanner/guard/daemon/hook_worker_responses.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_worker_responses.py
@@ -123,12 +123,16 @@ def _canonical_hook_harness(harness: str) -> str:
     return harness.strip().lower().replace("_", "-")
 
 
+_GROK_DECISION_HARNESSES = frozenset({"grok", "openclaw"})
+
+
 def harness_json_from_native_pre_tool(harness: str, response: Mapping[str, object]) -> dict[str, object]:
     action = response.get("minimum_action")
     reason = str(response.get("reason") or "HOL Guard requires native review before execution.")
     reason_code = str(response.get("reason_code") or "native_pre_tool_review")
+    canonical = _canonical_hook_harness(harness)
     if action in {"allow", "warn"} and response.get("decision") == "allow":
-        if _canonical_hook_harness(harness) in {"pi", "omp"}:
+        if canonical in {"pi", "omp"}:
             output: dict[str, object] = {
                 "decision": "allow",
                 "policy_action": action,
@@ -144,13 +148,23 @@ def harness_json_from_native_pre_tool(harness: str, response: Mapping[str, objec
         }
         if action == "warn":
             hook_specific["permissionDecisionReason"] = reason
+        if canonical in _GROK_DECISION_HARNESSES:
+            grok_allow: dict[str, object] = {
+                "decision": "allow",
+                "policy_action": action,
+                "reason_code": reason_code,
+                "hookSpecificOutput": hook_specific,
+            }
+            if action == "warn":
+                grok_allow["reason"] = reason
+            return grok_allow
         return {
             "continue": True,
             "policy_action": action,
             "reason_code": reason_code,
             "hookSpecificOutput": hook_specific,
         }
-    if _canonical_hook_harness(harness) in {"pi", "omp"}:
+    if canonical in {"pi", "omp"}:
         return {
             "decision": "deny",
             "reason": reason,
@@ -159,14 +173,23 @@ def harness_json_from_native_pre_tool(harness: str, response: Mapping[str, objec
             "policy_action": "block",
             "reason_code": reason_code,
         }
+    hook_specific_deny: dict[str, object] = {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": reason,
+    }
+    if canonical in _GROK_DECISION_HARNESSES:
+        return {
+            "decision": "deny",
+            "reason": reason,
+            "policy_action": "block",
+            "reason_code": reason_code,
+            "hookSpecificOutput": hook_specific_deny,
+        }
     return {
         "policy_action": "block",
         "reason_code": reason_code,
-        "hookSpecificOutput": {
-            "hookEventName": "PreToolUse",
-            "permissionDecision": "deny",
-            "permissionDecisionReason": reason,
-        },
+        "hookSpecificOutput": hook_specific_deny,
     }
 
 
@@ -191,7 +214,8 @@ def harness_json_from_native_pre_tool_review(
         if isinstance(raw_request_id, str) and raw_request_id.strip():
             approval_request_id = raw_request_id.strip()
     permission_decision = _native_review_permission_decision(harness)
-    if _canonical_hook_harness(harness) in {"pi", "omp"}:
+    canonical = _canonical_hook_harness(harness)
+    if canonical in {"pi", "omp"}:
         output: dict[str, object] = {
             "decision": "deny",
             "reason": reason,
@@ -217,6 +241,8 @@ def harness_json_from_native_pre_tool_review(
         "reason": reason,
         "hookSpecificOutput": hook_specific,
     }
+    if canonical in _GROK_DECISION_HARNESSES:
+        rendered["decision"] = "deny"
     if approval_url is not None:
         rendered["approval_url"] = approval_url
     if approval_request_id is not None:

--- a/src/codex_plugin_scanner/guard/native_resident_client.py
+++ b/src/codex_plugin_scanner/guard/native_resident_client.py
@@ -182,31 +182,14 @@ def _state_files(state_dir: Path) -> tuple[Path, ...]:
         return ()
 
 
-def _has_client_for_state(state_dir: Path) -> bool:
-    state_key = str(state_dir)
-    with _CLIENTS_LOCK:
-        return any(key[1] == state_key for key in _CLIENT_POOLS)
-
-
 def _contain_persistent_resident(client: _PersistentNativeClient) -> None:
-    """Authenticate shutdown after stream close, then await state retirement.
+    """Close one local stream without stopping the shared resident.
 
-    A different executable may have adopted the same Guard-home resident. In
-    that case its persistent client remains the owner of the shared service,
-    so this client only closes its own stream and does not send shutdown.
+    Hook processes and the local daemon share one managed resident. A one-shot
+    client exit that sends ``resident-stop`` kills in-flight reviews in other
+    processes. Explicit shutdown stays on ``close_native_residents``.
     """
-    state_files = _state_files(client._state_dir)
-    if not state_files or _has_client_for_state(client._state_dir):
-        return
-    stop_native_resident(
-        executable=client._executable,
-        state_dir=client._state_dir,
-        environment=client._environment,
-        timeout_seconds=0.5,
-    )
-    deadline = time.monotonic() + 2.5
-    while _state_files(client._state_dir) and time.monotonic() < deadline:
-        time.sleep(0.025)
+    _ = client
 
 
 def close_native_resident_clients(guard_home: Path | None = None) -> None:

--- a/src/codex_plugin_scanner/guard/native_resident_client.py
+++ b/src/codex_plugin_scanner/guard/native_resident_client.py
@@ -172,6 +172,7 @@ def _client_pool_for(executable: Path, state_dir: Path, environment: Mapping[str
             _CLIENT_POOLS[key] = pool
     if evicted is not None:
         evicted.close()
+    _track_resident(executable, normalized_state_dir, environment)
     return pool
 
 

--- a/tests/test_bounded_cli_hook_bridge.py
+++ b/tests/test_bounded_cli_hook_bridge.py
@@ -191,6 +191,25 @@ def test_grok_bridge_rewrites_daemon_review_after_wait(
     assert json.loads(stdout)["decision"] == "allow"
 
 
+def test_grok_daemon_review_translation_keeps_wait_metadata() -> None:
+    stdout, _stderr, code = bounded_cli_hook_bridge._daemon_response_to_native(
+        {
+            "policy_action": "review",
+            "reason": "needs review",
+            "approval_requests": [{"request_id": "req-1"}],
+            "primary_approval_request_id": "req-1",
+        },
+        harness="grok",
+        event_name="PreToolUse",
+    )
+    payload = json.loads(stdout)
+    assert code == 2
+    assert payload["decision"] == "deny"
+    assert payload["policy_action"] == "review"
+    assert payload["approval_requests"] == [{"request_id": "req-1"}]
+    assert payload["primary_approval_request_id"] == "req-1"
+
+
 def test_grok_bridge_preserves_daemon_result_when_store_fails(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_bounded_cli_hook_bridge.py
+++ b/tests/test_bounded_cli_hook_bridge.py
@@ -162,6 +162,35 @@ def test_success_preserves_child_stdout_and_returncode(
     assert output.getvalue() == '{"decision":"deny"}\n'
 
 
+def test_grok_bridge_rewrites_daemon_review_after_wait(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from codex_plugin_scanner.guard.adapters import grok_approval_resume
+
+    monkeypatch.setattr(
+        grok_approval_resume,
+        "wait_for_grok_live_approval",
+        lambda **_kwargs: "allow",
+    )
+    stdout, _stderr, code = bounded_cli_hook_bridge._apply_grok_bridge_approval_wait(
+        guard_home=tmp_path / "guard-home",
+        harness="grok",
+        input_text=json.dumps({"hook_event_name": "PreToolUse"}),
+        stdout=json.dumps(
+            {
+                "decision": "deny",
+                "policy_action": "review",
+                "approval_requests": [{"request_id": "req-1"}],
+            }
+        ),
+        stderr="",
+        exit_code=2,
+    )
+    assert code == 0
+    assert json.loads(stdout)["decision"] == "allow"
+
+
 def _signed_bundle_fixture(tmp_path: Path) -> tuple[Path, Path, Path]:
     bundle = tmp_path / "HOL Guard.app"
     macos = bundle / "Contents" / "MacOS"

--- a/tests/test_bounded_cli_hook_bridge.py
+++ b/tests/test_bounded_cli_hook_bridge.py
@@ -191,6 +191,33 @@ def test_grok_bridge_rewrites_daemon_review_after_wait(
     assert json.loads(stdout)["decision"] == "allow"
 
 
+def test_grok_bridge_preserves_daemon_result_when_store_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import sqlite3
+
+    from codex_plugin_scanner.guard.adapters import grok_approval_resume
+
+    def boom(*_args: object, **_kwargs: object) -> str:
+        del _args, _kwargs
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(grok_approval_resume, "apply_grok_pretool_approval_wait", boom)
+    original = json.dumps({"decision": "deny", "policy_action": "review"})
+    stdout, stderr, code = bounded_cli_hook_bridge._apply_grok_bridge_approval_wait(
+        guard_home=tmp_path / "guard-home",
+        harness="grok",
+        input_text=json.dumps({"hook_event_name": "PreToolUse"}),
+        stdout=original,
+        stderr="keep-stderr",
+        exit_code=2,
+    )
+    assert stdout == original
+    assert stderr == "keep-stderr"
+    assert code == 2
+
+
 def _signed_bundle_fixture(tmp_path: Path) -> tuple[Path, Path, Path]:
     bundle = tmp_path / "HOL Guard.app"
     macos = bundle / "Contents" / "MacOS"

--- a/tests/test_bounded_cli_hook_bridge.py
+++ b/tests/test_bounded_cli_hook_bridge.py
@@ -210,6 +210,34 @@ def test_grok_daemon_review_translation_keeps_wait_metadata() -> None:
     assert payload["primary_approval_request_id"] == "req-1"
 
 
+def test_grok_bridge_clamps_wait_to_remaining_seconds(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from codex_plugin_scanner.guard.adapters import grok_approval_resume
+
+    seen: dict[str, object] = {}
+
+    def capture(response: dict[str, object], **kwargs: object) -> dict[str, object]:
+        seen["timeout_seconds"] = kwargs["timeout_seconds"]
+        return response
+
+    monkeypatch.setattr(grok_approval_resume, "apply_grok_pretool_approval_wait", capture)
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    (guard_home / "config.toml").write_text("approval_wait_timeout_seconds = 80\n", encoding="utf-8")
+    bounded_cli_hook_bridge._apply_grok_bridge_approval_wait(
+        guard_home=guard_home,
+        harness="grok",
+        input_text=json.dumps({"hook_event_name": "PreToolUse"}),
+        stdout=json.dumps({"decision": "deny", "policy_action": "review"}),
+        stderr="",
+        exit_code=2,
+        timeout_seconds=2.9,
+    )
+    assert seen["timeout_seconds"] == 2
+
+
 def test_grok_bridge_preserves_daemon_result_when_store_fails(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_guard_grok_auto_resume.py
+++ b/tests/test_guard_grok_auto_resume.py
@@ -11,6 +11,8 @@ import time
 from contextlib import redirect_stderr
 from pathlib import Path
 
+import pytest
+
 from codex_plugin_scanner.guard.adapters.grok_approval_resume import (
     GROK_APPROVAL_WAIT_MAX_SECONDS,
     grok_live_approval_wait_seconds,
@@ -318,16 +320,84 @@ def test_grok_live_wait_ignores_unrelated_pending_requests(tmp_path: Path) -> No
     assert stale["status"] == "pending"
 
 
-def test_grok_pretool_skips_short_daemon_budget(tmp_path: Path) -> None:
-    from codex_plugin_scanner.guard.adapters.bounded_cli_hook_bridge import _try_daemon_hook
+def test_grok_pretool_posts_to_daemon(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from codex_plugin_scanner.guard.adapters import bounded_cli_hook_bridge
 
-    result = _try_daemon_hook(
+    posted: list[str] = []
+
+    class FakeResponse:
+        status = 200
+
+        def geturl(self) -> str:
+            return "http://127.0.0.1:4781/v1/hooks/grok"
+
+        def read(self, _size: int = -1) -> bytes:
+            return b'{"decision":"allow","policy_action":"allow"}'
+
+        def __enter__(self) -> FakeResponse:
+            return self
+
+        def __exit__(self, *args: object) -> bool:
+            del args
+            return False
+
+    class FakeOpener:
+        def open(self, request: object, timeout: float = 0) -> FakeResponse:
+            del timeout
+            posted.append(str(getattr(request, "full_url", request)))
+            return FakeResponse()
+
+    monkeypatch.setattr(
+        bounded_cli_hook_bridge,
+        "_daemon_hook_endpoint",
+        lambda *_args, **_kwargs: "http://127.0.0.1:4781/v1/hooks/grok",
+    )
+    monkeypatch.setattr(bounded_cli_hook_bridge, "_read_daemon_auth_token", lambda *_args, **_kwargs: "token")
+    monkeypatch.setattr(bounded_cli_hook_bridge, "_build_loopback_opener", lambda: FakeOpener())
+    stdout, _stderr, code = bounded_cli_hook_bridge._try_daemon_hook(
         guard_home=tmp_path / "guard-home",
         harness="grok",
         input_text=json.dumps({"hook_event_name": "PreToolUse", "tool_name": "Bash"}),
         timeout_seconds=5.0,
     )
-    assert result is None
+    assert posted
+    assert code == 0
+    assert json.loads(stdout)["decision"] == "allow"
+
+
+def test_grok_live_wait_runs_in_json_mode(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.add_approval_request(_request(tmp_path, "req-grok-json"), "2026-05-08T10:00:00+00:00")
+    payload: dict[str, object] = {"approval_requests": [{"request_id": "req-grok-json"}]}
+
+    def approve() -> None:
+        time.sleep(0.15)
+        apply_approval_resolution(
+            store=store,
+            request_id="req-grok-json",
+            action="allow",
+            scope="artifact",
+            workspace=str(tmp_path),
+            reason="reviewed",
+            now="2026-05-08T10:00:01+00:00",
+        )
+
+    thread = threading.Thread(target=approve)
+    thread.start()
+    decision = wait_for_grok_live_approval(
+        event_name="PreToolUse",
+        policy_action="require-reapproval",
+        response_payload=payload,
+        store=store,
+        timeout_seconds=4,
+        json_mode=True,
+        payload=payload,
+    )
+    thread.join(timeout=5)
+    assert decision == "allow"
 
 
 def test_grok_isolated_hook_resumes_after_approval(tmp_path: Path) -> None:
@@ -361,6 +431,7 @@ def test_grok_isolated_hook_resumes_after_approval(tmp_path: Path) -> None:
             str(guard_home),
             "--harness",
             "grok",
+            "--json",
             "--home",
             str(tmp_path),
             "--workspace",
@@ -410,3 +481,21 @@ def test_grok_isolated_hook_resumes_after_approval(tmp_path: Path) -> None:
     assert result.returncode == 0
     stdout_line = next(line for line in reversed(result.stdout.splitlines()) if line.strip())
     assert json.loads(stdout_line)["decision"] == "allow"
+
+
+def test_grok_json_mode_uses_native_hook_response() -> None:
+    from codex_plugin_scanner.guard.cli.commands_support_interaction import (
+        _should_emit_native_hook_json_response,
+        _should_emit_native_hook_response,
+    )
+
+    args = argparse.Namespace(harness="grok", json=True)
+    assert _should_emit_native_hook_response(args) is False
+    assert (
+        _should_emit_native_hook_json_response(
+            args,
+            event_name="PreToolUse",
+            output_stream=None,
+        )
+        is True
+    )

--- a/tests/test_guard_grok_auto_resume.py
+++ b/tests/test_guard_grok_auto_resume.py
@@ -525,3 +525,51 @@ def test_grok_json_mode_uses_native_hook_response() -> None:
         )
         is True
     )
+
+
+def test_apply_grok_pretool_wait_rewrites_hook_specific_output(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from codex_plugin_scanner.guard.adapters.grok_approval_resume import apply_grok_pretool_approval_wait
+    from codex_plugin_scanner.guard.adapters import grok_approval_resume
+
+    store = GuardStore(tmp_path / "guard-home")
+    response = {
+        "decision": "deny",
+        "policy_action": "review",
+        "reason": "needs review",
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": "needs review",
+        },
+    }
+
+    monkeypatch.setattr(grok_approval_resume, "wait_for_grok_live_approval", lambda **_kwargs: "allow")
+    allowed = apply_grok_pretool_approval_wait(
+        dict(response),
+        event_name="PreToolUse",
+        store=store,
+        timeout_seconds=4,
+    )
+    assert allowed["decision"] == "allow"
+    assert allowed["policy_action"] == "allow"
+    assert "reason" not in allowed
+    hook_specific = allowed["hookSpecificOutput"]
+    assert isinstance(hook_specific, dict)
+    assert hook_specific["permissionDecision"] == "allow"
+    assert "permissionDecisionReason" not in hook_specific
+
+    monkeypatch.setattr(grok_approval_resume, "wait_for_grok_live_approval", lambda **_kwargs: "block")
+    blocked = apply_grok_pretool_approval_wait(
+        dict(response),
+        event_name="PreToolUse",
+        store=store,
+        timeout_seconds=4,
+    )
+    assert blocked["decision"] == "deny"
+    assert blocked["policy_action"] == "block"
+    blocked_hook = blocked["hookSpecificOutput"]
+    assert isinstance(blocked_hook, dict)
+    assert blocked_hook["permissionDecision"] == "deny"

--- a/tests/test_guard_grok_auto_resume.py
+++ b/tests/test_guard_grok_auto_resume.py
@@ -96,6 +96,38 @@ def test_grok_live_wait_allows_after_approval(tmp_path: Path) -> None:
     assert metadata["grok_hook_waits_for_approval"] is True
 
 
+def test_grok_live_wait_reads_singular_approval_request_id(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.add_approval_request(_request(tmp_path, "req-grok-singular"), "2026-05-08T10:00:00+00:00")
+    payload: dict[str, object] = {"approval_request_id": "req-grok-singular"}
+
+    def approve() -> None:
+        time.sleep(0.15)
+        apply_approval_resolution(
+            store=store,
+            request_id="req-grok-singular",
+            action="allow",
+            scope="artifact",
+            workspace=str(tmp_path),
+            reason="reviewed",
+            now="2026-05-08T10:00:01+00:00",
+        )
+
+    thread = threading.Thread(target=approve)
+    thread.start()
+    decision = wait_for_grok_live_approval(
+        event_name="PreToolUse",
+        policy_action="review",
+        response_payload=payload,
+        store=store,
+        timeout_seconds=4,
+        json_mode=False,
+        payload=payload,
+    )
+    thread.join(timeout=5)
+    assert decision == "allow"
+
+
 def test_grok_live_wait_blocks_after_denial(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     store.add_approval_request(_request(tmp_path, "req-grok-block"), "2026-05-08T10:00:00+00:00")

--- a/tests/test_guard_grok_auto_resume.py
+++ b/tests/test_guard_grok_auto_resume.py
@@ -128,6 +128,32 @@ def test_grok_live_wait_blocks_after_denial(tmp_path: Path) -> None:
     assert decision == "block"
 
 
+def test_grok_live_wait_requires_explicit_allow(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.adapters import grok_approval_resume
+
+    store = GuardStore(tmp_path / "guard-home")
+    store.add_approval_request(_request(tmp_path, "req-grok-deny"), "2026-05-08T10:00:00+00:00")
+    payload: dict[str, object] = {"approval_requests": [{"request_id": "req-grok-deny"}]}
+    monkeypatch.setattr(
+        grok_approval_resume,
+        "wait_for_approval_requests",
+        lambda **_kwargs: {
+            "resolved": True,
+            "pending_request_ids": [],
+            "items": [{"resolution_action": "deny"}],
+        },
+    )
+    decision = wait_for_grok_live_approval(
+        event_name="PreToolUse",
+        policy_action="require-reapproval",
+        response_payload=payload,
+        store=store,
+        timeout_seconds=4,
+        json_mode=False,
+    )
+    assert decision == "block"
+
+
 def test_grok_live_wait_accepts_aliased_pretool_event_name(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     store.add_approval_request(_request(tmp_path, "req-grok-alias"), "2026-05-08T10:00:00+00:00")

--- a/tests/test_guard_hook_payload_workspace.py
+++ b/tests/test_guard_hook_payload_workspace.py
@@ -98,7 +98,7 @@ def test_run_guard_hook_uses_payload_cwd_when_cli_workspace_omitted(
             artifact_id=None,
             artifact_name=None,
             event_file=None,
-            harness="grok",
+            harness="cursor",
             json=True,
             policy_action=None,
             runtime_harness=None,

--- a/tests/test_native_pretool_generic.py
+++ b/tests/test_native_pretool_generic.py
@@ -136,6 +136,39 @@ def test_generic_result_decoder_rejects_raw_or_conflicting_content() -> None:
     assert _decode_edge(malformed_type) is None
 
 
+def test_generic_allow_result_renders_grok_decision_json() -> None:
+    edge = _edge("grok", "PreToolUse")
+    result = edge["result"]
+    assert isinstance(result, dict)
+    result.update(
+        {
+            "decision": "allow",
+            "policy_action": "allow",
+            "minimum_action": "allow",
+            "reason_code": "native_pre_tool_allow",
+            "reason": "",
+            "explicitly_benign": True,
+        }
+    )
+    _sync_receipt(edge)
+    rendered = harness_json_from_native_pre_tool("grok", result)
+    assert rendered["decision"] == "allow"
+    hook_specific = rendered["hookSpecificOutput"]
+    assert isinstance(hook_specific, dict)
+    assert hook_specific["permissionDecision"] == "allow"
+
+
+def test_generic_review_result_renders_grok_deny_decision() -> None:
+    edge = _edge("grok", "PreToolUse")
+    result = edge["result"]
+    assert isinstance(result, dict)
+    rendered = harness_json_from_native_pre_tool("grok", result)
+    assert rendered["decision"] == "deny"
+    hook_specific = rendered["hookSpecificOutput"]
+    assert isinstance(hook_specific, dict)
+    assert hook_specific["permissionDecision"] == "deny"
+
+
 def test_generic_warning_result_is_allow_with_warning_and_renders_mechanically() -> None:
     edge = _edge("codex", "PreToolUse")
     result = edge["result"]

--- a/tests/test_native_pretool_generic.py
+++ b/tests/test_native_pretool_generic.py
@@ -15,7 +15,10 @@ from codex_plugin_scanner.guard.cli import commands_hook, commands_hook_native_a
 from codex_plugin_scanner.guard.config import GuardConfig
 from codex_plugin_scanner.guard.daemon import hook_process_entrypoint
 from codex_plugin_scanner.guard.daemon.hook_worker import HookWorker
-from codex_plugin_scanner.guard.daemon.hook_worker_responses import harness_json_from_native_pre_tool
+from codex_plugin_scanner.guard.daemon.hook_worker_responses import (
+    harness_json_from_native_pre_tool,
+    harness_json_from_native_pre_tool_review,
+)
 from codex_plugin_scanner.guard.native_decision_receipt import canonical_receipt_bytes
 from codex_plugin_scanner.guard.native_hook_edge import _decode_edge
 from codex_plugin_scanner.guard.native_pretool import _decode_pre_tool
@@ -164,6 +167,23 @@ def test_generic_review_result_renders_grok_deny_decision() -> None:
     assert isinstance(result, dict)
     rendered = harness_json_from_native_pre_tool("grok", result)
     assert rendered["decision"] == "deny"
+    hook_specific = rendered["hookSpecificOutput"]
+    assert isinstance(hook_specific, dict)
+    assert hook_specific["permissionDecision"] == "deny"
+
+
+def test_generic_review_result_renders_grok_review_decision_with_approval() -> None:
+    edge = _edge("grok", "PreToolUse")
+    result = edge["result"]
+    assert isinstance(result, dict)
+    rendered = harness_json_from_native_pre_tool_review(
+        "grok",
+        result,
+        approval={"request_id": "req-1", "approval_url": "http://127.0.0.1/pending/req-1"},
+    )
+    assert rendered["decision"] == "deny"
+    assert rendered["policy_action"] == "review"
+    assert rendered["approval_request_id"] == "req-1"
     hook_specific = rendered["hookSpecificOutput"]
     assert isinstance(hook_specific, dict)
     assert hook_specific["permissionDecision"] == "deny"

--- a/tests/test_native_resident_client_cleanup.py
+++ b/tests/test_native_resident_client_cleanup.py
@@ -58,6 +58,39 @@ def test_stream_close_does_not_stop_shared_resident(
     assert stopped == []
 
 
+def test_close_native_residents_stops_tracked_production_pool(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client_module.close_native_resident_clients()
+    guard_home = tmp_path / "guard-home"
+    state_dir = guard_home / "native-runtime"
+    state_dir.mkdir(parents=True)
+    executable = tmp_path / "runtime"
+    executable.write_text("binary", encoding="utf-8")
+    with client_module._RESIDENTS_LOCK:
+        original = dict(client_module._RESIDENTS)
+        client_module._RESIDENTS.clear()
+    stopped: list[Path] = []
+    monkeypatch.setattr(client_module, "_state_files", lambda _state_dir: (state_dir / "generation.json",))
+    monkeypatch.setattr(
+        client_module,
+        "stop_native_resident",
+        lambda *, state_dir, **_kwargs: stopped.append(state_dir) or True,
+    )
+    try:
+        _ = client_module._client_pool_for(executable, state_dir, {})
+        assert client_module.close_native_residents(guard_home)
+        assert stopped == [state_dir]
+        with client_module._RESIDENTS_LOCK:
+            assert (executable, state_dir) not in client_module._RESIDENTS
+    finally:
+        client_module.close_native_resident_clients()
+        with client_module._RESIDENTS_LOCK:
+            client_module._RESIDENTS.clear()
+            client_module._RESIDENTS.update(original)
+
+
 def test_close_native_residents_preserves_another_guard_home(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_native_resident_client_cleanup.py
+++ b/tests/test_native_resident_client_cleanup.py
@@ -43,6 +43,11 @@ def test_stream_close_does_not_stop_shared_resident(
         "stop_native_resident",
         lambda *, state_dir, **_kwargs: stopped.append(state_dir) or True,
     )
+    monkeypatch.setattr(
+        client_module,
+        "_state_files",
+        lambda _state_dir: (tmp_path / "native-runtime" / "generation.json",),
+    )
     pool = _PersistentNativeClientPool(
         executable=tmp_path / "runtime",
         state_dir=tmp_path / "native-runtime",

--- a/tests/test_native_resident_client_cleanup.py
+++ b/tests/test_native_resident_client_cleanup.py
@@ -33,6 +33,31 @@ def test_close_native_resident_clients_attempts_all_selected_pools_before_raisin
     assert not any(Path(key[1]).parent == guard_home.resolve() for key in client_module._CLIENT_POOLS)
 
 
+def test_stream_close_does_not_stop_shared_resident(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stopped: list[Path] = []
+    monkeypatch.setattr(
+        client_module,
+        "stop_native_resident",
+        lambda *, state_dir, **_kwargs: stopped.append(state_dir) or True,
+    )
+    pool = _PersistentNativeClientPool(
+        executable=tmp_path / "runtime",
+        state_dir=tmp_path / "native-runtime",
+        environment={},
+    )
+    client = client_module._PersistentNativeClient(
+        executable=tmp_path / "runtime",
+        state_dir=tmp_path / "native-runtime",
+        environment={},
+    )
+    pool._clients.add(client)  # pyright: ignore[reportPrivateUsage]
+    pool.close()
+    assert stopped == []
+
+
 def test_close_native_residents_preserves_another_guard_home(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Keep the shared native resident running when a one-shot Grok PreToolUse process exits, instead of stopping it for every tool call.
- Send Grok PreToolUse through the daemon for fast allow or deny, then wait for live approval in the hook process when review is required, including `--json` mode.
- Emit Grok allow, deny, and review JSON with a top-level `decision` while still including `hookSpecificOutput.permissionDecision`.

## Testing
- `python -m pytest tests/test_native_resident_client_cleanup.py tests/test_native_pretool_generic.py tests/test_guard_grok_auto_resume.py tests/test_bounded_cli_hook_bridge.py tests/test_grok_adapter.py --tb=short`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Grok and OpenClaw hooks now receive explicit allow or deny decisions from policy checks.
  - Grok PreToolUse approvals can wait for user resolution within the hook timeout.
  - Approved Grok actions can resume automatically with appropriate permission details.

- **Bug Fixes**
  - Closing a client connection no longer stops the shared resident process.
  - Improved JSON responses for Grok approval and denial outcomes.
  - Approval-processing failures no longer prevent native results from being returned.

- **Tests**
  - Expanded coverage for approvals, decisions, JSON responses, error handling, and resident process cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->