### PR TITLE
fix(tests): retry daemon hook peer disconnects

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -7703,7 +7703,6 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 self.send_header(key, value)
             self.end_headers()
             self.wfile.write(body)
-            self.wfile.flush()
         except _PEER_DISCONNECT_ERRORS:
             self.close_connection = True
 

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -7703,6 +7703,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 self.send_header(key, value)
             self.end_headers()
             self.wfile.write(body)
+            self.wfile.flush()
         except _PEER_DISCONNECT_ERRORS:
             self.close_connection = True
 

--- a/tests/support/network.py
+++ b/tests/support/network.py
@@ -54,7 +54,15 @@ def urlopen_json(request: urllib.request.Request, *, timeout: float = 15, attemp
             raise ValueError("hook response must be an object")
         except urllib.error.HTTPError:
             raise
-        except (http.client.IncompleteRead, http.client.RemoteDisconnected, TimeoutError, urllib.error.URLError) as exc:
+        except (
+            BrokenPipeError,
+            ConnectionAbortedError,
+            ConnectionResetError,
+            TimeoutError,
+            http.client.IncompleteRead,
+            http.client.RemoteDisconnected,
+            urllib.error.URLError,
+        ) as exc:
             last_error = exc
             time.sleep(0.05)
     assert last_error is not None

--- a/tests/test_support_network.py
+++ b/tests/test_support_network.py
@@ -1,0 +1,66 @@
+"""Regression tests for shared HTTP test helpers."""
+
+from __future__ import annotations
+
+import urllib.error
+import urllib.request
+
+import pytest
+
+from tests.support.network import urlopen_json
+
+
+class _JsonResponse:
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    def __enter__(self) -> _JsonResponse:
+        return self
+
+    def __exit__(self, *_args: object) -> bool:
+        return False
+
+    def read(self) -> bytes:
+        return self._payload
+
+
+def test_urlopen_json_retries_connection_reset(monkeypatch: pytest.MonkeyPatch) -> None:
+    attempts = {"count": 0}
+
+    def fake_urlopen(_request: object, timeout: float | None = None) -> _JsonResponse:
+        del timeout
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise ConnectionResetError(104, "Connection reset by peer")
+        return _JsonResponse(b'{"decision":"deny"}')
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr("tests.support.network.time.sleep", lambda _seconds: None)
+
+    payload = urlopen_json(urllib.request.Request("http://127.0.0.1/v1/hooks/pi"))
+
+    assert payload == {"decision": "deny"}
+    assert attempts["count"] == 2
+
+
+def test_urlopen_json_does_not_retry_http_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    attempts = {"count": 0}
+
+    def fake_urlopen(_request: object, timeout: float | None = None) -> _JsonResponse:
+        del timeout
+        attempts["count"] += 1
+        raise urllib.error.HTTPError(
+            "http://127.0.0.1/v1/hooks/pi",
+            503,
+            "Service Unavailable",
+            {},
+            None,
+        )
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr("tests.support.network.time.sleep", lambda _seconds: None)
+
+    with pytest.raises(urllib.error.HTTPError):
+        urlopen_json(urllib.request.Request("http://127.0.0.1/v1/hooks/pi"))
+
+    assert attempts["count"] == 1


### PR DESCRIPTION
## Summary
- Retry peer disconnects such as `ConnectionResetError` in the hook HTTP helper so a completed daemon review is not lost when the socket resets.

## Testing
- `uv run pytest tests/test_support_network.py tests/test_guard_surface_server.py::TestGuardSurfaceServer::test_guard_daemon_pi_hook_endpoint_returns_blocked_runtime_review_payload --tb=short`
- `uv run ruff check tests/support/network.py tests/test_support_network.py`
