### PR TITLE
fix(tests): retry refused PI hook POSTs after healthz

### DIFF
--- a/tests/support/network.py
+++ b/tests/support/network.py
@@ -55,8 +55,6 @@ def urlopen_json(request: urllib.request.Request, *, timeout: float = 15, attemp
         except urllib.error.HTTPError:
             raise
         except urllib.error.URLError as exc:
-            if isinstance(exc.reason, ConnectionRefusedError):
-                raise
             last_error = exc
             time.sleep(0.05)
         except (

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -1063,18 +1063,27 @@ class TestGuardSurfaceServer:
                 method="POST",
             )
             hook_deadline = time.monotonic() + 5
+            last_post_error: BaseException | None = None
             while True:
+                remaining = hook_deadline - time.monotonic()
+                if remaining <= 0:
+                    if last_post_error is not None:
+                        raise last_post_error
+                    raise TimeoutError("PI hook POST did not become reachable after healthz")
                 try:
-                    hook_payload = urlopen_json(hook_request, timeout=15)
+                    hook_payload = urlopen_json(
+                        hook_request,
+                        timeout=min(2.0, max(0.1, remaining)),
+                        attempts=2,
+                    )
                     break
+                except ConnectionRefusedError as exc:
+                    last_post_error = exc
+                    time.sleep(0.05)
                 except urllib.error.URLError as exc:
-                    if not isinstance(
-                        exc.reason,
-                        (BrokenPipeError, ConnectionAbortedError, ConnectionRefusedError, ConnectionResetError),
-                    ):
+                    if not isinstance(exc.reason, ConnectionRefusedError):
                         raise
-                    if time.monotonic() >= hook_deadline:
-                        raise
+                    last_post_error = exc
                     time.sleep(0.05)
             if str(hook_payload.get("reason", "")).startswith(
                 "HOL Guard blocked this action because isolated local review could not complete safely."

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -1062,7 +1062,20 @@ class TestGuardSurfaceServer:
                 },
                 method="POST",
             )
-            hook_payload = urlopen_json(hook_request, timeout=15)
+            hook_deadline = time.monotonic() + 5
+            while True:
+                try:
+                    hook_payload = urlopen_json(hook_request, timeout=15)
+                    break
+                except urllib.error.URLError as exc:
+                    if not isinstance(
+                        exc.reason,
+                        (BrokenPipeError, ConnectionAbortedError, ConnectionRefusedError, ConnectionResetError),
+                    ):
+                        raise
+                    if time.monotonic() >= hook_deadline:
+                        raise
+                    time.sleep(0.05)
             if str(hook_payload.get("reason", "")).startswith(
                 "HOL Guard blocked this action because isolated local review could not complete safely."
             ):

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -1074,7 +1074,7 @@ class TestGuardSurfaceServer:
                     hook_payload = urlopen_json(
                         hook_request,
                         timeout=min(2.0, max(0.1, remaining)),
-                        attempts=2,
+                        attempts=1,
                     )
                     break
                 except ConnectionRefusedError as exc:

--- a/tests/test_support_network.py
+++ b/tests/test_support_network.py
@@ -66,18 +66,20 @@ def test_urlopen_json_does_not_retry_http_errors(monkeypatch: pytest.MonkeyPatch
     assert attempts["count"] == 1
 
 
-def test_urlopen_json_does_not_retry_connection_refused(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_urlopen_json_retries_connection_refused(monkeypatch: pytest.MonkeyPatch) -> None:
     attempts = {"count": 0}
 
     def fake_urlopen(_request: object, timeout: float | None = None) -> _JsonResponse:
         del timeout
         attempts["count"] += 1
-        raise urllib.error.URLError(ConnectionRefusedError(111, "Connection refused"))
+        if attempts["count"] == 1:
+            raise urllib.error.URLError(ConnectionRefusedError(111, "Connection refused"))
+        return _JsonResponse(b'{"decision":"deny"}')
 
     monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
     monkeypatch.setattr("tests.support.network.time.sleep", lambda _seconds: None)
 
-    with pytest.raises(urllib.error.URLError):
-        urlopen_json(urllib.request.Request("http://127.0.0.1/v1/hooks/pi"))
+    payload = urlopen_json(urllib.request.Request("http://127.0.0.1/v1/hooks/pi"))
 
-    assert attempts["count"] == 1
+    assert payload == {"decision": "deny"}
+    assert attempts["count"] == 2


### PR DESCRIPTION
## Summary
- Retry connection-refused PI hook POSTs for five seconds after `/healthz` is green.
- Keep the retry window bounded and skip response-level disconnects so a processed review is not posted twice.
- Keep HTTP errors unretried so real 5xx answers still fail immediately.

## Testing
- `uv run pytest tests/test_support_network.py tests/test_guard_surface_server.py::TestGuardSurfaceServer::test_guard_daemon_pi_hook_endpoint_returns_blocked_runtime_review_payload --tb=short`
- `uv run ruff check tests/support/network.py tests/test_support_network.py tests/test_guard_surface_server.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of connection-refused errors so they are retried before ultimately failing.
  - Tightened retry timing and limits for the PI hook endpoint, providing more predictable timeout behavior and clearer failure handling.

- **Tests**
  - Updated coverage to verify successful recovery after a connection-refused error and confirm the expected number of retry attempts.
  - Added validation for timeout behavior when the endpoint remains unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->