### PR TITLE
feat(paseo): bring the adapter onto main

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Guard connects through native agent hooks, managed MCP proxies, and launch integ
 
 ## Supported AI Agents
 
-Codex, Claude Code, GitHub Copilot CLI, Cursor, Cline, Gemini CLI, Grok, Hermes, Kimi Code, Pi, oh-my-pi, OpenClaw, OpenCode, Antigravity, and ZCode.
+Codex, Claude Code, GitHub Copilot CLI, Cursor, Cline, Gemini CLI, Grok, Hermes, Kimi Code, Pi, oh-my-pi, OpenClaw, OpenCode, Antigravity, and ZCode. [Paseo](docs/guard/paseo.md) is supported through these native provider integrations, with per-provider coverage.
 
 For example, to set up Codex explicitly:
 
@@ -344,7 +344,7 @@ Yes. Local protection, CLI commands, approvals, and receipts work without signin
 
 ### Which AI agents does HOL Guard support?
 
-Guard includes adapters for Codex, Claude Code, GitHub Copilot CLI, Cursor, Cline, Gemini CLI, Grok, Hermes, Kimi Code, Pi, oh-my-pi, OpenClaw, OpenCode, Antigravity, and ZCode. The [support matrix](docs/guard/harness-support.md) explains which events and enforcement paths each adapter supports.
+Guard includes adapters for Codex, Claude Code, GitHub Copilot CLI, Cursor, Cline, Gemini CLI, Grok, Hermes, Kimi Code, Pi, oh-my-pi, OpenClaw, OpenCode, Antigravity, and ZCode. [Paseo](docs/guard/paseo.md) is supported through these native provider integrations, with per-provider coverage. The [support matrix](docs/guard/harness-support.md) explains which events and enforcement paths each adapter supports.
 
 ### What is the difference between HOL Guard and Plugin Scanner?
 

--- a/docs/guard/contracts/hook-data-plane-ownership.v2.json
+++ b/docs/guard/contracts/hook-data-plane-ownership.v2.json
@@ -24,6 +24,7 @@
     "omp",
     "openclaw",
     "opencode",
+    "paseo",
     "pi",
     "zcode"
   ],
@@ -45,6 +46,7 @@
     "omp": {"pre_tool_use": "installed_canonical", "post_tool_use": "installed_canonical"},
     "openclaw": {"pre_tool_use": "installed_cli_bridge", "post_tool_use": "unavailable"},
     "opencode": {"pre_tool_use": "installed_cli_bridge", "post_tool_use": "unavailable"},
+    "paseo": {"pre_tool_use": "unavailable", "post_tool_use": "unavailable"},
     "pi": {"pre_tool_use": "installed_canonical", "post_tool_use": "installed_canonical_source_ref"},
     "zcode": {"pre_tool_use": "installed_canonical", "post_tool_use": "normalizer_only_not_installed"}
   },

--- a/docs/guard/harness-support.md
+++ b/docs/guard/harness-support.md
@@ -189,7 +189,7 @@ Generated from `src/codex_plugin_scanner/guard/adapters/contracts.py`.
 | `pi` | `pi`, `pi-agent`, `pi-coding-agent` | ✅ | ✅ | ✅ | shell, prompt, mcp_tool, file_read, tool_result |
 | `omp` | `omp`, `oh-my-pi` | ✅ | ✅ | ✅ | shell, prompt, mcp_tool, file_read, tool_result |
 | `zcode` | `zcode`, `zai`, `z-code`, `zai-zcode` | ❌ | ✅ | ❌ | shell, prompt, mcp_tool, file_read |
-| `paseo` | `paseo` | ❌ | ✅ | ❌ | — |
+| `paseo` | `paseo` | ❌ | ❌ | ❌ | — |
 
 ## Rust Authority Boundary
 

--- a/docs/guard/harness-support.md
+++ b/docs/guard/harness-support.md
@@ -189,6 +189,7 @@ Generated from `src/codex_plugin_scanner/guard/adapters/contracts.py`.
 | `pi` | `pi`, `pi-agent`, `pi-coding-agent` | ✅ | ✅ | ✅ | shell, prompt, mcp_tool, file_read, tool_result |
 | `omp` | `omp`, `oh-my-pi` | ✅ | ✅ | ✅ | shell, prompt, mcp_tool, file_read, tool_result |
 | `zcode` | `zcode`, `zai`, `z-code`, `zai-zcode` | ❌ | ✅ | ❌ | shell, prompt, mcp_tool, file_read |
+| `paseo` | `paseo` | ❌ | ✅ | ❌ | — |
 
 ## Rust Authority Boundary
 
@@ -203,3 +204,7 @@ approval coordination, dashboard control-plane work, and bounded
 non-authoritative evidence persistence. The repository-wide ownership gate
 prevents Python command evaluation or output-scanning fallback from being
 reintroduced as PreToolUse or PostToolUse authority.
+
+## Paseo
+
+Run `hol-guard install paseo` on the Paseo daemon host to install Guard for enabled, available native providers. This is not a universal Paseo permission hook. See [Paseo setup and coverage](paseo.md) for provider support, exclusions, diagnostics, and shared-hook ownership.

--- a/docs/guard/paseo.md
+++ b/docs/guard/paseo.md
@@ -99,3 +99,7 @@ The integration was checked against the Paseo 0.8 source snapshot [`f22a37e613e9
 - Native launch implementations under `packages/server/src/server/agent/providers`: Claude loads user/project/local settings, Codex starts the native app-server, Pi/OMP preserve extension-loading RPC launches, and OpenCode adds its bridge plugin without replacing the native integration.
 
 `tests/test_paseo_adapter.py` and `tests/test_paseo_inherited_profiles.py` exercise real native installers in isolated homes. Only executable discovery is substituted; no paid model requests or real credentials are required. Tests cover configuration preservation, native proof registration, workspace independence, custom profiles, unsupported overrides, malformed input, unsafe paths, repeated installation, drift, credential-free inventory, public CLI management, and conservative uninstall. These tests do not represent a live authenticated Paseo/model session.
+
+Paseo itself has no Guard hook endpoint or browser approval fallback. The ownership
+manifest therefore marks its own pre/post-tool routes unavailable; supported
+provider sessions keep their native harness identities and native Rust routes.

--- a/docs/guard/paseo.md
+++ b/docs/guard/paseo.md
@@ -1,0 +1,101 @@
+# Paseo adapter
+
+Paseo is a control plane for coding agents. Its providers execute tools in their own runtimes, so Guard installs the existing native integrations on the **Paseo daemon host**, not on the phone or remote client.
+
+**This is limited, provider-specific protection, not a firewall for everything Paseo does.** The adapter does not install a permission-event listener and call it enforcement.
+
+## Install and verify
+
+Use the same operating-system account and native configuration home as the Paseo daemon:
+
+```bash
+hol-guard install paseo --dry-run
+hol-guard install paseo
+hol-guard apps test paseo --json
+```
+
+The installer discovers `~/.paseo/config.json`, or `$PASEO_HOME/config.json` when an absolute `PASEO_HOME` is set. An explicit Guard `--home` selects that home's `.paseo/config.json` instead of inheriting `PASEO_HOME`. Install on each daemon host separately. Relative `PASEO_HOME` values are rejected rather than resolved against an unrelated working directory.
+
+It installs Guard only for enabled, supported providers whose native executable is available. Missing runtimes are listed as `runtime-unavailable`; OMP is disabled by default, matching Paseo. Custom profiles that extend a supported native provider share one native installation. Inherited commands and merged environment overrides are checked before a profile is classified; a harmless child profile cannot hide unsafe launch settings from its base. The adapter never enables disabled providers or changes Paseo credentials, models, provider commands, permission modes, or `plugins.enabled`.
+
+Start new provider sessions after installation or repair. Existing sessions can retain old hooks. The installer does not interrupt active sessions or restart the daemon. Changes to Paseo's own provider configuration remain subject to Paseo's normal `paseo reload` behavior.
+
+`guard-paseo` is also installed as an optional pre-launch inventory-check wrapper. Native provider commands are **not** replaced with wrappers, preserving the Claude SDK, Codex app-server, Pi/OMP RPC, and ACP stdio transports.
+
+## Native providers
+
+| Paseo provider | Guard integration installed | Boundary |
+| --- | --- | --- |
+| `claude` | `claude-code` user settings hooks | Native Claude tool/prompt hooks, including `PreToolUse` |
+| `codex` | Codex native hooks and existing MCP integration | Codex's native hook enforcement, including app-server sessions that load those settings |
+| `copilot` | Copilot global hooks and existing MCP integration | Native Copilot hook events; not an independent Paseo ACP interceptor |
+| `pi` | Managed Pi runtime extension | Events forwarded by the native extension in Pi sessions |
+| `omp` | Managed Oh My Pi runtime extension | Events forwarded by the native extension; only installed when enabled |
+| `opencode` | OpenCode native pretool plugin and existing native configuration | Native pretool protection; Guard-launcher-only overlays are not injected into Paseo |
+
+Each integration retains its existing approval behavior, failure behavior, and blind spots. Hook failures are **not** claimed to be uniformly fail-closed. Native hooks keep their native harness identity in Guard's policies, activity, and approvals. For example, a Claude action launched by Paseo is evaluated as `claude-code`, not as a fabricated `paseo` tool event. Native install records are registered so normal Guard health checks and repairs can verify them.
+
+OpenCode's Guard-launcher runtime overlay and any other launcher-only provider features are not inherited merely by installing this adapter. Read the native provider's coverage documentation for those distinctions.
+
+## Unsupported and unverified surfaces
+
+The following are not protected by this adapter:
+
+- Paseo terminals, daemon-managed git/browser operations, plugin execution, and other daemon hosts.
+- Arbitrary ACP or plugin providers. A display name that resembles a supported provider is not sufficient evidence.
+- Providers with custom `command` arrays, including wrappers, containers, custom binaries, and flags that disable hooks.
+- Provider environment overrides that redirect native homes/configuration, change executable lookup, or may disable Guard. Ordinary API credentials and endpoint profiles do not themselves redirect the native hook installation.
+
+The installer checks provider configuration and relevant environment overrides visible to the installing process. It cannot prove the environment of an already-running daemon or inspect future per-session/plugin launch overrides. Different daemon accounts, native settings overrides, disabled extensions, and per-session runtime options require separate verification. The adapter never changes those options silently.
+
+Paseo's `agent.permission_requested` event is a best-effort notification. It does not cover every tool call and event-handler errors do not prevent the original operation. The adapter intentionally does not use it to allow, deny, auto-approve, or claim coverage.
+
+## Diagnostics and repair
+
+`hol-guard apps test paseo --json` includes a `providers` report with these statuses:
+
+| Status | Meaning |
+| --- | --- |
+| `native-hooks-installed` | Recorded native installation files still match their installation fingerprints |
+| `disabled` | Disabled in Paseo; no native installation is requested for this profile |
+| `runtime-unavailable` | The native executable was not found in the installation context |
+| `unsupported` | Provider type, command, or environment needs separate integration/verification |
+| `not-installed` | A supported available provider has no recorded installation |
+| `changed` | A recorded native configuration, extension, or hook artifact changed or disappeared |
+
+Unsupported profiles remain coverage caveats and do not erase verified supported-provider installation. An enabled native provider that is unavailable or not installed makes aggregate setup `partial`; changed native artifacts make it `broken`.
+
+The report always says `coverage_status: limited` and `runtime_verification: not-performed`. A matching installation fingerprint is not a live model/tool execution attestation. Check native Guard receipts from a harmless action in a new Paseo session before relying on a deployment. Do not use real secrets as a smoke test.
+
+```bash
+hol-guard apps repair paseo
+hol-guard apps test paseo --json
+```
+
+Repair validates configuration before modifying native settings. Malformed JSON, duplicate keys, oversize files, and unsafe managed paths are rejected. A failed multi-provider install does not leave a successful Paseo receipt. Native integrations successfully installed before a later failure remain installed and registered; rerun repair after correcting the failure. The adapter does not roll back shared protections to an older snapshot.
+
+Receipts are stored under Guard's `managed/paseo` directory, keyed by the Paseo configuration path. They contain native file fingerprints, not provider credentials. Config/extension fingerprints also participate in Guard's normal managed-install proof validation. New available providers and unsupported profiles are reflected by diagnostics rather than inferred from an old install flag.
+
+## Cloud inventory compatibility
+
+The Paseo composite inventory is available in local diagnostics and exports. It is not uploaded as a new `paseo` cloud agent type: the current portal contract does not accept that type yet. Guard continues syncing the supported native provider inventories under their existing identities. Paseo diagnostics expose `cloud_inventory_status: native-providers-only`. This avoids rejecting a batch of otherwise valid native inventories or uploading Paseo configuration content through an unsupported schema.
+
+## Uninstall and ownership
+
+```bash
+hol-guard uninstall paseo
+```
+
+This removes only the Paseo installation receipt and `guard-paseo` launcher. **Shared native Guard hooks remain installed**, including native integrations originally installed through Paseo. This avoids disabling protection in another client or standalone CLI.
+
+To remove a native integration for every client using that native home, explicitly run its normal uninstall command, for example `hol-guard uninstall pi`. Paseo configuration and credentials are never restored from a stale backup or overwritten during uninstall.
+
+## Design reference and tests
+
+The integration was checked against the Paseo 0.8 source snapshot [`f22a37e613e965c8ebc02e1f5565e21fd72eaf2f`](https://github.com/getpaseo/paseo/tree/f22a37e613e965c8ebc02e1f5565e21fd72eaf2f):
+
+- [Provider configuration](https://github.com/getpaseo/paseo/blob/f22a37e613e965c8ebc02e1f5565e21fd72eaf2f/docs/custom-providers.md), including built-in defaults, `extends`, `command`, and `env`.
+- [Lifecycle contract](https://github.com/getpaseo/paseo/blob/f22a37e613e965c8ebc02e1f5565e21fd72eaf2f/packages/plugin/src/server/lifecycle.ts) and [hook failure semantics](https://github.com/getpaseo/paseo/blob/f22a37e613e965c8ebc02e1f5565e21fd72eaf2f/public-docs/plugins/v0.8/reference.md#context-and-cleanup).
+- Native launch implementations under `packages/server/src/server/agent/providers`: Claude loads user/project/local settings, Codex starts the native app-server, Pi/OMP preserve extension-loading RPC launches, and OpenCode adds its bridge plugin without replacing the native integration.
+
+`tests/test_paseo_adapter.py` and `tests/test_paseo_inherited_profiles.py` exercise real native installers in isolated homes. Only executable discovery is substituted; no paid model requests or real credentials are required. Tests cover configuration preservation, native proof registration, workspace independence, custom profiles, unsupported overrides, malformed input, unsafe paths, repeated installation, drift, credential-free inventory, public CLI management, and conservative uninstall. These tests do not represent a live authenticated Paseo/model session.

--- a/src/codex_plugin_scanner/guard/adapters/__init__.py
+++ b/src/codex_plugin_scanner/guard/adapters/__init__.py
@@ -23,6 +23,7 @@ _ADAPTER_SPECS: tuple[tuple[str, str], ...] = (
     (".openclaw", "OpenClawHarnessAdapter"),
     (".opencode", "OpenCodeHarnessAdapter"),
     (".zcode", "ZCodeHarnessAdapter"),
+    (".paseo", "PaseoHarnessAdapter"),
 )
 
 

--- a/src/codex_plugin_scanner/guard/adapters/contract_models.py
+++ b/src/codex_plugin_scanner/guard/adapters/contract_models.py
@@ -1,0 +1,125 @@
+"""Shared immutable harness setup and protection data contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessProtectionContract:
+    """Static protection profile for one AI coding harness.
+
+    Attributes:
+        harness: Canonical harness identifier (matches adapter `harness` field).
+        install_aliases: All strings accepted by `hol-guard install <alias>`.
+        config_paths: Glob-style paths where the harness stores config
+            (relative to ``$HOME`` unless absolute).
+        event_surfaces: Hook event types the harness exposes
+            (e.g. "shell", "prompt", "mcp_tool", "file_read").
+        native_approval: True if the harness has a first-class native approval
+            prompt that Guard can intercept without a browser fallback.
+        browser_fallback: True if Guard falls back to a browser approval page
+            when native approval is unavailable.
+        resume_support: True if the harness can resume the original command
+            after an async approval completes.
+        known_blind_spots: Human-readable description of event types or
+            surfaces that Guard cannot currently observe for this harness.
+        smoke_command: Shell command an operator can run to confirm Guard is
+            active for this harness.
+    """
+
+    harness: str
+    install_aliases: tuple[str, ...]
+    config_paths: tuple[str, ...]
+    event_surfaces: tuple[str, ...]
+    native_approval: bool
+    browser_fallback: bool
+    resume_support: bool
+    known_blind_spots: str
+    smoke_command: str
+    surface_capabilities: tuple[str, ...] = ()
+    supported_actions: tuple[str, ...] = ()
+    docs_path: str | None = None
+    icon_label: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessSetupStep:
+    """Plain-language action for connecting or checking one harness."""
+
+    step_id: str
+    title: str
+    body: str
+    command: tuple[str, ...] = ()
+    writes_config: bool = False
+    requires_confirmation: bool = False
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize the setup contract using the existing public payload keys."""
+        return {
+            "step_id": self.step_id,
+            "title": self.title,
+            "body": self.body,
+            "command": list(self.command),
+            "writes_config": self.writes_config,
+            "requires_confirmation": self.requires_confirmation,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessCoverageSummary:
+    """Summary of what Guard can and cannot observe for one harness."""
+
+    native_hooks: bool
+    browser_fallback: bool
+    mcp_proxy: bool
+    prompt_hooks: bool
+    blind_spots: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize the setup contract using the existing public payload keys."""
+        return {
+            "native_hooks": self.native_hooks,
+            "browser_fallback": self.browser_fallback,
+            "mcp_proxy": self.mcp_proxy,
+            "prompt_hooks": self.prompt_hooks,
+            "blind_spots": list(self.blind_spots),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessSetupContract:
+    """Dashboard and CLI setup contract for one supported harness."""
+
+    harness: str
+    display_name: str
+    install_aliases: tuple[str, ...]
+    setup_steps: tuple[HarnessSetupStep, ...]
+    verify_steps: tuple[HarnessSetupStep, ...]
+    repair_steps: tuple[HarnessSetupStep, ...]
+    coverage: HarnessCoverageSummary
+    surface_capabilities: tuple[str, ...] = ()
+    supported_actions: tuple[str, ...] = ()
+    docs_path: str | None = None
+    icon_label: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize the setup contract using the existing public payload keys."""
+        payload: dict[str, object] = {
+            "harness": self.harness,
+            "display_name": self.display_name,
+            "install_aliases": list(self.install_aliases),
+            "setup_steps": [step.to_dict() for step in self.setup_steps],
+            "verify_steps": [step.to_dict() for step in self.verify_steps],
+            "repair_steps": [step.to_dict() for step in self.repair_steps],
+            "coverage": self.coverage.to_dict(),
+        }
+        if self.surface_capabilities:
+            payload["surface_capabilities"] = list(self.surface_capabilities)
+        if self.supported_actions:
+            payload["supported_actions"] = list(self.supported_actions)
+        if self.docs_path is not None:
+            payload["docs_path"] = self.docs_path
+        if self.icon_label is not None:
+            payload["icon_label"] = self.icon_label
+        return payload

--- a/src/codex_plugin_scanner/guard/adapters/contract_rendering.py
+++ b/src/codex_plugin_scanner/guard/adapters/contract_rendering.py
@@ -1,0 +1,48 @@
+"""Display labels and Markdown rendering for harness contracts."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .contracts import HarnessProtectionContract
+
+DISPLAY_NAMES = {
+    "codex": "Codex",
+    "claude-code": "Claude Code",
+    "opencode": "OpenCode",
+    "copilot": "Copilot",
+    "cursor": "Cursor",
+    "cline": "Cline",
+    "gemini": "Gemini",
+    "hermes": "Hermes",
+    "openclaw": "OpenClaw",
+    "antigravity": "Antigravity",
+    "kimi": "Kimi",
+    "grok": "Grok",
+    "pi": "Pi",
+    "omp": "Oh My Pi",
+    "zcode": "ZCode",
+    "paseo": "Paseo",
+}
+
+
+def render_harness_contracts(contracts: Sequence[HarnessProtectionContract]) -> str:
+    """Return a Markdown table summarising all harness contracts."""
+    header = (
+        "| Harness | Install Aliases | Native Approval | Browser Fallback "
+        "| Resume | Event Surfaces |\n"
+        "|---------|-----------------|-----------------|------------------"
+        "|--------|----------------|\n"
+    )
+    rows: list[str] = []
+    for c in contracts:
+        aliases = ", ".join(f"`{a}`" for a in c.install_aliases)
+        surfaces = ", ".join(c.event_surfaces) if c.event_surfaces else "—"
+        rows.append(
+            f"| `{c.harness}` | {aliases} | {'✅' if c.native_approval else '❌'} "
+            f"| {'✅' if c.browser_fallback else '❌'} "
+            f"| {'✅' if c.resume_support else '❌'} | {surfaces} |"
+        )
+    return header + "\n".join(rows) + "\n"

--- a/src/codex_plugin_scanner/guard/adapters/contracts.py
+++ b/src/codex_plugin_scanner/guard/adapters/contracts.py
@@ -7,144 +7,12 @@ one AI coding harness that HOL Guard supports.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
-
-@dataclass(frozen=True, slots=True)
-class HarnessProtectionContract:
-    """Static protection profile for one AI coding harness.
-
-    Attributes:
-        harness: Canonical harness identifier (matches adapter `harness` field).
-        install_aliases: All strings accepted by `hol-guard install <alias>`.
-        config_paths: Glob-style paths where the harness stores config
-            (relative to ``$HOME`` unless absolute).
-        event_surfaces: Hook event types the harness exposes
-            (e.g. "shell", "prompt", "mcp_tool", "file_read").
-        native_approval: True if the harness has a first-class native approval
-            prompt that Guard can intercept without a browser fallback.
-        browser_fallback: True if Guard falls back to a browser approval page
-            when native approval is unavailable.
-        resume_support: True if the harness can resume the original command
-            after an async approval completes.
-        known_blind_spots: Human-readable description of event types or
-            surfaces that Guard cannot currently observe for this harness.
-        smoke_command: Shell command an operator can run to confirm Guard is
-            active for this harness.
-    """
-
-    harness: str
-    install_aliases: tuple[str, ...]
-    config_paths: tuple[str, ...]
-    event_surfaces: tuple[str, ...]
-    native_approval: bool
-    browser_fallback: bool
-    resume_support: bool
-    known_blind_spots: str
-    smoke_command: str
-    surface_capabilities: tuple[str, ...] = ()
-    supported_actions: tuple[str, ...] = ()
-    docs_path: str | None = None
-    icon_label: str | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class HarnessSetupStep:
-    """Plain-language action for connecting or checking one harness."""
-
-    step_id: str
-    title: str
-    body: str
-    command: tuple[str, ...] = ()
-    writes_config: bool = False
-    requires_confirmation: bool = False
-
-    def to_dict(self) -> dict[str, object]:
-        return {
-            "step_id": self.step_id,
-            "title": self.title,
-            "body": self.body,
-            "command": list(self.command),
-            "writes_config": self.writes_config,
-            "requires_confirmation": self.requires_confirmation,
-        }
-
-
-@dataclass(frozen=True, slots=True)
-class HarnessCoverageSummary:
-    """Summary of what Guard can and cannot observe for one harness."""
-
-    native_hooks: bool
-    browser_fallback: bool
-    mcp_proxy: bool
-    prompt_hooks: bool
-    blind_spots: tuple[str, ...]
-
-    def to_dict(self) -> dict[str, object]:
-        return {
-            "native_hooks": self.native_hooks,
-            "browser_fallback": self.browser_fallback,
-            "mcp_proxy": self.mcp_proxy,
-            "prompt_hooks": self.prompt_hooks,
-            "blind_spots": list(self.blind_spots),
-        }
-
-
-@dataclass(frozen=True, slots=True)
-class HarnessSetupContract:
-    """Dashboard and CLI setup contract for one supported harness."""
-
-    harness: str
-    display_name: str
-    install_aliases: tuple[str, ...]
-    setup_steps: tuple[HarnessSetupStep, ...]
-    verify_steps: tuple[HarnessSetupStep, ...]
-    repair_steps: tuple[HarnessSetupStep, ...]
-    coverage: HarnessCoverageSummary
-    surface_capabilities: tuple[str, ...] = ()
-    supported_actions: tuple[str, ...] = ()
-    docs_path: str | None = None
-    icon_label: str | None = None
-
-    def to_dict(self) -> dict[str, object]:
-        payload: dict[str, object] = {
-            "harness": self.harness,
-            "display_name": self.display_name,
-            "install_aliases": list(self.install_aliases),
-            "setup_steps": [step.to_dict() for step in self.setup_steps],
-            "verify_steps": [step.to_dict() for step in self.verify_steps],
-            "repair_steps": [step.to_dict() for step in self.repair_steps],
-            "coverage": self.coverage.to_dict(),
-        }
-        if self.surface_capabilities:
-            payload["surface_capabilities"] = list(self.surface_capabilities)
-        if self.supported_actions:
-            payload["supported_actions"] = list(self.supported_actions)
-        if self.docs_path is not None:
-            payload["docs_path"] = self.docs_path
-        if self.icon_label is not None:
-            payload["icon_label"] = self.icon_label
-        return payload
-
-
-_DISPLAY_NAMES = {
-    "codex": "Codex",
-    "claude-code": "Claude Code",
-    "opencode": "OpenCode",
-    "copilot": "Copilot",
-    "cursor": "Cursor",
-    "cline": "Cline",
-    "gemini": "Gemini",
-    "hermes": "Hermes",
-    "openclaw": "OpenClaw",
-    "antigravity": "Antigravity",
-    "kimi": "Kimi",
-    "grok": "Grok",
-    "pi": "Pi",
-    "omp": "Oh My Pi",
-    "zcode": "ZCode",
-}
-
+from .contract_models import HarnessCoverageSummary as HarnessCoverageSummary
+from .contract_models import HarnessProtectionContract as HarnessProtectionContract
+from .contract_models import HarnessSetupContract as HarnessSetupContract
+from .contract_models import HarnessSetupStep as HarnessSetupStep
+from .contract_rendering import DISPLAY_NAMES as _DISPLAY_NAMES
+from .contract_rendering import render_harness_contracts
 
 HARNESS_CONTRACTS: tuple[HarnessProtectionContract, ...] = (
     HarnessProtectionContract(
@@ -424,6 +292,24 @@ HARNESS_CONTRACTS: tuple[HarnessProtectionContract, ...] = (
         ),
         smoke_command="hol-guard install zcode --dry-run",
     ),
+    HarnessProtectionContract(
+        harness="paseo",
+        install_aliases=("paseo",),
+        config_paths=("~/.paseo/config.json",),
+        event_surfaces=(),
+        native_approval=False,
+        browser_fallback=True,
+        resume_support=False,
+        known_blind_spots=(
+            "Protection is delegated to supported native providers on the Paseo daemon host. "
+            "Paseo permission notifications are not blocking hooks. Terminals, daemon git/browser actions, "
+            "plugin code, custom commands, ACP providers, relocated native homes, and remote hosts are not covered. "
+            "Native runtime failure behavior and approval/resume support remain provider-specific."
+        ),
+        smoke_command="hol-guard install paseo --dry-run",
+        docs_path="docs/guard/paseo.md",
+        icon_label="Paseo",
+    ),
 )
 
 _CONTRACT_BY_ALIAS: dict[str, HarnessProtectionContract] = {}
@@ -463,7 +349,11 @@ def setup_contract_for(harness: str) -> HarnessSetupContract | None:
         HarnessSetupStep(
             step_id="connect",
             title=f"Connect {display_name}",
-            body=f"Add Guard's local protection hooks for {display_name}.",
+            body=(
+                "Install native provider hooks on the Paseo daemon host."
+                if contract.harness == "paseo"
+                else f"Add Guard's local protection hooks for {display_name}."
+            ),
             command=("hol-guard", "apps", "connect", alias),
             writes_config=True,
         ),
@@ -517,18 +407,4 @@ def all_setup_contracts() -> tuple[HarnessSetupContract, ...]:
 
 def harness_contracts_table() -> str:
     """Return a Markdown table summarising all harness contracts."""
-    header = (
-        "| Harness | Install Aliases | Native Approval | Browser Fallback "
-        "| Resume | Event Surfaces |\n"
-        "|---------|-----------------|-----------------|------------------"
-        "|--------|----------------|\n"
-    )
-    rows: list[str] = []
-    for c in HARNESS_CONTRACTS:
-        aliases = ", ".join(f"`{a}`" for a in c.install_aliases)
-        surfaces = ", ".join(c.event_surfaces) if c.event_surfaces else "—"
-        rows.append(
-            f"| `{c.harness}` | {aliases} | {'✅' if c.native_approval else '❌'} "
-            f"| {'✅' if c.browser_fallback else '❌'} | {'✅' if c.resume_support else '❌'} | {surfaces} |"
-        )
-    return header + "\n".join(rows) + "\n"
+    return render_harness_contracts(HARNESS_CONTRACTS)

--- a/src/codex_plugin_scanner/guard/adapters/contracts.py
+++ b/src/codex_plugin_scanner/guard/adapters/contracts.py
@@ -298,7 +298,7 @@ HARNESS_CONTRACTS: tuple[HarnessProtectionContract, ...] = (
         config_paths=("~/.paseo/config.json",),
         event_surfaces=(),
         native_approval=False,
-        browser_fallback=True,
+        browser_fallback=False,
         resume_support=False,
         known_blind_spots=(
             "Protection is delegated to supported native providers on the Paseo daemon host. "

--- a/src/codex_plugin_scanner/guard/adapters/grok.py
+++ b/src/codex_plugin_scanner/guard/adapters/grok.py
@@ -484,8 +484,8 @@ def grok_runtime_hooks_verified(context: HarnessContext) -> bool:
     from ..cli.install_commands import _grok_pretool_is_catchall, _grok_prompt_hook_is_observe
 
     hooks_dir = GrokHarnessAdapter._hooks_dir(context)
-    return _grok_pretool_is_catchall(hooks_dir / GUARD_HOOK_PRETOOL_FILE) and _grok_prompt_hook_is_observe(
-        hooks_dir / GUARD_HOOK_PROMPT_FILE
+    return _grok_pretool_is_catchall(hooks_dir / GUARD_HOOK_PRETOOL_FILE, context) and _grok_prompt_hook_is_observe(
+        hooks_dir / GUARD_HOOK_PROMPT_FILE, context
     )
 
 

--- a/src/codex_plugin_scanner/guard/adapters/paseo.py
+++ b/src/codex_plugin_scanner/guard/adapters/paseo.py
@@ -89,14 +89,15 @@ class PaseoHarnessAdapter(HarnessAdapter):
         for target in targets:
             preflight_native(target, context)
         for shim in self.guard_launcher_paths(native_context(context)):
-            require_local_path(context.guard_home, shim)
-        # A failed repair must not leave a receipt claiming the new install succeeded.
-        path.unlink(missing_ok=True)
+            require_local_path(context.guard_home, shim, home_dir=context.home_dir)
+        # Keep the last verified receipt until atomic replacement succeeds.
         proofs: dict[str, object] = {}
         for target in targets:
             proofs[target] = install_native(target, context)
         if paseo_providers(context) != providers:
             raise ValueError("Paseo providers changed during installation; rerun hol-guard install paseo.")
+        for shim in self.guard_launcher_paths(native_context(context)):
+            require_local_path(context.guard_home, shim, home_dir=context.home_dir)
         shim_manifest = install_guard_shim(self.harness, native_context(context))
         receipt = write_receipt(context, proofs)
         return {

--- a/src/codex_plugin_scanner/guard/adapters/paseo.py
+++ b/src/codex_plugin_scanner/guard/adapters/paseo.py
@@ -1,0 +1,163 @@
+"""Paseo integration through the native runtimes that execute its agent tools."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..models import GuardArtifact, HarnessDetection
+from ..shims import install_guard_shim, remove_guard_shim
+from .base import HarnessAdapter, HarnessContext
+from .paseo_config import PaseoProvider, paseo_config_path, paseo_providers, require_local_path
+from .paseo_install import (
+    install_native,
+    native_context,
+    preflight_native,
+    protection_paths,
+    provider_status,
+    read_receipt,
+    receipt_path,
+    write_receipt,
+)
+
+PASEO_COVERAGE_LIMIT = (
+    "Paseo delegates tool execution to native providers. Guard protects supported providers through their native "
+    "hooks, not Paseo's permission notifications. Paseo terminals, daemon git/browser actions, plugin code, "
+    "custom commands, ACP providers, and other hosts are not covered by this adapter."
+)
+
+
+def _provider_rows(
+    providers: tuple[PaseoProvider, ...], context: HarnessContext, receipt: dict[str, object]
+) -> list[dict[str, object]]:
+    """Combine credential-free provider metadata with verified installation status."""
+    return [{**provider.to_dict(), "status": provider_status(provider, context, receipt)} for provider in providers]
+
+
+class PaseoHarnessAdapter(HarnessAdapter):
+    harness = "paseo"
+    executable = "paseo"
+    approval_summary = "Approvals use each provider's native Guard integration on the Paseo daemon host."
+    fallback_hint = "Check the native provider in Guard on the daemon host; Paseo notifications do not enforce policy."
+
+    def policy_path(self, context: HarnessContext) -> Path:
+        """Locate the daemon configuration without treating it as a Guard policy file."""
+        return paseo_config_path(context)
+
+    def detect(self, context: HarnessContext) -> HarnessDetection:
+        """Discover enabled provider identities without exposing their environment values."""
+        available = self.resolved_executable(context) is not None
+        paths: tuple[str, ...] = ()
+        artifacts: tuple[GuardArtifact, ...] = ()
+        warnings: tuple[str, ...] = ()
+        try:
+            path = paseo_config_path(context)
+            paths = (str(path),) if path.is_file() else ()
+            if paths or available:
+                providers = paseo_providers(context)
+                artifacts = tuple(
+                    GuardArtifact(
+                        artifact_id=f"paseo:provider:{provider.provider_id}",
+                        name=provider.provider_id,
+                        harness=self.harness,
+                        artifact_type="agent",
+                        source_scope="global",
+                        config_path=str(path),
+                        metadata=provider.to_dict(),
+                    )
+                    for provider in providers
+                    if provider.enabled
+                )
+                warnings = (PASEO_COVERAGE_LIMIT,)
+        except ValueError as error:
+            warnings = (str(error),)
+        return HarnessDetection(self.harness, bool(paths) or available, available, paths, artifacts, warnings)
+
+    def install(self, context: HarnessContext) -> dict[str, object]:
+        """Install shared native hooks and publish a receipt only after their proofs verify."""
+        providers = paseo_providers(context)
+        path = receipt_path(context)
+        # Reinstall every available supported native provider, including drifted
+        # installations. An empty receipt intentionally makes each a fresh target.
+        rows = _provider_rows(providers, context, {})
+        targets = sorted({str(row["native_harness"]) for row in rows if row["status"] == "not-installed"})
+        if not targets:
+            raise ValueError(
+                "No supported, enabled Paseo provider runtime was found. Install a native provider on the daemon "
+                "host and remove custom command/config-home overrides, then run hol-guard install paseo again."
+            )
+        # Preflight all known write targets before touching shared native settings.
+        for target in targets:
+            preflight_native(target, context)
+        for shim in self.guard_launcher_paths(native_context(context)):
+            require_local_path(context.guard_home, shim)
+        # A failed repair must not leave a receipt claiming the new install succeeded.
+        path.unlink(missing_ok=True)
+        proofs: dict[str, object] = {}
+        for target in targets:
+            proofs[target] = install_native(target, context)
+        if paseo_providers(context) != providers:
+            raise ValueError("Paseo providers changed during installation; rerun hol-guard install paseo.")
+        shim_manifest = install_guard_shim(self.harness, native_context(context))
+        receipt = write_receipt(context, proofs)
+        return {
+            **shim_manifest,
+            "harness": self.harness,
+            "active": True,
+            "config_path": str(path),
+            "mode": "native-provider-hooks",
+            "coverage_status": "limited",
+            "cloud_inventory_status": "native-providers-only",
+            "runtime_verification": "not-performed",
+            "providers": _provider_rows(providers, context, receipt),
+            "protection_artifact_paths": protection_paths(receipt),
+            "notes": [
+                PASEO_COVERAGE_LIMIT,
+                "Start new provider sessions after installation. Existing sessions may retain old hooks.",
+                "Paseo configuration, provider commands, credentials, models, and permissions were not changed.",
+                "Native hooks are shared with other clients and remain installed when Paseo support is removed.",
+            ],
+        }
+
+    def uninstall(self, context: HarnessContext) -> dict[str, object]:
+        """Remove Paseo-owned artifacts without disabling other clients' shared native hooks."""
+        receipt_path(context).unlink(missing_ok=True)
+        return {
+            **remove_guard_shim(self.harness, context),
+            "harness": self.harness,
+            "active": False,
+            "notes": [
+                "Removed Paseo's installation receipt and launcher. Shared native Guard hooks were left intact.",
+                "Use hol-guard uninstall <native-harness> separately to remove native protection for all clients.",
+            ],
+        }
+
+    def diagnostics(self, context: HarnessContext) -> dict[str, object]:
+        """Report current per-provider coverage and installation drift without claiming live execution."""
+        payload = super().diagnostics(context)
+        try:
+            receipt = read_receipt(context)
+            rows = _provider_rows(paseo_providers(context), context, receipt)
+            installed = any(row["status"] == "native-hooks-installed" for row in rows)
+            changed = any(row["status"] == "changed" for row in rows)
+            incomplete = any(row["status"] in {"not-installed", "runtime-unavailable"} for row in rows)
+            found = payload.get("installed") or payload.get("config_paths")
+            if changed:
+                status = "broken"
+            elif installed and not incomplete:
+                status = "active"
+            elif found:
+                status = "partial"
+            else:
+                status = "not_found"
+            payload.update(
+                {
+                    "setup_status": status,
+                    "providers": rows,
+                    "coverage_status": "limited",
+                    "cloud_inventory_status": "native-providers-only",
+                    "runtime_verification": "not-performed",
+                }
+            )
+        except (OSError, ValueError) as error:
+            payload.update({"setup_status": "broken", "providers": [], "warnings": [str(error), PASEO_COVERAGE_LIMIT]})
+        return payload

--- a/src/codex_plugin_scanner/guard/adapters/paseo_config.py
+++ b/src/codex_plugin_scanner/guard/adapters/paseo_config.py
@@ -1,0 +1,198 @@
+"""Read Paseo configuration without persisting credentials or changing it."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+
+from .base import HarnessContext
+
+PASEO_NATIVE_HARNESSES = {
+    "claude": "claude-code",
+    "codex": "codex",
+    "copilot": "copilot",
+    "opencode": "opencode",
+    "pi": "pi",
+    "omp": "omp",
+}
+_MAX_CONFIG_BYTES = 2 * 1024 * 1024
+_PROVIDER_ID = re.compile(r"^[a-z][a-z0-9-]{0,127}$")
+_COMMON_OVERRIDES = frozenset(
+    {
+        "HOME",
+        "USERPROFILE",
+        "HOMEDRIVE",
+        "HOMEPATH",
+        "PATH",
+        "NODE_OPTIONS",
+        "PYTHONPATH",
+        "PYTHONHOME",
+        "LD_PRELOAD",
+        "LD_LIBRARY_PATH",
+        "DYLD_INSERT_LIBRARIES",
+        "DYLD_LIBRARY_PATH",
+        "BASH_ENV",
+        "ENV",
+    }
+)
+_RUNTIME_OVERRIDES = {
+    "claude-code": ("CLAUDE_CONFIG_DIR", "CLAUDE_CODE_DISABLE_HOOKS", "CLAUDE_CODE_SIMPLE"),
+    "codex": ("CODEX_HOME",),
+    "copilot": ("COPILOT_HOME", "COPILOT_CONFIG_DIR", "XDG_CONFIG_HOME"),
+    "opencode": ("OPENCODE_CONFIG", "OPENCODE_DISABLE", "XDG_CONFIG_HOME"),
+    "pi": ("PI_CODING_AGENT_DIR", "PI_CONFIG_DIR", "PI_PROFILE"),
+    "omp": ("PI_CODING_AGENT_DIR", "PI_CONFIG_DIR", "PI_PROFILE", "OMP_AGENT_DIR", "OMP_PROFILE"),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class PaseoProvider:
+    provider_id: str
+    native_harness: str | None
+    enabled: bool
+    unsupported_reason: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        """Expose provider identity and coverage limits without copying credentials."""
+        return {
+            "provider": self.provider_id,
+            "native_harness": self.native_harness,
+            "enabled": self.enabled,
+            "unsupported_reason": self.unsupported_reason,
+        }
+
+
+def paseo_config_path(context: HarnessContext) -> Path:
+    """Select the daemon home while respecting an explicitly supplied Guard home."""
+    override = "" if context.home_override_explicit else os.environ.get("PASEO_HOME", "").strip()
+    if not override:
+        return context.home_dir / ".paseo" / "config.json"
+    if override == "~" or override.startswith("~/"):
+        root = context.home_dir / override[2:] if override != "~" else context.home_dir
+    else:
+        root = Path(override)
+    if not root.is_absolute():
+        raise ValueError("Use an absolute PASEO_HOME on the Paseo daemon host.")
+    return root / "config.json"
+
+
+def require_local_path(root: Path, path: Path) -> None:
+    """Reject symlinks and non-regular leaves before managed native writes."""
+    try:
+        relative = path.absolute().relative_to(root.absolute())
+    except ValueError as error:
+        raise ValueError("Paseo managed path escapes its declared root.") from error
+    candidate = root
+    for part in ("", *relative.parts):
+        candidate = candidate / part if part else candidate
+        if candidate.is_symlink():
+            raise ValueError(f"Paseo refuses a symlink in a managed path: {candidate}")
+        if candidate.exists():
+            metadata = candidate.stat()
+            if not (stat.S_ISDIR(metadata.st_mode) or stat.S_ISREG(metadata.st_mode)):
+                raise ValueError(f"Paseo requires regular managed files: {candidate}")
+            if stat.S_ISREG(metadata.st_mode) and metadata.st_nlink != 1:
+                raise ValueError(f"Paseo refuses a multiply-linked managed file: {candidate}")
+
+
+def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    """Reject duplicate keys instead of silently accepting ambiguous provider settings."""
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError("Duplicate JSON keys are not supported in Paseo configuration.")
+        result[key] = value
+    return result
+
+
+def read_config_object(path: Path) -> dict[str, object]:
+    """Bounded, no-follow read; malformed content is never treated as empty."""
+    if not path.exists() and not path.is_symlink():
+        return {}
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    try:
+        if path.is_symlink():
+            raise ValueError("Symlinked configuration is not supported.")
+        descriptor = os.open(path, flags)
+        with os.fdopen(descriptor, "rb") as source:
+            metadata = os.fstat(source.fileno())
+            if not stat.S_ISREG(metadata.st_mode) or metadata.st_size > _MAX_CONFIG_BYTES:
+                raise ValueError("Configuration must be a bounded regular file.")
+            content = source.read(_MAX_CONFIG_BYTES + 1)
+        if len(content) > _MAX_CONFIG_BYTES:
+            raise ValueError("Configuration exceeds the size limit.")
+        payload = json.loads(content.decode("utf-8"), object_pairs_hook=_unique_object)
+        if not isinstance(payload, dict):
+            raise ValueError("Configuration must be a JSON object.")
+        return payload
+    except (OSError, UnicodeError, ValueError) as error:
+        # Never include JSON snippets or environment values in diagnostics.
+        raise ValueError(
+            f"Cannot safely read configuration at {path}; repair it before installing Paseo protection."
+        ) from error
+
+
+def _object_field(payload: dict[str, object], key: str) -> dict[str, object]:
+    """Read an optional object field without silently accepting malformed configuration."""
+    value = payload.get(key, {})
+    if not isinstance(value, dict):
+        raise ValueError(f"Paseo {key} must be a JSON object.")
+    return value
+
+
+def _override_reason(harness: str, entry: dict[str, object]) -> str | None:
+    """Identify execution overrides that can relocate or bypass native protection."""
+    if "command" in entry:
+        return "Custom provider commands require separate native Guard configuration and verification."
+    environment = _object_field(entry, "env")
+    if any(not isinstance(value, str) for value in environment.values()):
+        raise ValueError("Paseo provider environment values must be strings.")
+    prefixes = (*_RUNTIME_OVERRIDES[harness], "HOL_GUARD_", "GUARD_")
+    provider_keys = {str(key).upper() for key in environment}
+    if provider_keys.intersection(_COMMON_OVERRIDES) or any(key.startswith(prefixes) for key in provider_keys):
+        return "Provider environment overrides may relocate or disable native Guard protection."
+    if any(value and key.upper().startswith(_RUNTIME_OVERRIDES[harness]) for key, value in os.environ.items()):
+        return "The current environment redirects this runtime; verify the daemon's native configuration separately."
+    return None
+
+
+def _effective_provider_entry(raw: dict[str, object], base: object) -> dict[str, object]:
+    """Merge the inherited native command and environment before classifying coverage."""
+    if not isinstance(base, dict):
+        raise ValueError("Paseo inherited provider configuration must be a JSON object.")
+    return {**base, **raw, "env": {**_object_field(base, "env"), **_object_field(raw, "env")}}
+
+
+def _provider(provider_id: str, raw: object, entries: dict[str, object]) -> PaseoProvider:
+    """Classify a profile using its effective inherited command and environment."""
+    if not _PROVIDER_ID.fullmatch(provider_id) or not isinstance(raw, dict):
+        raise ValueError("Paseo providers must use valid provider IDs and JSON objects.")
+    enabled = raw.get("enabled", provider_id != "omp")
+    if not isinstance(enabled, bool):
+        raise ValueError("Paseo provider enabled must be a boolean.")
+    base = raw.get("extends", provider_id)
+    native = PASEO_NATIVE_HARNESSES.get(base) if isinstance(base, str) else None
+    reason = "ACP and plugin providers require a separately verified native Guard integration."
+    if native is not None:
+        inherited = entries.get(str(base), {}) if base != provider_id else {}
+        effective = _effective_provider_entry(raw, inherited)
+        if isinstance(inherited, dict) and "extends" in inherited:
+            reason = "Nested provider inheritance requires separate native Guard verification."
+        else:
+            reason = _override_reason(native, effective)
+    return PaseoProvider(provider_id, native, enabled, reason)
+
+
+def paseo_providers(context: HarnessContext) -> tuple[PaseoProvider, ...]:
+    """Read bounded provider configuration and include the supported native defaults."""
+    payload = read_config_object(paseo_config_path(context))
+    providers = _object_field(_object_field(payload, "agents"), "providers")
+    if len(providers) > 256:
+        raise ValueError("Paseo provider configuration exceeds the supported provider count.")
+    entries: dict[str, object] = {key: {} for key in PASEO_NATIVE_HARNESSES}
+    entries.update(providers)
+    return tuple(_provider(key, value, entries) for key, value in sorted(entries.items()))

--- a/src/codex_plugin_scanner/guard/adapters/paseo_config.py
+++ b/src/codex_plugin_scanner/guard/adapters/paseo_config.py
@@ -80,14 +80,27 @@ def paseo_config_path(context: HarnessContext) -> Path:
     return root / "config.json"
 
 
-def require_local_path(root: Path, path: Path) -> None:
-    """Reject symlinks and non-regular leaves before managed native writes."""
+def require_local_path(root: Path, path: Path, *, home_dir: Path | None = None) -> None:
+    """Reject redirected ancestors and non-regular files before managed writes.
+
+    A supplied user home is an explicit trust anchor and may itself be symlinked.
+    Links below that home, including above a not-yet-created Guard root, are not.
+    """
+    root = Path(os.path.abspath(root))
+    path = Path(os.path.abspath(path))
     try:
-        relative = path.absolute().relative_to(root.absolute())
+        relative = path.relative_to(root)
     except ValueError as error:
         raise ValueError("Paseo managed path escapes its declared root.") from error
-    candidate = root
-    for part in ("", *relative.parts):
+    anchor = Path(root.anchor)
+    if home_dir is not None:
+        home = Path(os.path.abspath(home_dir))
+        if root.is_relative_to(home):
+            anchor = home.resolve()
+            root = anchor / root.relative_to(home)
+            path = root / relative
+    candidate = anchor
+    for part in ("", *path.relative_to(anchor).parts):
         candidate = candidate / part if part else candidate
         if candidate.is_symlink():
             raise ValueError(f"Paseo refuses a symlink in a managed path: {candidate}")
@@ -97,6 +110,8 @@ def require_local_path(root: Path, path: Path) -> None:
                 raise ValueError(f"Paseo requires regular managed files: {candidate}")
             if stat.S_ISREG(metadata.st_mode) and metadata.st_nlink != 1:
                 raise ValueError(f"Paseo refuses a multiply-linked managed file: {candidate}")
+    if not path.resolve().is_relative_to(root.resolve()):
+        raise ValueError("Paseo managed path escapes its declared root.")
 
 
 def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
@@ -144,18 +159,34 @@ def _object_field(payload: dict[str, object], key: str) -> dict[str, object]:
     return value
 
 
-def _override_reason(harness: str, entry: dict[str, object]) -> str | None:
+def _override_reason(harness: str, entry: dict[str, object], context: HarnessContext) -> str | None:
     """Identify execution overrides that can relocate or bypass native protection."""
     if "command" in entry:
         return "Custom provider commands require separate native Guard configuration and verification."
-    environment = _object_field(entry, "env")
-    if any(not isinstance(value, str) for value in environment.values()):
-        raise ValueError("Paseo provider environment values must be strings.")
+    environment: dict[str, str] = {}
+    for key, value in _object_field(entry, "env").items():
+        if not isinstance(value, str):
+            raise ValueError("Paseo provider environment values must be strings.")
+        environment[key] = value
     prefixes = (*_RUNTIME_OVERRIDES[harness], "HOL_GUARD_", "GUARD_")
+
+    def redirects(key: str, value: str) -> bool:
+        """Allow only the normal XDG home, never alternate native configuration roots."""
+        if key.upper() == "XDG_CONFIG_HOME" and (
+            not value or (Path(value).is_absolute() and Path(os.path.abspath(value)) == context.home_dir / ".config")
+        ):
+            return False
+        return key.upper().startswith(prefixes)
+
     provider_keys = {str(key).upper() for key in environment}
-    if provider_keys.intersection(_COMMON_OVERRIDES) or any(key.startswith(prefixes) for key in provider_keys):
+    if provider_keys.intersection(_COMMON_OVERRIDES) or any(
+        redirects(key, value) for key, value in environment.items()
+    ):
         return "Provider environment overrides may relocate or disable native Guard protection."
-    if any(value and key.upper().startswith(_RUNTIME_OVERRIDES[harness]) for key, value in os.environ.items()):
+    if any(
+        value and key.upper().startswith(_RUNTIME_OVERRIDES[harness]) and redirects(key, value)
+        for key, value in os.environ.items()
+    ):
         return "The current environment redirects this runtime; verify the daemon's native configuration separately."
     return None
 
@@ -167,7 +198,7 @@ def _effective_provider_entry(raw: dict[str, object], base: object) -> dict[str,
     return {**base, **raw, "env": {**_object_field(base, "env"), **_object_field(raw, "env")}}
 
 
-def _provider(provider_id: str, raw: object, entries: dict[str, object]) -> PaseoProvider:
+def _provider(provider_id: str, raw: object, entries: dict[str, object], context: HarnessContext) -> PaseoProvider:
     """Classify a profile using its effective inherited command and environment."""
     if not _PROVIDER_ID.fullmatch(provider_id) or not isinstance(raw, dict):
         raise ValueError("Paseo providers must use valid provider IDs and JSON objects.")
@@ -183,7 +214,7 @@ def _provider(provider_id: str, raw: object, entries: dict[str, object]) -> Pase
         if isinstance(inherited, dict) and "extends" in inherited:
             reason = "Nested provider inheritance requires separate native Guard verification."
         else:
-            reason = _override_reason(native, effective)
+            reason = _override_reason(native, effective, context)
     return PaseoProvider(provider_id, native, enabled, reason)
 
 
@@ -195,4 +226,4 @@ def paseo_providers(context: HarnessContext) -> tuple[PaseoProvider, ...]:
         raise ValueError("Paseo provider configuration exceeds the supported provider count.")
     entries: dict[str, object] = {key: {} for key in PASEO_NATIVE_HARNESSES}
     entries.update(providers)
-    return tuple(_provider(key, value, entries) for key, value in sorted(entries.items()))
+    return tuple(_provider(key, value, entries, context) for key, value in sorted(entries.items()))

--- a/src/codex_plugin_scanner/guard/adapters/paseo_install.py
+++ b/src/codex_plugin_scanner/guard/adapters/paseo_install.py
@@ -41,7 +41,7 @@ def receipt_path(context: HarnessContext) -> Path:
     identity = str(paseo_config_path(context).absolute())
     suffix = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:20]
     path = context.guard_home / "managed" / "paseo" / f"{suffix}.json"
-    require_local_path(context.guard_home, path)
+    require_local_path(context.guard_home, path, home_dir=context.home_dir)
     return path
 
 
@@ -88,24 +88,27 @@ def preflight_native(harness: str, context: HarnessContext) -> None:
     """Validate every known native write target before shared configuration changes."""
     for relative in _NATIVE_CONFIGS[harness]:
         path = context.home_dir / relative
-        require_local_path(context.home_dir, path)
+        require_local_path(context.home_dir, path, home_dir=context.home_dir)
         if path.suffix == ".json":
             read_config_object(path)
     managed = context.guard_home / "managed" / harness
-    require_local_path(context.guard_home, managed)
+    require_local_path(context.guard_home, managed, home_dir=context.home_dir)
     if managed.is_dir():
         for path in managed.rglob("*"):
-            require_local_path(context.guard_home, path)
+            require_local_path(context.guard_home, path, home_dir=context.home_dir)
     if harness == "opencode":
-        require_local_path(context.guard_home, context.guard_home / "opencode/plugins/hol-guard-pretool.ts")
+        require_local_path(
+            context.guard_home, context.guard_home / "opencode/plugins/hol-guard-pretool.ts", home_dir=context.home_dir
+        )
     for path in get_adapter(harness).guard_launcher_paths(context):
-        require_local_path(context.guard_home, path)
+        require_local_path(context.guard_home, path, home_dir=context.home_dir)
 
 
 def install_native(harness: str, context: HarnessContext) -> dict[str, object]:
     """Install and register one native provider with all required artifact proofs."""
     from ..store import GuardStore
 
+    preflight_native(harness, context)
     manifest = get_adapter(harness).install(native_context(context))
     primary = manifest.get("config_path")
     if manifest.get("active") is not True or not isinstance(primary, str) or not Path(primary).is_file():

--- a/src/codex_plugin_scanner/guard/adapters/paseo_install.py
+++ b/src/codex_plugin_scanner/guard/adapters/paseo_install.py
@@ -1,0 +1,152 @@
+"""Paseo's native-provider installation receipt and shared-hook ownership."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ..codex_hook_integrity import atomic_write_text
+from ..managed_install_proof import bind_managed_install_proof, verify_managed_install_proof
+from . import get_adapter
+from .base import HarnessContext
+from .paseo_config import PaseoProvider, paseo_config_path, read_config_object, require_local_path
+
+_RECEIPT_SCHEMA = "guard.paseo-native-install.v1"
+_NATIVE_CONFIGS = {
+    "claude-code": (".claude/settings.json",),
+    "codex": (".codex/config.toml", ".codex/hooks.json"),
+    "copilot": (".copilot/config.json", ".copilot/mcp-config.json"),
+    "opencode": (
+        ".config/opencode/opencode.json",
+        ".config/opencode/opencode.jsonc",
+        ".config/opencode/plugins/hol-guard-pretool.ts",
+    ),
+    "pi": (".pi/agent/settings.json", ".pi/agent/extensions/hol-guard.ts"),
+    "omp": (".omp/agent/settings.json", ".omp/agent/extensions/hol-guard.ts"),
+}
+
+
+def native_context(context: HarnessContext) -> HarnessContext:
+    # Paseo chooses a different cwd for every session/worktree. Do not pin hooks
+    # to the workspace from which the user happened to run the installer.
+    """Install hooks for the daemon user rather than the caller's current worktree."""
+    return replace(context, workspace_dir=None, workspace_override_explicit=False)
+
+
+def receipt_path(context: HarnessContext) -> Path:
+    """Derive a safe per-daemon receipt path inside Guard's managed state."""
+    identity = str(paseo_config_path(context).absolute())
+    suffix = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:20]
+    path = context.guard_home / "managed" / "paseo" / f"{suffix}.json"
+    require_local_path(context.guard_home, path)
+    return path
+
+
+def read_receipt(context: HarnessContext) -> dict[str, object]:
+    """Validate that a receipt belongs to this daemon configuration and schema."""
+    payload = read_config_object(receipt_path(context))
+    if not payload:
+        return {}
+    if payload.get("schema_version") != _RECEIPT_SCHEMA or payload.get("paseo_config_path") != str(
+        paseo_config_path(context).absolute()
+    ):
+        raise ValueError("Paseo's installation receipt is invalid; run hol-guard apps repair paseo.")
+    if not isinstance(payload.get("native_proofs"), dict):
+        raise ValueError("Paseo's native installation proofs are missing; run hol-guard apps repair paseo.")
+    return payload
+
+
+def _proof_paths(proof: dict[str, object]) -> list[str]:
+    """Extract only explicitly recorded native protection artifact paths."""
+    envelope = proof.get("protection_artifact_proof")
+    artifacts = envelope.get("artifacts", []) if isinstance(envelope, dict) else []
+    if not isinstance(artifacts, list):
+        return []
+    return [item["path"] for item in artifacts if isinstance(item, dict) and isinstance(item.get("path"), str)]
+
+
+def provider_status(provider: PaseoProvider, context: HarnessContext, receipt: dict[str, object]) -> str:
+    """Distinguish disabled, unsupported, unavailable, missing, and changed native installs."""
+    if not provider.enabled:
+        return "disabled"
+    if provider.unsupported_reason or provider.native_harness is None:
+        return "unsupported"
+    adapter = get_adapter(provider.native_harness)
+    if adapter.resolved_executable(native_context(context)) is None:
+        return "runtime-unavailable"
+    proofs = receipt.get("native_proofs", {})
+    proof = proofs.get(provider.native_harness) if isinstance(proofs, dict) else None
+    if proof is None:
+        return "not-installed"
+    return "native-hooks-installed" if verify_managed_install_proof(proof, context) is True else "changed"
+
+
+def preflight_native(harness: str, context: HarnessContext) -> None:
+    """Validate every known native write target before shared configuration changes."""
+    for relative in _NATIVE_CONFIGS[harness]:
+        path = context.home_dir / relative
+        require_local_path(context.home_dir, path)
+        if path.suffix == ".json":
+            read_config_object(path)
+    managed = context.guard_home / "managed" / harness
+    require_local_path(context.guard_home, managed)
+    if managed.is_dir():
+        for path in managed.rglob("*"):
+            require_local_path(context.guard_home, path)
+    if harness == "opencode":
+        require_local_path(context.guard_home, context.guard_home / "opencode/plugins/hol-guard-pretool.ts")
+    for path in get_adapter(harness).guard_launcher_paths(context):
+        require_local_path(context.guard_home, path)
+
+
+def install_native(harness: str, context: HarnessContext) -> dict[str, object]:
+    """Install and register one native provider with all required artifact proofs."""
+    from ..store import GuardStore
+
+    manifest = get_adapter(harness).install(native_context(context))
+    primary = manifest.get("config_path")
+    if manifest.get("active") is not True or not isinstance(primary, str) or not Path(primary).is_file():
+        raise ValueError(f"The {harness} adapter did not install native protection; Paseo setup was not completed.")
+    additional = [
+        str(context.home_dir / relative)
+        for relative in _NATIVE_CONFIGS[harness]
+        if harness != "opencode" and (context.home_dir / relative).is_file()
+    ]
+    for key in ("managed_hook_manifest_path", "managed_hook_config_path", "managed_plugin_path", "global_plugin_path"):
+        value = manifest.get(key)
+        if isinstance(value, str):
+            additional.append(value)
+    bound = bind_managed_install_proof({**manifest, "protection_artifact_paths": additional}, context)
+    proof = {"protection_artifact_proof": bound["protection_artifact_proof"]}
+    if str(Path(primary).resolve()) not in _proof_paths(proof):
+        raise ValueError(f"Cannot verify {harness}'s native installation inside the managed home.")
+    # Native hook reviews retain the native harness identity. Register their
+    # manifests too, so health checks, repairs and approval proofs see them.
+    GuardStore(context.guard_home).set_managed_install(
+        harness, True, None, bound, datetime.now(timezone.utc).isoformat()
+    )
+    return proof
+
+
+def write_receipt(context: HarnessContext, proofs: dict[str, object]) -> dict[str, object]:
+    """Publish a private receipt only while every native proof still verifies."""
+    if not proofs or any(verify_managed_install_proof(proof, context) is not True for proof in proofs.values()):
+        raise ValueError("Native protection changed during Paseo installation; rerun setup before relying on it.")
+    payload: dict[str, object] = {
+        "schema_version": _RECEIPT_SCHEMA,
+        "paseo_config_path": str(paseo_config_path(context).absolute()),
+        "native_proofs": proofs,
+    }
+    atomic_write_text(receipt_path(context), json.dumps(payload, indent=2) + "\n")
+    return payload
+
+
+def protection_paths(receipt: dict[str, object]) -> list[str]:
+    """Deduplicate the native artifact paths included in the composite proof."""
+    proofs = receipt.get("native_proofs", {})
+    if not isinstance(proofs, dict):
+        return []
+    return sorted({path for proof in proofs.values() if isinstance(proof, dict) for path in _proof_paths(proof)})

--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -175,6 +175,8 @@ def sync_aibom_snapshots(
         primary_content_sources=primary_content_sources,
     )
     snapshots = cloud_syncable_snapshots(snapshots)
+    cloud_snapshot_ids = {snapshot.snapshot_id for snapshot in snapshots}
+    primary_content_sources = [source for source in primary_content_sources if source.snapshot_id in cloud_snapshot_ids]
     if not snapshots:
         synced_at = generated_at
         summary: dict[str, object] = {

--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -3,298 +3,79 @@
 from __future__ import annotations
 
 import importlib
-import json
 import os
-import time
+import time as time
 import urllib.error
-import uuid
-from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from types import SimpleNamespace
-from typing import Any, Literal
+from typing import Any
 
-from ..version import __version__
-from .adapters.base import HarnessContext
-from .aibom_content_upload import (
-    GuardAibomPrimaryContentSource,
-    empty_content_upload_summary,
-    merge_content_upload_summary,
-    primary_content_sources_from_artifacts,
-    upload_primary_content_sources,
-)
-from .aibom_trust_metadata import apply_local_trust_metadata
-from .inventory_cisco import run_cisco_inventory_scans
-from .inventory_contract import (
-    GuardAgentInventorySnapshot,
-    cloud_inventory_artifacts_from_detection,
-    extract_aibom_metadata_extensions,
-    inventory_snapshot_from_detection,
-    redact_local_path,
-    serialize_inventory_snapshot,
-)
-from .store import GuardStore
-
-AibomExportFormat = Literal["json", "markdown"]
-
-
-@dataclass(frozen=True, slots=True)
-class AibomCliOptions:
-    include_symlinks: bool = True
-    follow_unsafe_symlinks: bool = False
-    cisco_skill_scan: str = "off"
-    cisco_mcp_scan: str = "off"
-    cisco_timeout_seconds: float | None = None
-
-
-_AIBOM_CLOUD_SYNC_OPTIONS = AibomCliOptions(
-    cisco_skill_scan="auto",
-    cisco_mcp_scan="auto",
-    cisco_timeout_seconds=30.0,
-)
+from ..version import __version__ as __version__
+from .adapters.base import HarnessContext as HarnessContext
+from .aibom_cloud_contract import cloud_syncable_snapshots as cloud_syncable_snapshots
+from .aibom_cloud_contract import inventory_snapshot_event as _inventory_snapshot_event
+from .aibom_collection import _resolve_trust_attestation_context as _resolve_trust_attestation_context
+from .aibom_collection import collect_aibom_snapshots as collect_aibom_snapshots
+from .aibom_commands import build_aibom_export_payload as build_aibom_export_payload
+from .aibom_commands import build_aibom_status_payload as build_aibom_status_payload
+from .aibom_commands import build_inventory_json_payload as build_inventory_json_payload
+from .aibom_commands import sync_aibom_snapshots_if_due as sync_aibom_snapshots_if_due
+from .aibom_content_upload import GuardAibomPrimaryContentSource as GuardAibomPrimaryContentSource
+from .aibom_content_upload import empty_content_upload_summary as empty_content_upload_summary
+from .aibom_content_upload import merge_content_upload_summary as merge_content_upload_summary
+from .aibom_content_upload import primary_content_sources_from_artifacts as primary_content_sources_from_artifacts
+from .aibom_content_upload import upload_primary_content_sources as upload_primary_content_sources
+from .aibom_models import _AIBOM_AUTO_SYNC_INTERVAL_SECONDS as _AIBOM_AUTO_SYNC_INTERVAL_SECONDS
+from .aibom_models import _AIBOM_CLOUD_SYNC_OPTIONS as _AIBOM_CLOUD_SYNC_OPTIONS
+from .aibom_models import _AIBOM_EMPTY_SYNC_RETRY_SECONDS as _AIBOM_EMPTY_SYNC_RETRY_SECONDS
+from .aibom_models import _AIBOM_GUARD_EVENTS_BACKOFF_KEY as _AIBOM_GUARD_EVENTS_BACKOFF_KEY
+from .aibom_models import _AIBOM_GUARD_EVENTS_BACKOFF_MINUTES as _AIBOM_GUARD_EVENTS_BACKOFF_MINUTES
+from .aibom_models import _AIBOM_MAX_REQUEST_BODY_BYTES as _AIBOM_MAX_REQUEST_BODY_BYTES
+from .aibom_models import _AIBOM_SYNC_BATCH_SIZE as _AIBOM_SYNC_BATCH_SIZE
+from .aibom_models import AibomCliOptions as AibomCliOptions
+from .aibom_models import AibomExportFormat as AibomExportFormat
+from .aibom_reporting import _aggregate_redaction_report as _aggregate_redaction_report
+from .aibom_reporting import _aibom_connection_status as _aibom_connection_status
+from .aibom_reporting import _artifact_rows_from_store as _artifact_rows_from_store
+from .aibom_reporting import _metadata_lookup_from_snapshots as _metadata_lookup_from_snapshots
+from .aibom_reporting import _redact_inventory_store_item as _redact_inventory_store_item
+from .aibom_reporting import _render_aibom_markdown as _render_aibom_markdown
+from .aibom_reporting import _store_only_artifact_metadata_extensions as _store_only_artifact_metadata_extensions
+from .aibom_reporting import _store_row_config_path as _store_row_config_path
+from .aibom_reporting import summarize_aibom_drift as summarize_aibom_drift
+from .aibom_reporting import summarize_aibom_layers as summarize_aibom_layers
+from .aibom_reporting import summarize_aibom_trust as summarize_aibom_trust
+from .aibom_sync import _accepted_snapshot_ids as _accepted_snapshot_ids
+from .aibom_sync import _batch_inventory_events as _batch_inventory_events
+from .aibom_sync import _inventory_events_request_body as _inventory_events_request_body
+from .aibom_sync import _sync_summary as _sync_summary
+from .aibom_sync import _sync_timestamp_from_payload as _sync_timestamp_from_payload
+from .aibom_trust_metadata import apply_local_trust_metadata as apply_local_trust_metadata
+from .inventory_cisco import run_cisco_inventory_scans as run_cisco_inventory_scans
+from .inventory_contract import GuardAgentInventorySnapshot as GuardAgentInventorySnapshot
+from .inventory_contract import cloud_inventory_artifacts_from_detection as cloud_inventory_artifacts_from_detection
+from .inventory_contract import extract_aibom_metadata_extensions as extract_aibom_metadata_extensions
+from .inventory_contract import inventory_snapshot_from_detection as inventory_snapshot_from_detection
+from .inventory_contract import redact_local_path as redact_local_path
+from .inventory_contract import serialize_inventory_snapshot as serialize_inventory_snapshot
+from .store import GuardStore as GuardStore
 
 
 def _runner_module():
+    """Load the runtime lazily to retain the CLI dependency and testing interface."""
     return importlib.import_module(".runtime.runner", __package__)
 
 
 def detect_all(context: HarnessContext):
+    """Delegate native discovery through the current runtime module."""
     return importlib.import_module(".consumer", __package__).detect_all(context)
 
 
-def collect_aibom_snapshots(
-    context: HarnessContext,
-    *,
-    generated_at: str,
-    options: AibomCliOptions | None = None,
-    trust_attestation_context: dict[str, object] | None = None,
-    primary_content_sources: list[GuardAibomPrimaryContentSource] | None = None,
-) -> tuple[GuardAgentInventorySnapshot, ...]:
-    resolved = options or AibomCliOptions()
-    snapshots: list[GuardAgentInventorySnapshot] = []
-    remaining_cisco_timeout_seconds = resolved.cisco_timeout_seconds
-    for detection in detect_all(context):
-        if not detection.installed and not detection.artifacts:
-            continue
-        cisco_started = time.monotonic()
-        cisco_runs = run_cisco_inventory_scans(
-            harness=str(getattr(detection, "harness", "unknown")),
-            context=context,
-            detection=detection,
-            mcp_mode=resolved.cisco_mcp_scan,
-            skill_mode=resolved.cisco_skill_scan,
-            timeout_seconds=remaining_cisco_timeout_seconds,
-        )
-        if remaining_cisco_timeout_seconds is not None:
-            remaining_cisco_timeout_seconds = max(
-                remaining_cisco_timeout_seconds - max(time.monotonic() - cisco_started, 0.0),
-                0.0,
-            )
-        artifacts = cloud_inventory_artifacts_from_detection(
-            detection,
-            home_dir=context.home_dir,
-            workspace_dir=context.workspace_dir,
-        )
-        snapshot = inventory_snapshot_from_detection(
-            detection,
-            generated_at=generated_at,
-            home_dir=context.home_dir,
-            workspace_dir=context.workspace_dir,
-            cisco_runs=cisco_runs,
-            include_symlinks=resolved.include_symlinks,
-            follow_unsafe_symlinks=resolved.follow_unsafe_symlinks,
-            trust_attestation_context=trust_attestation_context,
-            artifacts=artifacts,
-        )
-        snapshots.append(snapshot)
-        if primary_content_sources is not None:
-            primary_content_sources.extend(
-                primary_content_sources_from_artifacts(
-                    artifacts,
-                    snapshot,
-                    workspace_dir=context.workspace_dir,
-                )
-            )
-    return tuple(snapshots)
-
-
-def _resolve_trust_attestation_context(
-    store: GuardStore,
-    *,
-    generated_at: str,
-    include_upload_session_bindings: bool = False,
-    workspace_id: str | None = None,
-) -> dict[str, object]:
-    from .runtime.trust_attestation import (
-        resolve_guard_oauth_trust_attestation_signing_config,
-        resolve_trust_attestation_signing_config,
-        trust_attestation_v2_enabled,
-    )
-
-    oauth_credentials = store.get_oauth_local_credentials(allow_primary=True)
-    signing_config = resolve_guard_oauth_trust_attestation_signing_config(oauth_credentials)
-    if signing_config is None:
-        # Only auto-generate persistent key during sync (not read-only status/export/inventory)
-        guard_home = store.guard_home if include_upload_session_bindings else None
-        signing_config = resolve_trust_attestation_signing_config(guard_home=guard_home)
-    enable_v2 = trust_attestation_v2_enabled()
-    resolved_workspace_id = workspace_id or store.get_cloud_workspace_id()
-    installation_id = store.get_or_create_installation_id() if enable_v2 else None
-    context: dict[str, object] = {
-        "analyzerId": "hol-guard" if enable_v2 else None,
-        "analyzerSpecVersion": "guard-aibom-trust-spec.v1" if enable_v2 else None,
-        "analyzerVersion": __version__ if enable_v2 else None,
-        "challengeId": None,
-        "deviceId": installation_id,
-        "expiresAt": None,
-        "installationId": installation_id,
-        "nonce": None,
-        "policyVersion": "guard-aibom-trust-policy.v1" if enable_v2 else None,
-        "sequence": None,
-        "signingConfig": signing_config,
-        "uploadId": None,
-        "workspaceId": resolved_workspace_id if enable_v2 else None,
-    }
-    if not enable_v2 or not include_upload_session_bindings:
-        return context
-    try:
-        expires_at = (_aware_utc_timestamp(generated_at) + timedelta(minutes=15)).isoformat().replace("+00:00", "Z")
-    except (OverflowError, TypeError, ValueError):
-        expires_at = None
-    context.update(
-        {
-            "challengeId": f"guard-aibom-challenge-{uuid.uuid4().hex}",
-            "expiresAt": expires_at,
-            "nonce": uuid.uuid4().hex,
-            "sequence": store.next_aibom_trust_attestation_sequence(generated_at),
-            "uploadId": f"guard-aibom-upload-{uuid.uuid4().hex}",
-        }
-    )
-    return context
-
-
-def build_inventory_json_payload(
-    store: Any,
-    context: HarnessContext,
-    *,
-    generated_at: str,
-    options: AibomCliOptions | None = None,
-) -> dict[str, object]:
-    snapshots = collect_aibom_snapshots(
-        context,
-        generated_at=generated_at,
-        options=options,
-        trust_attestation_context=_resolve_trust_attestation_context(store, generated_at=generated_at),
-    )
-    metadata_by_artifact = _metadata_lookup_from_snapshots(snapshots)
-    items: list[dict[str, object]] = []
-    for item in store.list_inventory():
-        enriched = _redact_inventory_store_item(item, home_dir=context.home_dir)
-        artifact_id = str(item.get("artifact_id") or "")
-        harness = str(item.get("harness") or "")
-        extensions = metadata_by_artifact.get((harness, artifact_id))
-        config_path = _store_row_config_path(item) if str(item.get("artifact_type") or "") == "skill_file" else None
-        config_path_exists = config_path.exists() if config_path is not None else None
-        if not extensions:
-            extensions = _store_only_artifact_metadata_extensions(
-                enriched,
-                context=context,
-                generated_at=generated_at,
-                config_path=config_path,
-                config_path_exists=config_path_exists,
-            )
-            if config_path_exists is False:
-                enriched["present"] = False
-        if extensions:
-            enriched.update(extensions)
-        items.append(enriched)
-    redaction_report = _aggregate_redaction_report(snapshots)
-    return {
-        "generated_at": generated_at,
-        "items": items,
-        "snapshots": [serialize_inventory_snapshot(snapshot) for snapshot in snapshots],
-        "redaction_report": redaction_report,
-    }
-
-
-def build_aibom_status_payload(
-    store: Any,
-    context: HarnessContext,
-    *,
-    generated_at: str,
-    options: AibomCliOptions | None = None,
-) -> dict[str, object]:
-    snapshots = collect_aibom_snapshots(
-        context,
-        generated_at=generated_at,
-        options=options,
-        trust_attestation_context=_resolve_trust_attestation_context(store, generated_at=generated_at),
-    )
-    sync_summary = _sync_summary(store)
-    layer_summary, trust_summary, drift_summary = summarize_aibom_layers(
-        snapshots,
-        generated_at=generated_at,
-    )
-    return {
-        "generated_at": generated_at,
-        "status": _aibom_connection_status(store),
-        "layer_summary": layer_summary,
-        "trust_summary": trust_summary,
-        "drift_summary": drift_summary,
-        "redaction_report": _aggregate_redaction_report(snapshots),
-        "last_sync_at": sync_summary.get("synced_at"),
-        "snapshot_count": len(snapshots),
-        "artifact_inventory_count": len(store.list_inventory()),
-    }
-
-
-def build_aibom_export_payload(
-    store: Any,
-    context: HarnessContext,
-    *,
-    generated_at: str,
-    options: AibomCliOptions | None = None,
-    export_format: AibomExportFormat = "json",
-) -> dict[str, object]:
-    snapshots = collect_aibom_snapshots(
-        context,
-        generated_at=generated_at,
-        options=options,
-        trust_attestation_context=_resolve_trust_attestation_context(store, generated_at=generated_at),
-    )
-    serialized_snapshots = [serialize_inventory_snapshot(snapshot) for snapshot in snapshots]
-    artifacts = _artifact_rows_from_store(store, snapshots, context=context, generated_at=generated_at)
-    layer_summary, trust_summary, drift_summary = summarize_aibom_layers(
-        snapshots,
-        generated_at=generated_at,
-    )
-    sync_summary = _sync_summary(store)
-    payload: dict[str, object] = {
-        "generated_at": generated_at,
-        "artifact_count": len(artifacts),
-        "artifacts": artifacts,
-        "snapshots": serialized_snapshots,
-        "layer_summary": layer_summary,
-        "trust_summary": trust_summary,
-        "drift_summary": drift_summary,
-        "redaction_report": _aggregate_redaction_report(snapshots),
-        "last_sync_at": sync_summary.get("synced_at"),
-    }
-    if export_format == "markdown":
-        payload["markdown"] = _render_aibom_markdown(payload)
-    return payload
-
-
-_AIBOM_AUTO_SYNC_INTERVAL_SECONDS = 15 * 60  # 15 min — stale AIBOM data undermines trust surfaces
-_AIBOM_EMPTY_SYNC_RETRY_SECONDS = 2 * 60
-_AIBOM_GUARD_EVENTS_BACKOFF_KEY = "aibom_guard_events_backoff"
-_AIBOM_GUARD_EVENTS_BACKOFF_MINUTES = 5  # matches _GUARD_EVENTS_ENDPOINT_UNAVAILABLE_RETRY_MINUTES
-_AIBOM_SYNC_BATCH_SIZE = 3  # keep each POST under Cloudflare's 100s origin timeout
 # Guard Cloud queues large projection work; preserve snapshot replacement semantics in transit.
-_AIBOM_MAX_REQUEST_BODY_BYTES = 7_500_000  # stay below the portal's 8 MB request limit
 
 
 def _aware_utc_timestamp(value: str) -> datetime:
+    """Normalize a recorded timestamp to timezone-aware UTC."""
     parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     if parsed.tzinfo is None:
         return parsed.replace(tzinfo=timezone.utc)
@@ -307,6 +88,7 @@ def _aibom_sync_is_due(
     generated_at: str,
     min_interval_seconds: int,
 ) -> bool:
+    """Apply freshness and empty-inventory retry intervals to prior sync state."""
     prior = store.get_sync_payload("aibom_sync_summary")
     if not isinstance(prior, dict):
         return True
@@ -328,8 +110,7 @@ def _aibom_sync_is_due(
 
 
 def _aibom_guard_events_endpoint_unavailable_recently(store: Any) -> bool:
-    from datetime import timedelta
-
+    """Respect the recorded missing-endpoint backoff interval."""
     summary = store.get_sync_payload(_AIBOM_GUARD_EVENTS_BACKOFF_KEY)
     if not isinstance(summary, dict):
         return False
@@ -346,77 +127,13 @@ def _aibom_guard_events_endpoint_unavailable_recently(store: Any) -> bool:
 
 
 def _resolve_operator_home_dir(home_dir: Path | None = None) -> Path:
+    """Resolve an explicitly configured operator home or the normal user home."""
     if home_dir is not None:
         return home_dir.expanduser().resolve()
     home_env = os.environ.get("HOME")
     if home_env:
         return Path(home_env).expanduser().resolve()
     return Path.home().resolve()
-
-
-def sync_aibom_snapshots_if_due(
-    store: Any,
-    *,
-    generated_at: str,
-    min_interval_seconds: int = _AIBOM_AUTO_SYNC_INTERVAL_SECONDS,
-    force: bool = False,
-    options: AibomCliOptions | None = None,
-    auth_context: dict[str, object] | None = None,
-    expected_workspace_id: str | None = None,
-    home_dir: Path | None = None,
-    workspace_dir: Path | None = None,
-) -> dict[str, object]:
-    runner = _runner_module()
-    guard_sync_not_configured_error = runner.GuardSyncNotConfiguredError
-
-    current_workspace_id = store.get_cloud_workspace_id()
-    if current_workspace_id is None:
-        return {"synced": False, "skipped": True, "reason": "not_configured"}
-    if expected_workspace_id is not None and current_workspace_id != expected_workspace_id:
-        return {
-            "synced": False,
-            "reason": "workspace_changed",
-            "error": "Guard Cloud workspace changed before AIBOM inventory sync.",
-        }
-    bound_workspace_id = expected_workspace_id or current_workspace_id
-    if _aibom_guard_events_endpoint_unavailable_recently(store):
-        return {
-            "synced": False,
-            "skipped": True,
-            "reason": "guard_events_endpoint_unavailable",
-        }
-    if not force and not _aibom_sync_is_due(
-        store,
-        generated_at=generated_at,
-        min_interval_seconds=min_interval_seconds,
-    ):
-        prior = store.get_sync_payload("aibom_sync_summary")
-        return {
-            "synced": False,
-            "skipped": True,
-            "reason": "recently_synced",
-            "last_sync_at": prior.get("synced_at") if isinstance(prior, dict) else None,
-        }
-    context = HarnessContext(
-        home_dir=_resolve_operator_home_dir(home_dir),
-        workspace_dir=workspace_dir,
-        guard_home=store.guard_home,
-    )
-    try:
-        return sync_aibom_snapshots(
-            store,
-            context,
-            generated_at=generated_at,
-            options=options,
-            auth_context=auth_context,
-            expected_workspace_id=bound_workspace_id,
-        )
-    except guard_sync_not_configured_error:
-        return {"synced": False, "skipped": True, "reason": "not_configured"}
-    except ValueError as error:
-        return {"synced": False, "error": str(error)}
-    except (OSError, RuntimeError) as error:
-        return {"synced": False, "error": str(error)}
 
 
 def sync_aibom_snapshots(
@@ -428,6 +145,7 @@ def sync_aibom_snapshots(
     auth_context: dict[str, object] | None = None,
     expected_workspace_id: str | None = None,
 ) -> dict[str, object]:
+    """Sync compatible snapshots and upload content only after cloud acknowledgment."""
     runner = _runner_module()
     guard_sync_not_configured_error = runner.GuardSyncNotConfiguredError
 
@@ -456,6 +174,7 @@ def sync_aibom_snapshots(
         trust_attestation_context=trust_attestation_context,
         primary_content_sources=primary_content_sources,
     )
+    snapshots = cloud_syncable_snapshots(snapshots)
     if not snapshots:
         synced_at = generated_at
         summary: dict[str, object] = {
@@ -463,7 +182,7 @@ def sync_aibom_snapshots(
             "synced_at": synced_at,
             "snapshots": 0,
             "accepted": 0,
-            "message": "No installed harness snapshots were available to sync.",
+            "message": "No cloud-compatible harness snapshots were available to sync.",
         }
         store.set_sync_payload("aibom_sync_summary", summary, synced_at)
         return summary
@@ -474,11 +193,7 @@ def sync_aibom_snapshots(
         _inventory_snapshot_event(
             snapshot=snapshot,
             workspace_id=workspace_id,
-            device_id=(
-                str(trust_attestation_context["deviceId"])
-                if isinstance(trust_attestation_context.get("deviceId"), str)
-                else None
-            ),
+            device_id=trust_attestation_context.get("deviceId"),
             generated_at=generated_at,
         )
         for snapshot in snapshots
@@ -661,392 +376,3 @@ def sync_aibom_snapshots(
         summary["reason"] = "content_upload_incomplete"
     store.set_sync_payload("aibom_sync_summary", summary, synced_at)
     return summary
-
-
-def summarize_aibom_layers(
-    snapshots: tuple[GuardAgentInventorySnapshot, ...],
-    *,
-    generated_at: str,
-) -> tuple[dict[str, object], dict[str, object], dict[str, object]]:
-    counts = {
-        "instructions": 0,
-        "skills": 0,
-        "mcp": 0,
-        "plugins": 0,
-        "policies": 0,
-        "findings": 0,
-        "trust": 0,
-        "sources": 0,
-        "configSources": 0,
-    }
-    for snapshot in snapshots:
-        counts["findings"] += len(snapshot.findings)
-        counts["configSources"] += len(snapshot.sources)
-        for item in snapshot.items:
-            if item.item_kind in {"overlay", "prompt_pack"}:
-                counts["instructions"] += 1
-            elif item.item_kind == "skill":
-                counts["skills"] += 1
-            elif item.item_kind in {"mcp_server", "mcp_tool"}:
-                counts["mcp"] += 1
-            elif item.item_kind in {"plugin", "daemon_plugin"}:
-                counts["plugins"] += 1
-            elif item.item_kind == "policy":
-                counts["policies"] += 1
-            if isinstance(item.metadata.get("trustResolution"), dict):
-                counts["trust"] += 1
-            source_links = item.metadata.get("sourceLinks")
-            source_of_truth = item.metadata.get("sourceOfTruth")
-            if isinstance(source_links, list) and source_links:
-                counts["sources"] += len(source_links)
-            elif isinstance(source_of_truth, dict):
-                counts["sources"] += 1
-    drift = summarize_aibom_drift(snapshots)
-    trust = summarize_aibom_trust(snapshots)
-    layer_summary = {
-        **counts,
-        "driftCount": drift.get("total", 0),
-        "highRiskCount": drift.get("high_risk", 0),
-        "lowTrustCount": trust.get("low_trust", 0),
-        "generatedAt": generated_at,
-        "staleSnapshot": False,
-    }
-    return layer_summary, trust, drift
-
-
-def summarize_aibom_trust(snapshots: tuple[GuardAgentInventorySnapshot, ...]) -> dict[str, object]:
-    covered = 0
-    eligible = 0
-    low_trust = 0
-    scores: list[int] = []
-    for snapshot in snapshots:
-        for item in snapshot.items:
-            if item.item_kind not in {"skill", "plugin", "mcp_server"}:
-                continue
-            eligible += 1
-            trust = item.metadata.get("trustResolution")
-            if not isinstance(trust, dict):
-                continue
-            covered += 1
-            score = trust.get("trustScore")
-            if isinstance(score, int):
-                scores.append(score)
-                if score < 70:
-                    low_trust += 1
-    coverage_percent = round((covered / eligible) * 100) if eligible else 100
-    average_score = round(sum(scores) / len(scores)) if scores else None
-    return {
-        "eligible": eligible,
-        "covered": covered,
-        "coverage_percent": coverage_percent,
-        "low_trust": low_trust,
-        "average_score": average_score,
-    }
-
-
-def summarize_aibom_drift(snapshots: tuple[GuardAgentInventorySnapshot, ...]) -> dict[str, object]:
-    counts = {"new": 0, "changed": 0, "removed": 0, "unchanged": 0, "high_risk": 0}
-    for snapshot in snapshots:
-        for item in snapshot.items:
-            state = item.drift_state
-            if state in counts:
-                counts[state] += 1
-            if item.risk_level in {"critical", "high"}:
-                counts["high_risk"] += 1
-        for drift in snapshot.drift:
-            state = drift.state
-            if state in counts:
-                counts[state] += 1
-    total = counts["new"] + counts["changed"] + counts["removed"]
-    return {
-        "new": counts["new"],
-        "changed": counts["changed"],
-        "removed": counts["removed"],
-        "unchanged": counts["unchanged"],
-        "high_risk": counts["high_risk"],
-        "total": total,
-    }
-
-
-def _metadata_lookup_from_snapshots(
-    snapshots: tuple[GuardAgentInventorySnapshot, ...],
-) -> dict[tuple[str, str], dict[str, object]]:
-    lookup: dict[tuple[str, str], dict[str, object]] = {}
-    for snapshot in snapshots:
-        harness = snapshot.agent_type
-        for item in snapshot.items:
-            extensions = extract_aibom_metadata_extensions(item.metadata)
-            if not extensions:
-                continue
-            lookup[(harness, item.item_id)] = extensions
-    return lookup
-
-
-def _artifact_rows_from_store(
-    store: Any,
-    snapshots: tuple[GuardAgentInventorySnapshot, ...],
-    *,
-    context: HarnessContext,
-    generated_at: str,
-) -> list[dict[str, object]]:
-    metadata_by_artifact = _metadata_lookup_from_snapshots(snapshots)
-    artifacts: list[dict[str, object]] = []
-    for item in store.list_inventory():
-        trust_verdict = str(item.get("last_policy_action") or "unknown")
-        harness = str(item.get("harness") or "")
-        artifact_id = str(item.get("artifact_id") or "")
-        row: dict[str, object] = dict(item)
-        row["trust_verdict"] = trust_verdict
-        extensions = metadata_by_artifact.get((harness, artifact_id))
-        config_path = _store_row_config_path(row) if str(row.get("artifact_type") or "") == "skill_file" else None
-        config_path_exists = config_path.exists() if config_path is not None else None
-        if not extensions:
-            extensions = _store_only_artifact_metadata_extensions(
-                row,
-                context=context,
-                generated_at=generated_at,
-                config_path=config_path,
-                config_path_exists=config_path_exists,
-            )
-            if config_path_exists is False:
-                row["present"] = False
-        if extensions:
-            row.update(extensions)
-        artifacts.append(row)
-    return artifacts
-
-
-def _store_row_config_path(row: dict[str, object]) -> Path | None:
-    raw_config_path = row.get("config_path")
-    if not isinstance(raw_config_path, str) or not raw_config_path.strip():
-        return None
-    return Path(raw_config_path).expanduser()
-
-
-def _store_only_artifact_metadata_extensions(
-    row: dict[str, object],
-    *,
-    context: HarnessContext,
-    generated_at: str,
-    config_path: Path | None,
-    config_path_exists: bool | None,
-) -> dict[str, object]:
-    artifact_type = str(row.get("artifact_type") or "")
-    if artifact_type != "skill_file":
-        return {}
-    if config_path is None or config_path_exists is not True:
-        return {}
-    artifact = SimpleNamespace(
-        artifact_id=str(row.get("artifact_id") or ""),
-        artifact_type=artifact_type,
-        config_path=str(config_path),
-        name=str(row.get("artifact_name") or row.get("artifact_id") or "skill_file"),
-    )
-    metadata = apply_local_trust_metadata(
-        artifact,
-        captured_at=generated_at,
-        item_kind="skill",
-        metadata={"artifactType": artifact_type},
-        workspace_dir=context.workspace_dir,
-    )
-    return extract_aibom_metadata_extensions(metadata)
-
-
-def _aggregate_redaction_report(
-    snapshots: tuple[GuardAgentInventorySnapshot, ...],
-) -> dict[str, object]:
-    redacted_fields: set[str] = set()
-    raw_secrets = False
-    symlink_items = 0
-    for snapshot in snapshots:
-        report = snapshot.redaction_report
-        if report.get("rawSecretsIncluded") is True:
-            raw_secrets = True
-        fields = report.get("redactedFields")
-        if isinstance(fields, (list, tuple)):
-            redacted_fields.update(str(field) for field in fields)
-        for item in snapshot.items:
-            source_of_truth = item.metadata.get("sourceOfTruth")
-            source_links = item.metadata.get("sourceLinks")
-            if isinstance(source_of_truth, dict) or (isinstance(source_links, list) and source_links):
-                symlink_items += 1
-    return {
-        "rawValuesIncluded": raw_secrets,
-        "redactedFields": sorted(redacted_fields),
-        "symlinkItems": symlink_items,
-        "snapshots": len(snapshots),
-    }
-
-
-def _redact_inventory_store_item(
-    item: dict[str, object],
-    *,
-    home_dir: Path,
-) -> dict[str, object]:
-    redacted = dict(item)
-    config_path = item.get("config_path")
-    if isinstance(config_path, str) and config_path:
-        redacted["config_path"] = redact_local_path(Path(config_path), home_dir=home_dir)
-    return redacted
-
-
-def _aibom_connection_status(store: Any) -> str:
-    if store.get_cloud_sync_profile() is None:
-        return "not_connected"
-    if store.get_cloud_workspace_id() is None:
-        return "workspace_required"
-    sync_summary = _sync_summary(store)
-    if sync_summary.get("synced") is True and sync_summary.get("synced_at"):
-        return "synced"
-    return "sync_required"
-
-
-def _sync_summary(store: Any) -> dict[str, object]:
-    payload = store.get_sync_payload("aibom_sync_summary")
-    return payload if isinstance(payload, dict) else {}
-
-
-def _inventory_snapshot_event(
-    *,
-    snapshot: GuardAgentInventorySnapshot,
-    workspace_id: str,
-    device_id: str | None,
-    generated_at: str,
-) -> dict[str, object]:
-    event_id = str(uuid.uuid4())
-    return {
-        "eventId": event_id,
-        "eventType": "agent.inventory_snapshot",
-        "idempotencyKey": snapshot.snapshot_id,
-        "occurredAt": generated_at,
-        "source": "edge",
-        "workspaceId": workspace_id,
-        "deviceId": device_id,
-        "payload": {"snapshot": serialize_inventory_snapshot(snapshot)},
-    }
-
-
-def _inventory_events_request_body(events: list[dict[str, object]]) -> bytes:
-    return json.dumps({"events": events}).encode("utf-8")
-
-
-def _batch_inventory_events(
-    events: list[dict[str, object]],
-    *,
-    max_batch_size: int = _AIBOM_SYNC_BATCH_SIZE,
-    max_body_bytes: int = _AIBOM_MAX_REQUEST_BODY_BYTES,
-) -> tuple[list[list[dict[str, object]]], list[dict[str, object]]]:
-    """Batch whole inventory snapshots without changing replacement semantics."""
-    if max_batch_size < 1 or max_body_bytes < 1:
-        raise ValueError("AIBOM request batch limits must be positive.")
-
-    batches: list[list[dict[str, object]]] = []
-    oversized_events: list[dict[str, object]] = []
-    batch: list[dict[str, object]] = []
-    for event in events:
-        if len(_inventory_events_request_body([event])) > max_body_bytes:
-            oversized_events.append(event)
-            continue
-
-        candidate = [*batch, event]
-        candidate_too_large = len(_inventory_events_request_body(candidate)) > max_body_bytes
-        if batch and (len(candidate) > max_batch_size or candidate_too_large):
-            batches.append(batch)
-            batch = [event]
-        else:
-            batch = candidate
-
-    if batch:
-        batches.append(batch)
-    return batches, oversized_events
-
-
-def _sync_timestamp_from_payload(payload: dict[str, object]) -> str | None:
-    for key in ("syncedAt", "synced_at", "acceptedAt"):
-        value = payload.get(key)
-        if isinstance(value, str) and value:
-            return value
-    return None
-
-
-def _accepted_snapshot_ids(
-    batch: list[dict[str, object]],
-    payload: dict[str, object],
-) -> set[str]:
-    snapshot_by_event_id: dict[str, str] = {}
-    for event in batch:
-        event_id = event.get("eventId")
-        event_payload = event.get("payload")
-        snapshot_payload = event_payload.get("snapshot") if isinstance(event_payload, dict) else None
-        snapshot_id = snapshot_payload.get("snapshotId") if isinstance(snapshot_payload, dict) else None
-        if isinstance(event_id, str) and isinstance(snapshot_id, str):
-            snapshot_by_event_id[event_id] = snapshot_id
-    accepted_event_ids: set[str] = set()
-    statuses = payload.get("statuses")
-    if isinstance(statuses, list):
-        for status in statuses:
-            if not isinstance(status, dict) or status.get("status") != "accepted":
-                continue
-            event_id = status.get("eventId")
-            if isinstance(event_id, str):
-                accepted_event_ids.add(event_id)
-    if not accepted_event_ids and payload.get("accepted") == len(batch):
-        accepted_event_ids = set(snapshot_by_event_id)
-    return {snapshot_by_event_id[event_id] for event_id in accepted_event_ids if event_id in snapshot_by_event_id}
-
-
-def _render_aibom_markdown(payload: dict[str, object]) -> str:
-    layer_summary = payload.get("layer_summary")
-    trust_summary = payload.get("trust_summary")
-    lines = [
-        "# HOL Guard AIBOM",
-        "",
-        "## Layer summary",
-        "",
-    ]
-    if isinstance(layer_summary, dict):
-        lines.extend(
-            [
-                f"- Instructions: {layer_summary.get('instructions', 0)}",
-                f"- Skills: {layer_summary.get('skills', 0)}",
-                f"- MCP: {layer_summary.get('mcp', 0)}",
-                f"- Plugins: {layer_summary.get('plugins', 0)}",
-                f"- Policies: {layer_summary.get('policies', 0)}",
-                f"- Findings: {layer_summary.get('findings', 0)}",
-                f"- Trust: {layer_summary.get('trust', 0)}",
-                f"- Sources: {layer_summary.get('sources', 0)}",
-                f"- Drift: {layer_summary.get('driftCount', 0)}",
-                "",
-            ]
-        )
-    lines.extend(
-        [
-            "## Artifacts",
-            "",
-            "| Artifact | Harness | Type | Scope | Verdict | Present |",
-            "| --- | --- | --- | --- | --- | --- |",
-        ]
-    )
-    artifacts = payload.get("artifacts")
-    if isinstance(artifacts, list):
-        for item in artifacts:
-            if not isinstance(item, dict):
-                continue
-            lines.append(
-                "| "
-                f"{item.get('artifact_name', '')} | {item.get('harness', '')} | {item.get('artifact_type', '')} | "
-                f"{item.get('source_scope', '')} | {item.get('trust_verdict', '')} | "
-                f"{'yes' if item.get('present') else 'no'} |"
-            )
-    if isinstance(trust_summary, dict):
-        lines.extend(
-            [
-                "",
-                "## Trust coverage",
-                "",
-                f"- Covered: {trust_summary.get('covered', 0)} / {trust_summary.get('eligible', 0)}",
-                f"- Coverage: {trust_summary.get('coverage_percent', 0)}%",
-                "",
-            ]
-        )
-    return "\n".join(lines) + "\n"

--- a/src/codex_plugin_scanner/guard/aibom_cloud_contract.py
+++ b/src/codex_plugin_scanner/guard/aibom_cloud_contract.py
@@ -1,0 +1,42 @@
+"""Consumer-compatible inventory events without relabeling local-only agents."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+
+from .inventory_contract import GuardAgentInventorySnapshot, serialize_inventory_snapshot
+
+
+def cloud_syncable_snapshots(
+    snapshots: Sequence[GuardAgentInventorySnapshot],
+) -> tuple[GuardAgentInventorySnapshot, ...]:
+    """Paseo's composite stays local until the cloud consumer accepts its type.
+
+    Native provider snapshots already carry the tools, policies and receipts.
+    Do not mislabel a Paseo snapshot as a different cloud-supported agent type.
+    """
+    return tuple(snapshot for snapshot in snapshots if snapshot.agent_type != "paseo")
+
+
+def inventory_snapshot_event(
+    *,
+    snapshot: GuardAgentInventorySnapshot,
+    workspace_id: str,
+    device_id: object,
+    generated_at: str,
+) -> dict[str, object]:
+    """Create a cloud-compatible event and reject local-only composite inventories."""
+    if snapshot.agent_type == "paseo":
+        raise ValueError("Paseo composite inventory is local-only; sync its native provider inventories instead.")
+    event_id = str(uuid.uuid4())
+    return {
+        "eventId": event_id,
+        "eventType": "agent.inventory_snapshot",
+        "idempotencyKey": snapshot.snapshot_id,
+        "occurredAt": generated_at,
+        "source": "edge",
+        "workspaceId": workspace_id,
+        "deviceId": device_id if isinstance(device_id, str) else None,
+        "payload": {"snapshot": serialize_inventory_snapshot(snapshot)},
+    }

--- a/src/codex_plugin_scanner/guard/aibom_collection.py
+++ b/src/codex_plugin_scanner/guard/aibom_collection.py
@@ -1,0 +1,135 @@
+"""Aibom collection helpers preserving the public CLI dependency seams."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from datetime import timedelta
+
+from .adapters.base import HarnessContext
+from .aibom_content_upload import (
+    GuardAibomPrimaryContentSource,
+)
+from .aibom_models import (
+    AibomCliOptions,
+)
+from .inventory_contract import (
+    GuardAgentInventorySnapshot,
+)
+from .store import GuardStore
+
+
+def collect_aibom_snapshots(
+    context: HarnessContext,
+    *,
+    generated_at: str,
+    options: AibomCliOptions | None = None,
+    trust_attestation_context: dict[str, object] | None = None,
+    primary_content_sources: list[GuardAibomPrimaryContentSource] | None = None,
+) -> tuple[GuardAgentInventorySnapshot, ...]:
+    """Collect redacted native inventories while preserving the CLI dependency interface."""
+    from . import aibom_cli as api
+
+    resolved = options or api.AibomCliOptions()
+    snapshots: list[api.GuardAgentInventorySnapshot] = []
+    remaining_cisco_timeout_seconds = resolved.cisco_timeout_seconds
+    for detection in api.detect_all(context):
+        if not detection.installed and not detection.artifacts:
+            continue
+        cisco_started = time.monotonic()
+        cisco_runs = api.run_cisco_inventory_scans(
+            harness=str(getattr(detection, "harness", "unknown")),
+            context=context,
+            detection=detection,
+            mcp_mode=resolved.cisco_mcp_scan,
+            skill_mode=resolved.cisco_skill_scan,
+            timeout_seconds=remaining_cisco_timeout_seconds,
+        )
+        if remaining_cisco_timeout_seconds is not None:
+            remaining_cisco_timeout_seconds = max(
+                remaining_cisco_timeout_seconds - max(time.monotonic() - cisco_started, 0.0),
+                0.0,
+            )
+        artifacts = api.cloud_inventory_artifacts_from_detection(
+            detection,
+            home_dir=context.home_dir,
+            workspace_dir=context.workspace_dir,
+        )
+        snapshot = api.inventory_snapshot_from_detection(
+            detection,
+            generated_at=generated_at,
+            home_dir=context.home_dir,
+            workspace_dir=context.workspace_dir,
+            cisco_runs=cisco_runs,
+            include_symlinks=resolved.include_symlinks,
+            follow_unsafe_symlinks=resolved.follow_unsafe_symlinks,
+            trust_attestation_context=trust_attestation_context,
+            artifacts=artifacts,
+        )
+        snapshots.append(snapshot)
+        if primary_content_sources is not None:
+            primary_content_sources.extend(
+                api.primary_content_sources_from_artifacts(
+                    artifacts,
+                    snapshot,
+                    workspace_dir=context.workspace_dir,
+                )
+            )
+    return tuple(snapshots)
+
+
+def _resolve_trust_attestation_context(
+    store: GuardStore,
+    *,
+    generated_at: str,
+    include_upload_session_bindings: bool = False,
+    workspace_id: str | None = None,
+) -> dict[str, object]:
+    """Resolve locally available trust context without changing workspace identity."""
+    from . import aibom_cli as api
+    from .runtime.trust_attestation import (
+        resolve_guard_oauth_trust_attestation_signing_config,
+        resolve_trust_attestation_signing_config,
+        trust_attestation_v2_enabled,
+    )
+
+    oauth_credentials = store.get_oauth_local_credentials(allow_primary=True)
+    signing_config = resolve_guard_oauth_trust_attestation_signing_config(oauth_credentials)
+    if signing_config is None:
+        # Only auto-generate persistent key during sync (not read-only status/export/inventory)
+        guard_home = store.guard_home if include_upload_session_bindings else None
+        signing_config = resolve_trust_attestation_signing_config(guard_home=guard_home)
+    enable_v2 = trust_attestation_v2_enabled()
+    resolved_workspace_id = workspace_id or store.get_cloud_workspace_id()
+    installation_id = store.get_or_create_installation_id() if enable_v2 else None
+    context: dict[str, object] = {
+        "analyzerId": "hol-guard" if enable_v2 else None,
+        "analyzerSpecVersion": "guard-aibom-trust-spec.v1" if enable_v2 else None,
+        "analyzerVersion": api.__version__ if enable_v2 else None,
+        "challengeId": None,
+        "deviceId": installation_id,
+        "expiresAt": None,
+        "installationId": installation_id,
+        "nonce": None,
+        "policyVersion": "guard-aibom-trust-policy.v1" if enable_v2 else None,
+        "sequence": None,
+        "signingConfig": signing_config,
+        "uploadId": None,
+        "workspaceId": resolved_workspace_id if enable_v2 else None,
+    }
+    if not enable_v2 or not include_upload_session_bindings:
+        return context
+    try:
+        expires_at = (api._aware_utc_timestamp(generated_at) + timedelta(minutes=15)).isoformat().replace("+00:00", "Z")
+    except (OverflowError, TypeError, ValueError):
+        expires_at = None
+    context.update(
+        {
+            "challengeId": f"guard-aibom-challenge-{uuid.uuid4().hex}",
+            "expiresAt": expires_at,
+            "nonce": uuid.uuid4().hex,
+            "sequence": store.next_aibom_trust_attestation_sequence(generated_at),
+            "uploadId": f"guard-aibom-upload-{uuid.uuid4().hex}",
+        }
+    )
+    return context

--- a/src/codex_plugin_scanner/guard/aibom_commands.py
+++ b/src/codex_plugin_scanner/guard/aibom_commands.py
@@ -1,0 +1,202 @@
+"""Aibom commands helpers preserving the public CLI dependency seams."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .adapters.base import HarnessContext
+from .aibom_models import (
+    _AIBOM_AUTO_SYNC_INTERVAL_SECONDS,
+    AibomCliOptions,
+    AibomExportFormat,
+)
+
+
+def build_inventory_json_payload(
+    store: Any,
+    context: HarnessContext,
+    *,
+    generated_at: str,
+    options: AibomCliOptions | None = None,
+) -> dict[str, object]:
+    """Build the public inventory response from current detection and stored evidence."""
+    from . import aibom_cli as api
+
+    snapshots = api.collect_aibom_snapshots(
+        context,
+        generated_at=generated_at,
+        options=options,
+        trust_attestation_context=api._resolve_trust_attestation_context(store, generated_at=generated_at),
+    )
+    metadata_by_artifact = api._metadata_lookup_from_snapshots(snapshots)
+    items: list[dict[str, object]] = []
+    for item in store.list_inventory():
+        enriched = api._redact_inventory_store_item(item, home_dir=context.home_dir)
+        artifact_id = str(item.get("artifact_id") or "")
+        harness = str(item.get("harness") or "")
+        extensions = metadata_by_artifact.get((harness, artifact_id))
+        config_path = api._store_row_config_path(item) if str(item.get("artifact_type") or "") == "skill_file" else None
+        config_path_exists = config_path.exists() if config_path is not None else None
+        if not extensions:
+            extensions = api._store_only_artifact_metadata_extensions(
+                enriched,
+                context=context,
+                generated_at=generated_at,
+                config_path=config_path,
+                config_path_exists=config_path_exists,
+            )
+            if config_path_exists is False:
+                enriched["present"] = False
+        if extensions:
+            enriched.update(extensions)
+        items.append(enriched)
+    redaction_report = api._aggregate_redaction_report(snapshots)
+    return {
+        "generated_at": generated_at,
+        "items": items,
+        "snapshots": [api.serialize_inventory_snapshot(snapshot) for snapshot in snapshots],
+        "redaction_report": redaction_report,
+    }
+
+
+def build_aibom_status_payload(
+    store: Any,
+    context: HarnessContext,
+    *,
+    generated_at: str,
+    options: AibomCliOptions | None = None,
+) -> dict[str, object]:
+    """Summarize local inventory, cloud connection, and the last synchronization."""
+    from . import aibom_cli as api
+
+    snapshots = api.collect_aibom_snapshots(
+        context,
+        generated_at=generated_at,
+        options=options,
+        trust_attestation_context=api._resolve_trust_attestation_context(store, generated_at=generated_at),
+    )
+    sync_summary = api._sync_summary(store)
+    layer_summary, trust_summary, drift_summary = api.summarize_aibom_layers(
+        snapshots,
+        generated_at=generated_at,
+    )
+    return {
+        "generated_at": generated_at,
+        "status": api._aibom_connection_status(store),
+        "layer_summary": layer_summary,
+        "trust_summary": trust_summary,
+        "drift_summary": drift_summary,
+        "redaction_report": api._aggregate_redaction_report(snapshots),
+        "last_sync_at": sync_summary.get("synced_at"),
+        "snapshot_count": len(snapshots),
+        "artifact_inventory_count": len(store.list_inventory()),
+    }
+
+
+def build_aibom_export_payload(
+    store: Any,
+    context: HarnessContext,
+    *,
+    generated_at: str,
+    options: AibomCliOptions | None = None,
+    export_format: AibomExportFormat = "json",
+) -> dict[str, object]:
+    """Export redacted AIBOM evidence in the requested supported format."""
+    from . import aibom_cli as api
+
+    snapshots = api.collect_aibom_snapshots(
+        context,
+        generated_at=generated_at,
+        options=options,
+        trust_attestation_context=api._resolve_trust_attestation_context(store, generated_at=generated_at),
+    )
+    serialized_snapshots = [api.serialize_inventory_snapshot(snapshot) for snapshot in snapshots]
+    artifacts = api._artifact_rows_from_store(store, snapshots, context=context, generated_at=generated_at)
+    layer_summary, trust_summary, drift_summary = api.summarize_aibom_layers(
+        snapshots,
+        generated_at=generated_at,
+    )
+    sync_summary = api._sync_summary(store)
+    payload: dict[str, object] = {
+        "generated_at": generated_at,
+        "artifact_count": len(artifacts),
+        "artifacts": artifacts,
+        "snapshots": serialized_snapshots,
+        "layer_summary": layer_summary,
+        "trust_summary": trust_summary,
+        "drift_summary": drift_summary,
+        "redaction_report": api._aggregate_redaction_report(snapshots),
+        "last_sync_at": sync_summary.get("synced_at"),
+    }
+    if export_format == "markdown":
+        payload["markdown"] = api._render_aibom_markdown(payload)
+    return payload
+
+
+def sync_aibom_snapshots_if_due(
+    store: Any,
+    *,
+    generated_at: str,
+    min_interval_seconds: int = _AIBOM_AUTO_SYNC_INTERVAL_SECONDS,
+    force: bool = False,
+    options: AibomCliOptions | None = None,
+    auth_context: dict[str, object] | None = None,
+    expected_workspace_id: str | None = None,
+    home_dir: Path | None = None,
+    workspace_dir: Path | None = None,
+) -> dict[str, object]:
+    """Apply connection and freshness checks before invoking the existing sync API."""
+    from . import aibom_cli as api
+
+    runner = api._runner_module()
+    guard_sync_not_configured_error = runner.GuardSyncNotConfiguredError
+
+    current_workspace_id = store.get_cloud_workspace_id()
+    if current_workspace_id is None:
+        return {"synced": False, "skipped": True, "reason": "not_configured"}
+    if expected_workspace_id is not None and current_workspace_id != expected_workspace_id:
+        return {
+            "synced": False,
+            "reason": "workspace_changed",
+            "error": "Guard Cloud workspace changed before AIBOM inventory sync.",
+        }
+    bound_workspace_id = expected_workspace_id or current_workspace_id
+    if api._aibom_guard_events_endpoint_unavailable_recently(store):
+        return {
+            "synced": False,
+            "skipped": True,
+            "reason": "guard_events_endpoint_unavailable",
+        }
+    if not force and not api._aibom_sync_is_due(
+        store,
+        generated_at=generated_at,
+        min_interval_seconds=min_interval_seconds,
+    ):
+        prior = store.get_sync_payload("aibom_sync_summary")
+        return {
+            "synced": False,
+            "skipped": True,
+            "reason": "recently_synced",
+            "last_sync_at": prior.get("synced_at") if isinstance(prior, dict) else None,
+        }
+    context = api.HarnessContext(
+        home_dir=api._resolve_operator_home_dir(home_dir),
+        workspace_dir=workspace_dir,
+        guard_home=store.guard_home,
+    )
+    try:
+        return api.sync_aibom_snapshots(
+            store,
+            context,
+            generated_at=generated_at,
+            options=options,
+            auth_context=auth_context,
+            expected_workspace_id=bound_workspace_id,
+        )
+    except guard_sync_not_configured_error:
+        return {"synced": False, "skipped": True, "reason": "not_configured"}
+    except ValueError as error:
+        return {"synced": False, "error": str(error)}
+    except (OSError, RuntimeError) as error:
+        return {"synced": False, "error": str(error)}

--- a/src/codex_plugin_scanner/guard/aibom_models.py
+++ b/src/codex_plugin_scanner/guard/aibom_models.py
@@ -1,0 +1,44 @@
+"""AIBOM CLI options and cloud wire-size defaults."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+AibomExportFormat = Literal["json", "markdown"]
+
+
+@dataclass(frozen=True, slots=True)
+class AibomCliOptions:
+    """Options controlling local inventory traversal and optional Cisco scans."""
+
+    include_symlinks: bool = True
+    follow_unsafe_symlinks: bool = False
+    cisco_skill_scan: str = "off"
+    cisco_mcp_scan: str = "off"
+    cisco_timeout_seconds: float | None = None
+
+
+_AIBOM_CLOUD_SYNC_OPTIONS = AibomCliOptions(
+    cisco_skill_scan="auto",
+    cisco_mcp_scan="auto",
+    cisco_timeout_seconds=30.0,
+)
+
+
+_AIBOM_AUTO_SYNC_INTERVAL_SECONDS = 15 * 60  # 15 min — stale AIBOM data undermines trust surfaces
+
+
+_AIBOM_EMPTY_SYNC_RETRY_SECONDS = 2 * 60
+
+
+_AIBOM_GUARD_EVENTS_BACKOFF_KEY = "aibom_guard_events_backoff"
+
+
+_AIBOM_GUARD_EVENTS_BACKOFF_MINUTES = 5  # matches _GUARD_EVENTS_ENDPOINT_UNAVAILABLE_RETRY_MINUTES
+
+
+_AIBOM_SYNC_BATCH_SIZE = 3  # keep each POST under Cloudflare's 100s origin timeout
+
+
+_AIBOM_MAX_REQUEST_BODY_BYTES = 7_500_000  # stay below the portal's 8 MB request limit

--- a/src/codex_plugin_scanner/guard/aibom_reporting.py
+++ b/src/codex_plugin_scanner/guard/aibom_reporting.py
@@ -257,6 +257,11 @@ def _redact_inventory_store_item(
     config_path = item.get("config_path")
     if isinstance(config_path, str) and config_path:
         redacted["config_path"] = api.redact_local_path(Path(config_path), home_dir=home_dir)
+    launch_command = item.get("launch_command")
+    if isinstance(launch_command, str):
+        from .inventory_contract import _redact_command_value
+
+        redacted["launch_command"] = _redact_command_value(launch_command, home_dir, None)
     return redacted
 
 

--- a/src/codex_plugin_scanner/guard/aibom_reporting.py
+++ b/src/codex_plugin_scanner/guard/aibom_reporting.py
@@ -1,0 +1,338 @@
+"""Aibom reporting helpers preserving the public CLI dependency seams."""
+
+from __future__ import annotations
+
+import html
+import re
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from .adapters.base import HarnessContext
+from .inventory_contract import (
+    GuardAgentInventorySnapshot,
+)
+
+
+def summarize_aibom_layers(
+    snapshots: tuple[GuardAgentInventorySnapshot, ...],
+    *,
+    generated_at: str,
+) -> tuple[dict[str, object], dict[str, object], dict[str, object]]:
+    """Count evidence by layer without discarding artifacts from other providers."""
+    from . import aibom_cli as api
+
+    counts = {
+        "instructions": 0,
+        "skills": 0,
+        "mcp": 0,
+        "plugins": 0,
+        "policies": 0,
+        "findings": 0,
+        "trust": 0,
+        "sources": 0,
+        "configSources": 0,
+    }
+    for snapshot in snapshots:
+        counts["findings"] += len(snapshot.findings)
+        counts["configSources"] += len(snapshot.sources)
+        for item in snapshot.items:
+            if item.item_kind in {"overlay", "prompt_pack"}:
+                counts["instructions"] += 1
+            elif item.item_kind == "skill":
+                counts["skills"] += 1
+            elif item.item_kind in {"mcp_server", "mcp_tool"}:
+                counts["mcp"] += 1
+            elif item.item_kind in {"plugin", "daemon_plugin"}:
+                counts["plugins"] += 1
+            elif item.item_kind == "policy":
+                counts["policies"] += 1
+            if isinstance(item.metadata.get("trustResolution"), dict):
+                counts["trust"] += 1
+            source_links = item.metadata.get("sourceLinks")
+            source_of_truth = item.metadata.get("sourceOfTruth")
+            if isinstance(source_links, list) and source_links:
+                counts["sources"] += len(source_links)
+            elif isinstance(source_of_truth, dict):
+                counts["sources"] += 1
+    drift = api.summarize_aibom_drift(snapshots)
+    trust = api.summarize_aibom_trust(snapshots)
+    layer_summary = {
+        **counts,
+        "driftCount": drift.get("total", 0),
+        "highRiskCount": drift.get("high_risk", 0),
+        "lowTrustCount": trust.get("low_trust", 0),
+        "generatedAt": generated_at,
+        "staleSnapshot": False,
+    }
+    return layer_summary, trust, drift
+
+
+def summarize_aibom_trust(snapshots: tuple[GuardAgentInventorySnapshot, ...]) -> dict[str, object]:
+    """Summarize recorded trust evidence without inventing unavailable assessments."""
+    covered = 0
+    eligible = 0
+    low_trust = 0
+    scores: list[int] = []
+    for snapshot in snapshots:
+        for item in snapshot.items:
+            if item.item_kind not in {"skill", "plugin", "mcp_server"}:
+                continue
+            eligible += 1
+            trust = item.metadata.get("trustResolution")
+            if not isinstance(trust, dict):
+                continue
+            covered += 1
+            score = trust.get("trustScore")
+            if isinstance(score, int):
+                scores.append(score)
+                if score < 70:
+                    low_trust += 1
+    coverage_percent = round((covered / eligible) * 100) if eligible else 100
+    average_score = round(sum(scores) / len(scores)) if scores else None
+    return {
+        "eligible": eligible,
+        "covered": covered,
+        "coverage_percent": coverage_percent,
+        "low_trust": low_trust,
+        "average_score": average_score,
+    }
+
+
+def summarize_aibom_drift(snapshots: tuple[GuardAgentInventorySnapshot, ...]) -> dict[str, object]:
+    """Report changed artifacts from the current stored inventory view."""
+    counts = {"new": 0, "changed": 0, "removed": 0, "unchanged": 0, "high_risk": 0}
+    for snapshot in snapshots:
+        for item in snapshot.items:
+            state = item.drift_state
+            if state in counts:
+                counts[state] += 1
+            if item.risk_level in {"critical", "high"}:
+                counts["high_risk"] += 1
+        for drift in snapshot.drift:
+            state = drift.state
+            if state in counts:
+                counts[state] += 1
+    total = counts["new"] + counts["changed"] + counts["removed"]
+    return {
+        "new": counts["new"],
+        "changed": counts["changed"],
+        "removed": counts["removed"],
+        "unchanged": counts["unchanged"],
+        "high_risk": counts["high_risk"],
+        "total": total,
+    }
+
+
+def _metadata_lookup_from_snapshots(
+    snapshots: tuple[GuardAgentInventorySnapshot, ...],
+) -> dict[tuple[str, str], dict[str, object]]:
+    """Index snapshot metadata for joining local stored artifact rows."""
+    from . import aibom_cli as api
+
+    lookup: dict[tuple[str, str], dict[str, object]] = {}
+    for snapshot in snapshots:
+        harness = snapshot.agent_type
+        for item in snapshot.items:
+            extensions = api.extract_aibom_metadata_extensions(item.metadata)
+            if not extensions:
+                continue
+            lookup[(harness, item.item_id)] = extensions
+    return lookup
+
+
+def _artifact_rows_from_store(
+    store: Any,
+    snapshots: tuple[GuardAgentInventorySnapshot, ...],
+    *,
+    context: HarnessContext,
+    generated_at: str,
+) -> list[dict[str, object]]:
+    """Combine stored artifact rows with available snapshot metadata."""
+    from . import aibom_cli as api
+
+    metadata_by_artifact = api._metadata_lookup_from_snapshots(snapshots)
+    artifacts: list[dict[str, object]] = []
+    for item in store.list_inventory():
+        trust_verdict = str(item.get("last_policy_action") or "unknown")
+        harness = str(item.get("harness") or "")
+        artifact_id = str(item.get("artifact_id") or "")
+        row = api._redact_inventory_store_item(item, home_dir=context.home_dir)
+        row["trust_verdict"] = trust_verdict
+        extensions = metadata_by_artifact.get((harness, artifact_id))
+        config_path = api._store_row_config_path(item) if str(item.get("artifact_type") or "") == "skill_file" else None
+        config_path_exists = config_path.exists() if config_path is not None else None
+        if not extensions:
+            extensions = api._store_only_artifact_metadata_extensions(
+                row,
+                context=context,
+                generated_at=generated_at,
+                config_path=config_path,
+                config_path_exists=config_path_exists,
+            )
+            if config_path_exists is False:
+                row["present"] = False
+        if extensions:
+            row.update(extensions)
+        artifacts.append(row)
+    return artifacts
+
+
+def _store_row_config_path(row: dict[str, object]) -> Path | None:
+    """Read a stored configuration path only when it has the expected shape."""
+    raw_config_path = row.get("config_path")
+    if not isinstance(raw_config_path, str) or not raw_config_path.strip():
+        return None
+    return Path(raw_config_path).expanduser()
+
+
+def _store_only_artifact_metadata_extensions(
+    row: dict[str, object],
+    *,
+    context: HarnessContext,
+    generated_at: str,
+    config_path: Path | None,
+    config_path_exists: bool | None,
+) -> dict[str, object]:
+    """Build metadata extensions for artifacts known only to the local store."""
+    from . import aibom_cli as api
+
+    artifact_type = str(row.get("artifact_type") or "")
+    if artifact_type != "skill_file":
+        return {}
+    if config_path is None or config_path_exists is not True:
+        return {}
+    artifact = SimpleNamespace(
+        artifact_id=str(row.get("artifact_id") or ""),
+        artifact_type=artifact_type,
+        config_path=str(config_path),
+        name=str(row.get("artifact_name") or row.get("artifact_id") or "skill_file"),
+    )
+    metadata = api.apply_local_trust_metadata(
+        artifact,
+        captured_at=generated_at,
+        item_kind="skill",
+        metadata={"artifactType": artifact_type},
+        workspace_dir=context.workspace_dir,
+    )
+    return api.extract_aibom_metadata_extensions(metadata)
+
+
+def _aggregate_redaction_report(
+    snapshots: tuple[GuardAgentInventorySnapshot, ...],
+) -> dict[str, object]:
+    """Combine per-snapshot redaction counts without exposing redacted values."""
+    redacted_fields: set[str] = set()
+    raw_secrets = False
+    symlink_items = 0
+    for snapshot in snapshots:
+        report = snapshot.redaction_report
+        if report.get("rawSecretsIncluded") is True:
+            raw_secrets = True
+        fields = report.get("redactedFields")
+        if isinstance(fields, (list, tuple)):
+            redacted_fields.update(str(field) for field in fields)
+        for item in snapshot.items:
+            source_of_truth = item.metadata.get("sourceOfTruth")
+            source_links = item.metadata.get("sourceLinks")
+            if isinstance(source_of_truth, dict) or (isinstance(source_links, list) and source_links):
+                symlink_items += 1
+    return {
+        "rawValuesIncluded": raw_secrets,
+        "redactedFields": sorted(redacted_fields),
+        "symlinkItems": symlink_items,
+        "snapshots": len(snapshots),
+    }
+
+
+def _redact_inventory_store_item(
+    item: dict[str, object],
+    *,
+    home_dir: Path,
+) -> dict[str, object]:
+    """Redact local paths before emitting a stored inventory row."""
+    from . import aibom_cli as api
+
+    redacted = dict(item)
+    config_path = item.get("config_path")
+    if isinstance(config_path, str) and config_path:
+        redacted["config_path"] = api.redact_local_path(Path(config_path), home_dir=home_dir)
+    return redacted
+
+
+def _aibom_connection_status(store: Any) -> str:
+    """Resolve the cloud connection summary through the existing runtime interface."""
+    from . import aibom_cli as api
+
+    if store.get_cloud_sync_profile() is None:
+        return "not_connected"
+    if store.get_cloud_workspace_id() is None:
+        return "workspace_required"
+    sync_summary = api._sync_summary(store)
+    if sync_summary.get("synced") is True and sync_summary.get("synced_at"):
+        return "synced"
+    return "sync_required"
+
+
+def _markdown_table_cell(value: object) -> str:
+    """Keep untrusted text literal and confined to one Markdown table cell."""
+    text = html.escape(" ".join(str(value).splitlines()), quote=False)
+    return re.sub(r"([\\|`*_\[\]()!~])", r"\\\1", text)
+
+
+def _render_aibom_markdown(payload: dict[str, object]) -> str:
+    """Render the redacted inventory report as human-readable Markdown."""
+    layer_summary = payload.get("layer_summary")
+    trust_summary = payload.get("trust_summary")
+    lines = [
+        "# HOL Guard AIBOM",
+        "",
+        "## Layer summary",
+        "",
+    ]
+    if isinstance(layer_summary, dict):
+        lines.extend(
+            [
+                f"- Instructions: {layer_summary.get('instructions', 0)}",
+                f"- Skills: {layer_summary.get('skills', 0)}",
+                f"- MCP: {layer_summary.get('mcp', 0)}",
+                f"- Plugins: {layer_summary.get('plugins', 0)}",
+                f"- Policies: {layer_summary.get('policies', 0)}",
+                f"- Findings: {layer_summary.get('findings', 0)}",
+                f"- Trust: {layer_summary.get('trust', 0)}",
+                f"- Sources: {layer_summary.get('sources', 0)}",
+                f"- Drift: {layer_summary.get('driftCount', 0)}",
+                "",
+            ]
+        )
+    lines.extend(
+        [
+            "## Artifacts",
+            "",
+            "| Artifact | Harness | Type | Scope | Verdict | Present |",
+            "| --- | --- | --- | --- | --- | --- |",
+        ]
+    )
+    artifacts = payload.get("artifacts")
+    if isinstance(artifacts, list):
+        for item in artifacts:
+            if not isinstance(item, dict):
+                continue
+            cells = [
+                _markdown_table_cell(item.get(field, ""))
+                for field in ("artifact_name", "harness", "artifact_type", "source_scope", "trust_verdict")
+            ]
+            cells.append("yes" if item.get("present") else "no")
+            lines.append("| " + " | ".join(cells) + " |")
+    if isinstance(trust_summary, dict):
+        lines.extend(
+            [
+                "",
+                "## Trust coverage",
+                "",
+                f"- Covered: {trust_summary.get('covered', 0)} / {trust_summary.get('eligible', 0)}",
+                f"- Coverage: {trust_summary.get('coverage_percent', 0)}%",
+                "",
+            ]
+        )
+    return "\n".join(lines) + "\n"

--- a/src/codex_plugin_scanner/guard/aibom_sync.py
+++ b/src/codex_plugin_scanner/guard/aibom_sync.py
@@ -1,0 +1,91 @@
+"""Aibom sync helpers preserving the public CLI dependency seams."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from .aibom_models import (
+    _AIBOM_MAX_REQUEST_BODY_BYTES,
+    _AIBOM_SYNC_BATCH_SIZE,
+)
+
+
+def _sync_summary(store: Any) -> dict[str, object]:
+    """Return a typed view of the most recent stored AIBOM synchronization."""
+    payload = store.get_sync_payload("aibom_sync_summary")
+    return payload if isinstance(payload, dict) else {}
+
+
+def _inventory_events_request_body(events: list[dict[str, object]]) -> bytes:
+    """Serialize one bounded batch using the existing inventory event envelope."""
+    return json.dumps({"events": events}).encode("utf-8")
+
+
+def _batch_inventory_events(
+    events: list[dict[str, object]],
+    *,
+    max_batch_size: int = _AIBOM_SYNC_BATCH_SIZE,
+    max_body_bytes: int = _AIBOM_MAX_REQUEST_BODY_BYTES,
+) -> tuple[list[list[dict[str, object]]], list[dict[str, object]]]:
+    """Batch whole inventory snapshots without changing replacement semantics."""
+    from . import aibom_cli as api
+
+    if max_batch_size < 1 or max_body_bytes < 1:
+        raise ValueError("AIBOM request batch limits must be positive.")
+
+    batches: list[list[dict[str, object]]] = []
+    oversized_events: list[dict[str, object]] = []
+    batch: list[dict[str, object]] = []
+    for event in events:
+        if len(api._inventory_events_request_body([event])) > max_body_bytes:
+            oversized_events.append(event)
+            continue
+
+        candidate = [*batch, event]
+        candidate_too_large = len(api._inventory_events_request_body(candidate)) > max_body_bytes
+        if batch and (len(candidate) > max_batch_size or candidate_too_large):
+            batches.append(batch)
+            batch = [event]
+        else:
+            batch = candidate
+
+    if batch:
+        batches.append(batch)
+    return batches, oversized_events
+
+
+def _sync_timestamp_from_payload(payload: dict[str, object]) -> str | None:
+    """Read a compatible acknowledgment timestamp without guessing one."""
+    for key in ("syncedAt", "synced_at", "acceptedAt"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _accepted_snapshot_ids(
+    batch: list[dict[str, object]],
+    payload: dict[str, object],
+) -> set[str]:
+    """Map explicit or legacy aggregate event acknowledgments to accepted snapshots."""
+    snapshot_by_event_id: dict[str, str] = {}
+    for event in batch:
+        event_id = event.get("eventId")
+        event_payload = event.get("payload")
+        snapshot_payload = event_payload.get("snapshot") if isinstance(event_payload, dict) else None
+        snapshot_id = snapshot_payload.get("snapshotId") if isinstance(snapshot_payload, dict) else None
+        if isinstance(event_id, str) and isinstance(snapshot_id, str):
+            snapshot_by_event_id[event_id] = snapshot_id
+    accepted_event_ids: set[str] = set()
+    statuses = payload.get("statuses")
+    if isinstance(statuses, list):
+        for status in statuses:
+            if not isinstance(status, dict) or status.get("status") != "accepted":
+                continue
+            event_id = status.get("eventId")
+            if isinstance(event_id, str):
+                accepted_event_ids.add(event_id)
+    if not accepted_event_ids and payload.get("accepted") == len(batch):
+        accepted_event_ids = set(snapshot_by_event_id)
+    return {snapshot_by_event_id[event_id] for event_id in accepted_event_ids if event_id in snapshot_by_event_id}

--- a/src/codex_plugin_scanner/guard/cli/grok_hook_validation.py
+++ b/src/codex_plugin_scanner/guard/cli/grok_hook_validation.py
@@ -86,8 +86,6 @@ def is_grok_hook_command(command: str) -> bool:
     """Reject marker-only commands without executing untrusted hook text or code."""
     try:
         args = _arguments(command)
-        if args == ("hol-guard", "hook", "grok"):
-            return True  # Retain the legacy direct invocation, not shell wrappers.
         if len(args) == 9:
             return _desktop_proxy(args)
         if len(args) == 3 and args[1] == "__guard-bounded-hook":

--- a/src/codex_plugin_scanner/guard/cli/grok_hook_validation.py
+++ b/src/codex_plugin_scanner/guard/cli/grok_hook_validation.py
@@ -8,7 +8,7 @@ import shlex
 import sys
 from pathlib import Path
 
-from ..adapters.base import _shell_command
+from ..adapters.base import HarnessContext, _shell_command
 from ..stable_guard_cli import prune_safe_cli_executable
 
 
@@ -24,7 +24,7 @@ def _arguments(command: str) -> tuple[str, ...]:
     return args if args and _shell_command(args) == command.strip() else ()
 
 
-def _config(text: str, executable: str, *, frozen: bool) -> dict[str, object] | None:
+def _config(text: str, executable: str, *, frozen: bool, context: HarnessContext | None) -> dict[str, object] | None:
     """Bind the bridge configuration to its executable and Grok hook invocation."""
     config = json.loads(text)
     if not isinstance(config, dict) or config.get("harness") != "grok":
@@ -56,10 +56,24 @@ def _config(text: str, executable: str, *, frozen: bool) -> dict[str, object] | 
         return None
     if any(not Path(value).is_absolute() for key, value in parsed.items() if key != "--harness"):
         return None
+    if context is not None and not _matches_context(parsed, context):
+        return None
     return config
 
 
-def _desktop_proxy(args: tuple[str, ...]) -> bool:
+def _matches_context(options: dict[str, str], context: HarnessContext) -> bool:
+    """Require the bridge's store, effective home, and workspace to match its owner."""
+    expected = {"--guard-home": context.guard_home, "--home": context.home_dir}
+    actual = {"--guard-home": options["--guard-home"], "--home": options.get("--home", str(Path.home()))}
+    if any(Path(actual[key]).resolve() != path.resolve() for key, path in expected.items()):
+        return False
+    workspace = options.get("--workspace")
+    if context.workspace_dir is None:
+        return workspace is None
+    return workspace is not None and Path(workspace).resolve() == context.workspace_dir.resolve()
+
+
+def _desktop_proxy(args: tuple[str, ...], context: HarnessContext | None) -> bool:
     """Accept only the generated macOS script and its verified same-team app paths."""
     from ..adapters import desktop_hook_proxy as proxy
 
@@ -77,28 +91,28 @@ def _desktop_proxy(args: tuple[str, ...]) -> bool:
         return False
     if proxy._bundle_for_executable(core_path) != bundle_path or not team or team == "not set":
         return False
-    if not _config(config, core, frozen=True):
+    if not _config(config, core, frozen=True, context=context):
         return False
     return all(proxy._codesign_team(path) == team for path in (candidate_path, core_path, bundle_path))
 
 
-def is_grok_hook_command(command: str) -> bool:
+def is_grok_hook_command(command: str, context: HarnessContext | None = None) -> bool:
     """Reject marker-only commands without executing untrusted hook text or code."""
     try:
         args = _arguments(command)
         if len(args) == 9:
-            return _desktop_proxy(args)
+            return _desktop_proxy(args, context)
         if len(args) == 3 and args[1] == "__guard-bounded-hook":
             expected = Path(prune_safe_cli_executable(sys.executable)).resolve()
             return (
                 bool(getattr(sys, "frozen", False))
                 and Path(args[0]).is_absolute()
                 and Path(args[0]).resolve() == expected
-                and _config(args[2], args[0], frozen=True) is not None
+                and _config(args[2], args[0], frozen=True, context=context) is not None
             )
         if len(args) != 5 or args[1:3] != ("-I", "-c"):
             return False
-        config = _config(args[4], args[0], frozen=False)
+        config = _config(args[4], args[0], frozen=False, context=context)
         if (
             config is None
             or not Path(args[0]).is_absolute()

--- a/src/codex_plugin_scanner/guard/cli/grok_hook_validation.py
+++ b/src/codex_plugin_scanner/guard/cli/grok_hook_validation.py
@@ -1,0 +1,121 @@
+"""Recognize the exact native Grok hook launch forms produced by Guard."""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import sys
+from pathlib import Path
+
+from ..adapters.base import _shell_command
+from ..stable_guard_cli import prune_safe_cli_executable
+
+
+def _arguments(command: str) -> tuple[str, ...]:
+    """Parse the host's serialized argv and reject noncanonical shell syntax."""
+    if os.name == "nt":
+        from ..windows_paths import windows_command_line_to_argv
+
+        args = tuple(windows_command_line_to_argv(command) or ())
+    else:
+        args = tuple(shlex.split(command))
+    # This also rejects shell expansions/operators outside quoted arguments.
+    return args if args and _shell_command(args) == command.strip() else ()
+
+
+def _config(text: str, executable: str, *, frozen: bool) -> dict[str, object] | None:
+    """Bind the bridge configuration to its executable and Grok hook invocation."""
+    config = json.loads(text)
+    if not isinstance(config, dict) or config.get("harness") != "grok":
+        return None
+    if config.get("frozen_launcher") is not frozen or config.get("python_executable") != executable:
+        return None
+    guard_home = config.get("guard_home")
+    package_root = config.get("package_root")
+    args = config.get("cli_args")
+    timeout = config.get("timeout_seconds")
+    if not isinstance(timeout, (int, float)) or isinstance(timeout, bool) or not 0 < timeout <= 120:
+        return None
+    if not isinstance(guard_home, str) or not Path(guard_home).is_absolute():
+        return None
+    if not isinstance(package_root, str) or not Path(package_root).is_absolute():
+        return None
+    if not isinstance(args, list) or not all(isinstance(arg, str) for arg in args):
+        return None
+    if args[:2] != ["guard", "hook"] or args[-1:] != ["--json"]:
+        return None
+    options = args[2:-1]
+    if len(options) % 2 or len(set(options[::2])) != len(options[::2]):
+        return None
+    parsed = dict(zip(options[::2], options[1::2], strict=True))
+    if parsed.get("--harness") != "grok" or not set(parsed) <= {"--harness", "--guard-home", "--home", "--workspace"}:
+        return None
+    configured_home = parsed.get("--guard-home")
+    if not configured_home or Path(configured_home).resolve() != Path(guard_home).resolve():
+        return None
+    if any(not Path(value).is_absolute() for key, value in parsed.items() if key != "--harness"):
+        return None
+    return config
+
+
+def _desktop_proxy(args: tuple[str, ...]) -> bool:
+    """Accept only the generated macOS script and its verified same-team app paths."""
+    from ..adapters import desktop_hook_proxy as proxy
+
+    if sys.platform != "darwin" or len(args) != 9:
+        return False
+    if args[:4] != ("/bin/sh", "-c", proxy._DESKTOP_PROXY_LAUNCH_SCRIPT, "hol-guard-desktop-proxy"):
+        return False
+    candidate, team, bundle, config, core = args[4:]
+    candidate_path, core_path, bundle_path = Path(candidate), Path(core), Path(bundle)
+    if not all(path.is_absolute() for path in (candidate_path, core_path, bundle_path)):
+        return False
+    if not proxy._trusted_desktop_path(candidate_path) or not proxy._trusted_desktop_path(core_path):
+        return False
+    if candidate_path.parent != core_path.parent or proxy._bundle_for_executable(candidate_path) != bundle_path:
+        return False
+    if proxy._bundle_for_executable(core_path) != bundle_path or not team or team == "not set":
+        return False
+    if not _config(config, core, frozen=True):
+        return False
+    return all(proxy._codesign_team(path) == team for path in (candidate_path, core_path, bundle_path))
+
+
+def is_grok_hook_command(command: str) -> bool:
+    """Reject marker-only commands without executing untrusted hook text or code."""
+    try:
+        args = _arguments(command)
+        if args == ("hol-guard", "hook", "grok"):
+            return True  # Retain the legacy direct invocation, not shell wrappers.
+        if len(args) == 9:
+            return _desktop_proxy(args)
+        if len(args) == 3 and args[1] == "__guard-bounded-hook":
+            expected = Path(prune_safe_cli_executable(sys.executable)).resolve()
+            return (
+                bool(getattr(sys, "frozen", False))
+                and Path(args[0]).is_absolute()
+                and Path(args[0]).resolve() == expected
+                and _config(args[2], args[0], frozen=True) is not None
+            )
+        if len(args) != 5 or args[1:3] != ("-I", "-c"):
+            return False
+        config = _config(args[4], args[0], frozen=False)
+        if (
+            config is None
+            or not Path(args[0]).is_absolute()
+            or Path(args[0]).resolve() != Path(sys.executable).resolve()
+        ):
+            return False
+        package_root = Path(__file__).resolve().parents[3]
+        if config["package_root"] != str(package_root):
+            return False
+        bootstrap = (
+            "import sys;"
+            f"sys.path.insert(0,{str(package_root)!r});"
+            "from codex_plugin_scanner.guard.adapters.bounded_cli_hook_bridge import main_from_argv;"
+            "raise SystemExit(main_from_argv(sys.argv[1:]))"
+        )
+        return args[3] == bootstrap
+    except (OSError, ValueError, TypeError, RuntimeError):
+        return False

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import glob as globlib
-import json
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -13,7 +12,7 @@ from ..adapters.cline import ClineHarnessAdapter
 from ..adapters.contracts import contract_for
 from ..adapters.cursor import CursorHarnessAdapter
 from ..agent_safety_guidance import install_agent_safety_guidance, uninstall_agent_safety_guidance
-from ..managed_install_proof import bind_managed_install_proof
+from ..managed_install_proof import bind_managed_install_proof, verify_managed_install_proof
 from ..runtime.mcp_skill_firewall import build_mcp_skill_firewall_fingerprints, portal_skill_identity
 from ..runtime.skill_protection import build_skill_identity, detect_skill_content_risk, skill_identity_metadata
 from ..store import GuardStore
@@ -24,6 +23,16 @@ from .cursor_actions import (
     cursor_protected_surfaces_from_store,
 )
 from .install_targets import _resolve_targets
+from .managed_install_payload import managed_install_payload as _managed_install_payload
+from .native_install_checks import _grok_event_has_command_hook as _grok_event_has_command_hook
+from .native_install_checks import _grok_hook_command_is_guard as _grok_hook_command_is_guard
+from .native_install_checks import _grok_managed_config_is_active as _grok_managed_config_is_active
+from .native_install_checks import _grok_pretool_is_catchall as _grok_pretool_is_catchall
+from .native_install_checks import _grok_prompt_hook_is_observe as _grok_prompt_hook_is_observe
+from .native_install_checks import _grok_protection_checks as _grok_protection_checks
+from .native_install_checks import _native_mcp_server_names as _native_mcp_server_names
+from .native_install_checks import _opencode_protection_checks as _opencode_protection_checks
+from .native_install_checks import grok_hooks_protection_ready as grok_hooks_protection_ready
 
 _HARNESS_OBSERVED_COPY = {
     "protected": "Active Guard protection is installed.",
@@ -119,33 +128,6 @@ def apply_managed_install(
     return payload
 
 
-def _managed_install_payload(managed_install: dict[str, object]) -> dict[str, object]:
-    payload = dict(managed_install)
-    harness = str(payload.get("harness") or "")
-    protection_contract = contract_for(harness)
-    if protection_contract is not None:
-        payload["native_hooks"] = protection_contract.native_approval
-        payload["browser_fallback"] = protection_contract.browser_fallback
-        payload["primary_integration"] = "native_hooks" if protection_contract.native_approval else "browser_fallback"
-    manifest = payload.get("manifest")
-    if isinstance(manifest, dict):
-        for key in (
-            "config_path",
-            "managed_config_path",
-            "shim_path",
-            "shim_paths",
-            "shim_command",
-            "shim_commands",
-            "mode",
-            "surface",
-            "surfaces",
-        ):
-            value = manifest.get(key)
-            if value is not None:
-                payload[key] = value
-    return payload
-
-
 def list_harness_setup_items(context: HarnessContext, store: GuardStore | None = None) -> list[dict[str, object]]:
     items: list[dict[str, object]] = []
     for adapter in list_adapters():
@@ -210,7 +192,11 @@ def build_harness_setup_plan(
             {
                 "step_id": "disconnect",
                 "title": f"Disconnect {contract.display_name}",
-                "body": "Remove Guard managed config for this app.",
+                "body": (
+                    "Remove Paseo's receipt and launcher. Shared native provider protection remains installed."
+                    if adapter.harness == "paseo"
+                    else "Remove Guard managed config for this app."
+                ),
                 "command": ["hol-guard", "apps", "disconnect", adapter.harness],
                 "writes_config": True,
                 "requires_confirmation": True,
@@ -288,254 +274,24 @@ def uninstall_confirmation_token(harness: str) -> str:
     return f"disconnect-{harness}"
 
 
-def _native_mcp_server_names(config_path: Path) -> set[str]:
-    from ...ecosystems.opencode import _load_json_or_jsonc
-
-    payload, parse_error, _ = _load_json_or_jsonc(config_path)
-    if parse_error or not isinstance(payload, dict):
-        return set()
-    mcp = payload.get("mcp")
-    if not isinstance(mcp, dict):
-        return set()
-    return {name for name in mcp if isinstance(name, str) and not name.startswith("hol-guard::")}
-
-
-def _opencode_protection_checks(context: HarnessContext, store: GuardStore | None) -> dict[str, object]:
-    from ..adapters.opencode import OpenCodeHarnessAdapter
-    from ..adapters.opencode_artifacts import runtime_config_path
-    from ..adapters.opencode_pretool import (
-        global_plugin_path,
-        opencode_config_has_mcp_servers,
-        opencode_config_uses_guard_proxy,
-    )
-
-    adapter = OpenCodeHarnessAdapter()
-    managed = store.get_managed_install("opencode") if store is not None else None
-    config_path = adapter._managed_install_config_path(context)
-    shim_path = context.guard_home / "bin" / "guard-opencode"
-    plugin_path = global_plugin_path(context)
-    loaded_config_paths = [Path(path) for path in adapter.detect(context).config_paths if Path(path).is_file()] or (
-        [config_path] if config_path.is_file() else []
-    )
-    has_loaded_mcp = any(opencode_config_has_mcp_servers(path) for path in loaded_config_paths)
-    if not has_loaded_mcp:
-        mcp_proxy_configured = False
-    else:
-        mcp_proxy_configured = all(
-            (not opencode_config_has_mcp_servers(path)) or opencode_config_uses_guard_proxy(path)
-            for path in loaded_config_paths
-        )
-        runtime_overlay_path = runtime_config_path(context)
-        if not mcp_proxy_configured and runtime_overlay_path.is_file():
-            try:
-                runtime_payload = json.loads(runtime_overlay_path.read_text(encoding="utf-8"))
-            except (OSError, json.JSONDecodeError):
-                runtime_payload = {}
-            runtime_mcp = runtime_payload.get("mcp")
-            if isinstance(runtime_mcp, dict) and runtime_mcp:
-                managed_server_names = {
-                    name
-                    for path in loaded_config_paths
-                    if opencode_config_has_mcp_servers(path)
-                    for name in _native_mcp_server_names(path)
-                }
-                mcp_proxy_configured = managed_server_names.issubset(set(runtime_mcp))
-    has_unproxied_mcp = has_loaded_mcp and not mcp_proxy_configured
-    warnings: list[str] = []
-    if not (managed and managed.get("active")):
-        warnings.append("Run `hol-guard install opencode` to activate Guard-managed OpenCode protection.")
-    if not plugin_path.is_file():
-        warnings.append(
-            "OpenCode pretool plugin is missing from ~/.config/opencode/plugins/. Re-run `hol-guard install opencode`."
-        )
-    if not config_path.is_file():
-        warnings.append(
-            "OpenCode root config is missing at ~/.config/opencode/opencode.json. Re-run `hol-guard install opencode`."
-        )
-    if has_unproxied_mcp:
-        warnings.append(
-            "OpenCode MCP servers are not routed through hol-guard companion servers or the runtime overlay. "
-            "Re-run `hol-guard install opencode`."
-        )
-    if not shim_path.is_file():
-        warnings.append(
-            f"guard-opencode launcher shim is missing. Add {context.guard_home / 'bin'} to PATH or launch with "
-            "`hol-guard run opencode` for pre-launch checks."
-        )
-    return {
-        "pretool_plugin_installed": plugin_path.is_file(),
-        "mcp_proxy_configured": mcp_proxy_configured,
-        "launch_shim_installed": shim_path.is_file(),
-        "managed_install_active": bool(managed and managed.get("active")),
-        "warnings": warnings,
-        "ready": not warnings,
-    }
-
-
-def _grok_pretool_is_catchall(pretool_hook: Path) -> bool:
-    if not pretool_hook.is_file():
-        return False
-    try:
-        payload = json.loads(pretool_hook.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return False
-    if not isinstance(payload, dict):
-        return False
-    hooks = payload.get("hooks")
-    if not isinstance(hooks, dict):
-        return False
-    entries = hooks.get("PreToolUse")
-    if not isinstance(entries, list) or len(entries) != 1 or not isinstance(entries[0], dict):
-        return False
-    matcher = entries[0].get("matcher")
-    if matcher not in {None, ""}:
-        return False
-    nested = entries[0].get("hooks")
-    if not isinstance(nested, list) or len(nested) != 1 or not isinstance(nested[0], dict):
-        return False
-    command = nested[0].get("command")
-    return nested[0].get("type") == "command" and isinstance(command, str) and _grok_hook_command_is_guard(command)
-
-
-def _grok_hook_command_is_guard(command: str) -> bool:
-    lowered = command.lower()
-    tokens = lowered.replace("=", " ").replace(",", " ").split()
-    if not tokens:
-        return False
-    first = tokens[0].rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
-    if first in {"echo", "true", "false", "printf", ":"}:
-        return False
-    return "hook" in lowered and (
-        "hol-guard" in tokens
-        or any(token.endswith("/hol-guard") or token.endswith("\\hol-guard") for token in tokens)
-        or "__guard-bounded-hook" in lowered
-        or "__guard-cursor-hook" in lowered
-        or "bounded_cli_hook_bridge" in lowered
-        or "codex_plugin_scanner.guard" in lowered
-    )
-
-
-def _grok_prompt_hook_is_observe(prompt_hook: Path) -> bool:
-    if not prompt_hook.is_file():
-        return False
-    try:
-        payload = json.loads(prompt_hook.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return False
-    if not isinstance(payload, dict):
-        return False
-    hooks = payload.get("hooks")
-    if not isinstance(hooks, dict):
-        return False
-    required = ("UserPromptSubmit", "SubagentStart", "SessionStart")
-    return all(_grok_event_has_command_hook(hooks.get(event_name)) for event_name in required)
-
-
-def _grok_event_has_command_hook(entries: object) -> bool:
-    if not isinstance(entries, list) or not entries:
-        return False
-    for entry in entries:
-        if not isinstance(entry, dict):
-            continue
-        nested = entry.get("hooks")
-        if not isinstance(nested, list):
-            continue
-        for hook_entry in nested:
-            if not isinstance(hook_entry, dict) or hook_entry.get("type") != "command":
-                continue
-            command = hook_entry.get("command")
-            if isinstance(command, str) and _grok_hook_command_is_guard(command):
-                return True
-    return False
-
-
-def _grok_managed_config_is_active(managed_text: str) -> bool:
-    from ..adapters.grok_config import GUARD_MANAGED_BEGIN, GUARD_MANAGED_END
-
-    start = managed_text.find(GUARD_MANAGED_BEGIN)
-    stop = managed_text.find(GUARD_MANAGED_END)
-    if start < 0 or stop <= start:
-        return False
-    for line in managed_text[start:stop].splitlines():
-        active = line.split("#", 1)[0].strip()
-        if "Read(**/.grok/auth/**)" in active:
-            return True
-    return False
-
-
-def grok_hooks_protection_ready(context: HarnessContext) -> bool:
-    """Return whether live Grok hook files and managed permission rules are active."""
-
-    checks = _grok_protection_checks(context)
-    warnings = checks.get("warnings")
-    warning_items = warnings if isinstance(warnings, list) else []
-    hook_warnings = [
-        warning
-        for warning in warning_items
-        if isinstance(warning, str) and "shim" not in warning.lower() and "launcher" not in warning.lower()
-    ]
-    return (
-        checks.get("pretool_catchall_installed") is True
-        and checks.get("prompt_hook_installed") is True
-        and checks.get("managed_config_installed") is True
-        and not hook_warnings
-    )
-
-
-def _grok_protection_checks(context: HarnessContext) -> dict[str, object]:
-    from ..adapters.grok import GrokHarnessAdapter
-
-    adapter = GrokHarnessAdapter()
-    hooks_dir = adapter._hooks_dir(context)
-    managed_config = adapter._managed_config_path(context)
-    pretool_hook = hooks_dir / "hol-guard-pretooluse.json"
-    prompt_hook = hooks_dir / "hol-guard-prompt.json"
-    warnings: list[str] = []
-    if not pretool_hook.is_file() or not prompt_hook.is_file():
-        warnings.append("Grok Guard hook files are missing from ~/.grok/hooks/. Re-run `hol-guard apps connect grok`.")
-    elif not _grok_pretool_is_catchall(pretool_hook):
-        warnings.append(
-            "Grok Guard pre-tool hook still uses a stale per-tool matcher list. Re-run `hol-guard apps repair grok`."
-        )
-    elif not _grok_prompt_hook_is_observe(prompt_hook):
-        warnings.append(
-            "Grok Guard observe hooks are missing prompt, session, or subagent events. "
-            "Re-run `hol-guard apps repair grok`."
-        )
-    managed_text = managed_config.read_text(encoding="utf-8") if managed_config.is_file() else ""
-    if not managed_config.is_file() or not _grok_managed_config_is_active(managed_text):
-        warnings.append(
-            "Grok managed permission rules are missing from ~/.grok/managed_config.toml. "
-            "Re-run `hol-guard apps connect grok`."
-        )
-    elif "Read(~/" in managed_text:
-        warnings.append(
-            "Grok managed deny rules still use literal home prefixes that Grok does not expand. "
-            "Re-run `hol-guard apps repair grok`."
-        )
-    shim_path = context.guard_home / "bin" / "guard-grok"
-    if not shim_path.is_file():
-        warnings.append(
-            f"guard-grok launcher shim is missing. Add {context.guard_home / 'bin'} to PATH or launch with "
-            "`hol-guard run grok` for pre-launch checks."
-        )
-    return {
-        "pretool_hook_installed": pretool_hook.is_file(),
-        "prompt_hook_installed": prompt_hook.is_file(),
-        "pretool_catchall_installed": _grok_pretool_is_catchall(pretool_hook),
-        "managed_config_installed": managed_config.is_file(),
-        "launch_shim_installed": shim_path.is_file(),
-        "warnings": warnings,
-        "ready": not warnings,
-    }
-
-
 def _safe_setup_detection(
     adapter: HarnessAdapter,
     context: HarnessContext,
     store: GuardStore | None,
 ) -> dict[str, object]:
     managed = store.get_managed_install(adapter.harness) if store is not None else None
+    if adapter.harness == "paseo":
+        diagnostics = adapter.diagnostics(context)
+        return {
+            "installed": bool(
+                managed
+                and managed.get("active")
+                and diagnostics.get("setup_status") == "active"
+                and verify_managed_install_proof(managed.get("manifest"), context) is True
+            ),
+            "command_available": diagnostics.get("command_available", False),
+            "config_paths": diagnostics.get("config_paths", []),
+        }
     protection_contract = contract_for(adapter.harness)
     config_paths = protection_contract.config_paths if protection_contract is not None else ()
     return {

--- a/src/codex_plugin_scanner/guard/cli/managed_install_payload.py
+++ b/src/codex_plugin_scanner/guard/cli/managed_install_payload.py
@@ -1,0 +1,36 @@
+"""Public summaries of recorded native and composite harness installations."""
+
+from __future__ import annotations
+
+from ..adapters.contracts import contract_for
+
+
+def managed_install_payload(managed_install: dict[str, object]) -> dict[str, object]:
+    """Summarize recorded integration ownership without inventing native Paseo hook support."""
+    payload = dict(managed_install)
+    harness = str(payload.get("harness") or "")
+    protection_contract = contract_for(harness)
+    if protection_contract is not None:
+        payload["native_hooks"] = protection_contract.native_approval
+        payload["browser_fallback"] = protection_contract.browser_fallback
+        payload["primary_integration"] = "native_hooks" if protection_contract.native_approval else "browser_fallback"
+    manifest = payload.get("manifest")
+    if isinstance(manifest, dict):
+        if manifest.get("mode") == "native-provider-hooks":
+            payload["primary_integration"] = "native-provider-hooks"
+            payload["coverage_status"] = "limited"
+        for key in (
+            "config_path",
+            "managed_config_path",
+            "shim_path",
+            "shim_paths",
+            "shim_command",
+            "shim_commands",
+            "mode",
+            "surface",
+            "surfaces",
+        ):
+            value = manifest.get(key)
+            if value is not None:
+                payload[key] = value
+    return payload

--- a/src/codex_plugin_scanner/guard/cli/native_install_checks.py
+++ b/src/codex_plugin_scanner/guard/cli/native_install_checks.py
@@ -1,0 +1,259 @@
+"""Native OpenCode and Grok verification used by harness setup flows."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ..adapters.base import HarnessContext
+from ..store import GuardStore
+
+
+def _native_mcp_server_names(config_path: Path) -> set[str]:
+    """Read configured native MCP names while excluding Guard companion identities."""
+    from ...ecosystems.opencode import _load_json_or_jsonc
+
+    payload, parse_error, _ = _load_json_or_jsonc(config_path)
+    if parse_error or not isinstance(payload, dict):
+        return set()
+    mcp = payload.get("mcp")
+    if not isinstance(mcp, dict):
+        return set()
+    return {name for name in mcp if isinstance(name, str) and not name.startswith("hol-guard::")}
+
+
+def _opencode_protection_checks(context: HarnessContext, store: GuardStore | None) -> dict[str, object]:
+    """Verify the managed OpenCode plugin, launcher, and MCP routing configuration."""
+    from ..adapters.opencode import OpenCodeHarnessAdapter
+    from ..adapters.opencode_artifacts import runtime_config_path
+    from ..adapters.opencode_pretool import (
+        global_plugin_path,
+        opencode_config_has_mcp_servers,
+        opencode_config_uses_guard_proxy,
+    )
+
+    adapter = OpenCodeHarnessAdapter()
+    managed = store.get_managed_install("opencode") if store is not None else None
+    config_path = adapter._managed_install_config_path(context)
+    shim_path = context.guard_home / "bin" / "guard-opencode"
+    plugin_path = global_plugin_path(context)
+    loaded_config_paths = [Path(path) for path in adapter.detect(context).config_paths if Path(path).is_file()] or (
+        [config_path] if config_path.is_file() else []
+    )
+    has_loaded_mcp = any(opencode_config_has_mcp_servers(path) for path in loaded_config_paths)
+    if not has_loaded_mcp:
+        mcp_proxy_configured = False
+    else:
+        mcp_proxy_configured = all(
+            (not opencode_config_has_mcp_servers(path)) or opencode_config_uses_guard_proxy(path)
+            for path in loaded_config_paths
+        )
+        runtime_overlay_path = runtime_config_path(context)
+        if not mcp_proxy_configured and runtime_overlay_path.is_file():
+            try:
+                runtime_payload = json.loads(runtime_overlay_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                runtime_payload = {}
+            runtime_mcp = runtime_payload.get("mcp")
+            if isinstance(runtime_mcp, dict) and runtime_mcp:
+                managed_server_names = {
+                    name
+                    for path in loaded_config_paths
+                    if opencode_config_has_mcp_servers(path)
+                    for name in _native_mcp_server_names(path)
+                }
+                mcp_proxy_configured = managed_server_names.issubset(set(runtime_mcp))
+    has_unproxied_mcp = has_loaded_mcp and not mcp_proxy_configured
+    warnings: list[str] = []
+    if not (managed and managed.get("active")):
+        warnings.append("Run `hol-guard install opencode` to activate Guard-managed OpenCode protection.")
+    if not plugin_path.is_file():
+        warnings.append(
+            "OpenCode pretool plugin is missing from ~/.config/opencode/plugins/. Re-run `hol-guard install opencode`."
+        )
+    if not config_path.is_file():
+        warnings.append(
+            "OpenCode root config is missing at ~/.config/opencode/opencode.json. Re-run `hol-guard install opencode`."
+        )
+    if has_unproxied_mcp:
+        warnings.append(
+            "OpenCode MCP servers are not routed through hol-guard companion servers or the runtime overlay. "
+            "Re-run `hol-guard install opencode`."
+        )
+    if not shim_path.is_file():
+        warnings.append(
+            f"guard-opencode launcher shim is missing. Add {context.guard_home / 'bin'} to PATH or launch with "
+            "`hol-guard run opencode` for pre-launch checks."
+        )
+    return {
+        "pretool_plugin_installed": plugin_path.is_file(),
+        "mcp_proxy_configured": mcp_proxy_configured,
+        "launch_shim_installed": shim_path.is_file(),
+        "managed_install_active": bool(managed and managed.get("active")),
+        "warnings": warnings,
+        "ready": not warnings,
+    }
+
+
+def _grok_pretool_is_catchall(pretool_hook: Path) -> bool:
+    """Check that Grok uses one managed catch-all pre-tool hook."""
+    if not pretool_hook.is_file():
+        return False
+    try:
+        payload = json.loads(pretool_hook.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    hooks = payload.get("hooks")
+    if not isinstance(hooks, dict):
+        return False
+    entries = hooks.get("PreToolUse")
+    if not isinstance(entries, list) or len(entries) != 1 or not isinstance(entries[0], dict):
+        return False
+    matcher = entries[0].get("matcher")
+    if matcher not in {None, ""}:
+        return False
+    nested = entries[0].get("hooks")
+    if not isinstance(nested, list) or len(nested) != 1 or not isinstance(nested[0], dict):
+        return False
+    command = nested[0].get("command")
+    return nested[0].get("type") == "command" and isinstance(command, str) and _grok_hook_command_is_guard(command)
+
+
+def _grok_hook_command_is_guard(command: str) -> bool:
+    """Identify a real Guard hook command rather than a shell placeholder."""
+    lowered = command.lower()
+    tokens = lowered.replace("=", " ").replace(",", " ").split()
+    if not tokens:
+        return False
+    first = tokens[0].rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+    if first in {"echo", "true", "false", "printf", ":"}:
+        return False
+    return "hook" in lowered and (
+        "hol-guard" in tokens
+        or any(token.endswith("/hol-guard") or token.endswith("\\hol-guard") for token in tokens)
+        or "__guard-bounded-hook" in lowered
+        or "__guard-cursor-hook" in lowered
+        or "bounded_cli_hook_bridge" in lowered
+        or "codex_plugin_scanner.guard" in lowered
+    )
+
+
+def _grok_prompt_hook_is_observe(prompt_hook: Path) -> bool:
+    """Verify the required Grok observation events have managed command hooks."""
+    if not prompt_hook.is_file():
+        return False
+    try:
+        payload = json.loads(prompt_hook.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    hooks = payload.get("hooks")
+    if not isinstance(hooks, dict):
+        return False
+    required = ("UserPromptSubmit", "SubagentStart", "SessionStart")
+    return all(_grok_event_has_command_hook(hooks.get(event_name)) for event_name in required)
+
+
+def _grok_event_has_command_hook(entries: object) -> bool:
+    """Find a valid Guard command hook in a native event configuration."""
+    if not isinstance(entries, list) or not entries:
+        return False
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        nested = entry.get("hooks")
+        if not isinstance(nested, list):
+            continue
+        for hook_entry in nested:
+            if not isinstance(hook_entry, dict) or hook_entry.get("type") != "command":
+                continue
+            command = hook_entry.get("command")
+            if isinstance(command, str) and _grok_hook_command_is_guard(command):
+                return True
+    return False
+
+
+def _grok_managed_config_is_active(managed_text: str) -> bool:
+    """Check the active managed section for the required credential deny rule."""
+    from ..adapters.grok_config import GUARD_MANAGED_BEGIN, GUARD_MANAGED_END
+
+    start = managed_text.find(GUARD_MANAGED_BEGIN)
+    stop = managed_text.find(GUARD_MANAGED_END)
+    if start < 0 or stop <= start:
+        return False
+    for line in managed_text[start:stop].splitlines():
+        active = line.split("#", 1)[0].strip()
+        if "Read(**/.grok/auth/**)" in active:
+            return True
+    return False
+
+
+def grok_hooks_protection_ready(context: HarnessContext) -> bool:
+    """Return whether live Grok hook files and managed permission rules are active."""
+
+    checks = _grok_protection_checks(context)
+    warnings = checks.get("warnings")
+    warning_items = warnings if isinstance(warnings, list) else []
+    hook_warnings = [
+        warning
+        for warning in warning_items
+        if isinstance(warning, str) and "shim" not in warning.lower() and "launcher" not in warning.lower()
+    ]
+    return (
+        checks.get("pretool_catchall_installed") is True
+        and checks.get("prompt_hook_installed") is True
+        and checks.get("managed_config_installed") is True
+        and not hook_warnings
+    )
+
+
+def _grok_protection_checks(context: HarnessContext) -> dict[str, object]:
+    """Report missing or stale Grok protection artifacts with repair instructions."""
+    from ..adapters.grok import GrokHarnessAdapter
+
+    adapter = GrokHarnessAdapter()
+    hooks_dir = adapter._hooks_dir(context)
+    managed_config = adapter._managed_config_path(context)
+    pretool_hook = hooks_dir / "hol-guard-pretooluse.json"
+    prompt_hook = hooks_dir / "hol-guard-prompt.json"
+    warnings: list[str] = []
+    if not pretool_hook.is_file() or not prompt_hook.is_file():
+        warnings.append("Grok Guard hook files are missing from ~/.grok/hooks/. Re-run `hol-guard apps connect grok`.")
+    elif not _grok_pretool_is_catchall(pretool_hook):
+        warnings.append(
+            "Grok Guard pre-tool hook still uses a stale per-tool matcher list. Re-run `hol-guard apps repair grok`."
+        )
+    elif not _grok_prompt_hook_is_observe(prompt_hook):
+        warnings.append(
+            "Grok Guard observe hooks are missing prompt, session, or subagent events. "
+            "Re-run `hol-guard apps repair grok`."
+        )
+    managed_text = managed_config.read_text(encoding="utf-8") if managed_config.is_file() else ""
+    if not managed_config.is_file() or not _grok_managed_config_is_active(managed_text):
+        warnings.append(
+            "Grok managed permission rules are missing from ~/.grok/managed_config.toml. "
+            "Re-run `hol-guard apps connect grok`."
+        )
+    elif "Read(~/" in managed_text:
+        warnings.append(
+            "Grok managed deny rules still use literal home prefixes that Grok does not expand. "
+            "Re-run `hol-guard apps repair grok`."
+        )
+    shim_path = context.guard_home / "bin" / "guard-grok"
+    if not shim_path.is_file():
+        warnings.append(
+            f"guard-grok launcher shim is missing. Add {context.guard_home / 'bin'} to PATH or launch with "
+            "`hol-guard run grok` for pre-launch checks."
+        )
+    return {
+        "pretool_hook_installed": pretool_hook.is_file(),
+        "prompt_hook_installed": prompt_hook.is_file(),
+        "pretool_catchall_installed": _grok_pretool_is_catchall(pretool_hook),
+        "managed_config_installed": managed_config.is_file(),
+        "launch_shim_installed": shim_path.is_file(),
+        "warnings": warnings,
+        "ready": not warnings,
+    }

--- a/src/codex_plugin_scanner/guard/cli/native_install_checks.py
+++ b/src/codex_plugin_scanner/guard/cli/native_install_checks.py
@@ -95,7 +95,7 @@ def _opencode_protection_checks(context: HarnessContext, store: GuardStore | Non
     }
 
 
-def _grok_pretool_is_catchall(pretool_hook: Path) -> bool:
+def _grok_pretool_is_catchall(pretool_hook: Path, context: HarnessContext | None = None) -> bool:
     """Check that Grok uses one managed catch-all pre-tool hook."""
     if not pretool_hook.is_file():
         return False
@@ -118,17 +118,21 @@ def _grok_pretool_is_catchall(pretool_hook: Path) -> bool:
     if not isinstance(nested, list) or len(nested) != 1 or not isinstance(nested[0], dict):
         return False
     command = nested[0].get("command")
-    return nested[0].get("type") == "command" and isinstance(command, str) and _grok_hook_command_is_guard(command)
+    return (
+        nested[0].get("type") == "command"
+        and isinstance(command, str)
+        and _grok_hook_command_is_guard(command, context)
+    )
 
 
-def _grok_hook_command_is_guard(command: str) -> bool:
+def _grok_hook_command_is_guard(command: str, context: HarnessContext | None = None) -> bool:
     """Validate a serialized native hook invocation, not arbitrary Guard marker text."""
     from .grok_hook_validation import is_grok_hook_command
 
-    return is_grok_hook_command(command)
+    return is_grok_hook_command(command, context)
 
 
-def _grok_prompt_hook_is_observe(prompt_hook: Path) -> bool:
+def _grok_prompt_hook_is_observe(prompt_hook: Path, context: HarnessContext | None = None) -> bool:
     """Verify the required Grok observation events have managed command hooks."""
     if not prompt_hook.is_file():
         return False
@@ -142,10 +146,10 @@ def _grok_prompt_hook_is_observe(prompt_hook: Path) -> bool:
     if not isinstance(hooks, dict):
         return False
     required = ("UserPromptSubmit", "SubagentStart", "SessionStart")
-    return all(_grok_event_has_command_hook(hooks.get(event_name)) for event_name in required)
+    return all(_grok_event_has_command_hook(hooks.get(event_name), context) for event_name in required)
 
 
-def _grok_event_has_command_hook(entries: object) -> bool:
+def _grok_event_has_command_hook(entries: object, context: HarnessContext | None = None) -> bool:
     """Find a valid Guard command hook in a native event configuration."""
     if not isinstance(entries, list) or not entries:
         return False
@@ -159,7 +163,7 @@ def _grok_event_has_command_hook(entries: object) -> bool:
             if not isinstance(hook_entry, dict) or hook_entry.get("type") != "command":
                 continue
             command = hook_entry.get("command")
-            if isinstance(command, str) and _grok_hook_command_is_guard(command):
+            if isinstance(command, str) and _grok_hook_command_is_guard(command, context):
                 return True
     return False
 
@@ -213,11 +217,11 @@ def _grok_protection_checks(context: HarnessContext) -> dict[str, object]:
     warnings: list[str] = []
     if not pretool_hook.is_file() or not prompt_hook.is_file():
         warnings.append("Grok Guard hook files are missing from ~/.grok/hooks/. Re-run `hol-guard apps connect grok`.")
-    elif not _grok_pretool_is_catchall(pretool_hook):
+    elif not _grok_pretool_is_catchall(pretool_hook, context):
         warnings.append(
             "Grok Guard pre-tool hook still uses a stale per-tool matcher list. Re-run `hol-guard apps repair grok`."
         )
-    elif not _grok_prompt_hook_is_observe(prompt_hook):
+    elif not _grok_prompt_hook_is_observe(prompt_hook, context):
         warnings.append(
             "Grok Guard observe hooks are missing prompt, session, or subagent events. "
             "Re-run `hol-guard apps repair grok`."
@@ -249,7 +253,7 @@ def _grok_protection_checks(context: HarnessContext) -> dict[str, object]:
     return {
         "pretool_hook_installed": pretool_hook.is_file(),
         "prompt_hook_installed": prompt_hook.is_file(),
-        "pretool_catchall_installed": _grok_pretool_is_catchall(pretool_hook),
+        "pretool_catchall_installed": _grok_pretool_is_catchall(pretool_hook, context),
         "managed_config_installed": managed_config.is_file(),
         "launch_shim_installed": shim_path.is_file(),
         "warnings": warnings,

--- a/src/codex_plugin_scanner/guard/cli/native_install_checks.py
+++ b/src/codex_plugin_scanner/guard/cli/native_install_checks.py
@@ -122,22 +122,10 @@ def _grok_pretool_is_catchall(pretool_hook: Path) -> bool:
 
 
 def _grok_hook_command_is_guard(command: str) -> bool:
-    """Identify a real Guard hook command rather than a shell placeholder."""
-    lowered = command.lower()
-    tokens = lowered.replace("=", " ").replace(",", " ").split()
-    if not tokens:
-        return False
-    first = tokens[0].rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
-    if first in {"echo", "true", "false", "printf", ":"}:
-        return False
-    return "hook" in lowered and (
-        "hol-guard" in tokens
-        or any(token.endswith("/hol-guard") or token.endswith("\\hol-guard") for token in tokens)
-        or "__guard-bounded-hook" in lowered
-        or "__guard-cursor-hook" in lowered
-        or "bounded_cli_hook_bridge" in lowered
-        or "codex_plugin_scanner.guard" in lowered
-    )
+    """Validate a serialized native hook invocation, not arbitrary Guard marker text."""
+    from .grok_hook_validation import is_grok_hook_command
+
+    return is_grok_hook_command(command)
 
 
 def _grok_prompt_hook_is_observe(prompt_hook: Path) -> bool:
@@ -177,18 +165,21 @@ def _grok_event_has_command_hook(entries: object) -> bool:
 
 
 def _grok_managed_config_is_active(managed_text: str) -> bool:
-    """Check the active managed section for the required credential deny rule."""
+    """Require the credential deny rule in the parsed managed permission table."""
     from ..adapters.grok_config import GUARD_MANAGED_BEGIN, GUARD_MANAGED_END
+    from ..codex_config import tomllib
 
     start = managed_text.find(GUARD_MANAGED_BEGIN)
     stop = managed_text.find(GUARD_MANAGED_END)
     if start < 0 or stop <= start:
         return False
-    for line in managed_text[start:stop].splitlines():
-        active = line.split("#", 1)[0].strip()
-        if "Read(**/.grok/auth/**)" in active:
-            return True
-    return False
+    try:
+        payload = tomllib.loads(managed_text[start:stop])
+    except (ValueError, TypeError):
+        return False
+    permission = payload.get("permission")
+    denied = permission.get("deny") if isinstance(permission, dict) else None
+    return isinstance(denied, list) and "Read(**/.grok/auth/**)" in denied
 
 
 def grok_hooks_protection_ready(context: HarnessContext) -> bool:
@@ -231,8 +222,15 @@ def _grok_protection_checks(context: HarnessContext) -> dict[str, object]:
             "Grok Guard observe hooks are missing prompt, session, or subagent events. "
             "Re-run `hol-guard apps repair grok`."
         )
-    managed_text = managed_config.read_text(encoding="utf-8") if managed_config.is_file() else ""
-    if not managed_config.is_file() or not _grok_managed_config_is_active(managed_text):
+    try:
+        managed_text = managed_config.read_text(encoding="utf-8") if managed_config.is_file() else ""
+        managed_read_error = False
+    except (OSError, UnicodeError):
+        managed_text = ""
+        managed_read_error = True
+    if managed_read_error:
+        warnings.append("Grok managed config could not be read. Re-run `hol-guard apps repair grok`.")
+    elif not managed_config.is_file() or not _grok_managed_config_is_active(managed_text):
         warnings.append(
             "Grok managed permission rules are missing from ~/.grok/managed_config.toml. "
             "Re-run `hol-guard apps connect grok`."

--- a/src/codex_plugin_scanner/guard/daemon/client.py
+++ b/src/codex_plugin_scanner/guard/daemon/client.py
@@ -5,13 +5,17 @@ from __future__ import annotations
 import http.client
 import io
 import json
+import socket
 import time
 import urllib.error
 import urllib.request
 from collections.abc import Callable, Mapping
-from contextlib import suppress
+from contextlib import closing, suppress
+from http.client import HTTPConnection, HTTPException
 from pathlib import Path
+from threading import Timer
 from typing import Protocol, TypeGuard, cast
+from urllib.parse import urlsplit
 
 from .manager import (
     clear_guard_daemon_state,
@@ -20,6 +24,63 @@ from .manager import (
     load_guard_daemon_url,
     load_running_guard_daemon_identity,
 )
+
+_HEALTH_PROBE_DEADLINE_SECONDS = 1.0
+
+
+def _interrupt_health_socket(stream: socket.socket) -> None:
+    """Interrupt a blocked header/body read when the whole probe deadline expires."""
+    # A completed request may already have closed its socket.
+    with suppress(OSError):
+        stream.shutdown(socket.SHUT_RDWR)
+
+
+def read_guard_health_details(daemon_url: str, auth_token: str) -> dict[str, object] | None:
+    """Read bounded authenticated health details over direct, non-redirecting loopback IPC."""
+    try:
+        parsed = urlsplit(daemon_url)
+        if (
+            parsed.scheme != "http"
+            or parsed.hostname not in {"127.0.0.1", "::1"}
+            or parsed.port is None
+            or not 1 <= parsed.port <= 65_535
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.path not in {"", "/"}
+            or parsed.query
+            or parsed.fragment
+        ):
+            return None
+        # HTTPConnection neither consults proxy environment variables nor follows
+        # redirects. Never forward the daemon token to a redirected authority.
+        deadline = time.monotonic() + _HEALTH_PROBE_DEADLINE_SECONDS
+        with closing(
+            HTTPConnection(parsed.hostname, parsed.port, timeout=_HEALTH_PROBE_DEADLINE_SECONDS)
+        ) as connection:
+            connection.connect()
+            stream = connection.sock
+            remaining = deadline - time.monotonic()
+            if stream is None or remaining <= 0:
+                return None
+            interrupt = Timer(remaining, _interrupt_health_socket, args=(stream,))
+            interrupt.daemon = True
+            interrupt.start()
+            try:
+                connection.request("GET", "/v1/healthz/details", headers={"X-Guard-Token": auth_token})
+                response = connection.getresponse()
+                if response.status != 200:
+                    return None
+                content = response.read(65_537)
+            finally:
+                interrupt.cancel()
+        if time.monotonic() >= deadline:
+            return None
+        if len(content) > 65_536:
+            return None
+        payload = json.loads(content.decode("utf-8"))
+        return payload if isinstance(payload, dict) else None
+    except (OSError, ValueError, HTTPException):
+        return None
 
 
 class GuardDaemonRequestError(RuntimeError):

--- a/src/codex_plugin_scanner/guard/daemon/live_identity.py
+++ b/src/codex_plugin_scanner/guard/daemon/live_identity.py
@@ -2,49 +2,17 @@
 
 from __future__ import annotations
 
-import json
-import urllib.error
-import urllib.request
 from pathlib import Path
-
-from typing_extensions import override
 
 from .discovery import load_authenticated_daemon_state
 from .manager import GUARD_DAEMON_COMPATIBILITY_VERSION, load_guard_daemon_auth_token
 
-_MAX_HEALTH_DETAILS_BYTES = 65_536
-
-
-class _RejectRedirectHandler(urllib.request.HTTPRedirectHandler):
-    @override
-    def redirect_request(self, *_args: object, **_kwargs: object) -> None:
-        return None
-
 
 def _proxy_disabled_health_details(url: str, auth_token: str) -> dict[str, object] | None:
-    request = urllib.request.Request(
-        f"{url}/v1/healthz/details",
-        headers={"X-Guard-Token": auth_token},
-        method="GET",
-    )
-    opener = urllib.request.build_opener(
-        urllib.request.ProxyHandler({}),
-        _RejectRedirectHandler(),
-    )
-    try:
-        with opener.open(request, timeout=1.0) as response:
-            if getattr(response, "status", None) != 200:
-                return None
-            response_bytes = response.read(_MAX_HEALTH_DETAILS_BYTES + 1)
-    except (OSError, ValueError, urllib.error.URLError):
-        return None
-    if len(response_bytes) > _MAX_HEALTH_DETAILS_BYTES:
-        return None
-    try:
-        payload = json.loads(response_bytes.decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError):
-        return None
-    return payload if isinstance(payload, dict) else None
+    """Use the bounded loopback client without changing authenticated identity checks."""
+    from .client import read_guard_health_details
+
+    return read_guard_health_details(url, auth_token)
 
 
 def verified_live_guard_daemon_identity(guard_home: Path) -> dict[str, object] | None:

--- a/src/codex_plugin_scanner/guard/inventory_agent_types.py
+++ b/src/codex_plugin_scanner/guard/inventory_agent_types.py
@@ -1,0 +1,46 @@
+"""Canonical agent identities accepted by Guard inventory snapshots."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+AgentInventoryType = Literal[
+    "hermes",
+    "openclaw",
+    "codex",
+    "claude-code",
+    "cursor",
+    "antigravity",
+    "gemini",
+    "opencode",
+    "kimi",
+    "grok",
+    "pi",
+    "omp",
+    "zcode",
+    "paseo",
+]
+_AGENT_INVENTORY_TYPES: tuple[AgentInventoryType, ...] = (
+    "hermes",
+    "openclaw",
+    "codex",
+    "claude-code",
+    "cursor",
+    "antigravity",
+    "gemini",
+    "opencode",
+    "kimi",
+    "grok",
+    "pi",
+    "omp",
+    "zcode",
+    "paseo",
+)
+
+
+def agent_type(value: str) -> AgentInventoryType:
+    """Normalize a harness identity to the inventory contract's supported agent types."""
+    for agent_type in _AGENT_INVENTORY_TYPES:
+        if value == agent_type:
+            return agent_type
+    return "codex"

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -17,6 +17,9 @@ from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from ..path_support import resolves_within_root
 from ..version import __version__
+from .inventory_agent_types import _AGENT_INVENTORY_TYPES as _AGENT_INVENTORY_TYPES
+from .inventory_agent_types import AgentInventoryType
+from .inventory_agent_types import agent_type as _agent_type
 from .path_security import path_has_symlink_component
 from .skill_directory_identity import validated_complete_skill_directory_hash
 
@@ -63,36 +66,7 @@ InventorySeverity = Literal["critical", "high", "medium", "low", "info"]
 InventoryConfidence = Literal["high", "medium", "low", "unknown"]
 InventoryDriftState = Literal["new", "changed", "removed", "unchanged"]
 DockerProofStatus = Literal["passed", "failed", "skipped", "stale"]
-AgentInventoryType = Literal[
-    "hermes",
-    "openclaw",
-    "codex",
-    "claude-code",
-    "cursor",
-    "antigravity",
-    "gemini",
-    "opencode",
-    "kimi",
-    "grok",
-    "pi",
-    "omp",
-    "zcode",
-]
-_AGENT_INVENTORY_TYPES: tuple[AgentInventoryType, ...] = (
-    "hermes",
-    "openclaw",
-    "codex",
-    "claude-code",
-    "cursor",
-    "antigravity",
-    "gemini",
-    "opencode",
-    "kimi",
-    "grok",
-    "pi",
-    "omp",
-    "zcode",
-)
+
 
 _SENSITIVE_KEY_RE = re.compile(
     r"(auth|authorization|bearer|token|secret|password|credential|api[^a-z0-9]?key)",
@@ -1351,13 +1325,6 @@ def _safe_finding_text(value: str, *, home_dir: Path, workspace_dir: Path | None
     redacted = _SENSITIVE_VALUE_RE.sub("redacted", value)
     redacted = _redact_command_value(redacted, home_dir, workspace_dir)
     return redacted[:500]
-
-
-def _agent_type(value: str) -> AgentInventoryType:
-    for agent_type in _AGENT_INVENTORY_TYPES:
-        if value == agent_type:
-            return agent_type
-    return "codex"
 
 
 def _item_kind(artifact_type: str) -> InventoryItemKind:

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -1,277 +1,137 @@
-"""Structured Guard agent inventory contract and safe serializers."""
+"""Public inventory API and snapshot assembly; legacy exports remain compatible."""
 
 from __future__ import annotations
 
-import hashlib
-import importlib
-import ipaddress
-import json
-import re
-from collections.abc import Mapping
-from dataclasses import asdict, dataclass, field
-from datetime import datetime, timezone
-from pathlib import Path
-from types import SimpleNamespace
-from typing import Literal
-from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+import hashlib as hashlib
+import importlib as importlib
+import ipaddress as ipaddress
+import json as json
+import re as re
+from collections.abc import Mapping as Mapping
+from dataclasses import asdict as asdict
+from dataclasses import dataclass as dataclass
+from dataclasses import field as field
+from datetime import datetime as datetime
+from datetime import timezone as timezone
+from pathlib import Path as Path
+from types import SimpleNamespace as SimpleNamespace
+from typing import Literal as Literal
+from urllib.parse import parse_qsl as parse_qsl
+from urllib.parse import urlencode as urlencode
+from urllib.parse import urlsplit as urlsplit
+from urllib.parse import urlunsplit as urlunsplit
 
-from ..path_support import resolves_within_root
-from ..version import __version__
+from ..path_support import resolves_within_root as resolves_within_root
+from ..version import __version__ as __version__
 from .inventory_agent_types import _AGENT_INVENTORY_TYPES as _AGENT_INVENTORY_TYPES
-from .inventory_agent_types import AgentInventoryType
+from .inventory_agent_types import AgentInventoryType as AgentInventoryType
 from .inventory_agent_types import agent_type as _agent_type
-from .path_security import path_has_symlink_component
-from .skill_directory_identity import validated_complete_skill_directory_hash
-
-InventoryItemKind = Literal[
-    "agent",
-    "daemon_plugin",
-    "harness",
-    "model_provider",
-    "package",
-    "prompt_pack",
-    "skill",
-    "mcp_server",
-    "mcp_tool",
-    "plugin",
-    "channel",
-    "hook",
-    "overlay",
-    "repository",
-    "container_image",
-    "policy",
-    "secret_reference",
-    "network_endpoint",
-]
-InventoryCapability = Literal[
-    "reads_files",
-    "reads_secrets",
-    "writes_files",
-    "deletes_files",
-    "runs_shell",
-    "executes_code",
-    "network_egress",
-    "network_ingress",
-    "posts_messages",
-    "reads_messages",
-    "uses_browser",
-    "uses_clipboard",
-    "uses_model_sampling",
-    "changes_permissions",
-    "loads_remote_code",
-    "unknown",
-]
-InventoryFindingSource = Literal["cisco-mcp-scanner", "cisco-skill-scanner", "hol-detector", "docker-proof", "metadata"]
-InventorySeverity = Literal["critical", "high", "medium", "low", "info"]
-InventoryConfidence = Literal["high", "medium", "low", "unknown"]
-InventoryDriftState = Literal["new", "changed", "removed", "unchanged"]
-DockerProofStatus = Literal["passed", "failed", "skipped", "stale"]
-
-
-_SENSITIVE_KEY_RE = re.compile(
-    r"(auth|authorization|bearer|token|secret|password|credential|api[^a-z0-9]?key)",
-    re.IGNORECASE,
+from .inventory_contract_constants import _AIBOM_METADATA_KEYS as _AIBOM_METADATA_KEYS
+from .inventory_contract_constants import _FREE_FORM_RECORD_KEYS as _FREE_FORM_RECORD_KEYS
+from .inventory_contract_constants import _IGNORED_TREE_DIR_NAMES as _IGNORED_TREE_DIR_NAMES
+from .inventory_contract_constants import _INVENTORY_DATETIME_KEYS as _INVENTORY_DATETIME_KEYS
+from .inventory_contract_constants import _MAX_FINGERPRINT_FILE_BYTES as _MAX_FINGERPRINT_FILE_BYTES
+from .inventory_contract_constants import _MCP_DELETE_RE as _MCP_DELETE_RE
+from .inventory_contract_constants import _MCP_MODEL_RE as _MCP_MODEL_RE
+from .inventory_contract_constants import _MCP_NETWORK_RE as _MCP_NETWORK_RE
+from .inventory_contract_constants import _MCP_PERMISSION_RE as _MCP_PERMISSION_RE
+from .inventory_contract_constants import _MCP_READ_RE as _MCP_READ_RE
+from .inventory_contract_constants import _MCP_SECRET_RE as _MCP_SECRET_RE
+from .inventory_contract_constants import _MCP_SHELL_RE as _MCP_SHELL_RE
+from .inventory_contract_constants import _MCP_WRITE_RE as _MCP_WRITE_RE
+from .inventory_contract_constants import _OPTIONAL_ONLY_CONTRACT_KEYS as _OPTIONAL_ONLY_CONTRACT_KEYS
+from .inventory_contract_constants import _SAFE_SERIALIZED_MARKERS as _SAFE_SERIALIZED_MARKERS
+from .inventory_contract_constants import _SENSITIVE_KEY_RE as _SENSITIVE_KEY_RE
+from .inventory_contract_constants import _SENSITIVE_VALUE_RE as _SENSITIVE_VALUE_RE
+from .inventory_contract_constants import _SERIALIZER_REDACTED_VALUE as _SERIALIZER_REDACTED_VALUE
+from .inventory_contract_constants import _SERIALIZER_SECRET_ASSIGNMENT_RE as _SERIALIZER_SECRET_ASSIGNMENT_RE
+from .inventory_contract_constants import _SERIALIZER_UNSAFE_PATH_PATTERN as _SERIALIZER_UNSAFE_PATH_PATTERN
+from .inventory_contract_constants import _SERIALIZER_UNSAFE_PATH_RE as _SERIALIZER_UNSAFE_PATH_RE
+from .inventory_contract_constants import _UNSAFE_PATH_MARKERS as _UNSAFE_PATH_MARKERS
+from .inventory_contract_constants import _WHITESPACE_RE as _WHITESPACE_RE
+from .inventory_contract_constants import _path_has_symlink_component as _path_has_symlink_component
+from .inventory_contract_fingerprints import _fingerprint_file_bytes as _fingerprint_file_bytes
+from .inventory_contract_fingerprints import _inventory_snapshot_content_hash as _inventory_snapshot_content_hash
+from .inventory_contract_fingerprints import _stable_snapshot_sort_key as _stable_snapshot_sort_key
+from .inventory_contract_fingerprints import _stable_snapshot_value as _stable_snapshot_value
+from .inventory_contract_fingerprints import fingerprint_mapping as fingerprint_mapping
+from .inventory_contract_fingerprints import fingerprint_path_tree as fingerprint_path_tree
+from .inventory_contract_fingerprints import fingerprint_text as fingerprint_text
+from .inventory_contract_fingerprints import inventory_item_id as inventory_item_id
+from .inventory_contract_items import _item_from_artifact as _item_from_artifact
+from .inventory_contract_items import _mcp_tool_items_from_artifact as _mcp_tool_items_from_artifact
+from .inventory_contract_mcp import _apply_tool_trust_attestation_metadata as _apply_tool_trust_attestation_metadata
+from .inventory_contract_mcp import _attestation_path_hash as _attestation_path_hash
+from .inventory_contract_mcp import _attestation_repository_id as _attestation_repository_id
+from .inventory_contract_mcp import _capabilities_for_mcp_tool as _capabilities_for_mcp_tool
+from .inventory_contract_mcp import _first_present_value as _first_present_value
+from .inventory_contract_mcp import _mcp_schema_signal_text as _mcp_schema_signal_text
+from .inventory_contract_mcp import _mcp_tool_definitions as _mcp_tool_definitions
+from .inventory_contract_mcp import _optional_context_string as _optional_context_string
+from .inventory_contract_mcp import _risk_level_for_capabilities as _risk_level_for_capabilities
+from .inventory_contract_mcp import _string_value as _string_value
+from .inventory_contract_metadata import _aibom_detection_module as _aibom_detection_module
+from .inventory_contract_metadata import _aibom_symlink_module as _aibom_symlink_module
+from .inventory_contract_metadata import _aibom_trust_metadata_module as _aibom_trust_metadata_module
+from .inventory_contract_metadata import _apply_aibom_metadata_enrichment as _apply_aibom_metadata_enrichment
+from .inventory_contract_metadata import _apply_source_of_truth_metadata as _apply_source_of_truth_metadata
+from .inventory_contract_metadata import _bind_skill_document_evidence as _bind_skill_document_evidence
+from .inventory_contract_metadata import _canonical_inventory_content_hash as _canonical_inventory_content_hash
+from .inventory_contract_metadata import _capabilities_for_artifact as _capabilities_for_artifact
+from .inventory_contract_metadata import (
+    _discard_unverified_skill_directory_hash as _discard_unverified_skill_directory_hash,
 )
-_SENSITIVE_VALUE_RE = re.compile(r"(?i)(gh[pousr]_[a-z0-9_]+|sk-[a-z0-9_-]+|guard_live_[a-z0-9_-]+|bearer\s+\S+)")
-_UNSAFE_PATH_MARKERS = (
-    "".join(("/", "Users", "/")),
-    "".join(("/", "home", "/")),
-    "".join(("/", "root", "/")),
-    "".join(("\\", "Users", "\\")),
-    "".join(("/", "var", "/", "folders", "/")),
-    "".join(("/", "workspace", "/")),
-    "".join(("/", "tmp", "/")),
-    "".join(("/", "etc", "/")),
-    "".join(("/", "mnt", "/")),
+from .inventory_contract_metadata import _inventory_item_description_module as _inventory_item_description_module
+from .inventory_contract_metadata import _item_kind as _item_kind
+from .inventory_contract_metadata import _primary_artifact_content_hash as _primary_artifact_content_hash
+from .inventory_contract_metadata import _resolve_item_content_hash as _resolve_item_content_hash
+from .inventory_contract_metadata import _risk_level as _risk_level
+from .inventory_contract_metadata import _safe_roots_for_inspection as _safe_roots_for_inspection
+from .inventory_contract_models import DockerProofStatus as DockerProofStatus
+from .inventory_contract_models import GuardAgentIntegrationRun as GuardAgentIntegrationRun
+from .inventory_contract_models import GuardAgentInventoryDockerProof as GuardAgentInventoryDockerProof
+from .inventory_contract_models import GuardAgentInventoryDrift as GuardAgentInventoryDrift
+from .inventory_contract_models import GuardAgentInventoryFinding as GuardAgentInventoryFinding
+from .inventory_contract_models import GuardAgentInventoryItem as GuardAgentInventoryItem
+from .inventory_contract_models import GuardAgentInventorySnapshot as GuardAgentInventorySnapshot
+from .inventory_contract_models import GuardHarnessSetupStep as GuardHarnessSetupStep
+from .inventory_contract_models import GuardInventoryRiskComponent as GuardInventoryRiskComponent
+from .inventory_contract_models import GuardInventorySource as GuardInventorySource
+from .inventory_contract_models import InventoryCapability as InventoryCapability
+from .inventory_contract_models import InventoryConfidence as InventoryConfidence
+from .inventory_contract_models import InventoryDriftState as InventoryDriftState
+from .inventory_contract_models import InventoryFindingSource as InventoryFindingSource
+from .inventory_contract_models import InventoryItemKind as InventoryItemKind
+from .inventory_contract_models import InventorySeverity as InventorySeverity
+from .inventory_contract_redaction import (
+    _assert_serialized_inventory_payload_safe as _assert_serialized_inventory_payload_safe,
 )
-_SERIALIZER_UNSAFE_PATH_PATTERN = (
-    r"(?:^|[\s\"'=:({])(?:" + "|".join(re.escape(marker) for marker in _UNSAFE_PATH_MARKERS) + ")"
-)
-_SERIALIZER_UNSAFE_PATH_RE = re.compile(_SERIALIZER_UNSAFE_PATH_PATTERN, re.IGNORECASE)
-_SERIALIZER_SECRET_ASSIGNMENT_RE = re.compile(
-    r"(?i)\b(?:api[_-]?key|authorization|password|secret|token|access[_-]?token|refresh[_-]?token)\b\s*[:=]\s*(?!redacted\b)\S+",
-)
-_SERIALIZER_REDACTED_VALUE = "[REDACTED]"
-_SAFE_SERIALIZED_MARKERS = frozenset(
-    {
-        _SERIALIZER_REDACTED_VALUE,
-        "present_redacted",
-        "present",
-        "redacted",
-        "malformed_url_redacted",
-    }
-)
-_WHITESPACE_RE = re.compile(r"\s+")
-_MCP_READ_RE = re.compile(
-    r"(?<![a-z0-9])(read|reads|reading|search|searches|list|lists)(?![a-z0-9])",
-    re.IGNORECASE,
-)
-_MCP_DELETE_RE = re.compile(
-    r"(?<![a-z0-9])(delete|deletes|remove|removes|destroy|destroys)(?![a-z0-9])",
-    re.IGNORECASE,
-)
-_MCP_WRITE_RE = re.compile(
-    r"(?<![a-z0-9])(write|writes|update|updates|create|creates|modify|modifies)(?![a-z0-9])",
-    re.IGNORECASE,
-)
-_MCP_SHELL_RE = re.compile(
-    r"(?<![a-z0-9])(shell|command|commands|execute|exec|subprocess)(?![a-z0-9])",
-    re.IGNORECASE,
-)
-
-
-def _aibom_detection_module():
-    return importlib.import_module(".aibom_detection", __package__)
-
-
-def _aibom_symlink_module():
-    return importlib.import_module(".aibom_symlink", __package__)
-
-
-def _aibom_trust_metadata_module():
-    return importlib.import_module(".aibom_trust_metadata", __package__)
-
-
-def _inventory_item_description_module():
-    return importlib.import_module(".inventory_item_description", __package__)
-
-
-_MCP_SECRET_RE = re.compile(
-    r"(?<![a-z0-9])(secret|secrets|token|tokens|password|passwords|credential|credentials|api[_\-\s]?key)(?![a-z0-9])",
-    re.IGNORECASE,
-)
-_MCP_NETWORK_RE = re.compile(
-    r"(?<![a-z0-9])(http|url|urls|network|fetch|webhook|webhooks)(?![a-z0-9])",
-    re.IGNORECASE,
-)
-_MCP_MODEL_RE = re.compile(r"(?<![a-z0-9])(sampling|model|models|llm)(?![a-z0-9])", re.IGNORECASE)
-_MCP_PERMISSION_RE = re.compile(
-    r"(?<![a-z0-9])(permission|permissions|chmod)(?![a-z0-9])",
-    re.IGNORECASE,
-)
-_IGNORED_TREE_DIR_NAMES = {".git", ".hg", ".svn", "__pycache__", ".mypy_cache", ".ruff_cache", ".venv", "node_modules"}
-_MAX_FINGERPRINT_FILE_BYTES = 1024 * 1024
-_AIBOM_METADATA_KEYS = (
-    "instructionRole",
-    "localSecurity",
-    "registryIdentity",
-    "skillDirectoryIdentity",
-    "sourceLinks",
-    "sourceOfTruth",
-    "trustLayers",
-    "trustResolution",
-    "unverifiedAdapterEvidence",
-    "versionInfo",
-)
-
-
-@dataclass(frozen=True, slots=True)
-class GuardAgentInventoryFinding:
-    finding_id: str
-    source: InventoryFindingSource
-    severity: InventorySeverity
-    confidence: InventoryConfidence
-    title: str
-    artifact_id: str
-    check_id: str
-    summary: str | None = None
-    evidence: dict[str, object] = field(default_factory=dict)
-
-
-@dataclass(frozen=True, slots=True)
-class GuardAgentInventoryDrift:
-    drift_id: str
-    item_id: str
-    state: InventoryDriftState
-    previous_hash: str | None
-    current_hash: str | None
-    changed_fields: tuple[str, ...] = ()
-
-
-@dataclass(frozen=True, slots=True)
-class GuardAgentInventoryDockerProof:
-    proof_id: str
-    agent_id: str
-    agent_type: str
-    image_reference: str
-    status: DockerProofStatus
-    captured_at: str
-    log_hash: str
-    redaction_report: dict[str, object] = field(default_factory=dict)
-
-
-@dataclass(frozen=True, slots=True)
-class GuardAgentIntegrationRun:
-    run_id: str
-    agent_id: str
-    agent_type: str
-    status: Literal["started", "completed", "failed"]
-    started_at: str
-    completed_at: str | None = None
-    message: str | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class GuardHarnessSetupStep:
-    step_id: str
-    agent_type: str
-    status: Literal["not_started", "running", "completed", "failed"]
-    label: str
-    safe_command: str | None = None
-    detail: str | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class GuardInventoryRiskComponent:
-    component_id: str
-    source: InventoryFindingSource
-    severity: InventorySeverity
-    confidence: InventoryConfidence
-    score_delta: int
-    summary: str
-
-
-@dataclass(frozen=True, slots=True)
-class GuardInventorySource:
-    source_id: str
-    source_type: Literal["config", "docker", "scanner", "runtime", "repository"]
-    status: Literal["available", "missing", "failed"]
-    captured_at: str | None = None
-    detail: str | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class GuardAgentInventoryItem:
-    item_id: str
-    item_kind: InventoryItemKind
-    display_name: str
-    description: str
-    source_fingerprint: str
-    content_hash: str
-    capability_categories: tuple[InventoryCapability, ...]
-    risk_level: InventorySeverity = "info"
-    security_score: int = 100
-    scanner_sources: tuple[InventoryFindingSource, ...] = ()
-    drift_state: InventoryDriftState = "unchanged"
-    metadata: dict[str, object] = field(default_factory=dict)
-
-
-@dataclass(frozen=True, slots=True)
-class GuardAgentInventorySnapshot:
-    snapshot_id: str
-    agent_id: str
-    agent_type: AgentInventoryType
-    generated_at: str
-    runtime_version: str | None = None
-    items: tuple[GuardAgentInventoryItem, ...] = ()
-    findings: tuple[GuardAgentInventoryFinding, ...] = ()
-    drift: tuple[GuardAgentInventoryDrift, ...] = ()
-    docker_proofs: tuple[GuardAgentInventoryDockerProof, ...] = ()
-    sources: tuple[GuardInventorySource, ...] = ()
-    redaction_report: dict[str, object] = field(default_factory=dict)
+from .inventory_contract_redaction import _redact_command_value as _redact_command_value
+from .inventory_contract_redaction import _redact_known_path as _redact_known_path
+from .inventory_contract_redaction import _safe_artifact_metadata as _safe_artifact_metadata
+from .inventory_contract_redaction import _safe_finding_text as _safe_finding_text
+from .inventory_contract_redaction import _safe_json as _safe_json
+from .inventory_contract_redaction import _safe_source_detail as _safe_source_detail
+from .inventory_contract_redaction import _sanitize_paths as _sanitize_paths
+from .inventory_contract_redaction import _sanitize_serializer_string as _sanitize_serializer_string
+from .inventory_contract_redaction import classify_endpoint_host as classify_endpoint_host
+from .inventory_contract_redaction import redact_headers as redact_headers
+from .inventory_contract_redaction import redact_local_path as redact_local_path
+from .inventory_contract_redaction import redact_url as redact_url
+from .inventory_contract_scans import _artifact_id_for_cisco_finding as _artifact_id_for_cisco_finding
+from .inventory_contract_scans import _cisco_inventory_findings as _cisco_inventory_findings
+from .inventory_contract_scans import _cisco_inventory_sources as _cisco_inventory_sources
+from .inventory_contract_scans import _cisco_source as _cisco_source
+from .inventory_contract_scans import _inventory_severity as _inventory_severity
+from .inventory_contract_scans import _score_delta_for_severity as _score_delta_for_severity
+from .inventory_contract_scans import _source_status_for_cisco_status as _source_status_for_cisco_status
+from .inventory_contract_scans import _symlink_findings_from_items as _symlink_findings_from_items
+from .path_security import path_has_symlink_component as path_has_symlink_component
+from .skill_directory_identity import validated_complete_skill_directory_hash as validated_complete_skill_directory_hash
 
 
 def _snake_to_camel_case_key(key: str) -> str:
+    """Translate a Python field name to the inventory wire key."""
     if "_" not in key:
         return key
     head, *tail = key.split("_")
@@ -279,6 +139,7 @@ def _snake_to_camel_case_key(key: str) -> str:
 
 
 def _normalize_redaction_report(report: object) -> dict[str, object]:
+    """Validate and normalize redaction counts into the public report shape."""
     if not isinstance(report, dict):
         return {"rawSecretsIncluded": False, "redactedFields": []}
     raw_secrets = report.get("rawSecretsIncluded")
@@ -295,23 +156,8 @@ def _normalize_redaction_report(report: object) -> dict[str, object]:
     }
 
 
-_INVENTORY_DATETIME_KEYS = frozenset(
-    {
-        "capturedAt",
-        "completedAt",
-        "firstSeenAt",
-        "generatedAt",
-        "lastSeenAt",
-        "startedAt",
-    }
-)
-
-_FREE_FORM_RECORD_KEYS = frozenset({"metadata", "evidence"})
-
-_OPTIONAL_ONLY_CONTRACT_KEYS = frozenset({"summary"})
-
-
 def _normalize_inventory_datetime(value: object) -> object:
+    """Serialize a valid inventory timestamp consistently in UTC."""
     if not isinstance(value, str) or not value.strip():
         return value
     try:
@@ -323,6 +169,7 @@ def _normalize_inventory_datetime(value: object) -> object:
 
 
 def _inventory_contract_json(value: object) -> object:
+    """Serialize contract data through the established field-name and safety rules."""
     if isinstance(value, list):
         return [_inventory_contract_json(item) for item in value]
     if isinstance(value, dict):
@@ -346,6 +193,7 @@ def _inventory_contract_json(value: object) -> object:
 
 
 def serialize_inventory_snapshot(snapshot: GuardAgentInventorySnapshot) -> dict[str, object]:
+    """Emit the inventory wire contract after applying final redaction checks."""
     payload = _safe_json(asdict(snapshot))
     if not isinstance(payload, dict):
         raise TypeError("Inventory snapshot serialization produced invalid payload.")
@@ -406,6 +254,7 @@ def inventory_snapshot_from_detection(
     trust_attestation_context: Mapping[str, object] | None = None,
     artifacts: tuple[object, ...] | None = None,
 ) -> GuardAgentInventorySnapshot:
+    """Assemble native artifacts, scanner findings, and trust evidence into one snapshot."""
     harness = str(getattr(detection, "harness", "unknown"))
     artifact_tuple = (
         artifacts
@@ -483,1303 +332,3 @@ def inventory_snapshot_from_detection(
             "redactedFields": ("headers", "env", "url", "paths", "ciscoFindingText"),
         },
     )
-
-
-def fingerprint_text(value: str) -> str:
-    return hashlib.sha256(value.encode("utf-8")).hexdigest()
-
-
-def fingerprint_mapping(value: object) -> str:
-    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
-    return fingerprint_text(encoded)
-
-
-def _inventory_snapshot_content_hash(
-    *,
-    agent_type: str,
-    items: tuple[GuardAgentInventoryItem, ...],
-    findings: tuple[GuardAgentInventoryFinding, ...],
-    sources: tuple[GuardInventorySource, ...],
-    runtime_version: str | None,
-) -> str:
-    return fingerprint_mapping(
-        {
-            "agent_type": agent_type,
-            "runtime_version": runtime_version,
-            "items": [
-                {
-                    "capability_categories": item.capability_categories,
-                    "content_hash": item.content_hash,
-                    "drift_state": item.drift_state,
-                    "item_id": item.item_id,
-                    "item_kind": item.item_kind,
-                    "metadata": _stable_snapshot_value(item.metadata),
-                    "risk_level": item.risk_level,
-                    "scanner_sources": item.scanner_sources,
-                    "security_score": item.security_score,
-                    "source_fingerprint": item.source_fingerprint,
-                }
-                for item in sorted(items, key=lambda value: (value.item_kind, value.item_id))
-            ],
-            "findings": [
-                {
-                    "artifact_id": finding.artifact_id,
-                    "check_id": finding.check_id,
-                    "confidence": finding.confidence,
-                    "evidence": _stable_snapshot_value(finding.evidence),
-                    "finding_id": finding.finding_id,
-                    "severity": finding.severity,
-                    "source": finding.source,
-                    "summary": finding.summary,
-                    "title": finding.title,
-                }
-                for finding in sorted(findings, key=lambda value: (value.source, value.finding_id))
-            ],
-            "sources": [
-                {
-                    "detail": source.detail,
-                    "source_id": source.source_id,
-                    "source_type": source.source_type,
-                    "status": source.status,
-                }
-                for source in sorted(sources, key=lambda value: (value.source_type, value.source_id))
-            ],
-        }
-    )
-
-
-def _stable_snapshot_value(value: object) -> object:
-    if isinstance(value, dict):
-        return {
-            key: _stable_snapshot_value(item)
-            for key, item in sorted(value.items(), key=lambda entry: str(entry[0]))
-            if str(key)
-            not in {
-                "attestation",
-                "attestationBindings",
-                "capturedAt",
-                "duration_ms",
-                "durationMs",
-                "elapsedMs",
-                "evidenceHash",
-                "generatedAt",
-                "lastSeenAt",
-                "observedAt",
-                "scanDurationMs",
-                "syncedAt",
-            }
-        }
-    if isinstance(value, (list, tuple)):
-        return sorted((_stable_snapshot_value(item) for item in value), key=_stable_snapshot_sort_key)
-    return value
-
-
-def _stable_snapshot_sort_key(value: object) -> str:
-    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
-
-
-def inventory_item_id(agent_type: str, item_kind: str, display_name: str, semantic_text: str) -> str:
-    normalized_text = _WHITESPACE_RE.sub(" ", semantic_text.strip())
-    digest = fingerprint_mapping(
-        {
-            "agent_type": agent_type,
-            "display_name": display_name.strip().lower(),
-            "item_kind": item_kind,
-            "semantic_text": normalized_text,
-        }
-    )
-    return f"{agent_type}:{item_kind}:{digest[:24]}"
-
-
-def fingerprint_path_tree(root: Path, *, home_dir: Path | None = None) -> str:
-    entries: list[dict[str, str]] = []
-    if root.is_file():
-        paths = [root]
-    else:
-        paths = sorted(
-            path
-            for path in root.rglob("*")
-            if path.is_file()
-            and path.name != ".env"
-            and not any(part in _IGNORED_TREE_DIR_NAMES for part in path.parts)
-        )
-    for path in paths:
-        safe_path = redact_local_path(path, home_dir=home_dir)
-        content_hash = _fingerprint_file_bytes(path)
-        entries.append({"path": safe_path, "sha256": content_hash})
-    return fingerprint_mapping(entries)
-
-
-def redact_local_path(path: str | Path, *, home_dir: Path | None = None) -> str:
-    candidate = Path(path)
-    if home_dir is None:
-        return candidate.name
-    try:
-        relative = candidate.resolve().relative_to(home_dir.resolve())
-    except (OSError, RuntimeError, ValueError):
-        return candidate.name
-    return f"{{home}}/{relative.as_posix()}"
-
-
-def redact_headers(headers: dict[str, str]) -> dict[str, str]:
-    return {key.lower(): "present_redacted" if _SENSITIVE_KEY_RE.search(key) else "present" for key in headers}
-
-
-def redact_url(value: str) -> str:
-    try:
-        parsed = urlsplit(value)
-    except ValueError:
-        return "malformed_url_redacted"
-    hostname = parsed.hostname or parsed.netloc
-    if ":" in hostname and not hostname.startswith("["):
-        hostname = f"[{hostname}]"
-    netloc = hostname
-    try:
-        port = parsed.port
-    except ValueError:
-        port = None
-    if port is not None:
-        netloc = f"{netloc}:{port}"
-    redacted_pairs = [
-        (key, "redacted" if _SENSITIVE_KEY_RE.search(key) else item)
-        for key, item in parse_qsl(parsed.query.replace(";", "&"), keep_blank_values=True)
-    ]
-    return urlunsplit((parsed.scheme, netloc, parsed.path, urlencode(redacted_pairs), parsed.fragment))
-
-
-def classify_endpoint_host(value: str | None) -> Literal["none", "local_loopback", "local_private", "remote_public"]:
-    if not value:
-        return "none"
-    try:
-        parsed = urlsplit(value)
-    except ValueError:
-        return "remote_public"
-    host = (parsed.hostname or "").lower()
-    if host in {"localhost", "127.0.0.1", "::1"}:
-        return "local_loopback"
-    try:
-        if ipaddress.ip_address(host).is_private:
-            return "local_private"
-    except ValueError:
-        pass
-    return "remote_public"
-
-
-def _item_from_artifact(
-    harness: str,
-    artifact: object,
-    *,
-    generated_at: str,
-    home_dir: Path,
-    workspace_dir: Path | None,
-    cisco_runs: tuple[object, ...] = (),
-    include_symlinks: bool = True,
-    follow_unsafe_symlinks: bool = False,
-    trust_attestation_context: Mapping[str, object] | None = None,
-) -> GuardAgentInventoryItem:
-    artifact_id = str(getattr(artifact, "artifact_id", "artifact"))
-    artifact_type = str(getattr(artifact, "artifact_type", "unknown"))
-    name = str(getattr(artifact, "name", artifact_id))
-    safe_metadata = _safe_artifact_metadata(artifact, home_dir=home_dir, workspace_dir=workspace_dir)
-    item_kind = _item_kind(artifact_type)
-    safe_metadata = _apply_aibom_metadata_enrichment(
-        artifact,
-        captured_at=generated_at,
-        item_kind=item_kind,
-        metadata=safe_metadata,
-        home_dir=home_dir,
-        workspace_dir=workspace_dir,
-        cisco_runs=cisco_runs,
-    )
-    if include_symlinks:
-        safe_metadata = _apply_source_of_truth_metadata(
-            artifact,
-            harness=harness,
-            item_kind=item_kind,
-            metadata=safe_metadata,
-            home_dir=home_dir,
-            workspace_dir=workspace_dir,
-            follow_unsafe_symlinks=follow_unsafe_symlinks,
-        )
-    primary_content_hash = _primary_artifact_content_hash(
-        artifact,
-        artifact_type=artifact_type,
-        home_dir=home_dir,
-        workspace_dir=workspace_dir,
-    )
-    if artifact_type == "skill":
-        safe_metadata = _bind_skill_document_evidence(
-            safe_metadata,
-            primary_content_hash=primary_content_hash,
-        )
-        safe_metadata = _discard_unverified_skill_directory_hash(safe_metadata)
-    semantic_text = fingerprint_mapping(
-        {
-            "artifact_id": artifact_id,
-            "artifact_type": artifact_type,
-            "name": name,
-            "metadata": _stable_snapshot_value(safe_metadata),
-        }
-    )
-    if artifact_type == "skill":
-        content_hash = validated_complete_skill_directory_hash(safe_metadata) or primary_content_hash or semantic_text
-    elif artifact_type == "instruction":
-        content_hash = primary_content_hash or semantic_text
-    else:
-        content_hash = _resolve_item_content_hash(safe_metadata, semantic_text)
-    from .runtime.trust_attestation import (
-        GuardTrustAttestationSigningConfig,
-        apply_trust_attestation_metadata,
-    )
-
-    workspace_id = None
-    device_id = None
-    analyzer_id = None
-    analyzer_spec_version = None
-    analyzer_version = None
-    policy_version = None
-    installation_id = None
-    upload_id = None
-    challenge_id = None
-    nonce = None
-    sequence = None
-    expires_at = None
-    signing_config = None
-    if isinstance(trust_attestation_context, Mapping):
-        raw_workspace_id = trust_attestation_context.get("workspaceId")
-        workspace_id = raw_workspace_id if isinstance(raw_workspace_id, str) and raw_workspace_id else None
-        raw_device_id = trust_attestation_context.get("deviceId")
-        device_id = raw_device_id if isinstance(raw_device_id, str) and raw_device_id else None
-        raw_analyzer_id = trust_attestation_context.get("analyzerId")
-        analyzer_id = raw_analyzer_id if isinstance(raw_analyzer_id, str) and raw_analyzer_id else None
-        raw_analyzer_spec_version = trust_attestation_context.get("analyzerSpecVersion")
-        analyzer_spec_version = (
-            raw_analyzer_spec_version
-            if isinstance(raw_analyzer_spec_version, str) and raw_analyzer_spec_version
-            else None
-        )
-        raw_analyzer_version = trust_attestation_context.get("analyzerVersion")
-        analyzer_version = (
-            raw_analyzer_version if isinstance(raw_analyzer_version, str) and raw_analyzer_version else None
-        )
-        raw_installation_id = trust_attestation_context.get("installationId")
-        installation_id = raw_installation_id if isinstance(raw_installation_id, str) and raw_installation_id else None
-        raw_upload_id = trust_attestation_context.get("uploadId")
-        upload_id = raw_upload_id if isinstance(raw_upload_id, str) and raw_upload_id else None
-        raw_challenge_id = trust_attestation_context.get("challengeId")
-        challenge_id = raw_challenge_id if isinstance(raw_challenge_id, str) and raw_challenge_id else None
-        raw_nonce = trust_attestation_context.get("nonce")
-        nonce = raw_nonce if isinstance(raw_nonce, str) and raw_nonce else None
-        raw_sequence = trust_attestation_context.get("sequence")
-        if isinstance(raw_sequence, int):
-            sequence = raw_sequence
-        raw_policy_version = trust_attestation_context.get("policyVersion")
-        policy_version = raw_policy_version if isinstance(raw_policy_version, str) and raw_policy_version else None
-        raw_expires_at = trust_attestation_context.get("expiresAt")
-        expires_at = raw_expires_at if isinstance(raw_expires_at, str) and raw_expires_at else None
-        raw_signing_config = trust_attestation_context.get("signingConfig")
-        if isinstance(raw_signing_config, GuardTrustAttestationSigningConfig):
-            signing_config = raw_signing_config
-
-    safe_metadata = apply_trust_attestation_metadata(
-        safe_metadata,
-        agent_id=f"{harness}:local",
-        analyzer_id=analyzer_id,
-        analyzer_spec_version=analyzer_spec_version,
-        analyzer_version=analyzer_version,
-        item_id=artifact_id,
-        item_kind=item_kind,
-        content_hash=content_hash,
-        challenge_id=challenge_id,
-        expires_at=expires_at,
-        installation_id=installation_id,
-        nonce=nonce,
-        policy_version=policy_version,
-        sequence=sequence,
-        upload_id=upload_id,
-        workspace_id=workspace_id,
-        device_id=device_id,
-        adapter_id=harness,
-        adapter_version=__version__,
-        config_path_hash=_attestation_path_hash(getattr(artifact, "config_path", None), fallback=artifact_id),
-        repository_id=_attestation_repository_id(home_dir=home_dir, workspace_dir=workspace_dir),
-        signing_config=signing_config,
-    )
-    publisher = getattr(artifact, "publisher", None)
-    publisher_text = publisher if isinstance(publisher, str) else None
-    description = _inventory_item_description_module().resolve_inventory_item_description(
-        harness=harness,
-        item_kind=item_kind,
-        display_name=name,
-        metadata=safe_metadata,
-        publisher=publisher_text,
-        home_dir=home_dir,
-        workspace_dir=workspace_dir,
-    )
-    return GuardAgentInventoryItem(
-        item_id=artifact_id,
-        item_kind=item_kind,
-        display_name=name,
-        description=description,
-        source_fingerprint=fingerprint_mapping({"harness": harness, "artifact_id": artifact_id}),
-        content_hash=content_hash,
-        capability_categories=_capabilities_for_artifact(artifact_type, safe_metadata),
-        risk_level=_risk_level(safe_metadata),
-        scanner_sources=("hol-detector",),
-        metadata=safe_metadata,
-    )
-
-
-def _mcp_tool_items_from_artifact(
-    harness: str,
-    artifact: object,
-    server_item: GuardAgentInventoryItem,
-    *,
-    generated_at: str,
-    home_dir: Path,
-    workspace_dir: Path | None,
-    cisco_runs: tuple[object, ...] = (),
-    trust_attestation_context: Mapping[str, object] | None = None,
-) -> tuple[GuardAgentInventoryItem, ...]:
-    artifact_type = str(getattr(artifact, "artifact_type", "unknown"))
-    if artifact_type != "mcp_server":
-        return ()
-    raw_metadata = getattr(artifact, "metadata", {})
-    if not isinstance(raw_metadata, dict):
-        return ()
-    raw_tools = _mcp_tool_definitions(raw_metadata)
-    if not raw_tools:
-        return ()
-
-    items: list[GuardAgentInventoryItem] = []
-    raw_trust_layers = server_item.metadata.get("trustLayers")
-    inherited_layers: list[dict[str, object]] = []
-    if isinstance(raw_trust_layers, list):
-        for layer in raw_trust_layers:
-            if isinstance(layer, dict) and layer.get("layerType") == "cisco_mcp_scanner":
-                inherited_layers.append(dict(layer))
-    for raw_tool in raw_tools:
-        if not isinstance(raw_tool, dict):
-            continue
-        name = raw_tool.get("name")
-        if not isinstance(name, str) or not name.strip():
-            continue
-        display_name = _string_value(raw_tool.get("title")) or name
-        description = _string_value(raw_tool.get("description")) or ""
-        input_schema = _first_present_value(raw_tool, "inputSchema", "input_schema")
-        output_schema = _first_present_value(raw_tool, "outputSchema", "output_schema")
-        annotations = raw_tool.get("annotations")
-        safe_annotations = annotations if isinstance(annotations, dict) else {}
-        server_command = getattr(artifact, "command", None)
-        server_url = getattr(artifact, "url", None)
-        metadata: dict[str, object] = {
-            "serverItemId": server_item.item_id,
-            "toolName": name,
-            "title": display_name,
-            "serverCommand": _redact_command_value(server_command, home_dir, workspace_dir)
-            if isinstance(server_command, str) and server_command
-            else None,
-            "serverUrl": redact_url(server_url) if isinstance(server_url, str) and server_url else None,
-            "serverTransport": getattr(artifact, "transport", None),
-            "descriptionHash": fingerprint_text(description),
-            "inputSchemaHash": fingerprint_mapping(input_schema) if input_schema is not None else None,
-            "outputSchemaHash": fingerprint_mapping(output_schema) if output_schema is not None else None,
-            "annotations": safe_annotations,
-            "schemaPresent": input_schema is not None or output_schema is not None,
-        }
-        tool_artifact = SimpleNamespace(
-            artifact_id=f"{getattr(artifact, 'artifact_id', server_item.item_id)}:tool:{name}",
-            artifact_type="mcp_tool",
-            config_path=getattr(artifact, "config_path", ""),
-            name=name,
-            command=getattr(artifact, "command", None),
-            url=getattr(artifact, "url", None),
-            transport=getattr(artifact, "transport", None),
-        )
-        metadata = _aibom_trust_metadata_module().apply_local_trust_metadata(
-            tool_artifact,
-            captured_at=generated_at,
-            item_kind="mcp_tool",
-            metadata=metadata,
-            workspace_dir=workspace_dir,
-            cisco_runs=cisco_runs,
-        )
-        capabilities = _capabilities_for_mcp_tool(name, description, input_schema, safe_annotations)
-        tool_item_id = f"{server_item.item_id}:tool:{name}"
-        semantic_hash = fingerprint_mapping(
-            {
-                "server": server_item.item_id,
-                "name": name,
-                "description": description,
-                "inputSchema": input_schema,
-                "outputSchema": output_schema,
-                "annotations": safe_annotations,
-            }
-        )
-        tool_layers = metadata.get("trustLayers")
-        tool_layer_dicts = (
-            [layer for layer in tool_layers if isinstance(layer, dict)] if isinstance(tool_layers, list) else []
-        )
-        if tool_layer_dicts:
-            metadata["trustLayers"] = tool_layer_dicts
-        metadata = _apply_tool_trust_attestation_metadata(
-            metadata,
-            harness=harness,
-            item_id=tool_item_id,
-            content_hash=semantic_hash,
-            config_path_hash=_attestation_path_hash(
-                getattr(artifact, "config_path", None),
-                fallback=server_item.item_id,
-            ),
-            repository_id=_attestation_repository_id(home_dir=home_dir, workspace_dir=workspace_dir),
-            trust_attestation_context=trust_attestation_context,
-        )
-        signed_tool_layers = metadata.get("trustLayers")
-        tool_layer_dicts = (
-            [layer for layer in signed_tool_layers if isinstance(layer, dict)]
-            if isinstance(signed_tool_layers, list)
-            else []
-        )
-        has_tool_cisco_layer = any(layer.get("layerType") == "cisco_mcp_scanner" for layer in tool_layer_dicts)
-        if inherited_layers and not has_tool_cisco_layer:
-            inherited_tool_layers: list[dict[str, object]] = []
-            for layer in inherited_layers:
-                raw_layer_metadata = layer.get("metadata")
-                layer_metadata = dict(raw_layer_metadata) if isinstance(raw_layer_metadata, dict) else {}
-                inherited_tool_layers.append(
-                    {
-                        **layer,
-                        "metadata": {
-                            **{
-                                key: value
-                                for key, value in layer_metadata.items()
-                                if key
-                                not in {
-                                    "attestation",
-                                    "attestationBindings",
-                                    "attestationRef",
-                                    "attestationStatus",
-                                    "attestationVerification",
-                                }
-                            },
-                            "attestationStatus": "unsigned",
-                            "inheritedFromServerItemId": server_item.item_id,
-                        },
-                    }
-                )
-            metadata["trustLayers"] = [*tool_layer_dicts, *inherited_tool_layers]
-        tool_description = _inventory_item_description_module().resolve_inventory_item_description(
-            harness=harness,
-            item_kind="mcp_tool",
-            display_name=display_name,
-            metadata=metadata,
-            explicit_description=description or None,
-            home_dir=home_dir,
-            workspace_dir=workspace_dir,
-        )
-        items.append(
-            GuardAgentInventoryItem(
-                item_id=tool_item_id,
-                item_kind="mcp_tool",
-                display_name=display_name,
-                description=tool_description,
-                source_fingerprint=fingerprint_mapping(
-                    {"harness": harness, "server": server_item.item_id, "tool": name}
-                ),
-                content_hash=semantic_hash,
-                capability_categories=capabilities,
-                risk_level=_risk_level_for_capabilities(capabilities),
-                scanner_sources=("hol-detector",),
-                metadata=metadata,
-            )
-        )
-    return tuple(items)
-
-
-def _apply_tool_trust_attestation_metadata(
-    metadata: dict[str, object],
-    *,
-    harness: str,
-    item_id: str,
-    content_hash: str,
-    config_path_hash: str,
-    repository_id: str,
-    trust_attestation_context: Mapping[str, object] | None,
-) -> dict[str, object]:
-    from .runtime.trust_attestation import (
-        GuardTrustAttestationSigningConfig,
-        apply_trust_attestation_metadata,
-    )
-
-    if not isinstance(trust_attestation_context, Mapping):
-        return apply_trust_attestation_metadata(
-            metadata,
-            agent_id=f"{harness}:local",
-            item_id=item_id,
-            item_kind="mcp_tool",
-            content_hash=content_hash,
-            adapter_id=harness,
-            adapter_version=__version__,
-            config_path_hash=config_path_hash,
-            repository_id=repository_id,
-        )
-
-    raw_signing_config = trust_attestation_context.get("signingConfig")
-    signing_config = raw_signing_config if isinstance(raw_signing_config, GuardTrustAttestationSigningConfig) else None
-    raw_sequence = trust_attestation_context.get("sequence")
-    sequence = raw_sequence if isinstance(raw_sequence, int) else None
-
-    return apply_trust_attestation_metadata(
-        metadata,
-        agent_id=f"{harness}:local",
-        analyzer_id=_optional_context_string(trust_attestation_context, "analyzerId"),
-        analyzer_spec_version=_optional_context_string(trust_attestation_context, "analyzerSpecVersion"),
-        analyzer_version=_optional_context_string(trust_attestation_context, "analyzerVersion"),
-        item_id=item_id,
-        item_kind="mcp_tool",
-        content_hash=content_hash,
-        challenge_id=_optional_context_string(trust_attestation_context, "challengeId"),
-        expires_at=_optional_context_string(trust_attestation_context, "expiresAt"),
-        installation_id=_optional_context_string(trust_attestation_context, "installationId"),
-        nonce=_optional_context_string(trust_attestation_context, "nonce"),
-        policy_version=_optional_context_string(trust_attestation_context, "policyVersion"),
-        sequence=sequence,
-        upload_id=_optional_context_string(trust_attestation_context, "uploadId"),
-        workspace_id=_optional_context_string(trust_attestation_context, "workspaceId"),
-        device_id=_optional_context_string(trust_attestation_context, "deviceId"),
-        adapter_id=harness,
-        adapter_version=__version__,
-        config_path_hash=config_path_hash,
-        repository_id=repository_id,
-        signing_config=signing_config,
-    )
-
-
-def _attestation_path_hash(value: object, *, fallback: str) -> str:
-    raw = value if isinstance(value, str) and value else f"artifact:{fallback}"
-    try:
-        normalized = str(Path(raw).expanduser().resolve(strict=False))
-    except (OSError, RuntimeError, ValueError):
-        normalized = raw
-    return f"sha256:{hashlib.sha256(normalized.encode('utf-8')).hexdigest()}"
-
-
-def _attestation_repository_id(*, home_dir: Path, workspace_dir: Path | None) -> str:
-    root = workspace_dir if workspace_dir is not None else home_dir
-    try:
-        normalized = str(root.expanduser().resolve(strict=False))
-    except (OSError, RuntimeError, ValueError):
-        normalized = str(root)
-    return f"sha256:{hashlib.sha256(normalized.encode('utf-8')).hexdigest()}"
-
-
-def _optional_context_string(context: Mapping[str, object], key: str) -> str | None:
-    value = context.get(key)
-    return value if isinstance(value, str) and value else None
-
-
-def _string_value(value: object) -> str | None:
-    return value if isinstance(value, str) else None
-
-
-def _first_present_value(mapping: dict[str, object], *keys: str) -> object | None:
-    for key in keys:
-        if key in mapping:
-            return mapping[key]
-    return None
-
-
-def _mcp_tool_definitions(metadata: dict[str, object]) -> tuple[dict[str, object], ...]:
-    tools: list[dict[str, object]] = []
-    seen_names: set[str] = set()
-    for key in ("tools", "tool_schemas", "toolSchemas"):
-        raw_tools = metadata.get(key)
-        if not isinstance(raw_tools, list):
-            continue
-        for raw_tool in raw_tools:
-            if not isinstance(raw_tool, dict):
-                continue
-            name = raw_tool.get("name")
-            if not isinstance(name, str) or not name.strip() or name in seen_names:
-                continue
-            tools.append(raw_tool)
-            seen_names.add(name)
-    return tuple(tools)
-
-
-def _mcp_schema_signal_text(value: object) -> str:
-    if isinstance(value, dict):
-        parts: list[str] = []
-        for key, item in value.items():
-            if key in {"$schema", "$id"}:
-                continue
-            parts.append(key)
-            parts.append(_mcp_schema_signal_text(item))
-        return " ".join(part for part in parts if part)
-    if isinstance(value, list):
-        return " ".join(_mcp_schema_signal_text(item) for item in value)
-    if isinstance(value, str):
-        return value
-    return ""
-
-
-def _capabilities_for_mcp_tool(
-    name: str,
-    description: str,
-    input_schema: object,
-    annotations: dict[str, object],
-) -> tuple[InventoryCapability, ...]:
-    text = f"{name} {description} {_mcp_schema_signal_text(input_schema)}".lower()
-    capabilities: set[InventoryCapability] = set()
-    if annotations.get("readOnlyHint") is True or _MCP_READ_RE.search(text):
-        capabilities.add("reads_files")
-    if annotations.get("destructiveHint") is True or _MCP_DELETE_RE.search(text):
-        capabilities.update({"writes_files", "deletes_files"})
-    if annotations.get("writeHint") is True or _MCP_WRITE_RE.search(text):
-        capabilities.add("writes_files")
-    if _MCP_SHELL_RE.search(text):
-        capabilities.add("runs_shell")
-    if _MCP_SECRET_RE.search(text):
-        capabilities.add("reads_secrets")
-    if _MCP_NETWORK_RE.search(text):
-        capabilities.add("network_egress")
-    if _MCP_MODEL_RE.search(text):
-        capabilities.add("uses_model_sampling")
-    if _MCP_PERMISSION_RE.search(text):
-        capabilities.add("changes_permissions")
-    return tuple(sorted(capabilities)) if capabilities else ("unknown",)
-
-
-def _risk_level_for_capabilities(capabilities: tuple[InventoryCapability, ...]) -> InventorySeverity:
-    if any(capability in capabilities for capability in ("deletes_files", "reads_secrets", "runs_shell")):
-        return "high"
-    if any(
-        capability in capabilities
-        for capability in ("writes_files", "network_egress", "uses_model_sampling", "changes_permissions")
-    ):
-        return "medium"
-    return "info"
-
-
-def _cisco_inventory_findings(
-    cisco_runs: tuple[object, ...],
-    *,
-    items: tuple[GuardAgentInventoryItem, ...],
-    home_dir: Path,
-    workspace_dir: Path | None,
-) -> tuple[GuardAgentInventoryFinding, ...]:
-    findings: list[GuardAgentInventoryFinding] = []
-    seen: set[str] = set()
-    for run in cisco_runs:
-        source = _cisco_source(run)
-        if source is None:
-            continue
-        run_status = str(getattr(run, "status", "unknown"))
-        run_message = _safe_finding_text(
-            str(getattr(run, "message", "")),
-            home_dir=home_dir,
-            workspace_dir=workspace_dir,
-        )
-        duration_ms = getattr(run, "duration_ms", None)
-        for raw_finding in tuple(getattr(run, "findings", ()) or ()):
-            rule_id = str(getattr(raw_finding, "rule_id", "cisco-finding") or "cisco-finding")
-            title = _safe_finding_text(
-                str(getattr(raw_finding, "title", "Cisco scanner finding") or "Cisco scanner finding"),
-                home_dir=home_dir,
-                workspace_dir=workspace_dir,
-            )
-            file_path = getattr(raw_finding, "file_path", None)
-            safe_path = (
-                _redact_known_path(str(file_path), home_dir, workspace_dir)
-                if isinstance(file_path, str) and file_path
-                else None
-            )
-            line_number = getattr(raw_finding, "line_number", None)
-            finding_hash = fingerprint_mapping(
-                {
-                    "source": source,
-                    "rule_id": rule_id,
-                    "title": title,
-                    "path": safe_path,
-                    "line": line_number if isinstance(line_number, int) else None,
-                }
-            )
-            finding_id = f"{source}:{rule_id}:{finding_hash[:16]}"
-            if finding_id in seen:
-                continue
-            seen.add(finding_id)
-            severity = _inventory_severity(getattr(raw_finding, "severity", "info"))
-            findings.append(
-                GuardAgentInventoryFinding(
-                    finding_id=finding_id,
-                    source=source,
-                    severity=severity,
-                    confidence="high" if run_status == "enabled" else "unknown",
-                    title=title,
-                    artifact_id=_artifact_id_for_cisco_finding(safe_path, items),
-                    check_id=rule_id,
-                    summary=_safe_finding_text(
-                        str(getattr(raw_finding, "description", "") or ""),
-                        home_dir=home_dir,
-                        workspace_dir=workspace_dir,
-                    ),
-                    evidence={
-                        "scannerStatus": run_status,
-                        "scannerMessage": run_message,
-                        "filePath": safe_path,
-                        "lineNumber": line_number if isinstance(line_number, int) else None,
-                        "durationMs": duration_ms if isinstance(duration_ms, int) else None,
-                        "riskComponent": {
-                            "source": source,
-                            "severity": severity,
-                            "confidence": "high" if run_status == "enabled" else "unknown",
-                            "scoreDelta": _score_delta_for_severity(severity),
-                        },
-                    },
-                )
-            )
-    return tuple(findings)
-
-
-def _cisco_inventory_sources(cisco_runs: tuple[object, ...]) -> tuple[GuardInventorySource, ...]:
-    sources: list[GuardInventorySource] = []
-    for run in cisco_runs:
-        source = _cisco_source(run)
-        if source is None:
-            continue
-        status = str(getattr(run, "status", "unknown"))
-        detail = _safe_source_detail(run)
-        sources.append(
-            GuardInventorySource(
-                source_id=f"{source}:{fingerprint_mapping({'status': status, 'detail': detail})[:12]}",
-                source_type="scanner",
-                status=_source_status_for_cisco_status(status),
-                detail=detail,
-            )
-        )
-    return tuple(sources)
-
-
-def _cisco_source(run: object) -> InventoryFindingSource | None:
-    source = str(getattr(run, "source", ""))
-    if source == "cisco-mcp-scanner":
-        return "cisco-mcp-scanner"
-    if source == "cisco-skill-scanner":
-        return "cisco-skill-scanner"
-    return None
-
-
-def _inventory_severity(value: object) -> InventorySeverity:
-    severity_value = str(getattr(value, "value", value)).strip().lower()
-    if severity_value == "critical":
-        return "critical"
-    if severity_value == "high":
-        return "high"
-    if severity_value == "medium":
-        return "medium"
-    if severity_value == "low":
-        return "low"
-    if severity_value == "info":
-        return "info"
-    return "info"
-
-
-def _score_delta_for_severity(severity: InventorySeverity) -> int:
-    return {"critical": -40, "high": -25, "medium": -12, "low": -5, "info": 0}[severity]
-
-
-def _artifact_id_for_cisco_finding(
-    safe_path: str | None,
-    items: tuple[GuardAgentInventoryItem, ...],
-) -> str:
-    if safe_path is None:
-        return "unknown"
-    for item in items:
-        config_path = item.metadata.get("configPath")
-        if isinstance(config_path, str) and (config_path == safe_path or config_path.endswith(safe_path)):
-            return item.item_id
-    return "unknown"
-
-
-def _source_status_for_cisco_status(status: str) -> Literal["available", "missing", "failed"]:
-    if status == "enabled":
-        return "available"
-    if status in {"failed", "timed_out"}:
-        return "failed"
-    return "missing"
-
-
-def _safe_source_detail(run: object) -> str:
-    status = str(getattr(run, "status", "unknown"))
-    metadata = getattr(run, "metadata", {})
-    finding_count = None
-    if isinstance(metadata, dict):
-        candidate = metadata.get("totalFindings")
-        if isinstance(candidate, int):
-            finding_count = candidate
-    suffix = f", findings={finding_count}" if finding_count is not None else ""
-    return f"status={status}{suffix}"
-
-
-def _safe_finding_text(value: str, *, home_dir: Path, workspace_dir: Path | None) -> str:
-    redacted = _SENSITIVE_VALUE_RE.sub("redacted", value)
-    redacted = _redact_command_value(redacted, home_dir, workspace_dir)
-    return redacted[:500]
-
-
-def _item_kind(artifact_type: str) -> InventoryItemKind:
-    mapping: dict[str, InventoryItemKind] = {
-        "skill": "skill",
-        "skill_file": "skill",
-        "mcp_server": "mcp_server",
-        "mcp_tool": "mcp_tool",
-        "channel": "channel",
-        "gateway_config": "agent",
-        "config": "agent",
-        "agent": "agent",
-        "hook": "hook",
-        "instruction": "overlay",
-        "overlay": "overlay",
-        "command": "prompt_pack",
-        "extension": "plugin",
-        "plugin": "plugin",
-        "plugin-file": "plugin",
-        "repository": "repository",
-        "container_image": "container_image",
-        "policy": "policy",
-        "secret_reference": "secret_reference",
-        "network_endpoint": "network_endpoint",
-        "guard_launcher_shim": "harness",
-        "package": "package",
-        "daemon_plugin": "daemon_plugin",
-        "model_provider": "model_provider",
-        "prompt_pack": "prompt_pack",
-    }
-    return mapping.get(artifact_type, "plugin")
-
-
-def _resolve_item_content_hash(metadata: dict[str, object], semantic_text: str) -> str:
-    for key in ("content_hash", "directory_hash"):
-        candidate = metadata.get(key)
-        if isinstance(candidate, str) and candidate:
-            return _canonical_inventory_content_hash(candidate)
-    version_info = metadata.get("versionInfo")
-    if isinstance(version_info, dict):
-        version_hash = version_info.get("contentHash")
-        if isinstance(version_hash, str) and version_hash:
-            return _canonical_inventory_content_hash(version_hash)
-    return semantic_text
-
-
-def _discard_unverified_skill_directory_hash(metadata: dict[str, object]) -> dict[str, object]:
-    if "skillDirectoryIdentity" not in metadata or validated_complete_skill_directory_hash(metadata) is not None:
-        return metadata
-    sanitized = dict(metadata)
-    sanitized.pop("directory_hash", None)
-    return sanitized
-
-
-def _primary_artifact_content_hash(
-    artifact: object,
-    *,
-    artifact_type: str,
-    home_dir: Path,
-    workspace_dir: Path | None,
-) -> str | None:
-    path_value = getattr(artifact, "config_path", None)
-    if not isinstance(path_value, str) or not path_value.strip():
-        return None
-    path = Path(path_value).expanduser()
-    if artifact_type == "skill":
-        if path.name != "SKILL.md":
-            return None
-        skills_root = next((parent for parent in path.parents if parent.name.lower() == "skills"), None)
-        if skills_root is None:
-            return None
-        try:
-            relative = path.relative_to(skills_root)
-        except ValueError:
-            return None
-        if len(relative.parts) < 2:
-            return None
-        outer_root = next(
-            (
-                root
-                for root in (home_dir, workspace_dir)
-                if root is not None and resolves_within_root(root, skills_root, require_exists=True)
-            ),
-            None,
-        )
-        if outer_root is None:
-            return None
-        allowed_roots = (skills_root,)
-    elif artifact_type == "instruction":
-        if workspace_dir is None or path.suffix.lower() not in {".md", ".mdc"}:
-            return None
-        allowed_roots = (workspace_dir,)
-    else:
-        return None
-    allowed_root = next(
-        (root for root in allowed_roots if root is not None and resolves_within_root(root, path, require_exists=True)),
-        None,
-    )
-    if allowed_root is None or _path_has_symlink_component(path, allowed_root=allowed_root):
-        return None
-    try:
-        digest = hashlib.sha256()
-        with path.open("rb") as handle:
-            for chunk in iter(lambda: handle.read(64 * 1024), b""):
-                digest.update(chunk)
-    except OSError:
-        return None
-    return f"sha256:{digest.hexdigest()}"
-
-
-_path_has_symlink_component = path_has_symlink_component
-
-
-def _canonical_inventory_content_hash(value: str) -> str:
-    normalized = value.lower()
-    if re.fullmatch(r"[0-9a-f]{64}", normalized):
-        return f"sha256:{normalized}"
-    return value
-
-
-def _safe_roots_for_inspection(
-    *,
-    home_dir: Path,
-    workspace_dir: Path | None,
-) -> tuple[Path, ...]:
-    roots: list[Path] = [home_dir]
-    if workspace_dir is not None:
-        roots.insert(0, workspace_dir)
-    return tuple(roots)
-
-
-def _apply_source_of_truth_metadata(
-    artifact: object,
-    *,
-    harness: str,
-    item_kind: InventoryItemKind,
-    metadata: dict[str, object],
-    home_dir: Path,
-    workspace_dir: Path | None,
-    follow_unsafe_symlinks: bool = False,
-) -> dict[str, object]:
-    config_path = getattr(artifact, "config_path", None)
-    if not isinstance(config_path, str) or not config_path:
-        return metadata
-    path = Path(config_path)
-    if not path.is_symlink():
-        return metadata
-    inspection = _aibom_symlink_module().inspect_aibom_source_path(
-        path,
-        safe_roots=_safe_roots_for_inspection(home_dir=home_dir, workspace_dir=workspace_dir),
-        home_dir=home_dir,
-        workspace_dir=workspace_dir,
-        follow_unsafe_symlinks=follow_unsafe_symlinks,
-    )
-    source_link_id = f"{harness}:{item_kind}:{inspection.source_fingerprint[:24]}"
-    enriched = dict(metadata)
-    enriched["sourceOfTruth"] = _aibom_symlink_module().source_of_truth_metadata_from_inspection(
-        inspection,
-        source_link_id=source_link_id,
-    )
-    return enriched
-
-
-def _symlink_findings_from_items(
-    harness: str,
-    items: tuple[GuardAgentInventoryItem, ...],
-) -> tuple[GuardAgentInventoryFinding, ...]:
-    findings: list[GuardAgentInventoryFinding] = []
-    for item in items:
-        source_of_truth = item.metadata.get("sourceOfTruth")
-        if not isinstance(source_of_truth, dict):
-            continue
-        validation_state = source_of_truth.get("validationState")
-        if validation_state == "valid":
-            continue
-        if not isinstance(validation_state, str):
-            continue
-        severity: InventorySeverity = "high" if validation_state in {"loop", "escape_blocked"} else "medium"
-        findings.append(
-            GuardAgentInventoryFinding(
-                finding_id=f"{harness}:symlink:{item.item_id}:{validation_state}",
-                source="hol-detector",
-                severity=severity,
-                confidence="high",
-                title=f"Symlink source {validation_state.replace('_', ' ')}",
-                artifact_id=item.item_id,
-                check_id=f"aibom.symlink.{validation_state}",
-                summary=f"Inventory item references a symlink source in state {validation_state}.",
-                evidence={
-                    "validationState": validation_state,
-                    "sourceFingerprint": source_of_truth.get("sourceFingerprint"),
-                    "pathClass": source_of_truth.get("pathClass"),
-                },
-            )
-        )
-    return tuple(findings)
-
-
-def _apply_aibom_metadata_enrichment(
-    artifact: object,
-    *,
-    captured_at: str,
-    item_kind: InventoryItemKind,
-    metadata: dict[str, object],
-    home_dir: Path,
-    workspace_dir: Path | None,
-    cisco_runs: tuple[object, ...] = (),
-) -> dict[str, object]:
-    enriched = dict(metadata)
-    artifact_type = str(getattr(artifact, "artifact_type", "unknown"))
-    if artifact_type == "skill":
-        from .skill_document_evidence import enrich_skill_document_metadata
-
-        enriched = enrich_skill_document_metadata(
-            getattr(artifact, "config_path", None),
-            enriched,
-            home_dir=home_dir,
-            workspace_dir=workspace_dir,
-        )
-    if item_kind == "overlay" and "instructionRole" not in enriched:
-        config_path = getattr(artifact, "config_path", None)
-        if isinstance(config_path, str):
-            role = _aibom_detection_module().instruction_role_for_path(Path(config_path))
-            if role is not None:
-                enriched["instructionRole"] = role
-    return _aibom_trust_metadata_module().apply_local_trust_metadata(
-        artifact,
-        captured_at=captured_at,
-        item_kind=item_kind,
-        metadata=enriched,
-        workspace_dir=workspace_dir,
-        cisco_runs=cisco_runs,
-    )
-
-
-def _capabilities_for_artifact(
-    artifact_type: str,
-    metadata: dict[str, object],
-) -> tuple[InventoryCapability, ...]:
-    capabilities: set[InventoryCapability] = set()
-    if artifact_type in {"instruction", "overlay", "command"}:
-        capabilities.add("reads_files")
-    if artifact_type == "mcp_server":
-        capabilities.add("network_egress")
-        if metadata.get("transport") == "stdio":
-            capabilities.add("runs_shell")
-    if artifact_type == "channel":
-        capabilities.update({"reads_messages", "posts_messages", "network_ingress"})
-    if bool(metadata.get("envConfigurationPresent")) or bool(metadata.get("has_auth_headers")):
-        capabilities.add("reads_secrets")
-    return tuple(sorted(capabilities)) if capabilities else ("unknown",)
-
-
-def _bind_skill_document_evidence(
-    metadata: dict[str, object],
-    *,
-    primary_content_hash: str | None,
-) -> dict[str, object]:
-    bound = dict(metadata)
-    # This value is derived from Guard's own full, safe read of SKILL.md.  It
-    # remains the authority for primary-body upload when the inventory item's
-    # public content hash is upgraded to the full directory identity.
-    if isinstance(primary_content_hash, str):
-        bound["primaryContentHash"] = primary_content_hash
-    else:
-        bound.pop("primaryContentHash", None)
-
-    evidence = metadata.get("contentEvidence")
-    if (
-        isinstance(evidence, dict)
-        and isinstance(primary_content_hash, str)
-        and evidence.get("contentHash") == primary_content_hash
-    ):
-        return bound
-
-    if isinstance(evidence, dict) and "contentHash" not in evidence:
-        bound.pop("documentedCapabilities", None)
-        return bound
-
-    bound.pop("contentEvidence", None)
-    bound.pop("documentedCapabilities", None)
-    return bound
-
-
-def _risk_level(metadata: dict[str, object]) -> InventorySeverity:
-    if metadata.get("has_auth_headers") or metadata.get("envConfigurationPresent"):
-        return "high"
-    if metadata.get("endpointHostClass") == "remote_public":
-        return "medium"
-    return "info"
-
-
-def _safe_artifact_metadata(
-    artifact: object,
-    *,
-    home_dir: Path,
-    workspace_dir: Path | None,
-) -> dict[str, object]:
-    artifact_type = str(getattr(artifact, "artifact_type", "unknown"))
-    raw_metadata = getattr(artifact, "metadata", {})
-    metadata = _sanitize_paths(raw_metadata if isinstance(raw_metadata, dict) else {}, home_dir, workspace_dir)
-    if not isinstance(metadata, dict):
-        metadata = {}
-    from .trust_metadata_boundary import separate_untrusted_adapter_trust_metadata
-
-    metadata = separate_untrusted_adapter_trust_metadata(metadata)
-    config_path = getattr(artifact, "config_path", None)
-    command = getattr(artifact, "command", None)
-    url = getattr(artifact, "url", None)
-    transport = getattr(artifact, "transport", None)
-    if isinstance(config_path, str) and config_path:
-        metadata["configPath"] = _redact_known_path(config_path, home_dir, workspace_dir)
-    if isinstance(command, str) and command:
-        metadata["command"] = _redact_command_value(command, home_dir, workspace_dir)
-    if isinstance(url, str) and url:
-        metadata["url"] = redact_url(url)
-        metadata["endpointHostClass"] = classify_endpoint_host(url)
-    if isinstance(transport, str) and transport:
-        metadata["transport"] = transport
-    metadata["artifactType"] = artifact_type
-    return metadata
-
-
-def _sanitize_paths(value: object, home_dir: Path, workspace_dir: Path | None) -> object:
-    if isinstance(value, Path):
-        return _redact_known_path(str(value), home_dir, workspace_dir)
-    if isinstance(value, dict):
-        redacted: dict[str, object] = {}
-        for key, item in value.items():
-            string_key = str(key)
-            if _SENSITIVE_KEY_RE.search(string_key):
-                redacted[string_key] = item if isinstance(item, bool) else "present_redacted"
-                continue
-            redacted[string_key] = _sanitize_paths(item, home_dir, workspace_dir)
-        return redacted
-    if isinstance(value, (list, tuple)):
-        return [_sanitize_paths(item, home_dir, workspace_dir) for item in value]
-    if isinstance(value, str):
-        if "://" in value:
-            return redact_url(value)
-        return _redact_known_path(value, home_dir, workspace_dir)
-    return value
-
-
-def _redact_known_path(value: str, home_dir: Path, workspace_dir: Path | None) -> str:
-    path = Path(value)
-    if path.is_absolute():
-        home_redacted = redact_local_path(path, home_dir=home_dir)
-        if home_redacted.startswith("{home}/"):
-            return home_redacted
-        if workspace_dir is not None:
-            try:
-                relative = path.resolve().relative_to(workspace_dir.resolve())
-                return f"{{workspace}}/{relative.as_posix()}"
-            except (OSError, RuntimeError, ValueError):
-                return path.name
-        return path.name
-    return value
-
-
-def _redact_command_value(value: str, home_dir: Path, workspace_dir: Path | None) -> str:
-    redacted = re.sub(
-        r"(?i)\b[a-z][a-z0-9+.-]*://[^\s]+",
-        lambda match: redact_url(match.group(0)),
-        value,
-    )
-    redacted = re.sub(
-        r"(^|\s)(/[^\s]+)",
-        lambda match: f"{match.group(1)}{_redact_known_path(match.group(2), home_dir, workspace_dir)}",
-        redacted,
-    )
-    redacted = re.sub(
-        r"(?i)(authorization:\s*bearer\s+)\S+",
-        r"\1redacted",
-        redacted,
-    )
-    redacted = re.sub(
-        r"(?i)((?:api[_-]?key|auth|password|secret|token)=)\S+",
-        r"\1redacted",
-        redacted,
-    )
-    redacted = re.sub(
-        r"(?i)((?:--)?(?:api[_-]?key|auth|password|secret|token)\s+)\S+",
-        r"\1redacted",
-        redacted,
-    )
-    return redacted
-
-
-def _sanitize_serializer_string(
-    value: str,
-    *,
-    parent_key: str = "",
-    parent_sensitive: bool = False,
-) -> str:
-    if value in _SAFE_SERIALIZED_MARKERS:
-        return value
-    if parent_sensitive or (parent_key and _SENSITIVE_KEY_RE.search(parent_key)):
-        return _SERIALIZER_REDACTED_VALUE
-    if _SERIALIZER_UNSAFE_PATH_RE.search(value):
-        return _SERIALIZER_REDACTED_VALUE
-    if _SENSITIVE_VALUE_RE.search(value):
-        return _SERIALIZER_REDACTED_VALUE
-    if _SERIALIZER_SECRET_ASSIGNMENT_RE.search(value):
-        return _SERIALIZER_REDACTED_VALUE
-    return value
-
-
-def _assert_serialized_inventory_payload_safe(payload: object) -> None:
-    encoded = json.dumps(payload, sort_keys=True)
-    if (
-        _SERIALIZER_UNSAFE_PATH_RE.search(encoded)
-        or _SENSITIVE_VALUE_RE.search(encoded)
-        or _SERIALIZER_SECRET_ASSIGNMENT_RE.search(encoded)
-    ):
-        raise ValueError("Inventory snapshot serialization produced unsafe payload.")
-
-
-def _safe_json(
-    value: object,
-    *,
-    parent_key: str = "",
-    parent_sensitive: bool = False,
-) -> object:
-    key_sensitive = parent_sensitive or bool(parent_key and _SENSITIVE_KEY_RE.search(parent_key))
-    if isinstance(value, dict):
-        return {
-            _sanitize_serializer_string(str(key), parent_sensitive=parent_sensitive): _safe_json(
-                item,
-                parent_key=str(key),
-                parent_sensitive=key_sensitive,
-            )
-            for key, item in value.items()
-        }
-    if isinstance(value, (list, tuple)):
-        return [_safe_json(item, parent_key=parent_key, parent_sensitive=parent_sensitive) for item in value]
-    if isinstance(value, Path):
-        return value.name
-    if isinstance(value, str):
-        return _sanitize_serializer_string(
-            value,
-            parent_key=parent_key,
-            parent_sensitive=parent_sensitive,
-        )
-    return value
-
-
-def _fingerprint_file_bytes(path: Path) -> str:
-    digest = hashlib.sha256()
-    remaining = _MAX_FINGERPRINT_FILE_BYTES
-    with path.open("rb") as file_handle:
-        while remaining > 0:
-            chunk = file_handle.read(min(65536, remaining))
-            if not chunk:
-                break
-            digest.update(chunk)
-            remaining -= len(chunk)
-    return digest.hexdigest()

--- a/src/codex_plugin_scanner/guard/inventory_contract_constants.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract_constants.py
@@ -1,0 +1,144 @@
+"""Shared inventory redaction, capability, and wire-format constants."""
+
+from __future__ import annotations
+
+import re
+
+from .path_security import path_has_symlink_component
+
+_SENSITIVE_KEY_RE = re.compile(
+    r"(auth|authorization|bearer|token|secret|password|credential|api[^a-z0-9]?key)",
+    re.IGNORECASE,
+)
+
+
+_SENSITIVE_VALUE_RE = re.compile(r"(?i)(gh[pousr]_[a-z0-9_]+|sk-[a-z0-9_-]+|guard_live_[a-z0-9_-]+|bearer\s+\S+)")
+
+
+_UNSAFE_PATH_MARKERS = (
+    "".join(("/", "Users", "/")),
+    "".join(("/", "home", "/")),
+    "".join(("/", "root", "/")),
+    "".join(("\\", "Users", "\\")),
+    "".join(("/", "var", "/", "folders", "/")),
+    "".join(("/", "workspace", "/")),
+    "".join(("/", "tmp", "/")),
+    "".join(("/", "etc", "/")),
+    "".join(("/", "mnt", "/")),
+)
+
+
+_SERIALIZER_UNSAFE_PATH_PATTERN = (
+    r"(?:^|[\s\"'=:({])(?:" + "|".join(re.escape(marker) for marker in _UNSAFE_PATH_MARKERS) + ")"
+)
+
+
+_SERIALIZER_UNSAFE_PATH_RE = re.compile(_SERIALIZER_UNSAFE_PATH_PATTERN, re.IGNORECASE)
+
+
+_SERIALIZER_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b(?:api[_-]?key|authorization|password|secret|token|access[_-]?token|refresh[_-]?token)\b\s*[:=]\s*(?!redacted\b)\S+",
+)
+
+
+_SERIALIZER_REDACTED_VALUE = "[REDACTED]"
+
+
+_SAFE_SERIALIZED_MARKERS = frozenset(
+    {
+        _SERIALIZER_REDACTED_VALUE,
+        "present_redacted",
+        "present",
+        "redacted",
+        "malformed_url_redacted",
+    }
+)
+
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+_MCP_READ_RE = re.compile(
+    r"(?<![a-z0-9])(read|reads|reading|search|searches|list|lists)(?![a-z0-9])",
+    re.IGNORECASE,
+)
+
+
+_MCP_DELETE_RE = re.compile(
+    r"(?<![a-z0-9])(delete|deletes|remove|removes|destroy|destroys)(?![a-z0-9])",
+    re.IGNORECASE,
+)
+
+
+_MCP_WRITE_RE = re.compile(
+    r"(?<![a-z0-9])(write|writes|update|updates|create|creates|modify|modifies)(?![a-z0-9])",
+    re.IGNORECASE,
+)
+
+
+_MCP_SHELL_RE = re.compile(
+    r"(?<![a-z0-9])(shell|command|commands|execute|exec|subprocess)(?![a-z0-9])",
+    re.IGNORECASE,
+)
+
+
+_MCP_SECRET_RE = re.compile(
+    r"(?<![a-z0-9])(secret|secrets|token|tokens|password|passwords|credential|credentials|api[_\-\s]?key)(?![a-z0-9])",
+    re.IGNORECASE,
+)
+
+
+_MCP_NETWORK_RE = re.compile(
+    r"(?<![a-z0-9])(http|url|urls|network|fetch|webhook|webhooks)(?![a-z0-9])",
+    re.IGNORECASE,
+)
+
+
+_MCP_MODEL_RE = re.compile(r"(?<![a-z0-9])(sampling|model|models|llm)(?![a-z0-9])", re.IGNORECASE)
+
+
+_MCP_PERMISSION_RE = re.compile(
+    r"(?<![a-z0-9])(permission|permissions|chmod)(?![a-z0-9])",
+    re.IGNORECASE,
+)
+
+
+_IGNORED_TREE_DIR_NAMES = {".git", ".hg", ".svn", "__pycache__", ".mypy_cache", ".ruff_cache", ".venv", "node_modules"}
+
+
+_MAX_FINGERPRINT_FILE_BYTES = 1024 * 1024
+
+
+_AIBOM_METADATA_KEYS = (
+    "instructionRole",
+    "localSecurity",
+    "registryIdentity",
+    "skillDirectoryIdentity",
+    "sourceLinks",
+    "sourceOfTruth",
+    "trustLayers",
+    "trustResolution",
+    "unverifiedAdapterEvidence",
+    "versionInfo",
+)
+
+
+_INVENTORY_DATETIME_KEYS = frozenset(
+    {
+        "capturedAt",
+        "completedAt",
+        "firstSeenAt",
+        "generatedAt",
+        "lastSeenAt",
+        "startedAt",
+    }
+)
+
+
+_FREE_FORM_RECORD_KEYS = frozenset({"metadata", "evidence"})
+
+
+_OPTIONAL_ONLY_CONTRACT_KEYS = frozenset({"summary"})
+
+
+_path_has_symlink_component = path_has_symlink_component

--- a/src/codex_plugin_scanner/guard/inventory_contract_fingerprints.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract_fingerprints.py
@@ -1,0 +1,157 @@
+"""Stable content identities and bounded inventory fingerprints."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from .inventory_contract_constants import _IGNORED_TREE_DIR_NAMES, _MAX_FINGERPRINT_FILE_BYTES, _WHITESPACE_RE
+from .inventory_contract_models import GuardAgentInventoryFinding, GuardAgentInventoryItem, GuardInventorySource
+from .inventory_contract_redaction import redact_local_path
+
+
+def fingerprint_text(value: str) -> str:
+    """Hash UTF-8 text using the inventory content-identity algorithm."""
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def fingerprint_mapping(value: object) -> str:
+    """Hash a mapping after deterministic JSON serialization."""
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return fingerprint_text(encoded)
+
+
+def _inventory_snapshot_content_hash(
+    *,
+    agent_type: str,
+    items: tuple[GuardAgentInventoryItem, ...],
+    findings: tuple[GuardAgentInventoryFinding, ...],
+    sources: tuple[GuardInventorySource, ...],
+    runtime_version: str | None,
+) -> str:
+    """Compute snapshot identity from stable evidence rather than observation timestamps."""
+    return fingerprint_mapping(
+        {
+            "agent_type": agent_type,
+            "runtime_version": runtime_version,
+            "items": [
+                {
+                    "capability_categories": item.capability_categories,
+                    "content_hash": item.content_hash,
+                    "drift_state": item.drift_state,
+                    "item_id": item.item_id,
+                    "item_kind": item.item_kind,
+                    "metadata": _stable_snapshot_value(item.metadata),
+                    "risk_level": item.risk_level,
+                    "scanner_sources": item.scanner_sources,
+                    "security_score": item.security_score,
+                    "source_fingerprint": item.source_fingerprint,
+                }
+                for item in sorted(items, key=lambda value: (value.item_kind, value.item_id))
+            ],
+            "findings": [
+                {
+                    "artifact_id": finding.artifact_id,
+                    "check_id": finding.check_id,
+                    "confidence": finding.confidence,
+                    "evidence": _stable_snapshot_value(finding.evidence),
+                    "finding_id": finding.finding_id,
+                    "severity": finding.severity,
+                    "source": finding.source,
+                    "summary": finding.summary,
+                    "title": finding.title,
+                }
+                for finding in sorted(findings, key=lambda value: (value.source, value.finding_id))
+            ],
+            "sources": [
+                {
+                    "detail": source.detail,
+                    "source_id": source.source_id,
+                    "source_type": source.source_type,
+                    "status": source.status,
+                }
+                for source in sorted(sources, key=lambda value: (value.source_type, value.source_id))
+            ],
+        }
+    )
+
+
+def _stable_snapshot_value(value: object) -> object:
+    """Remove volatile fields before calculating a repeatable snapshot fingerprint."""
+    if isinstance(value, dict):
+        return {
+            key: _stable_snapshot_value(item)
+            for key, item in sorted(value.items(), key=lambda entry: str(entry[0]))
+            if str(key)
+            not in {
+                "attestation",
+                "attestationBindings",
+                "capturedAt",
+                "duration_ms",
+                "durationMs",
+                "elapsedMs",
+                "evidenceHash",
+                "generatedAt",
+                "lastSeenAt",
+                "observedAt",
+                "scanDurationMs",
+                "syncedAt",
+            }
+        }
+    if isinstance(value, (list, tuple)):
+        return sorted((_stable_snapshot_value(item) for item in value), key=_stable_snapshot_sort_key)
+    return value
+
+
+def _stable_snapshot_sort_key(value: object) -> str:
+    """Build a deterministic key for ordering stable snapshot values."""
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def inventory_item_id(agent_type: str, item_kind: str, display_name: str, semantic_text: str) -> str:
+    """Build a stable item identifier from harness, source, and artifact identity."""
+    normalized_text = _WHITESPACE_RE.sub(" ", semantic_text.strip())
+    digest = fingerprint_mapping(
+        {
+            "agent_type": agent_type,
+            "display_name": display_name.strip().lower(),
+            "item_kind": item_kind,
+            "semantic_text": normalized_text,
+        }
+    )
+    return f"{agent_type}:{item_kind}:{digest[:24]}"
+
+
+def fingerprint_path_tree(root: Path, *, home_dir: Path | None = None) -> str:
+    """Fingerprint a bounded set of files without following untrusted path traversal."""
+    entries: list[dict[str, str]] = []
+    if root.is_file():
+        paths = [root]
+    else:
+        paths = sorted(
+            path
+            for path in root.rglob("*")
+            if path.is_file()
+            and path.name != ".env"
+            and not any(part in _IGNORED_TREE_DIR_NAMES for part in path.parts)
+        )
+    for path in paths:
+        safe_path = redact_local_path(path, home_dir=home_dir)
+        content_hash = _fingerprint_file_bytes(path)
+        entries.append({"path": safe_path, "sha256": content_hash})
+    return fingerprint_mapping(entries)
+
+
+def _fingerprint_file_bytes(path: Path) -> str:
+    """Read bounded file content for fingerprinting within the permitted inspection roots."""
+    digest = hashlib.sha256()
+    remaining = _MAX_FINGERPRINT_FILE_BYTES
+    with path.open("rb") as file_handle:
+        while remaining > 0:
+            chunk = file_handle.read(min(65536, remaining))
+            if not chunk:
+                break
+            digest.update(chunk)
+            remaining -= len(chunk)
+    return digest.hexdigest()

--- a/src/codex_plugin_scanner/guard/inventory_contract_items.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract_items.py
@@ -1,0 +1,369 @@
+"""Native artifact and MCP-tool inventory item assembly."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from types import SimpleNamespace
+
+from ..version import __version__
+from .inventory_contract_fingerprints import _stable_snapshot_value, fingerprint_mapping, fingerprint_text
+from .inventory_contract_mcp import (
+    _apply_tool_trust_attestation_metadata,
+    _attestation_path_hash,
+    _attestation_repository_id,
+    _capabilities_for_mcp_tool,
+    _first_present_value,
+    _mcp_tool_definitions,
+    _risk_level_for_capabilities,
+    _string_value,
+)
+from .inventory_contract_metadata import (
+    _aibom_trust_metadata_module,
+    _apply_aibom_metadata_enrichment,
+    _apply_source_of_truth_metadata,
+    _bind_skill_document_evidence,
+    _capabilities_for_artifact,
+    _discard_unverified_skill_directory_hash,
+    _inventory_item_description_module,
+    _item_kind,
+    _primary_artifact_content_hash,
+    _resolve_item_content_hash,
+    _risk_level,
+)
+from .inventory_contract_models import GuardAgentInventoryItem
+from .inventory_contract_redaction import _redact_command_value, _safe_artifact_metadata, redact_url
+from .skill_directory_identity import validated_complete_skill_directory_hash
+
+
+def _item_from_artifact(
+    harness: str,
+    artifact: object,
+    *,
+    generated_at: str,
+    home_dir: Path,
+    workspace_dir: Path | None,
+    cisco_runs: tuple[object, ...] = (),
+    include_symlinks: bool = True,
+    follow_unsafe_symlinks: bool = False,
+    trust_attestation_context: Mapping[str, object] | None = None,
+) -> GuardAgentInventoryItem:
+    """Convert a native artifact into an inventory item with source and trust metadata."""
+    artifact_id = str(getattr(artifact, "artifact_id", "artifact"))
+    artifact_type = str(getattr(artifact, "artifact_type", "unknown"))
+    name = str(getattr(artifact, "name", artifact_id))
+    safe_metadata = _safe_artifact_metadata(artifact, home_dir=home_dir, workspace_dir=workspace_dir)
+    item_kind = _item_kind(artifact_type)
+    safe_metadata = _apply_aibom_metadata_enrichment(
+        artifact,
+        captured_at=generated_at,
+        item_kind=item_kind,
+        metadata=safe_metadata,
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        cisco_runs=cisco_runs,
+    )
+    if include_symlinks:
+        safe_metadata = _apply_source_of_truth_metadata(
+            artifact,
+            harness=harness,
+            item_kind=item_kind,
+            metadata=safe_metadata,
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+            follow_unsafe_symlinks=follow_unsafe_symlinks,
+        )
+    primary_content_hash = _primary_artifact_content_hash(
+        artifact,
+        artifact_type=artifact_type,
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+    )
+    if artifact_type == "skill":
+        safe_metadata = _bind_skill_document_evidence(
+            safe_metadata,
+            primary_content_hash=primary_content_hash,
+        )
+        safe_metadata = _discard_unverified_skill_directory_hash(safe_metadata)
+    semantic_text = fingerprint_mapping(
+        {
+            "artifact_id": artifact_id,
+            "artifact_type": artifact_type,
+            "name": name,
+            "metadata": _stable_snapshot_value(safe_metadata),
+        }
+    )
+    if artifact_type == "skill":
+        content_hash = validated_complete_skill_directory_hash(safe_metadata) or primary_content_hash or semantic_text
+    elif artifact_type == "instruction":
+        content_hash = primary_content_hash or semantic_text
+    else:
+        content_hash = _resolve_item_content_hash(safe_metadata, semantic_text)
+    from .runtime.trust_attestation import (
+        GuardTrustAttestationSigningConfig,
+        apply_trust_attestation_metadata,
+    )
+
+    workspace_id = None
+    device_id = None
+    analyzer_id = None
+    analyzer_spec_version = None
+    analyzer_version = None
+    policy_version = None
+    installation_id = None
+    upload_id = None
+    challenge_id = None
+    nonce = None
+    sequence = None
+    expires_at = None
+    signing_config = None
+    if isinstance(trust_attestation_context, Mapping):
+        raw_workspace_id = trust_attestation_context.get("workspaceId")
+        workspace_id = raw_workspace_id if isinstance(raw_workspace_id, str) and raw_workspace_id else None
+        raw_device_id = trust_attestation_context.get("deviceId")
+        device_id = raw_device_id if isinstance(raw_device_id, str) and raw_device_id else None
+        raw_analyzer_id = trust_attestation_context.get("analyzerId")
+        analyzer_id = raw_analyzer_id if isinstance(raw_analyzer_id, str) and raw_analyzer_id else None
+        raw_analyzer_spec_version = trust_attestation_context.get("analyzerSpecVersion")
+        analyzer_spec_version = (
+            raw_analyzer_spec_version
+            if isinstance(raw_analyzer_spec_version, str) and raw_analyzer_spec_version
+            else None
+        )
+        raw_analyzer_version = trust_attestation_context.get("analyzerVersion")
+        analyzer_version = (
+            raw_analyzer_version if isinstance(raw_analyzer_version, str) and raw_analyzer_version else None
+        )
+        raw_installation_id = trust_attestation_context.get("installationId")
+        installation_id = raw_installation_id if isinstance(raw_installation_id, str) and raw_installation_id else None
+        raw_upload_id = trust_attestation_context.get("uploadId")
+        upload_id = raw_upload_id if isinstance(raw_upload_id, str) and raw_upload_id else None
+        raw_challenge_id = trust_attestation_context.get("challengeId")
+        challenge_id = raw_challenge_id if isinstance(raw_challenge_id, str) and raw_challenge_id else None
+        raw_nonce = trust_attestation_context.get("nonce")
+        nonce = raw_nonce if isinstance(raw_nonce, str) and raw_nonce else None
+        raw_sequence = trust_attestation_context.get("sequence")
+        if isinstance(raw_sequence, int):
+            sequence = raw_sequence
+        raw_policy_version = trust_attestation_context.get("policyVersion")
+        policy_version = raw_policy_version if isinstance(raw_policy_version, str) and raw_policy_version else None
+        raw_expires_at = trust_attestation_context.get("expiresAt")
+        expires_at = raw_expires_at if isinstance(raw_expires_at, str) and raw_expires_at else None
+        raw_signing_config = trust_attestation_context.get("signingConfig")
+        if isinstance(raw_signing_config, GuardTrustAttestationSigningConfig):
+            signing_config = raw_signing_config
+
+    safe_metadata = apply_trust_attestation_metadata(
+        safe_metadata,
+        agent_id=f"{harness}:local",
+        analyzer_id=analyzer_id,
+        analyzer_spec_version=analyzer_spec_version,
+        analyzer_version=analyzer_version,
+        item_id=artifact_id,
+        item_kind=item_kind,
+        content_hash=content_hash,
+        challenge_id=challenge_id,
+        expires_at=expires_at,
+        installation_id=installation_id,
+        nonce=nonce,
+        policy_version=policy_version,
+        sequence=sequence,
+        upload_id=upload_id,
+        workspace_id=workspace_id,
+        device_id=device_id,
+        adapter_id=harness,
+        adapter_version=__version__,
+        config_path_hash=_attestation_path_hash(getattr(artifact, "config_path", None), fallback=artifact_id),
+        repository_id=_attestation_repository_id(home_dir=home_dir, workspace_dir=workspace_dir),
+        signing_config=signing_config,
+    )
+    publisher = getattr(artifact, "publisher", None)
+    publisher_text = publisher if isinstance(publisher, str) else None
+    description = _inventory_item_description_module().resolve_inventory_item_description(
+        harness=harness,
+        item_kind=item_kind,
+        display_name=name,
+        metadata=safe_metadata,
+        publisher=publisher_text,
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+    )
+    return GuardAgentInventoryItem(
+        item_id=artifact_id,
+        item_kind=item_kind,
+        display_name=name,
+        description=description,
+        source_fingerprint=fingerprint_mapping({"harness": harness, "artifact_id": artifact_id}),
+        content_hash=content_hash,
+        capability_categories=_capabilities_for_artifact(artifact_type, safe_metadata),
+        risk_level=_risk_level(safe_metadata),
+        scanner_sources=("hol-detector",),
+        metadata=safe_metadata,
+    )
+
+
+def _mcp_tool_items_from_artifact(
+    harness: str,
+    artifact: object,
+    server_item: GuardAgentInventoryItem,
+    *,
+    generated_at: str,
+    home_dir: Path,
+    workspace_dir: Path | None,
+    cisco_runs: tuple[object, ...] = (),
+    trust_attestation_context: Mapping[str, object] | None = None,
+) -> tuple[GuardAgentInventoryItem, ...]:
+    """Expand advertised MCP tool definitions into individually attributable inventory items."""
+    artifact_type = str(getattr(artifact, "artifact_type", "unknown"))
+    if artifact_type != "mcp_server":
+        return ()
+    raw_metadata = getattr(artifact, "metadata", {})
+    if not isinstance(raw_metadata, dict):
+        return ()
+    raw_tools = _mcp_tool_definitions(raw_metadata)
+    if not raw_tools:
+        return ()
+
+    items: list[GuardAgentInventoryItem] = []
+    raw_trust_layers = server_item.metadata.get("trustLayers")
+    inherited_layers: list[dict[str, object]] = []
+    if isinstance(raw_trust_layers, list):
+        for layer in raw_trust_layers:
+            if isinstance(layer, dict) and layer.get("layerType") == "cisco_mcp_scanner":
+                inherited_layers.append(dict(layer))
+    for raw_tool in raw_tools:
+        if not isinstance(raw_tool, dict):
+            continue
+        name = raw_tool.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        display_name = _string_value(raw_tool.get("title")) or name
+        description = _string_value(raw_tool.get("description")) or ""
+        input_schema = _first_present_value(raw_tool, "inputSchema", "input_schema")
+        output_schema = _first_present_value(raw_tool, "outputSchema", "output_schema")
+        annotations = raw_tool.get("annotations")
+        safe_annotations = annotations if isinstance(annotations, dict) else {}
+        server_command = getattr(artifact, "command", None)
+        server_url = getattr(artifact, "url", None)
+        metadata: dict[str, object] = {
+            "serverItemId": server_item.item_id,
+            "toolName": name,
+            "title": display_name,
+            "serverCommand": _redact_command_value(server_command, home_dir, workspace_dir)
+            if isinstance(server_command, str) and server_command
+            else None,
+            "serverUrl": redact_url(server_url) if isinstance(server_url, str) and server_url else None,
+            "serverTransport": getattr(artifact, "transport", None),
+            "descriptionHash": fingerprint_text(description),
+            "inputSchemaHash": fingerprint_mapping(input_schema) if input_schema is not None else None,
+            "outputSchemaHash": fingerprint_mapping(output_schema) if output_schema is not None else None,
+            "annotations": safe_annotations,
+            "schemaPresent": input_schema is not None or output_schema is not None,
+        }
+        tool_artifact = SimpleNamespace(
+            artifact_id=f"{getattr(artifact, 'artifact_id', server_item.item_id)}:tool:{name}",
+            artifact_type="mcp_tool",
+            config_path=getattr(artifact, "config_path", ""),
+            name=name,
+            command=getattr(artifact, "command", None),
+            url=getattr(artifact, "url", None),
+            transport=getattr(artifact, "transport", None),
+        )
+        metadata = _aibom_trust_metadata_module().apply_local_trust_metadata(
+            tool_artifact,
+            captured_at=generated_at,
+            item_kind="mcp_tool",
+            metadata=metadata,
+            workspace_dir=workspace_dir,
+            cisco_runs=cisco_runs,
+        )
+        capabilities = _capabilities_for_mcp_tool(name, description, input_schema, safe_annotations)
+        tool_item_id = f"{server_item.item_id}:tool:{name}"
+        semantic_hash = fingerprint_mapping(
+            {
+                "server": server_item.item_id,
+                "name": name,
+                "description": description,
+                "inputSchema": input_schema,
+                "outputSchema": output_schema,
+                "annotations": safe_annotations,
+            }
+        )
+        tool_layers = metadata.get("trustLayers")
+        tool_layer_dicts = (
+            [layer for layer in tool_layers if isinstance(layer, dict)] if isinstance(tool_layers, list) else []
+        )
+        if tool_layer_dicts:
+            metadata["trustLayers"] = tool_layer_dicts
+        metadata = _apply_tool_trust_attestation_metadata(
+            metadata,
+            harness=harness,
+            item_id=tool_item_id,
+            content_hash=semantic_hash,
+            config_path_hash=_attestation_path_hash(
+                getattr(artifact, "config_path", None),
+                fallback=server_item.item_id,
+            ),
+            repository_id=_attestation_repository_id(home_dir=home_dir, workspace_dir=workspace_dir),
+            trust_attestation_context=trust_attestation_context,
+        )
+        signed_tool_layers = metadata.get("trustLayers")
+        tool_layer_dicts = (
+            [layer for layer in signed_tool_layers if isinstance(layer, dict)]
+            if isinstance(signed_tool_layers, list)
+            else []
+        )
+        has_tool_cisco_layer = any(layer.get("layerType") == "cisco_mcp_scanner" for layer in tool_layer_dicts)
+        if inherited_layers and not has_tool_cisco_layer:
+            inherited_tool_layers: list[dict[str, object]] = []
+            for layer in inherited_layers:
+                raw_layer_metadata = layer.get("metadata")
+                layer_metadata = dict(raw_layer_metadata) if isinstance(raw_layer_metadata, dict) else {}
+                inherited_tool_layers.append(
+                    {
+                        **layer,
+                        "metadata": {
+                            **{
+                                key: value
+                                for key, value in layer_metadata.items()
+                                if key
+                                not in {
+                                    "attestation",
+                                    "attestationBindings",
+                                    "attestationRef",
+                                    "attestationStatus",
+                                    "attestationVerification",
+                                }
+                            },
+                            "attestationStatus": "unsigned",
+                            "inheritedFromServerItemId": server_item.item_id,
+                        },
+                    }
+                )
+            metadata["trustLayers"] = [*tool_layer_dicts, *inherited_tool_layers]
+        tool_description = _inventory_item_description_module().resolve_inventory_item_description(
+            harness=harness,
+            item_kind="mcp_tool",
+            display_name=display_name,
+            metadata=metadata,
+            explicit_description=description or None,
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+        )
+        items.append(
+            GuardAgentInventoryItem(
+                item_id=tool_item_id,
+                item_kind="mcp_tool",
+                display_name=display_name,
+                description=tool_description,
+                source_fingerprint=fingerprint_mapping(
+                    {"harness": harness, "server": server_item.item_id, "tool": name}
+                ),
+                content_hash=semantic_hash,
+                capability_categories=capabilities,
+                risk_level=_risk_level_for_capabilities(capabilities),
+                scanner_sources=("hol-detector",),
+                metadata=metadata,
+            )
+        )
+    return tuple(items)

--- a/src/codex_plugin_scanner/guard/inventory_contract_mcp.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract_mcp.py
@@ -1,0 +1,195 @@
+"""MCP capability classification and tool attestation metadata."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from pathlib import Path
+
+from ..version import __version__
+from .inventory_contract_constants import (
+    _MCP_DELETE_RE,
+    _MCP_MODEL_RE,
+    _MCP_NETWORK_RE,
+    _MCP_PERMISSION_RE,
+    _MCP_READ_RE,
+    _MCP_SECRET_RE,
+    _MCP_SHELL_RE,
+    _MCP_WRITE_RE,
+)
+from .inventory_contract_models import InventoryCapability, InventorySeverity
+
+
+def _apply_tool_trust_attestation_metadata(
+    metadata: dict[str, object],
+    *,
+    harness: str,
+    item_id: str,
+    content_hash: str,
+    config_path_hash: str,
+    repository_id: str,
+    trust_attestation_context: Mapping[str, object] | None,
+) -> dict[str, object]:
+    """Attach tool-level trust metadata only when compatible attestation evidence exists."""
+    from .runtime.trust_attestation import (
+        GuardTrustAttestationSigningConfig,
+        apply_trust_attestation_metadata,
+    )
+
+    if not isinstance(trust_attestation_context, Mapping):
+        return apply_trust_attestation_metadata(
+            metadata,
+            agent_id=f"{harness}:local",
+            item_id=item_id,
+            item_kind="mcp_tool",
+            content_hash=content_hash,
+            adapter_id=harness,
+            adapter_version=__version__,
+            config_path_hash=config_path_hash,
+            repository_id=repository_id,
+        )
+
+    raw_signing_config = trust_attestation_context.get("signingConfig")
+    signing_config = raw_signing_config if isinstance(raw_signing_config, GuardTrustAttestationSigningConfig) else None
+    raw_sequence = trust_attestation_context.get("sequence")
+    sequence = raw_sequence if isinstance(raw_sequence, int) else None
+
+    return apply_trust_attestation_metadata(
+        metadata,
+        agent_id=f"{harness}:local",
+        analyzer_id=_optional_context_string(trust_attestation_context, "analyzerId"),
+        analyzer_spec_version=_optional_context_string(trust_attestation_context, "analyzerSpecVersion"),
+        analyzer_version=_optional_context_string(trust_attestation_context, "analyzerVersion"),
+        item_id=item_id,
+        item_kind="mcp_tool",
+        content_hash=content_hash,
+        challenge_id=_optional_context_string(trust_attestation_context, "challengeId"),
+        expires_at=_optional_context_string(trust_attestation_context, "expiresAt"),
+        installation_id=_optional_context_string(trust_attestation_context, "installationId"),
+        nonce=_optional_context_string(trust_attestation_context, "nonce"),
+        policy_version=_optional_context_string(trust_attestation_context, "policyVersion"),
+        sequence=sequence,
+        upload_id=_optional_context_string(trust_attestation_context, "uploadId"),
+        workspace_id=_optional_context_string(trust_attestation_context, "workspaceId"),
+        device_id=_optional_context_string(trust_attestation_context, "deviceId"),
+        adapter_id=harness,
+        adapter_version=__version__,
+        config_path_hash=config_path_hash,
+        repository_id=repository_id,
+        signing_config=signing_config,
+    )
+
+
+def _attestation_path_hash(value: object, *, fallback: str) -> str:
+    """Hash an attestation path without exporting the private absolute path."""
+    raw = value if isinstance(value, str) and value else f"artifact:{fallback}"
+    try:
+        normalized = str(Path(raw).expanduser().resolve(strict=False))
+    except (OSError, RuntimeError, ValueError):
+        normalized = raw
+    return f"sha256:{hashlib.sha256(normalized.encode('utf-8')).hexdigest()}"
+
+
+def _attestation_repository_id(*, home_dir: Path, workspace_dir: Path | None) -> str:
+    """Resolve repository identity from the available artifact metadata."""
+    root = workspace_dir if workspace_dir is not None else home_dir
+    try:
+        normalized = str(root.expanduser().resolve(strict=False))
+    except (OSError, RuntimeError, ValueError):
+        normalized = str(root)
+    return f"sha256:{hashlib.sha256(normalized.encode('utf-8')).hexdigest()}"
+
+
+def _optional_context_string(context: Mapping[str, object], key: str) -> str | None:
+    """Read a nonempty optional string from an untrusted metadata context."""
+    value = context.get(key)
+    return value if isinstance(value, str) and value else None
+
+
+def _string_value(value: object) -> str | None:
+    """Normalize an optional metadata value to a safe string."""
+    return value if isinstance(value, str) else None
+
+
+def _first_present_value(mapping: dict[str, object], *keys: str) -> object | None:
+    """Select the first available metadata value in precedence order."""
+    for key in keys:
+        if key in mapping:
+            return mapping[key]
+    return None
+
+
+def _mcp_tool_definitions(metadata: dict[str, object]) -> tuple[dict[str, object], ...]:
+    """Read supported MCP definition shapes without treating arbitrary metadata as tools."""
+    tools: list[dict[str, object]] = []
+    seen_names: set[str] = set()
+    for key in ("tools", "tool_schemas", "toolSchemas"):
+        raw_tools = metadata.get(key)
+        if not isinstance(raw_tools, list):
+            continue
+        for raw_tool in raw_tools:
+            if not isinstance(raw_tool, dict):
+                continue
+            name = raw_tool.get("name")
+            if not isinstance(name, str) or not name.strip() or name in seen_names:
+                continue
+            tools.append(raw_tool)
+            seen_names.add(name)
+    return tuple(tools)
+
+
+def _mcp_schema_signal_text(value: object) -> str:
+    """Extract textual signals from a tool schema for capability classification."""
+    if isinstance(value, dict):
+        parts: list[str] = []
+        for key, item in value.items():
+            if key in {"$schema", "$id"}:
+                continue
+            parts.append(key)
+            parts.append(_mcp_schema_signal_text(item))
+        return " ".join(part for part in parts if part)
+    if isinstance(value, list):
+        return " ".join(_mcp_schema_signal_text(item) for item in value)
+    if isinstance(value, str):
+        return value
+    return ""
+
+
+def _capabilities_for_mcp_tool(
+    name: str,
+    description: str,
+    input_schema: object,
+    annotations: dict[str, object],
+) -> tuple[InventoryCapability, ...]:
+    """Classify tool capabilities from its advertised name, description, and schema."""
+    text = f"{name} {description} {_mcp_schema_signal_text(input_schema)}".lower()
+    capabilities: set[InventoryCapability] = set()
+    if annotations.get("readOnlyHint") is True or _MCP_READ_RE.search(text):
+        capabilities.add("reads_files")
+    if annotations.get("destructiveHint") is True or _MCP_DELETE_RE.search(text):
+        capabilities.update({"writes_files", "deletes_files"})
+    if annotations.get("writeHint") is True or _MCP_WRITE_RE.search(text):
+        capabilities.add("writes_files")
+    if _MCP_SHELL_RE.search(text):
+        capabilities.add("runs_shell")
+    if _MCP_SECRET_RE.search(text):
+        capabilities.add("reads_secrets")
+    if _MCP_NETWORK_RE.search(text):
+        capabilities.add("network_egress")
+    if _MCP_MODEL_RE.search(text):
+        capabilities.add("uses_model_sampling")
+    if _MCP_PERMISSION_RE.search(text):
+        capabilities.add("changes_permissions")
+    return tuple(sorted(capabilities)) if capabilities else ("unknown",)
+
+
+def _risk_level_for_capabilities(capabilities: tuple[InventoryCapability, ...]) -> InventorySeverity:
+    """Derive the inventory risk category from the classified capabilities."""
+    if any(capability in capabilities for capability in ("deletes_files", "reads_secrets", "runs_shell")):
+        return "high"
+    if any(
+        capability in capabilities
+        for capability in ("writes_files", "network_egress", "uses_model_sampling", "changes_permissions")
+    ):
+        return "medium"
+    return "info"

--- a/src/codex_plugin_scanner/guard/inventory_contract_metadata.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract_metadata.py
@@ -1,0 +1,296 @@
+"""Inventory evidence enrichment and safe source-of-truth inspection."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import re
+from pathlib import Path
+
+from ..path_support import resolves_within_root
+from .inventory_contract_constants import _path_has_symlink_component
+from .inventory_contract_models import InventoryCapability, InventoryItemKind, InventorySeverity
+from .skill_directory_identity import validated_complete_skill_directory_hash
+
+
+def _aibom_detection_module():
+    """Load source-of-truth detection lazily to avoid inventory initialization cycles."""
+    return importlib.import_module(".aibom_detection", __package__)
+
+
+def _aibom_symlink_module():
+    """Load symlink evidence helpers only when inventory enrichment requires them."""
+    return importlib.import_module(".aibom_symlink", __package__)
+
+
+def _aibom_trust_metadata_module():
+    """Load trust metadata enrichment without eagerly initializing its dependencies."""
+    return importlib.import_module(".aibom_trust_metadata", __package__)
+
+
+def _inventory_item_description_module():
+    """Load native item description helpers through their existing module interface."""
+    return importlib.import_module(".inventory_item_description", __package__)
+
+
+def _item_kind(artifact_type: str) -> InventoryItemKind:
+    """Map a native artifact category to the inventory item-kind contract."""
+    mapping: dict[str, InventoryItemKind] = {
+        "skill": "skill",
+        "skill_file": "skill",
+        "mcp_server": "mcp_server",
+        "mcp_tool": "mcp_tool",
+        "channel": "channel",
+        "gateway_config": "agent",
+        "config": "agent",
+        "agent": "agent",
+        "hook": "hook",
+        "instruction": "overlay",
+        "overlay": "overlay",
+        "command": "prompt_pack",
+        "extension": "plugin",
+        "plugin": "plugin",
+        "plugin-file": "plugin",
+        "repository": "repository",
+        "container_image": "container_image",
+        "policy": "policy",
+        "secret_reference": "secret_reference",
+        "network_endpoint": "network_endpoint",
+        "guard_launcher_shim": "harness",
+        "package": "package",
+        "daemon_plugin": "daemon_plugin",
+        "model_provider": "model_provider",
+        "prompt_pack": "prompt_pack",
+    }
+    return mapping.get(artifact_type, "plugin")
+
+
+def _resolve_item_content_hash(metadata: dict[str, object], semantic_text: str) -> str:
+    """Choose a verified content hash from supported artifact evidence."""
+    for key in ("content_hash", "directory_hash"):
+        candidate = metadata.get(key)
+        if isinstance(candidate, str) and candidate:
+            return _canonical_inventory_content_hash(candidate)
+    version_info = metadata.get("versionInfo")
+    if isinstance(version_info, dict):
+        version_hash = version_info.get("contentHash")
+        if isinstance(version_hash, str) and version_hash:
+            return _canonical_inventory_content_hash(version_hash)
+    return semantic_text
+
+
+def _discard_unverified_skill_directory_hash(metadata: dict[str, object]) -> dict[str, object]:
+    """Remove a directory hash when its content cannot be verified safely."""
+    if "skillDirectoryIdentity" not in metadata or validated_complete_skill_directory_hash(metadata) is not None:
+        return metadata
+    sanitized = dict(metadata)
+    sanitized.pop("directory_hash", None)
+    return sanitized
+
+
+def _primary_artifact_content_hash(
+    artifact: object,
+    *,
+    artifact_type: str,
+    home_dir: Path,
+    workspace_dir: Path | None,
+) -> str | None:
+    """Read the primary artifact fingerprint without substituting unrelated evidence."""
+    path_value = getattr(artifact, "config_path", None)
+    if not isinstance(path_value, str) or not path_value.strip():
+        return None
+    path = Path(path_value).expanduser()
+    if artifact_type == "skill":
+        if path.name != "SKILL.md":
+            return None
+        skills_root = next((parent for parent in path.parents if parent.name.lower() == "skills"), None)
+        if skills_root is None:
+            return None
+        try:
+            relative = path.relative_to(skills_root)
+        except ValueError:
+            return None
+        if len(relative.parts) < 2:
+            return None
+        outer_root = next(
+            (
+                root
+                for root in (home_dir, workspace_dir)
+                if root is not None and resolves_within_root(root, skills_root, require_exists=True)
+            ),
+            None,
+        )
+        if outer_root is None:
+            return None
+        allowed_roots = (skills_root,)
+    elif artifact_type == "instruction":
+        if workspace_dir is None or path.suffix.lower() not in {".md", ".mdc"}:
+            return None
+        allowed_roots = (workspace_dir,)
+    else:
+        return None
+    allowed_root = next(
+        (root for root in allowed_roots if root is not None and resolves_within_root(root, path, require_exists=True)),
+        None,
+    )
+    if allowed_root is None or _path_has_symlink_component(path, allowed_root=allowed_root):
+        return None
+    try:
+        digest = hashlib.sha256()
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(64 * 1024), b""):
+                digest.update(chunk)
+    except OSError:
+        return None
+    return f"sha256:{digest.hexdigest()}"
+
+
+def _canonical_inventory_content_hash(value: str) -> str:
+    """Normalize a supported content fingerprint into its canonical wire form."""
+    normalized = value.lower()
+    if re.fullmatch(r"[0-9a-f]{64}", normalized):
+        return f"sha256:{normalized}"
+    return value
+
+
+def _safe_roots_for_inspection(
+    *,
+    home_dir: Path,
+    workspace_dir: Path | None,
+) -> tuple[Path, ...]:
+    """Derive bounded filesystem roots permitted for source-of-truth inspection."""
+    roots: list[Path] = [home_dir]
+    if workspace_dir is not None:
+        roots.insert(0, workspace_dir)
+    return tuple(roots)
+
+
+def _apply_source_of_truth_metadata(
+    artifact: object,
+    *,
+    harness: str,
+    item_kind: InventoryItemKind,
+    metadata: dict[str, object],
+    home_dir: Path,
+    workspace_dir: Path | None,
+    follow_unsafe_symlinks: bool = False,
+) -> dict[str, object]:
+    """Reconcile metadata with the native source while retaining bounded inspection."""
+    config_path = getattr(artifact, "config_path", None)
+    if not isinstance(config_path, str) or not config_path:
+        return metadata
+    path = Path(config_path)
+    if not path.is_symlink():
+        return metadata
+    inspection = _aibom_symlink_module().inspect_aibom_source_path(
+        path,
+        safe_roots=_safe_roots_for_inspection(home_dir=home_dir, workspace_dir=workspace_dir),
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        follow_unsafe_symlinks=follow_unsafe_symlinks,
+    )
+    source_link_id = f"{harness}:{item_kind}:{inspection.source_fingerprint[:24]}"
+    enriched = dict(metadata)
+    enriched["sourceOfTruth"] = _aibom_symlink_module().source_of_truth_metadata_from_inspection(
+        inspection,
+        source_link_id=source_link_id,
+    )
+    return enriched
+
+
+def _apply_aibom_metadata_enrichment(
+    artifact: object,
+    *,
+    captured_at: str,
+    item_kind: InventoryItemKind,
+    metadata: dict[str, object],
+    home_dir: Path,
+    workspace_dir: Path | None,
+    cisco_runs: tuple[object, ...] = (),
+) -> dict[str, object]:
+    """Add inventory detection, symlink, and trust evidence through established helpers."""
+    enriched = dict(metadata)
+    artifact_type = str(getattr(artifact, "artifact_type", "unknown"))
+    if artifact_type == "skill":
+        from .skill_document_evidence import enrich_skill_document_metadata
+
+        enriched = enrich_skill_document_metadata(
+            getattr(artifact, "config_path", None),
+            enriched,
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+        )
+    if item_kind == "overlay" and "instructionRole" not in enriched:
+        config_path = getattr(artifact, "config_path", None)
+        if isinstance(config_path, str):
+            role = _aibom_detection_module().instruction_role_for_path(Path(config_path))
+            if role is not None:
+                enriched["instructionRole"] = role
+    return _aibom_trust_metadata_module().apply_local_trust_metadata(
+        artifact,
+        captured_at=captured_at,
+        item_kind=item_kind,
+        metadata=enriched,
+        workspace_dir=workspace_dir,
+        cisco_runs=cisco_runs,
+    )
+
+
+def _capabilities_for_artifact(
+    artifact_type: str,
+    metadata: dict[str, object],
+) -> tuple[InventoryCapability, ...]:
+    """Classify native artifact capabilities from supported metadata and findings."""
+    capabilities: set[InventoryCapability] = set()
+    if artifact_type in {"instruction", "overlay", "command"}:
+        capabilities.add("reads_files")
+    if artifact_type == "mcp_server":
+        capabilities.add("network_egress")
+        if metadata.get("transport") == "stdio":
+            capabilities.add("runs_shell")
+    if artifact_type == "channel":
+        capabilities.update({"reads_messages", "posts_messages", "network_ingress"})
+    if bool(metadata.get("envConfigurationPresent")) or bool(metadata.get("has_auth_headers")):
+        capabilities.add("reads_secrets")
+    return tuple(sorted(capabilities)) if capabilities else ("unknown",)
+
+
+def _bind_skill_document_evidence(
+    metadata: dict[str, object],
+    *,
+    primary_content_hash: str | None,
+) -> dict[str, object]:
+    """Bind skill document identity and content evidence to its inventory item."""
+    bound = dict(metadata)
+    # This value is derived from Guard's own full, safe read of SKILL.md.  It
+    # remains the authority for primary-body upload when the inventory item's
+    # public content hash is upgraded to the full directory identity.
+    if isinstance(primary_content_hash, str):
+        bound["primaryContentHash"] = primary_content_hash
+    else:
+        bound.pop("primaryContentHash", None)
+
+    evidence = metadata.get("contentEvidence")
+    if (
+        isinstance(evidence, dict)
+        and isinstance(primary_content_hash, str)
+        and evidence.get("contentHash") == primary_content_hash
+    ):
+        return bound
+
+    if isinstance(evidence, dict) and "contentHash" not in evidence:
+        bound.pop("documentedCapabilities", None)
+        return bound
+
+    bound.pop("contentEvidence", None)
+    bound.pop("documentedCapabilities", None)
+    return bound
+
+
+def _risk_level(metadata: dict[str, object]) -> InventorySeverity:
+    """Normalize a scanner severity to a supported inventory risk level."""
+    if metadata.get("has_auth_headers") or metadata.get("envConfigurationPresent"):
+        return "high"
+    if metadata.get("endpointHostClass") == "remote_public":
+        return "medium"
+    return "info"

--- a/src/codex_plugin_scanner/guard/inventory_contract_models.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract_models.py
@@ -1,0 +1,170 @@
+"""Inventory value types and immutable wire-contract models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+from .inventory_agent_types import AgentInventoryType
+
+InventoryItemKind = Literal[
+    "agent",
+    "daemon_plugin",
+    "harness",
+    "model_provider",
+    "package",
+    "prompt_pack",
+    "skill",
+    "mcp_server",
+    "mcp_tool",
+    "plugin",
+    "channel",
+    "hook",
+    "overlay",
+    "repository",
+    "container_image",
+    "policy",
+    "secret_reference",
+    "network_endpoint",
+]
+
+
+InventoryCapability = Literal[
+    "reads_files",
+    "reads_secrets",
+    "writes_files",
+    "deletes_files",
+    "runs_shell",
+    "executes_code",
+    "network_egress",
+    "network_ingress",
+    "posts_messages",
+    "reads_messages",
+    "uses_browser",
+    "uses_clipboard",
+    "uses_model_sampling",
+    "changes_permissions",
+    "loads_remote_code",
+    "unknown",
+]
+
+
+InventoryFindingSource = Literal["cisco-mcp-scanner", "cisco-skill-scanner", "hol-detector", "docker-proof", "metadata"]
+
+
+InventorySeverity = Literal["critical", "high", "medium", "low", "info"]
+
+
+InventoryConfidence = Literal["high", "medium", "low", "unknown"]
+
+
+InventoryDriftState = Literal["new", "changed", "removed", "unchanged"]
+
+
+DockerProofStatus = Literal["passed", "failed", "skipped", "stale"]
+
+
+@dataclass(frozen=True, slots=True)
+class GuardAgentInventoryFinding:
+    finding_id: str
+    source: InventoryFindingSource
+    severity: InventorySeverity
+    confidence: InventoryConfidence
+    title: str
+    artifact_id: str
+    check_id: str
+    summary: str | None = None
+    evidence: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class GuardAgentInventoryDrift:
+    drift_id: str
+    item_id: str
+    state: InventoryDriftState
+    previous_hash: str | None
+    current_hash: str | None
+    changed_fields: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class GuardAgentInventoryDockerProof:
+    proof_id: str
+    agent_id: str
+    agent_type: str
+    image_reference: str
+    status: DockerProofStatus
+    captured_at: str
+    log_hash: str
+    redaction_report: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class GuardAgentIntegrationRun:
+    run_id: str
+    agent_id: str
+    agent_type: str
+    status: Literal["started", "completed", "failed"]
+    started_at: str
+    completed_at: str | None = None
+    message: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class GuardHarnessSetupStep:
+    step_id: str
+    agent_type: str
+    status: Literal["not_started", "running", "completed", "failed"]
+    label: str
+    safe_command: str | None = None
+    detail: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class GuardInventoryRiskComponent:
+    component_id: str
+    source: InventoryFindingSource
+    severity: InventorySeverity
+    confidence: InventoryConfidence
+    score_delta: int
+    summary: str
+
+
+@dataclass(frozen=True, slots=True)
+class GuardInventorySource:
+    source_id: str
+    source_type: Literal["config", "docker", "scanner", "runtime", "repository"]
+    status: Literal["available", "missing", "failed"]
+    captured_at: str | None = None
+    detail: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class GuardAgentInventoryItem:
+    item_id: str
+    item_kind: InventoryItemKind
+    display_name: str
+    description: str
+    source_fingerprint: str
+    content_hash: str
+    capability_categories: tuple[InventoryCapability, ...]
+    risk_level: InventorySeverity = "info"
+    security_score: int = 100
+    scanner_sources: tuple[InventoryFindingSource, ...] = ()
+    drift_state: InventoryDriftState = "unchanged"
+    metadata: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class GuardAgentInventorySnapshot:
+    snapshot_id: str
+    agent_id: str
+    agent_type: AgentInventoryType
+    generated_at: str
+    runtime_version: str | None = None
+    items: tuple[GuardAgentInventoryItem, ...] = ()
+    findings: tuple[GuardAgentInventoryFinding, ...] = ()
+    drift: tuple[GuardAgentInventoryDrift, ...] = ()
+    docker_proofs: tuple[GuardAgentInventoryDockerProof, ...] = ()
+    sources: tuple[GuardInventorySource, ...] = ()
+    redaction_report: dict[str, object] = field(default_factory=dict)

--- a/src/codex_plugin_scanner/guard/inventory_contract_redaction.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract_redaction.py
@@ -1,0 +1,260 @@
+"""Inventory redaction and safe serialization of untrusted strings."""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import re
+from pathlib import Path
+from typing import Literal
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+from .inventory_contract_constants import (
+    _SAFE_SERIALIZED_MARKERS,
+    _SENSITIVE_KEY_RE,
+    _SENSITIVE_VALUE_RE,
+    _SERIALIZER_REDACTED_VALUE,
+    _SERIALIZER_SECRET_ASSIGNMENT_RE,
+    _SERIALIZER_UNSAFE_PATH_RE,
+)
+
+
+def redact_local_path(path: str | Path, *, home_dir: Path | None = None) -> str:
+    """Replace private absolute path prefixes while preserving useful relative identity."""
+    candidate = Path(path)
+    if home_dir is None:
+        return candidate.name
+    try:
+        relative = candidate.resolve().relative_to(home_dir.resolve())
+    except (OSError, RuntimeError, ValueError):
+        return candidate.name
+    return f"{{home}}/{relative.as_posix()}"
+
+
+def redact_headers(headers: dict[str, str]) -> dict[str, str]:
+    """Preserve header names while redacting credential-bearing header values."""
+    return {key.lower(): "present_redacted" if _SENSITIVE_KEY_RE.search(key) else "present" for key in headers}
+
+
+def redact_url(value: str) -> str:
+    """Remove sensitive URL credentials and query values before exporting an endpoint."""
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return "malformed_url_redacted"
+    hostname = parsed.hostname or parsed.netloc
+    if ":" in hostname and not hostname.startswith("["):
+        hostname = f"[{hostname}]"
+    netloc = hostname
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
+    if port is not None:
+        netloc = f"{netloc}:{port}"
+    redacted_pairs = [
+        (key, "redacted" if _SENSITIVE_KEY_RE.search(key) else item)
+        for key, item in parse_qsl(parsed.query.replace(";", "&"), keep_blank_values=True)
+    ]
+    return urlunsplit((parsed.scheme, netloc, parsed.path, urlencode(redacted_pairs), parsed.fragment))
+
+
+def classify_endpoint_host(value: str | None) -> Literal["none", "local_loopback", "local_private", "remote_public"]:
+    """Classify an endpoint host without making a network request."""
+    if not value:
+        return "none"
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return "remote_public"
+    host = (parsed.hostname or "").lower()
+    if host in {"localhost", "127.0.0.1", "::1"}:
+        return "local_loopback"
+    try:
+        if ipaddress.ip_address(host).is_private:
+            return "local_private"
+    except ValueError:
+        pass
+    return "remote_public"
+
+
+def _safe_source_detail(run: object) -> str:
+    """Redact source descriptions and record the resulting redaction counts."""
+    status = str(getattr(run, "status", "unknown"))
+    metadata = getattr(run, "metadata", {})
+    finding_count = None
+    if isinstance(metadata, dict):
+        candidate = metadata.get("totalFindings")
+        if isinstance(candidate, int):
+            finding_count = candidate
+    suffix = f", findings={finding_count}" if finding_count is not None else ""
+    return f"status={status}{suffix}"
+
+
+def _safe_finding_text(value: str, *, home_dir: Path, workspace_dir: Path | None) -> str:
+    """Sanitize finding text without exposing private paths or credential values."""
+    redacted = _SENSITIVE_VALUE_RE.sub("redacted", value)
+    redacted = _redact_command_value(redacted, home_dir, workspace_dir)
+    return redacted[:500]
+
+
+def _safe_artifact_metadata(
+    artifact: object,
+    *,
+    home_dir: Path,
+    workspace_dir: Path | None,
+) -> dict[str, object]:
+    """Restrict exported artifact metadata to supported fields and sanitized values."""
+    artifact_type = str(getattr(artifact, "artifact_type", "unknown"))
+    raw_metadata = getattr(artifact, "metadata", {})
+    metadata = _sanitize_paths(raw_metadata if isinstance(raw_metadata, dict) else {}, home_dir, workspace_dir)
+    if not isinstance(metadata, dict):
+        metadata = {}
+    from .trust_metadata_boundary import separate_untrusted_adapter_trust_metadata
+
+    metadata = separate_untrusted_adapter_trust_metadata(metadata)
+    config_path = getattr(artifact, "config_path", None)
+    command = getattr(artifact, "command", None)
+    url = getattr(artifact, "url", None)
+    transport = getattr(artifact, "transport", None)
+    if isinstance(config_path, str) and config_path:
+        metadata["configPath"] = _redact_known_path(config_path, home_dir, workspace_dir)
+    if isinstance(command, str) and command:
+        metadata["command"] = _redact_command_value(command, home_dir, workspace_dir)
+    if isinstance(url, str) and url:
+        metadata["url"] = redact_url(url)
+        metadata["endpointHostClass"] = classify_endpoint_host(url)
+    if isinstance(transport, str) and transport:
+        metadata["transport"] = transport
+    metadata["artifactType"] = artifact_type
+    return metadata
+
+
+def _sanitize_paths(value: object, home_dir: Path, workspace_dir: Path | None) -> object:
+    """Recursively sanitize private path values in supported metadata structures."""
+    if isinstance(value, Path):
+        return _redact_known_path(str(value), home_dir, workspace_dir)
+    if isinstance(value, dict):
+        redacted: dict[str, object] = {}
+        for key, item in value.items():
+            string_key = str(key)
+            if _SENSITIVE_KEY_RE.search(string_key):
+                redacted[string_key] = item if isinstance(item, bool) else "present_redacted"
+                continue
+            redacted[string_key] = _sanitize_paths(item, home_dir, workspace_dir)
+        return redacted
+    if isinstance(value, (list, tuple)):
+        return [_sanitize_paths(item, home_dir, workspace_dir) for item in value]
+    if isinstance(value, str):
+        if "://" in value:
+            return redact_url(value)
+        return _redact_known_path(value, home_dir, workspace_dir)
+    return value
+
+
+def _redact_known_path(value: str, home_dir: Path, workspace_dir: Path | None) -> str:
+    """Redact one known local path using the operator home boundary."""
+    path = Path(value)
+    if path.is_absolute():
+        home_redacted = redact_local_path(path, home_dir=home_dir)
+        if home_redacted.startswith("{home}/"):
+            return home_redacted
+        if workspace_dir is not None:
+            try:
+                relative = path.resolve().relative_to(workspace_dir.resolve())
+                return f"{{workspace}}/{relative.as_posix()}"
+            except (OSError, RuntimeError, ValueError):
+                return path.name
+        return path.name
+    return value
+
+
+def _redact_command_value(value: str, home_dir: Path, workspace_dir: Path | None) -> str:
+    """Redact path and credential values from an exported command string."""
+    redacted = re.sub(
+        r"(?i)\b[a-z][a-z0-9+.-]*://[^\s]+",
+        lambda match: redact_url(match.group(0)),
+        value,
+    )
+    redacted = re.sub(
+        r"(^|\s)(/[^\s]+)",
+        lambda match: f"{match.group(1)}{_redact_known_path(match.group(2), home_dir, workspace_dir)}",
+        redacted,
+    )
+    redacted = re.sub(
+        r"(?i)(authorization:\s*bearer\s+)\S+",
+        r"\1redacted",
+        redacted,
+    )
+    redacted = re.sub(
+        r"(?i)((?:api[_-]?key|auth|password|secret|token)=)\S+",
+        r"\1redacted",
+        redacted,
+    )
+    redacted = re.sub(
+        r"(?i)((?:--)?(?:api[_-]?key|auth|password|secret|token)\s+)\S+",
+        r"\1redacted",
+        redacted,
+    )
+    return redacted
+
+
+def _sanitize_serializer_string(
+    value: str,
+    *,
+    parent_key: str = "",
+    parent_sensitive: bool = False,
+) -> str:
+    """Apply final string redaction before inventory serialization."""
+    if value in _SAFE_SERIALIZED_MARKERS:
+        return value
+    if parent_sensitive or (parent_key and _SENSITIVE_KEY_RE.search(parent_key)):
+        return _SERIALIZER_REDACTED_VALUE
+    if _SERIALIZER_UNSAFE_PATH_RE.search(value):
+        return _SERIALIZER_REDACTED_VALUE
+    if _SENSITIVE_VALUE_RE.search(value):
+        return _SERIALIZER_REDACTED_VALUE
+    if _SERIALIZER_SECRET_ASSIGNMENT_RE.search(value):
+        return _SERIALIZER_REDACTED_VALUE
+    return value
+
+
+def _assert_serialized_inventory_payload_safe(payload: object) -> None:
+    """Reject serialized inventory that still violates the export safety contract."""
+    encoded = json.dumps(payload, sort_keys=True)
+    if (
+        _SERIALIZER_UNSAFE_PATH_RE.search(encoded)
+        or _SENSITIVE_VALUE_RE.search(encoded)
+        or _SERIALIZER_SECRET_ASSIGNMENT_RE.search(encoded)
+    ):
+        raise ValueError("Inventory snapshot serialization produced unsafe payload.")
+
+
+def _safe_json(
+    value: object,
+    *,
+    parent_key: str = "",
+    parent_sensitive: bool = False,
+) -> object:
+    """Normalize metadata into bounded JSON-compatible evidence."""
+    key_sensitive = parent_sensitive or bool(parent_key and _SENSITIVE_KEY_RE.search(parent_key))
+    if isinstance(value, dict):
+        return {
+            _sanitize_serializer_string(str(key), parent_sensitive=parent_sensitive): _safe_json(
+                item,
+                parent_key=str(key),
+                parent_sensitive=key_sensitive,
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_safe_json(item, parent_key=parent_key, parent_sensitive=parent_sensitive) for item in value]
+    if isinstance(value, Path):
+        return value.name
+    if isinstance(value, str):
+        return _sanitize_serializer_string(
+            value,
+            parent_key=parent_key,
+            parent_sensitive=parent_sensitive,
+        )
+    return value

--- a/src/codex_plugin_scanner/guard/inventory_contract_redaction.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract_redaction.py
@@ -42,7 +42,7 @@ def redact_url(value: str) -> str:
         parsed = urlsplit(value)
     except ValueError:
         return "malformed_url_redacted"
-    hostname = parsed.hostname or parsed.netloc
+    hostname = parsed.hostname or ""
     if ":" in hostname and not hostname.startswith("["):
         hostname = f"[{hostname}]"
     netloc = hostname
@@ -240,7 +240,7 @@ def _safe_json(
     key_sensitive = parent_sensitive or bool(parent_key and _SENSITIVE_KEY_RE.search(parent_key))
     if isinstance(value, dict):
         return {
-            _sanitize_serializer_string(str(key), parent_sensitive=parent_sensitive): _safe_json(
+            _sanitize_serializer_string(str(key)): _safe_json(
                 item,
                 parent_key=str(key),
                 parent_sensitive=key_sensitive,

--- a/src/codex_plugin_scanner/guard/inventory_contract_scans.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract_scans.py
@@ -1,0 +1,207 @@
+"""Scanner results and symlink findings normalized into inventory evidence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+from .inventory_contract_fingerprints import fingerprint_mapping
+from .inventory_contract_models import (
+    GuardAgentInventoryFinding,
+    GuardAgentInventoryItem,
+    GuardInventorySource,
+    InventoryFindingSource,
+    InventorySeverity,
+)
+from .inventory_contract_redaction import _redact_known_path, _safe_finding_text, _safe_source_detail
+
+
+def _cisco_inventory_findings(
+    cisco_runs: tuple[object, ...],
+    *,
+    items: tuple[GuardAgentInventoryItem, ...],
+    home_dir: Path,
+    workspace_dir: Path | None,
+) -> tuple[GuardAgentInventoryFinding, ...]:
+    """Map optional scanner findings into the canonical inventory finding contract."""
+    findings: list[GuardAgentInventoryFinding] = []
+    seen: set[str] = set()
+    for run in cisco_runs:
+        source = _cisco_source(run)
+        if source is None:
+            continue
+        run_status = str(getattr(run, "status", "unknown"))
+        run_message = _safe_finding_text(
+            str(getattr(run, "message", "")),
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+        )
+        duration_ms = getattr(run, "duration_ms", None)
+        for raw_finding in tuple(getattr(run, "findings", ()) or ()):
+            rule_id = str(getattr(raw_finding, "rule_id", "cisco-finding") or "cisco-finding")
+            title = _safe_finding_text(
+                str(getattr(raw_finding, "title", "Cisco scanner finding") or "Cisco scanner finding"),
+                home_dir=home_dir,
+                workspace_dir=workspace_dir,
+            )
+            file_path = getattr(raw_finding, "file_path", None)
+            safe_path = (
+                _redact_known_path(str(file_path), home_dir, workspace_dir)
+                if isinstance(file_path, str) and file_path
+                else None
+            )
+            line_number = getattr(raw_finding, "line_number", None)
+            finding_hash = fingerprint_mapping(
+                {
+                    "source": source,
+                    "rule_id": rule_id,
+                    "title": title,
+                    "path": safe_path,
+                    "line": line_number if isinstance(line_number, int) else None,
+                }
+            )
+            finding_id = f"{source}:{rule_id}:{finding_hash[:16]}"
+            if finding_id in seen:
+                continue
+            seen.add(finding_id)
+            severity = _inventory_severity(getattr(raw_finding, "severity", "info"))
+            findings.append(
+                GuardAgentInventoryFinding(
+                    finding_id=finding_id,
+                    source=source,
+                    severity=severity,
+                    confidence="high" if run_status == "enabled" else "unknown",
+                    title=title,
+                    artifact_id=_artifact_id_for_cisco_finding(safe_path, items),
+                    check_id=rule_id,
+                    summary=_safe_finding_text(
+                        str(getattr(raw_finding, "description", "") or ""),
+                        home_dir=home_dir,
+                        workspace_dir=workspace_dir,
+                    ),
+                    evidence={
+                        "scannerStatus": run_status,
+                        "scannerMessage": run_message,
+                        "filePath": safe_path,
+                        "lineNumber": line_number if isinstance(line_number, int) else None,
+                        "durationMs": duration_ms if isinstance(duration_ms, int) else None,
+                        "riskComponent": {
+                            "source": source,
+                            "severity": severity,
+                            "confidence": "high" if run_status == "enabled" else "unknown",
+                            "scoreDelta": _score_delta_for_severity(severity),
+                        },
+                    },
+                )
+            )
+    return tuple(findings)
+
+
+def _cisco_inventory_sources(cisco_runs: tuple[object, ...]) -> tuple[GuardInventorySource, ...]:
+    """Record scanner sources and their availability alongside inventory evidence."""
+    sources: list[GuardInventorySource] = []
+    for run in cisco_runs:
+        source = _cisco_source(run)
+        if source is None:
+            continue
+        status = str(getattr(run, "status", "unknown"))
+        detail = _safe_source_detail(run)
+        sources.append(
+            GuardInventorySource(
+                source_id=f"{source}:{fingerprint_mapping({'status': status, 'detail': detail})[:12]}",
+                source_type="scanner",
+                status=_source_status_for_cisco_status(status),
+                detail=detail,
+            )
+        )
+    return tuple(sources)
+
+
+def _cisco_source(run: object) -> InventoryFindingSource | None:
+    """Build a source descriptor for one supported scanner."""
+    source = str(getattr(run, "source", ""))
+    if source == "cisco-mcp-scanner":
+        return "cisco-mcp-scanner"
+    if source == "cisco-skill-scanner":
+        return "cisco-skill-scanner"
+    return None
+
+
+def _inventory_severity(value: object) -> InventorySeverity:
+    """Normalize scanner severity without elevating unknown values."""
+    severity_value = str(getattr(value, "value", value)).strip().lower()
+    if severity_value == "critical":
+        return "critical"
+    if severity_value == "high":
+        return "high"
+    if severity_value == "medium":
+        return "medium"
+    if severity_value == "low":
+        return "low"
+    if severity_value == "info":
+        return "info"
+    return "info"
+
+
+def _score_delta_for_severity(severity: InventorySeverity) -> int:
+    """Map a finding severity to the established inventory score adjustment."""
+    return {"critical": -40, "high": -25, "medium": -12, "low": -5, "info": 0}[severity]
+
+
+def _artifact_id_for_cisco_finding(
+    safe_path: str | None,
+    items: tuple[GuardAgentInventoryItem, ...],
+) -> str:
+    """Associate a scanner finding with a known native artifact when possible."""
+    if safe_path is None:
+        return "unknown"
+    for item in items:
+        config_path = item.metadata.get("configPath")
+        if isinstance(config_path, str) and (config_path == safe_path or config_path.endswith(safe_path)):
+            return item.item_id
+    return "unknown"
+
+
+def _source_status_for_cisco_status(status: str) -> Literal["available", "missing", "failed"]:
+    """Map scanner completion state to the public inventory source status."""
+    if status == "enabled":
+        return "available"
+    if status in {"failed", "timed_out"}:
+        return "failed"
+    return "missing"
+
+
+def _symlink_findings_from_items(
+    harness: str,
+    items: tuple[GuardAgentInventoryItem, ...],
+) -> tuple[GuardAgentInventoryFinding, ...]:
+    """Convert recorded symlink evidence into attributable inventory findings."""
+    findings: list[GuardAgentInventoryFinding] = []
+    for item in items:
+        source_of_truth = item.metadata.get("sourceOfTruth")
+        if not isinstance(source_of_truth, dict):
+            continue
+        validation_state = source_of_truth.get("validationState")
+        if validation_state == "valid":
+            continue
+        if not isinstance(validation_state, str):
+            continue
+        severity: InventorySeverity = "high" if validation_state in {"loop", "escape_blocked"} else "medium"
+        findings.append(
+            GuardAgentInventoryFinding(
+                finding_id=f"{harness}:symlink:{item.item_id}:{validation_state}",
+                source="hol-detector",
+                severity=severity,
+                confidence="high",
+                title=f"Symlink source {validation_state.replace('_', ' ')}",
+                artifact_id=item.item_id,
+                check_id=f"aibom.symlink.{validation_state}",
+                summary=f"Inventory item references a symlink source in state {validation_state}.",
+                evidence={
+                    "validationState": validation_state,
+                    "sourceFingerprint": source_of_truth.get("sourceFingerprint"),
+                    "pathClass": source_of_truth.get("pathClass"),
+                },
+            )
+        )
+    return tuple(findings)

--- a/src/codex_plugin_scanner/guard/managed_install_proof.py
+++ b/src/codex_plugin_scanner/guard/managed_install_proof.py
@@ -20,7 +20,7 @@ _MANAGED_PATH_KEYS = (
     "prompt_hook_path",
     "shim_path",
 )
-_MANAGED_PATH_LIST_KEYS = ("shim_paths",)
+_MANAGED_PATH_LIST_KEYS = ("shim_paths", "protection_artifact_paths")
 _MAX_PROOF_FILE_BYTES = 4 * 1024 * 1024
 
 

--- a/src/codex_plugin_scanner/guard/protection_capabilities.py
+++ b/src/codex_plugin_scanner/guard/protection_capabilities.py
@@ -32,6 +32,11 @@ class HarnessProtectionCapability:
 
 
 def honesty_sentence(capability: HarnessProtectionCapability, display_name: str) -> str:
+    if capability.harness == "paseo":
+        return (
+            "Paseo uses each provider's native Guard hooks; some providers continue if a hook fails. "
+            "Other Paseo actions are not covered."
+        )
     if capability.can_ask_inline and capability.has_native_remember:
         return f"{display_name} uses this app's prompt when it can."
     if capability.can_ask_inline:
@@ -60,6 +65,7 @@ HARNESS_PROTECTION_CAPABILITIES: tuple[HarnessProtectionCapability, ...] = (
     HarnessProtectionCapability("pi", True, False, False, True),
     HarnessProtectionCapability("omp", True, False, False, True),
     HarnessProtectionCapability("zcode", True, False, False, True),
+    HarnessProtectionCapability("paseo", True, False, False, True, True),
 )
 
 _CAPABILITY_BY_HARNESS = {item.harness: item for item in HARNESS_PROTECTION_CAPABILITIES}

--- a/src/codex_plugin_scanner/guard/schemas/guard_product_model_v1.json
+++ b/src/codex_plugin_scanner/guard/schemas/guard_product_model_v1.json
@@ -58,7 +58,8 @@
         "grok",
         "pi",
         "omp",
-        "zcode"
+        "zcode",
+        "paseo"
     ],
     "action_categories": [
         "secrets",

--- a/tests/test_grok_hook_context.py
+++ b/tests/test_grok_hook_context.py
@@ -1,0 +1,122 @@
+"""Grok hook readiness binds every generated launch form to its actual owner."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext, _shell_command
+from codex_plugin_scanner.guard.adapters.grok import GrokHarnessAdapter, grok_runtime_hooks_verified
+from codex_plugin_scanner.guard.cli.grok_hook_validation import is_grok_hook_command
+from codex_plugin_scanner.guard.cli.native_install_checks import grok_hooks_protection_ready
+
+
+def _context(tmp_path: Path, *, workspace: bool = True) -> HarnessContext:
+    """Select an explicit home and an optional workspace for a real generated hook."""
+    return HarnessContext(tmp_path / "home", tmp_path / "workspace" if workspace else None, tmp_path / "guard")
+
+
+def _redirect(command: tuple[str, ...], target: Path, option: str) -> tuple[str, ...]:
+    """Change paired configuration values while keeping the command internally consistent."""
+    offset = 7 if len(command) == 9 else len(command) - 1
+    config = json.loads(command[offset])
+    args = config["cli_args"]
+    args[args.index(option) + 1] = str(target)
+    if option == "--guard-home":
+        config["guard_home"] = str(target)
+    changed = list(command)
+    changed[offset] = json.dumps(config)
+    return tuple(changed)
+
+
+def _generated(context: HarnessContext, mode: str, monkeypatch: pytest.MonkeyPatch) -> tuple[str, ...]:
+    """Generate native Python/frozen hooks or the signed desktop proxy envelope."""
+    monkeypatch.delenv("HOL_GUARD_DESKTOP", raising=False)
+    if mode == "frozen":
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+    command = GrokHarnessAdapter._hook_command_parts(context)
+    if mode != "desktop":
+        return command
+    from codex_plugin_scanner.guard.adapters import desktop_hook_proxy as proxy
+
+    bundle = context.home_dir / "Guard.app"
+    candidate = bundle / "Contents/MacOS/proxy"
+    core = candidate.with_name("core")
+    config = json.loads(command[-1])
+    config.update(frozen_launcher=True, python_executable=str(core))
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(proxy, "_trusted_desktop_path", lambda _path: True)
+    monkeypatch.setattr(proxy, "_codesign_team", lambda _path: "TEAM123")
+    return (
+        "/bin/sh",
+        "-c",
+        proxy._DESKTOP_PROXY_LAUNCH_SCRIPT,
+        "hol-guard-desktop-proxy",
+        str(candidate),
+        "TEAM123",
+        str(bundle),
+        json.dumps(config),
+        str(core),
+    )
+
+
+@pytest.mark.security_critical
+@pytest.mark.parametrize("mode", ["python", "frozen", "desktop"])
+@pytest.mark.parametrize("option", ["--guard-home", "--home", "--workspace"])
+def test_all_generated_forms_reject_paired_path_redirects(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mode: str, option: str
+) -> None:
+    """Valid signatures and internally consistent arguments cannot authorize another context."""
+    if mode == "desktop" and os.name == "nt":
+        pytest.skip("The signed macOS proxy uses POSIX command serialization.")
+    context = _context(tmp_path)
+    command = _generated(context, mode, monkeypatch)
+    assert is_grok_hook_command(_shell_command(command), context)
+    changed = _redirect(command, tmp_path / "redirected", option)
+    assert is_grok_hook_command(_shell_command(changed))  # Syntax alone is intentionally insufficient.
+    assert not is_grok_hook_command(_shell_command(changed), context)
+
+
+@pytest.mark.security_critical
+@pytest.mark.parametrize("pinned", [False, True])
+def test_workspace_boundaries_are_not_interchangeable(tmp_path: Path, pinned: bool) -> None:
+    """A workspace-specific hook cannot claim machine-wide coverage, or vice versa."""
+    context = _context(tmp_path, workspace=pinned)
+    command = _shell_command(GrokHarnessAdapter._hook_command_parts(context))
+    assert is_grok_hook_command(command, context)
+    assert not is_grok_hook_command(command, _context(tmp_path, workspace=not pinned))
+
+
+def test_implicit_native_home_must_match_current_user(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The generator may omit --home only when the process's home is the intended one."""
+    context = _context(tmp_path, workspace=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: context.home_dir))
+    command = _shell_command(GrokHarnessAdapter._hook_command_parts(context))
+    assert is_grok_hook_command(command, context)
+    assert not is_grok_hook_command(command, replace(context, home_dir=tmp_path / "other-home"))
+
+
+@pytest.mark.security_critical
+@pytest.mark.parametrize("option", ["--guard-home", "--home", "--workspace"])
+def test_installed_readiness_rejects_consistent_path_redirects(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, option: str
+) -> None:
+    """Both public readiness paths bind on-disk hook configuration to the supplied owner."""
+    context = _context(tmp_path)
+    monkeypatch.delenv("GROK_HOME", raising=False)
+    adapter = GrokHarnessAdapter()
+    adapter.install(context)
+    assert grok_runtime_hooks_verified(context)
+    assert grok_hooks_protection_ready(context)
+    hook = adapter._hooks_dir(context) / "hol-guard-pretooluse.json"
+    payload = json.loads(hook.read_text())
+    command = _redirect(adapter._hook_command_parts(context), tmp_path / "redirected", option)
+    payload["hooks"]["PreToolUse"][0]["hooks"][0]["command"] = _shell_command(command)
+    hook.write_text(json.dumps(payload), encoding="utf-8")
+    assert not grok_runtime_hooks_verified(context)
+    assert not grok_hooks_protection_ready(context)

--- a/tests/test_grok_hook_validation.py
+++ b/tests/test_grok_hook_validation.py
@@ -1,0 +1,137 @@
+"""Generated Grok invocations, permission tables, and readable repair diagnostics."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext, _shell_command
+from codex_plugin_scanner.guard.adapters.grok import GrokHarnessAdapter
+from codex_plugin_scanner.guard.cli.grok_hook_validation import is_grok_hook_command
+from codex_plugin_scanner.guard.cli.native_install_checks import (
+    _grok_managed_config_is_active,
+    _grok_protection_checks,
+)
+
+
+def _command(tmp_path: Path) -> tuple[str, ...]:
+    """Use the real generator so validation remains compatible with installed hooks."""
+    context = HarnessContext(tmp_path / "home", tmp_path / "workspace", tmp_path / "guard")
+    return GrokHarnessAdapter._hook_command_parts(context)
+
+
+def test_generated_grok_bridge_is_recognized(tmp_path: Path) -> None:
+    """The current interpreter, isolated bootstrap, and Grok arguments are accepted."""
+    assert is_grok_hook_command(_shell_command(_command(tmp_path))) is True
+
+
+@pytest.mark.parametrize("mutation", ["bootstrap", "executable", "harness", "home", "extra", "shell", "malformed"])
+def test_grok_bridge_rejects_marker_only_or_modified_invocations(tmp_path: Path, mutation: str) -> None:
+    """Marker strings cannot make an ineffective or redirected command report ready."""
+    command = list(_command(tmp_path))
+    config = json.loads(command[-1])
+    if mutation == "bootstrap":
+        command[3] = "print('bounded_cli_hook_bridge hol-guard hook')"
+    elif mutation == "executable":
+        command[0] = config["python_executable"] = "/bin/echo"
+    elif mutation == "harness":
+        config["cli_args"][5] = "pi"
+    elif mutation == "home":
+        config["guard_home"] = str(tmp_path / "another")
+    elif mutation == "extra":
+        config["cli_args"] += ["--help"]
+    elif mutation == "shell":
+        command = ["sh", "-c", "echo hol-guard hook"]
+    elif mutation == "malformed":
+        return_value = is_grok_hook_command("'unterminated")
+        assert return_value is False
+        return
+    if mutation != "shell":
+        command[-1] = json.dumps(config)
+    assert is_grok_hook_command(_shell_command(tuple(command))) is False
+
+
+def test_frozen_generated_grok_bridge_is_recognized(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Packaged Core hooks retain the supported frozen bridge form."""
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.delenv("HOL_GUARD_DESKTOP", raising=False)
+    assert is_grok_hook_command(_shell_command(_command(tmp_path))) is True
+
+
+@pytest.mark.skipif(os.name == "nt", reason="macOS signed proxy uses POSIX shell serialization")
+def test_desktop_grok_proxy_requires_all_signatures(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The known proxy script needs matching verified bundle, proxy, and Core teams."""
+    from codex_plugin_scanner.guard.adapters import desktop_hook_proxy as proxy
+
+    base = _command(tmp_path)
+    config = json.loads(base[-1])
+    bundle = tmp_path / "Guard.app"
+    candidate = bundle / "Contents/MacOS/proxy"
+    core = candidate.with_name("core")
+    config.update(frozen_launcher=True, python_executable=str(core))
+    command = (
+        "/bin/sh",
+        "-c",
+        proxy._DESKTOP_PROXY_LAUNCH_SCRIPT,
+        "hol-guard-desktop-proxy",
+        str(candidate),
+        "TEAM123",
+        str(bundle),
+        json.dumps(config),
+        str(core),
+    )
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(proxy, "_trusted_desktop_path", lambda _path: True)
+    monkeypatch.setattr(proxy, "_codesign_team", lambda _path: "TEAM123")
+    assert is_grok_hook_command(_shell_command(command)) is True
+    monkeypatch.setattr(proxy, "_codesign_team", lambda path: None if path == core else "TEAM123")
+    assert is_grok_hook_command(_shell_command(command)) is False
+    altered = (*command[:2], "echo hol-guard hook", *command[3:])
+    assert is_grok_hook_command(_shell_command(altered)) is False
+
+
+@pytest.mark.parametrize(
+    "table",
+    [
+        '[permission]\nallow = ["Read(**/.grok/auth/**)"]',
+        '[other]\ndeny = ["Read(**/.grok/auth/**)"]',
+        'deny = ["Read(**/.grok/auth/**)"]',
+        "[permission]\ndeny = [] # Read(**/.grok/auth/**)",
+        '[permission]\ndeny = "Read(**/.grok/auth/**)"',
+        '[permission]\ndeny = ["Read(**/.grok/auth/**)"',
+    ],
+)
+def test_grok_readiness_requires_real_permission_deny_list(table: str) -> None:
+    """Rules in allow, unrelated tables, comments, or invalid TOML do not protect secrets."""
+    assert (
+        _grok_managed_config_is_active(f"# BEGIN HOL GUARD MANAGED GROK\n{table}\n# END HOL GUARD MANAGED GROK\n")
+        is False
+    )
+
+
+@pytest.mark.parametrize("error", ["unicode", "io"])
+def test_unreadable_grok_managed_config_returns_repair_warning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, error: str
+) -> None:
+    """Unreadable settings degrade readiness rather than breaking status/repair callers."""
+    context = HarnessContext(tmp_path / "home", None, tmp_path / "guard")
+    monkeypatch.delenv("GROK_HOME", raising=False)
+    path = context.home_dir / ".grok/managed_config.toml"
+    path.parent.mkdir(parents=True)
+    path.write_bytes(b"\xff")
+    original = Path.read_text
+
+    def read(candidate: Path, *args: object, **kwargs: object) -> str:
+        """Make only the managed TOML path fail as an unreadable file."""
+        if candidate == path and error == "io":
+            raise OSError("unreadable")
+        return original(candidate, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", read)
+    checks = _grok_protection_checks(context)
+    assert checks["ready"] is False
+    assert any("could not be read" in warning for warning in checks["warnings"])

--- a/tests/test_guard_aibom_export_safety.py
+++ b/tests/test_guard_aibom_export_safety.py
@@ -41,6 +41,7 @@ def test_export_redacts_paths_without_changing_skill_presence(
         "last_policy_action": "allow",
         "present": True,
         "custom_field": "preserve-me",
+        "launch_command": f"python {home}/server.py --token fake-secret",
     }
     store = SimpleNamespace(list_inventory=lambda: [original], get_sync_payload=lambda _key: None)
     context = HarnessContext(home, skill_root, tmp_path / "guard")
@@ -57,6 +58,9 @@ def test_export_redacts_paths_without_changing_skill_presence(
     assert row["present"] is present
     assert row["trust_verdict"] == "allow"
     assert row["custom_field"] == "preserve-me"
+    assert row["launch_command"] == "python {home}/server.py --token redacted"
+    assert "fake-secret" not in json.dumps(payload)
+    assert original["launch_command"].endswith("--token fake-secret")
     assert str(skill_file) not in json.dumps(payload)
     assert str(home) not in json.dumps(payload)
     assert original["config_path"] == str(skill_file)

--- a/tests/test_guard_aibom_export_safety.py
+++ b/tests/test_guard_aibom_export_safety.py
@@ -1,0 +1,94 @@
+"""AIBOM exports redact local paths and keep untrusted fields inside table cells."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from codex_plugin_scanner.guard import aibom_cli
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+
+
+@pytest.mark.security_critical
+@pytest.mark.parametrize("export_format", ["json", "markdown"])
+@pytest.mark.parametrize("outside_home", [False, True])
+@pytest.mark.parametrize("present", [False, True])
+def test_export_redacts_paths_without_changing_skill_presence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    export_format: str,
+    outside_home: bool,
+    present: bool,
+) -> None:
+    """Both export formats use real paths for presence, but never include their absolute forms."""
+    home = tmp_path / "private-home"
+    home.mkdir()
+    skill_root = tmp_path / "private-workspace" if outside_home else home / ".pi/skills/example"
+    skill_root.mkdir(parents=True)
+    skill_file = skill_root / "SKILL.md"
+    if present:
+        skill_file.write_text("---\nname: example\n---\n# Example\n", encoding="utf-8")
+    original = {
+        "artifact_id": "example-skill",
+        "artifact_name": "Example",
+        "artifact_type": "skill_file",
+        "harness": "pi",
+        "source_scope": "global",
+        "config_path": str(skill_file),
+        "last_policy_action": "allow",
+        "present": True,
+        "custom_field": "preserve-me",
+    }
+    store = SimpleNamespace(list_inventory=lambda: [original], get_sync_payload=lambda _key: None)
+    context = HarnessContext(home, skill_root, tmp_path / "guard")
+    monkeypatch.setattr(aibom_cli, "collect_aibom_snapshots", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(aibom_cli, "_resolve_trust_attestation_context", lambda *_args, **_kwargs: {})
+
+    payload = aibom_cli.build_aibom_export_payload(
+        store, context, generated_at="2026-09-11T00:00:00Z", export_format=export_format
+    )
+
+    row = payload["artifacts"][0]
+    expected = "SKILL.md" if outside_home else "{home}/.pi/skills/example/SKILL.md"
+    assert row["config_path"] == expected
+    assert row["present"] is present
+    assert row["trust_verdict"] == "allow"
+    assert row["custom_field"] == "preserve-me"
+    assert str(skill_file) not in json.dumps(payload)
+    assert str(home) not in json.dumps(payload)
+    assert original["config_path"] == str(skill_file)
+    assert original["present"] is True
+
+
+@pytest.mark.parametrize("present", [False, True])
+def test_markdown_export_escapes_every_artifact_cell(present: bool) -> None:
+    """Pipes, multiline text, HTML and formatting cannot create extra table cells or rows."""
+    untrusted = "first\\|second\r\nthird\nfourth <img> `code` [link](url) *bold* _italic_"
+    row = dict.fromkeys(("artifact_name", "harness", "artifact_type", "source_scope", "trust_verdict"), untrusted)
+    row["present"] = present
+    payload = {
+        "artifacts": [row, {"artifact_name": "Plain", "present": True}],
+        "layer_summary": {},
+        "trust_summary": {},
+    }
+
+    markdown = aibom_cli._render_aibom_markdown(payload)
+
+    table_rows = [line for line in markdown.splitlines() if line.startswith("| ")]
+    assert len(table_rows) == 4  # Heading, separator, and exactly two artifact rows.
+    cells = table_rows[2].removeprefix("| ").removesuffix(" |").split(" | ")
+    assert len(cells) == 6
+    assert cells[-1] == ("yes" if present else "no")
+    assert all(cell == cells[0] for cell in cells[:5])
+    assert "\\|" in cells[0]
+    assert "first\\\\" in cells[0]
+    assert "second third fourth" in cells[0]
+    assert "&lt;img&gt;" in cells[0]
+    assert "\\`code\\`" in cells[0]
+    assert "\\[link\\]\\(url\\)" in cells[0]
+    assert "\\*bold\\*" in cells[0]
+    assert "\\_italic\\_" in cells[0]
+    assert row["artifact_name"] == untrusted

--- a/tests/test_guard_daemon_health_transport.py
+++ b/tests/test_guard_daemon_health_transport.py
@@ -1,0 +1,123 @@
+"""Authenticated daemon health stays within the audited loopback transport boundary."""
+
+from __future__ import annotations
+
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from codex_plugin_scanner.guard.daemon import client, live_identity
+
+
+@pytest.mark.security_critical
+@pytest.mark.parametrize(
+    "status,body,expected",
+    [
+        (200, b'{"ok":true}', {"ok": True}),
+        (302, b'{"ok":true}', None),
+        (500, b'{"ok":true}', None),
+        (200, b"[]", None),
+        (200, b"not-json", None),
+        (200, b"\xff", None),
+        (200, b" " * 65_537, None),
+    ],
+)
+def test_health_probe_is_bounded_proxy_free_and_does_not_follow_redirects(
+    monkeypatch: pytest.MonkeyPatch, status: int, body: bytes, expected: object
+) -> None:
+    """Use a real loopback server to verify token delivery and refusal of unsafe responses."""
+    requests: list[tuple[str, str | None]] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            """Return the selected response and record any attempted redirect follow-up."""
+            requests.append((self.path, self.headers.get("X-Guard-Token")))
+            self.send_response(status)
+            self.send_header("Location", "/redirected")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, message_format: str, *args: object) -> None:
+            """Keep the test server's expected error statuses out of console output."""
+
+    for key in ("HTTP_PROXY", "http_proxy", "ALL_PROXY", "all_proxy"):
+        monkeypatch.setenv(key, "http://127.0.0.1:1")
+    monkeypatch.setenv("NO_PROXY", "")
+    monkeypatch.setenv("no_proxy", "")
+    with ThreadingHTTPServer(("127.0.0.1", 0), Handler) as server:
+        thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.01}, daemon=True)
+        thread.start()
+        try:
+            url = f"http://127.0.0.1:{server.server_port}"
+            assert live_identity._proxy_disabled_health_details(url, "test-token") == expected
+            assert requests == [("/v1/healthz/details", "test-token")]
+        finally:
+            server.shutdown()
+            thread.join(timeout=2)
+
+
+@pytest.mark.security_critical
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://example.test:1234",
+        "https://127.0.0.1:1234",
+        "http://127.0.0.1",
+        "http://user:password@127.0.0.1:1234",
+        "http://127.0.0.1:0",
+        "http://127.0.0.1:65536",
+        "http://127.0.0.1:1234/wrong-path",
+        "http://127.0.0.1:1234?redirect=external",
+        "http://[::1]:1234#fragment",
+    ],
+)
+def test_health_probe_rejects_invalid_authorities_before_connecting(monkeypatch: pytest.MonkeyPatch, url: str) -> None:
+    """Malformed and non-loopback URLs must not open a socket with the daemon token."""
+
+    def unexpected_connection(*args: object, **kwargs: object) -> None:
+        """Fail immediately if URL validation allows a network connection."""
+        pytest.fail("Invalid daemon authority reached the network transport")
+
+    monkeypatch.setattr(client, "HTTPConnection", unexpected_connection)
+    assert client.read_guard_health_details(url, "test-token") is None
+
+
+@pytest.mark.security_critical
+@pytest.mark.parametrize("drip_headers", [False, True])
+def test_health_probe_enforces_deadline_against_byte_drip(monkeypatch: pytest.MonkeyPatch, drip_headers: bool) -> None:
+    """Neither a partial header nor a slowly arriving body can extend the total deadline."""
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            """Drip bytes more frequently than the socket timeout until the client closes."""
+            if not drip_headers:
+                self.send_response(200)
+                self.send_header("Content-Length", "1000")
+                self.end_headers()
+            try:
+                for _ in range(100):
+                    self.wfile.write(b"x")
+                    self.wfile.flush()
+                    time.sleep(0.04)
+            except OSError:
+                pass  # The deadline deliberately closes the client connection.
+
+        def log_message(self, message_format: str, *args: object) -> None:
+            """Suppress expected loopback-test access logs."""
+
+    monkeypatch.setattr(client, "_HEALTH_PROBE_DEADLINE_SECONDS", 0.2)
+    with ThreadingHTTPServer(("127.0.0.1", 0), Handler) as server:
+        thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.01}, daemon=True)
+        thread.start()
+        try:
+            started = time.monotonic()
+            result = client.read_guard_health_details(f"http://127.0.0.1:{server.server_port}", "test-token")
+            elapsed = time.monotonic() - started
+            assert result is None
+            assert elapsed < 1.0
+        finally:
+            server.shutdown()
+            thread.join(timeout=2)

--- a/tests/test_guard_daemon_runtime_repair.py
+++ b/tests/test_guard_daemon_runtime_repair.py
@@ -460,19 +460,33 @@ def test_live_identity_rejects_empty_health_guard_home(
 
 
 def test_live_identity_rejects_authenticated_probe_redirects() -> None:
-    request = live_identity.urllib.request.Request("http://127.0.0.1:5474/v1/healthz/details")
-    handler = live_identity._RejectRedirectHandler()
+    """The authenticated production client must not follow even a loopback redirect."""
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+    from threading import Thread
 
-    redirected = handler.redirect_request(
-        request,
-        None,
-        302,
-        "Found",
-        {},
-        "https://example.invalid/collect",
-    )
+    paths: list[str] = []
 
-    assert redirected is None
+    class Redirect(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            """Record requests and redirect the health probe to a token collection path."""
+            paths.append(self.path)
+            self.send_response(302 if self.path.endswith("details") else 200)
+            self.send_header("Location", "/collect")
+            self.end_headers()
+
+        def log_message(self, *_args: object) -> None:
+            """Suppress loopback-test access logs."""
+
+    with ThreadingHTTPServer(("127.0.0.1", 0), Redirect) as server:
+        worker = Thread(target=server.serve_forever, kwargs={"poll_interval": 0.01}, daemon=True)
+        worker.start()
+        try:
+            result = live_identity._proxy_disabled_health_details(f"http://127.0.0.1:{server.server_port}", "token")
+            assert result is None
+            assert paths == ["/v1/healthz/details"]
+        finally:
+            server.shutdown()
+            worker.join(timeout=2)
 
 
 def test_daemon_start_lock_is_reentrant_for_repair_transaction(tmp_path: Path) -> None:

--- a/tests/test_guard_protection_recovery.py
+++ b/tests/test_guard_protection_recovery.py
@@ -40,9 +40,10 @@ def _clear_grok_home(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def _ctx(tmp_path: Path) -> HarnessContext:
+    """Match the machine-wide installs registered with workspace=None in these tests."""
     return HarnessContext(
         home_dir=tmp_path / "home",
-        workspace_dir=tmp_path / "workspace",
+        workspace_dir=None,
         guard_home=tmp_path / "guard-home",
     )
 

--- a/tests/test_guard_protection_recovery.py
+++ b/tests/test_guard_protection_recovery.py
@@ -9,8 +9,8 @@ from pathlib import Path
 import pytest
 
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
-from codex_plugin_scanner.guard.approvals import _live_hook_verification
 from codex_plugin_scanner.guard.adapters.grok import grok_runtime_hooks_verified
+from codex_plugin_scanner.guard.approvals import _live_hook_verification
 from codex_plugin_scanner.guard.cli.install_commands import (
     _grok_hook_command_is_guard,
     _grok_managed_config_is_active,
@@ -175,7 +175,8 @@ def test_live_grok_hooks_reject_empty_observe_events(
         encoding="utf-8",
     )
     (ctx.home_dir / ".grok" / "managed_config.toml").write_text(
-        '# BEGIN HOL GUARD MANAGED GROK\ndeny = ["Read(**/.grok/auth/**)"]\n# END HOL GUARD MANAGED GROK\n',
+        "# BEGIN HOL GUARD MANAGED GROK\n[permission]\n"
+        'deny = ["Read(**/.grok/auth/**)"]\n# END HOL GUARD MANAGED GROK\n',
         encoding="utf-8",
     )
     store = GuardStore(ctx.guard_home, prime_policy_integrity=False)
@@ -191,9 +192,7 @@ def test_live_grok_hooks_reject_managed_rule_outside_block(
     monkeypatch.setattr(Path, "home", lambda: ctx.home_dir)
     hooks_dir = ctx.home_dir / ".grok" / "hooks"
     hooks_dir.mkdir(parents=True)
-    command_hook = {
-        "hooks": [{"type": "command", "command": "hol-guard hook grok", "timeout": 15}]
-    }
+    command_hook = {"hooks": [{"type": "command", "command": "hol-guard hook grok", "timeout": 15}]}
     (hooks_dir / "hol-guard-pretooluse.json").write_text(
         json.dumps(
             {
@@ -247,13 +246,15 @@ def test_grok_hook_command_rejects_placeholder_invocations() -> None:
 def test_grok_managed_config_rejects_inline_commented_rule() -> None:
     assert (
         _grok_managed_config_is_active(
-            '# BEGIN HOL GUARD MANAGED GROK\ndeny = ["Read(**/.grok/auth/**)"]\n# END HOL GUARD MANAGED GROK\n'
+            "# BEGIN HOL GUARD MANAGED GROK\n[permission]\n"
+            'deny = ["Read(**/.grok/auth/**)"]\n# END HOL GUARD MANAGED GROK\n'
         )
         is True
     )
     assert (
         _grok_managed_config_is_active(
-            "# BEGIN HOL GUARD MANAGED GROK\ndeny = [] # Read(**/.grok/auth/**)\n# END HOL GUARD MANAGED GROK\n"
+            "# BEGIN HOL GUARD MANAGED GROK\n[permission]\n"
+            "deny = [] # Read(**/.grok/auth/**)\n# END HOL GUARD MANAGED GROK\n"
         )
         is False
     )

--- a/tests/test_guard_protection_recovery.py
+++ b/tests/test_guard_protection_recovery.py
@@ -8,8 +8,8 @@ from pathlib import Path
 
 import pytest
 
-from codex_plugin_scanner.guard.adapters.base import HarnessContext
-from codex_plugin_scanner.guard.adapters.grok import grok_runtime_hooks_verified
+from codex_plugin_scanner.guard.adapters.base import HarnessContext, _shell_command
+from codex_plugin_scanner.guard.adapters.grok import GrokHarnessAdapter, grok_runtime_hooks_verified
 from codex_plugin_scanner.guard.approvals import _live_hook_verification
 from codex_plugin_scanner.guard.cli.install_commands import (
     _grok_hook_command_is_guard,
@@ -47,6 +47,11 @@ def _ctx(tmp_path: Path) -> HarnessContext:
     )
 
 
+def _native_grok_command(context: HarnessContext) -> str:
+    """Use the real generated bridge rather than a non-executable marker command."""
+    return _shell_command(GrokHarnessAdapter._hook_command_parts(context))
+
+
 def _stale_pretool_payload() -> dict[str, object]:
     return {
         "hooks": {
@@ -66,9 +71,10 @@ def test_protection_repair_probe_avoids_force_push() -> None:
     assert "git status --porcelain=v1" in _PROTECTION_REPAIR_PROBE_COMMAND
 
 
-def _write_intercepting_grok_hooks(hooks_dir: Path) -> None:
+def _write_intercepting_grok_hooks(context: HarnessContext) -> None:
+    hooks_dir = context.home_dir / ".grok" / "hooks"
     hooks_dir.mkdir(parents=True, exist_ok=True)
-    command = "hol-guard hook grok"
+    command = _native_grok_command(context)
     (hooks_dir / "hol-guard-pretooluse.json").write_text(
         json.dumps(
             {
@@ -102,7 +108,7 @@ def test_live_grok_hooks_pass_when_managed_config_is_missing(
 ) -> None:
     ctx = _ctx(tmp_path)
     monkeypatch.setattr(Path, "home", lambda: ctx.home_dir)
-    _write_intercepting_grok_hooks(ctx.home_dir / ".grok" / "hooks")
+    _write_intercepting_grok_hooks(ctx)
     store = GuardStore(ctx.guard_home, prime_policy_integrity=False)
     store.set_managed_install("grok", True, None, {"harness": "grok", "active": True}, "2026-08-17T12:00:00+00:00")
 
@@ -117,7 +123,7 @@ def test_repair_restores_missing_grok_managed_config_when_hooks_already_intercep
 ) -> None:
     ctx = _ctx(tmp_path)
     monkeypatch.setattr(Path, "home", lambda: ctx.home_dir)
-    _write_intercepting_grok_hooks(ctx.home_dir / ".grok" / "hooks")
+    _write_intercepting_grok_hooks(ctx)
     store = GuardStore(ctx.guard_home, prime_policy_integrity=False)
     store.set_managed_install("grok", True, None, {"harness": "grok", "active": True}, "2026-08-17T12:00:00+00:00")
     managed = ctx.home_dir / ".grok" / "managed_config.toml"
@@ -151,7 +157,7 @@ def test_live_grok_hooks_reject_empty_observe_events(
                             "hooks": [
                                 {
                                     "type": "command",
-                                    "command": "hol-guard hook grok",
+                                    "command": _native_grok_command(ctx),
                                     "timeout": 30,
                                 }
                             ]
@@ -192,7 +198,7 @@ def test_live_grok_hooks_reject_managed_rule_outside_block(
     monkeypatch.setattr(Path, "home", lambda: ctx.home_dir)
     hooks_dir = ctx.home_dir / ".grok" / "hooks"
     hooks_dir.mkdir(parents=True)
-    command_hook = {"hooks": [{"type": "command", "command": "hol-guard hook grok", "timeout": 15}]}
+    command_hook = {"hooks": [{"type": "command", "command": _native_grok_command(ctx), "timeout": 15}]}
     (hooks_dir / "hol-guard-pretooluse.json").write_text(
         json.dumps(
             {
@@ -202,7 +208,7 @@ def test_live_grok_hooks_reject_managed_rule_outside_block(
                             "hooks": [
                                 {
                                     "type": "command",
-                                    "command": "hol-guard hook grok",
+                                    "command": _native_grok_command(ctx),
                                     "timeout": 30,
                                 }
                             ]
@@ -237,8 +243,9 @@ def test_live_grok_hooks_reject_managed_rule_outside_block(
     assert grok_hooks_protection_ready(ctx) is False
 
 
-def test_grok_hook_command_rejects_placeholder_invocations() -> None:
-    assert _grok_hook_command_is_guard("hol-guard hook grok") is True
+def test_grok_hook_command_rejects_placeholder_invocations(tmp_path: Path) -> None:
+    assert _grok_hook_command_is_guard(_native_grok_command(_ctx(tmp_path))) is True
+    assert _grok_hook_command_is_guard("hol-guard hook grok") is False
     assert _grok_hook_command_is_guard("echo hol-guard hook") is False
     assert _grok_hook_command_is_guard("true") is False
 

--- a/tests/test_inventory_redaction_review.py
+++ b/tests/test_inventory_redaction_review.py
@@ -1,0 +1,60 @@
+"""Regression coverage for malformed authorities and nested sensitive metadata."""
+
+from __future__ import annotations
+
+import copy
+import json
+
+import pytest
+
+from codex_plugin_scanner.guard.inventory_contract_redaction import _safe_json, redact_url
+
+
+@pytest.mark.security_critical
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("http://user:private-value@", "http://"),
+        ("https://user:private-value@/api?token=private-value&mode=fast", "https:///api?token=redacted&mode=fast"),
+        ("https://user:private-value@example.test:8443/api", "https://example.test:8443/api"),
+        ("http://user:private-value@[::1]:8080/api", "http://[::1]:8080/api"),
+        ("http://[::1]:8080/api?token=private-value&mode=fast", "http://[::1]:8080/api?token=redacted&mode=fast"),
+    ],
+)
+def test_url_authority_never_falls_back_to_userinfo(source: str, expected: str) -> None:
+    """An absent hostname must not preserve credentials or damage valid IPv6 authorities."""
+    result = redact_url(source)
+    assert result == expected
+    assert "private-value" not in result
+    assert "user" not in result
+
+
+@pytest.mark.security_critical
+@pytest.mark.parametrize("sensitive_parent", [False, True])
+def test_nested_sensitive_metadata_keeps_all_sibling_keys(sensitive_parent: bool) -> None:
+    """Keep every nested field while redacting its sensitive values without modifying the input."""
+    source = {
+        "tokenInfo": {
+            "primary": {"value": "first-private-value", "note": "first-private-note"},
+            "secondary": {"value": "second-private-value", "note": "second-private-note"},
+            "history": [{"left": "third-private-value", "right": "fourth-private-value"}],
+        }
+    }
+    original = copy.deepcopy(source)
+    result = _safe_json(source, parent_sensitive=sensitive_parent)
+    assert result == {
+        "tokenInfo": {
+            "primary": {"value": "[REDACTED]", "note": "[REDACTED]"},
+            "secondary": {"value": "[REDACTED]", "note": "[REDACTED]"},
+            "history": [{"left": "[REDACTED]", "right": "[REDACTED]"}],
+        }
+    }
+    assert source == original
+    assert "private-value" not in json.dumps(result)
+    assert "private-note" not in json.dumps(result)
+
+
+def test_sensitive_ancestor_does_not_disable_unsafe_key_redaction() -> None:
+    """Preserve structural names, not literal secrets embedded in a key itself."""
+    result = _safe_json({"safeField": "private-value", "sk-secret-key": "another-private-value"}, parent_sensitive=True)
+    assert result == {"safeField": "[REDACTED]", "[REDACTED]": "[REDACTED]"}

--- a/tests/test_paseo_adapter.py
+++ b/tests/test_paseo_adapter.py
@@ -1,0 +1,494 @@
+"""Paseo installation, ownership, configuration and coverage contracts."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters import get_adapter
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.paseo import PaseoHarnessAdapter
+from codex_plugin_scanner.guard.adapters.paseo_config import (
+    PASEO_NATIVE_HARNESSES,
+    paseo_config_path,
+    paseo_providers,
+    read_config_object,
+)
+from codex_plugin_scanner.guard.adapters.paseo_install import read_receipt, receipt_path
+from codex_plugin_scanner.guard.cli.install_commands import apply_managed_install, build_harness_setup_plan
+from codex_plugin_scanner.guard.inventory_contract import (
+    inventory_snapshot_from_detection,
+    serialize_inventory_snapshot,
+)
+from codex_plugin_scanner.guard.managed_install_proof import bind_managed_install_proof, verify_managed_install_proof
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+@pytest.fixture
+def context(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> HarnessContext:
+    """Isolate native homes and substitute executable discovery without skipping installers."""
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    home.mkdir()
+    workspace.mkdir()
+    for key in list(os.environ):
+        if key.startswith(("PASEO_", "PI_", "OMP_", "OPENCODE_", "CODEX_HOME", "CLAUDE_CONFIG", "XDG_")):
+            monkeypatch.delenv(key)
+    for harness in (*PASEO_NATIVE_HARNESSES.values(), "paseo"):
+        # The actual installers run; only discovery of paid/authenticated CLIs is faked.
+        monkeypatch.setattr(get_adapter(harness), "resolved_executable", lambda _context: sys.executable)
+    return HarnessContext(
+        home, workspace, tmp_path / "guard", home_override_explicit=True, workspace_override_explicit=True
+    )
+
+
+def write_json(path: Path, payload: object) -> None:
+    """Write a deterministic JSON fixture inside the isolated test home."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def configure(context: HarnessContext, providers: dict[str, object]) -> Path:
+    """Disable unrelated native providers while preserving unrelated Paseo settings."""
+    entries: dict[str, object] = {name: {"enabled": False} for name in PASEO_NATIVE_HARNESSES}
+    entries.update(providers)
+    path = paseo_config_path(context)
+    write_json(path, {"agents": {"providers": entries}, "plugins": {"enabled": False}, "custom": {"keep": True}})
+    return path
+
+
+def statuses(payload: dict[str, object]) -> dict[str, str]:
+    """Index the public provider report by profile identity."""
+    return {item["provider"]: item["status"] for item in payload["providers"]}
+
+
+@pytest.mark.adapter_contract
+@pytest.mark.parametrize("provider", tuple(PASEO_NATIVE_HARNESSES))
+def test_paseo_installs_real_native_hooks_and_registers_native_proofs(context: HarnessContext, provider: str) -> None:
+    """Exercise each real native installer and verify both native and composite records."""
+    path = configure(context, {provider: {"enabled": True}})
+    original = path.read_bytes()
+    adapter = PaseoHarnessAdapter()
+    manifest = adapter.install(context)
+    native = PASEO_NATIVE_HARNESSES[provider]
+    assert manifest["active"] is True
+    assert statuses(manifest)[provider] == "native-hooks-installed"
+    assert manifest["runtime_verification"] == "not-performed"
+    assert manifest["coverage_status"] == "limited"
+    assert path.read_bytes() == original
+    assert verify_managed_install_proof(bind_managed_install_proof(manifest, context), context) is True
+    native_install = GuardStore(context.guard_home).get_managed_install(native)
+    assert native_install and native_install["active"]
+    assert native_install["workspace"] is None
+    assert verify_managed_install_proof(native_install["manifest"], context) is True
+    assert not list(context.workspace_dir.rglob("*"))
+
+
+def test_claude_preserves_user_hooks_and_installs_pretool_for_all_workspaces(context: HarnessContext) -> None:
+    """Preserve user permissions and hooks while adding workspace-independent protection."""
+    configure(context, {"claude": {"enabled": True}})
+    settings = context.home_dir / ".claude/settings.json"
+    user_hook = {"matcher": "Bash", "hooks": [{"type": "command", "command": "echo user-hook"}]}
+    write_json(settings, {"hooks": {"PreToolUse": [user_hook]}, "permissions": {"allow": ["Read"]}})
+    PaseoHarnessAdapter().install(context)
+    result = json.loads(settings.read_text())
+    assert result["permissions"] == {"allow": ["Read"]}
+    assert user_hook in result["hooks"]["PreToolUse"]
+    managed = [entry for entry in result["hooks"]["PreToolUse"] if entry != user_hook]
+    assert managed
+    assert str(context.workspace_dir) not in json.dumps(managed)
+
+
+def test_shared_profiles_install_once_and_repeat_install_is_idempotent(
+    context: HarnessContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Share one native installation across profiles without duplicating hooks during repair."""
+    configure(context, {"pi": {"enabled": True}, "pi-work": {"extends": "pi", "label": "Work"}})
+    native = get_adapter("pi")
+    original_install = native.install
+    calls: list[HarnessContext] = []
+
+    def record_install(native_context: HarnessContext) -> dict[str, object]:
+        """Record each real native install and the context it received."""
+        calls.append(native_context)
+        return original_install(native_context)
+
+    monkeypatch.setattr(native, "install", record_install)
+    adapter = PaseoHarnessAdapter()
+    first = adapter.install(context)
+    extension = context.home_dir / ".pi/agent/extensions/hol-guard.ts"
+    original = extension.read_bytes()
+    second = adapter.install(context)
+    assert len(calls) == 2
+    assert all(call.workspace_dir is None and not call.workspace_override_explicit for call in calls)
+    assert extension.read_bytes() == original
+    assert statuses(first)["pi-work"] == statuses(second)["pi-work"] == "native-hooks-installed"
+    assert len(read_receipt(context)["native_proofs"]) == 1
+
+
+@pytest.mark.security_critical
+@pytest.mark.parametrize("changed_file", ("settings.json", "extensions/hol-guard.ts"))
+def test_native_hook_drift_is_not_reported_as_protected(context: HarnessContext, changed_file: str) -> None:
+    """Removing a required native artifact invalidates both diagnostics and the composite proof."""
+    configure(context, {"pi": {"enabled": True}})
+    adapter = PaseoHarnessAdapter()
+    manifest = bind_managed_install_proof(adapter.install(context), context)
+    (context.home_dir / ".pi/agent" / changed_file).unlink()
+    assert verify_managed_install_proof(manifest, context) is False
+    diagnosis = adapter.diagnostics(context)
+    assert diagnosis["setup_status"] == "broken"
+    assert statuses(diagnosis)["pi"] == "changed"
+
+
+def test_uninstall_keeps_shared_hooks_settings_credentials_and_native_records(context: HarnessContext) -> None:
+    """Paseo disconnection must not remove protection still used by other clients."""
+    path = configure(context, {"pi": {"enabled": True, "env": {"API_KEY": "test-private-value"}}})
+    adapter = PaseoHarnessAdapter()
+    adapter.install(context)
+    settings = context.home_dir / ".pi/agent/settings.json"
+    extension = context.home_dir / ".pi/agent/extensions/hol-guard.ts"
+    before = (path.read_bytes(), settings.read_bytes(), extension.read_bytes())
+    assert adapter.uninstall(context)["active"] is False
+    assert (path.read_bytes(), settings.read_bytes(), extension.read_bytes()) == before
+    assert not receipt_path(context).exists()
+    assert not (context.guard_home / "bin/guard-paseo").exists()
+    assert GuardStore(context.guard_home).get_managed_install("pi")["active"] is True
+    assert adapter.uninstall(context)["active"] is False
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        [],
+        {"agents": []},
+        {"agents": {"providers": []}},
+        {"agents": {"providers": {"pi": {"enabled": "yes"}}}},
+        {"agents": {"providers": {"../escape": {}}}},
+        {"agents": {"providers": {"pi": {"env": {"HOME": 1}}}}},
+    ],
+)
+def test_malformed_paseo_configuration_is_not_overwritten(context: HarnessContext, bad: object) -> None:
+    """Invalid provider types fail before any native settings or Guard state are written."""
+    path = paseo_config_path(context)
+    write_json(path, bad)
+    original = path.read_bytes()
+    with pytest.raises(ValueError):
+        PaseoHarnessAdapter().install(context)
+    assert path.read_bytes() == original
+    assert not context.guard_home.exists()
+
+
+@pytest.mark.parametrize(
+    "raw", [b'{"agents":', b"null", b'{"agents":{},"agents":{}}', b"\xff", b" " * (2 * 1024 * 1024 + 1)]
+)
+def test_unsafe_json_is_bounded_and_never_echoed(context: HarnessContext, raw: bytes) -> None:
+    """Reject ambiguous, malformed, and oversized configuration without rewriting it."""
+    path = configure(context, {})
+    path.write_bytes(raw)
+    with pytest.raises(ValueError, match="Cannot safely read configuration"):
+        read_config_object(path)
+    assert path.read_bytes() == raw
+
+
+@pytest.mark.security_critical
+@pytest.mark.parametrize("relative", [".pi", ".pi/agent/settings.json", ".pi/agent/extensions/hol-guard.ts"])
+def test_native_symlink_targets_are_rejected_before_install(
+    context: HarnessContext, tmp_path: Path, relative: str
+) -> None:
+    """Prevent native configuration writes from following links outside the declared home."""
+    configure(context, {"pi": {"enabled": True}})
+    target = tmp_path / "outside"
+    link = context.home_dir / relative
+    link.parent.mkdir(parents=True, exist_ok=True)
+    if relative == ".pi":
+        target.mkdir()
+    else:
+        target.write_text("{}", encoding="utf-8")
+    try:
+        link.symlink_to(target, target_is_directory=target.is_dir())
+    except OSError:
+        pytest.skip("This platform does not allow symlinks.")
+    with pytest.raises(ValueError, match="symlink"):
+        PaseoHarnessAdapter().install(context)
+    assert target.is_dir() or target.read_text() == "{}"
+    assert not context.guard_home.exists()
+
+
+def test_preflight_checks_every_selected_provider_before_any_write(context: HarnessContext) -> None:
+    """A later provider's invalid settings must prevent earlier native writes."""
+    configure(context, {"claude": {"enabled": True}, "pi": {"enabled": True}})
+    path = context.home_dir / ".pi/agent/settings.json"
+    path.parent.mkdir(parents=True)
+    path.write_text("not-json", encoding="utf-8")
+    with pytest.raises(ValueError):
+        PaseoHarnessAdapter().install(context)
+    assert not (context.home_dir / ".claude/settings.json").exists()
+    assert not context.guard_home.exists()
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"command": ["pi", "--no-extensions"]},
+        {"env": {"PI_CODING_AGENT_DIR": "/another-home"}},
+        {"env": {"PATH": "/custom-bin"}},
+        {"env": {"HOL_GUARD_DISABLED": "1"}},
+        {"env": {"LD_PRELOAD": "/untrusted.so"}},
+        {"env": {"PYTHONPATH": "/untrusted-python"}},
+        {"env": {"BASH_ENV": "/untrusted.sh"}},
+        {"env": {"NODE_OPTIONS": "--require=/untrusted.js"}},
+    ],
+)
+def test_custom_provider_execution_is_explicitly_uncovered(
+    context: HarnessContext, override: dict[str, object]
+) -> None:
+    """Keep custom execution excluded while preserving verified supported-provider status."""
+    configure(context, {"pi": {"enabled": True}, "custom-pi": {"extends": "pi", "label": "Custom", **override}})
+    manifest = PaseoHarnessAdapter().install(context)
+    assert statuses(manifest)["pi"] == "native-hooks-installed"
+    assert statuses(manifest)["custom-pi"] == "unsupported"
+    assert PaseoHarnessAdapter().diagnostics(context)["setup_status"] == "active"
+
+
+def test_default_providers_disabled_omp_and_acp_profile_contract(context: HarnessContext) -> None:
+    """Match built-in defaults without assigning native coverage to an ACP profile."""
+    defaults = {provider.provider_id: provider for provider in paseo_providers(context)}
+    assert len(defaults) == 6
+    assert defaults["omp"].enabled is False
+    assert all(provider.enabled for name, provider in defaults.items() if name != "omp")
+    configure(context, {"my-omp": {"extends": "omp", "label": "My OMP"}, "other": {"extends": "acp"}})
+    providers = {provider.provider_id: provider for provider in paseo_providers(context)}
+    assert providers["my-omp"].enabled is True
+    assert providers["other"].native_harness is None
+    assert providers["other"].unsupported_reason
+
+
+def test_credentials_do_not_enter_manifest_diagnostics_or_inventory(context: HarnessContext) -> None:
+    """Leave credentials in Paseo configuration but exclude them from exported Guard state."""
+    secret = "sk-do-not-persist-this-paseo-provider-secret"
+    path = configure(context, {"pi": {"enabled": True, "env": {"API_KEY": secret}}})
+    adapter = PaseoHarnessAdapter()
+    outputs = [adapter.install(context), adapter.diagnostics(context), read_receipt(context)]
+    detection = adapter.detect(context)
+    outputs.append(detection.to_dict())
+    inventory = inventory_snapshot_from_detection(
+        detection, generated_at="2026-09-11T00:00:00Z", home_dir=context.home_dir
+    )
+    outputs.append(serialize_inventory_snapshot(inventory))
+    assert secret not in json.dumps(outputs)
+    assert secret in path.read_text()
+
+
+def test_home_selection_and_per_instance_receipts(context: HarnessContext, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Respect explicit homes and keep distinct daemon receipts separate."""
+    custom = context.home_dir / "another-paseo"
+    monkeypatch.setenv("PASEO_HOME", str(custom))
+    assert paseo_config_path(context) == context.home_dir / ".paseo/config.json"
+    inherited = replace(context, home_override_explicit=False)
+    assert paseo_config_path(inherited) == custom / "config.json"
+    assert receipt_path(context) != receipt_path(inherited)
+    monkeypatch.setenv("PASEO_HOME", "~/custom-paseo")
+    assert paseo_config_path(inherited) == context.home_dir / "custom-paseo/config.json"
+    monkeypatch.setenv("PASEO_HOME", "relative-home")
+    with pytest.raises(ValueError, match="absolute PASEO_HOME"):
+        paseo_config_path(inherited)
+
+
+def test_missing_runtime_cannot_create_an_active_install(
+    context: HarnessContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Do not publish an installation receipt without an available supported native runtime."""
+    configure(context, {"pi": {"enabled": True}})
+    monkeypatch.setattr(get_adapter("pi"), "resolved_executable", lambda _context: None)
+    with pytest.raises(ValueError, match="No supported, enabled"):
+        PaseoHarnessAdapter().install(context)
+    assert not receipt_path(context).exists()
+
+
+def test_install_failure_removes_old_receipt_but_does_not_uninstall_shared_hooks(
+    context: HarnessContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed repair invalidates composite success without rolling back shared protection."""
+    configure(context, {"pi": {"enabled": True}})
+    adapter = PaseoHarnessAdapter()
+    adapter.install(context)
+    extension = context.home_dir / ".pi/agent/extensions/hol-guard.ts"
+    original = extension.read_bytes()
+
+    def fail(_context: HarnessContext) -> dict[str, object]:
+        """Simulate a native installer failure after an earlier successful installation."""
+        raise ValueError("test installation failure")
+
+    monkeypatch.setattr(get_adapter("pi"), "install", fail)
+    with pytest.raises(ValueError, match="test installation failure"):
+        adapter.install(context)
+    assert not receipt_path(context).exists()
+    assert extension.read_bytes() == original
+    assert adapter.diagnostics(context)["setup_status"] != "active"
+
+
+def test_public_install_flow_and_dry_run_use_paseo_contract(context: HarnessContext) -> None:
+    """Verify the public install summary, safe dry run, and workspace-free launcher."""
+    configure(context, {"pi": {"enabled": True}})
+    plan = build_harness_setup_plan("install", "paseo", context, dry_run=True)
+    assert plan
+    assert not context.guard_home.exists()
+    store = GuardStore(context.guard_home)
+    payload = apply_managed_install("install", "paseo", False, context, store, None, "2026-09-11T00:00:00Z")
+    managed = payload["managed_install"]
+    assert managed["primary_integration"] == "native-provider-hooks"
+    assert managed["coverage_status"] == "limited"
+    assert managed["native_hooks"] is False
+    launcher = (context.guard_home / "bin/guard-paseo").read_text()
+    assert str(context.workspace_dir) not in launcher
+    assert "--workspace" not in launcher
+    assert verify_managed_install_proof(managed["manifest"], context) is True
+
+
+def test_omp_accepts_unrelated_linux_session_environment(
+    context: HarnessContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Normal Linux desktop variables must not prevent installation of OMP hooks."""
+    environment = {"XDG_RUNTIME_DIR": "/run/user/1000", "XDG_SESSION_TYPE": "wayland"}
+    configure(context, {"omp": {"enabled": True, "env": environment}})
+    for key, value in environment.items():
+        monkeypatch.setenv(key, value)
+    manifest = PaseoHarnessAdapter().install(context)
+    assert statuses(manifest)["omp"] == "native-hooks-installed"
+
+
+def test_missing_enabled_native_runtime_reports_partial_coverage(
+    context: HarnessContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unavailable enabled runtime cannot be hidden by another verified native install."""
+    configure(context, {"pi": {"enabled": True}, "codex": {"enabled": True}})
+    monkeypatch.setattr(get_adapter("codex"), "resolved_executable", lambda _context: None)
+    adapter = PaseoHarnessAdapter()
+    adapter.install(context)
+    result = adapter.diagnostics(context)
+    assert result["setup_status"] == "partial"
+    assert statuses(result)["pi"] == "native-hooks-installed"
+    assert statuses(result)["codex"] == "runtime-unavailable"
+
+
+def test_opencode_unselected_config_files_do_not_invalidate_protection(context: HarnessContext) -> None:
+    """Unrelated OpenCode-home files must not participate in Guard artifact proofs."""
+    configure(context, {"opencode": {"enabled": True}})
+    root = context.home_dir / ".config/opencode"
+    write_json(root / "opencode.json", {})
+    write_json(root / "opencode.jsonc", {})
+    (root / "config.json").write_text("not an OpenCode configuration", encoding="utf-8")
+    adapter = PaseoHarnessAdapter()
+    manifest = bind_managed_install_proof(adapter.install(context), context)
+    (root / "config.json").write_text("an unrelated edit", encoding="utf-8")
+    write_json(root / "opencode.jsonc", {"unused": "changed"})
+    assert verify_managed_install_proof(manifest, context) is True
+    assert adapter.diagnostics(context)["setup_status"] == "active"
+
+
+@pytest.mark.parametrize("provider,key", [("codex", "managed_hook_manifest_path"), ("opencode", "managed_plugin_path")])
+def test_native_managed_artifacts_participate_in_paseo_proofs(context: HarnessContext, provider: str, key: str) -> None:
+    """Deleting an authenticated manifest or managed plugin invalidates composite protection."""
+    configure(context, {provider: {"enabled": True}})
+    adapter = PaseoHarnessAdapter()
+    manifest = bind_managed_install_proof(adapter.install(context), context)
+    native = GuardStore(context.guard_home).get_managed_install(PASEO_NATIVE_HARNESSES[provider])
+    artifact = Path(native["manifest"][key])
+    artifact.unlink()
+    assert verify_managed_install_proof(manifest, context) is False
+    assert adapter.diagnostics(context)["setup_status"] == "broken"
+
+
+def test_child_drift_before_receipt_publication_rejects_install(
+    context: HarnessContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reject success when an earlier child changes before the composite receipt is written."""
+    configure(context, {"claude": {"enabled": True}, "pi": {"enabled": True}})
+    native = get_adapter("pi")
+    original = native.install
+
+    def change_earlier_install(native_context: HarnessContext) -> dict[str, object]:
+        """Simulate another writer changing the first provider during the second install."""
+        manifest = original(native_context)
+        write_json(context.home_dir / ".claude/settings.json", {"changed": True})
+        return manifest
+
+    monkeypatch.setattr(native, "install", change_earlier_install)
+    with pytest.raises(ValueError, match="Native protection changed"):
+        PaseoHarnessAdapter().install(context)
+    assert not receipt_path(context).exists()
+    assert (context.home_dir / ".pi/agent/extensions/hol-guard.ts").is_file()
+
+
+def test_paseo_capability_does_not_claim_uniform_fail_closed_hooks() -> None:
+    """Keep the public failure-behavior claim consistent with the supported native providers."""
+    from codex_plugin_scanner.guard.protection_capabilities import protection_capability_payloads
+
+    capabilities = {item["harness"]: item for item in protection_capability_payloads()}
+    assert capabilities["paseo"]["fail_open_on_hook_failure"] is True
+    assert capabilities["paseo"]["limited"] is True
+    assert "some providers continue" in capabilities["paseo"]["honesty_sentence"]
+
+
+@pytest.mark.parametrize("include_native", [False, True])
+def test_cloud_sync_preserves_native_inventories_without_sending_local_paseo_content(
+    context: HarnessContext, monkeypatch: pytest.MonkeyPatch, include_native: bool
+) -> None:
+    """Keep unsupported composite events and content out of otherwise valid native cloud batches."""
+    from types import SimpleNamespace
+
+    from codex_plugin_scanner.guard import aibom_cli
+    from codex_plugin_scanner.guard.aibom_content_upload import empty_content_upload_summary
+    from codex_plugin_scanner.guard.inventory_contract import GuardAgentInventorySnapshot
+    from codex_plugin_scanner.guard.runtime import runner
+
+    generated = "2026-09-11T00:00:00Z"
+    local = GuardAgentInventorySnapshot("paseo:local", "paseo:agent", "paseo", generated)
+    native = GuardAgentInventorySnapshot("pi:native", "pi:agent", "pi", generated)
+    snapshots = (local, native) if include_native else (local,)
+    store = GuardStore(context.guard_home)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: "workspace-1")
+    sent: list[dict[str, object]] = []
+    uploads: list[tuple[object, ...]] = []
+
+    def collect(*_args, primary_content_sources, **_kwargs):
+        """Provide local and native fixtures while exposing a local-only content candidate."""
+        primary_content_sources.append(SimpleNamespace(snapshot_id=local.snapshot_id))
+        return snapshots
+
+    def request(_auth, *, data, **_kwargs):
+        """Capture the outgoing cloud event body without making a network request."""
+        sent.append(json.loads(data))
+        return object()
+
+    def upload(_store, _runner, auth, *, sources, **_kwargs):
+        """Record content candidates passed to the uploader without transferring files."""
+        uploads.append(sources)
+        return empty_content_upload_summary(), auth
+
+    monkeypatch.setattr(aibom_cli, "collect_aibom_snapshots", collect)
+    monkeypatch.setattr(aibom_cli, "upload_primary_content_sources", upload)
+    monkeypatch.setattr(runner, "_guard_events_sync_url", lambda url: url)
+    monkeypatch.setattr(runner, "_guard_sync_request", request)
+    monkeypatch.setattr(runner, "_urlopen_json_with_timeout_retry", lambda **_kwargs: {"accepted": 1, "rejected": 0})
+    summary = aibom_cli.sync_aibom_snapshots(
+        store,
+        context,
+        generated_at=generated,
+        auth_context={"sync_url": "https://hol.test/api/v1/guard/events", "token": "test-token"},
+    )
+    assert summary["synced"] is True
+    assert summary["snapshots"] == int(include_native)
+    assert len(sent) == int(include_native)
+    assert all(event["payload"]["snapshot"]["agentType"] == "pi" for batch in sent for event in batch["events"])
+    assert all(not sources for sources in uploads)
+    assert serialize_inventory_snapshot(local)["agentType"] == "paseo"
+    with pytest.raises(ValueError, match="local-only"):
+        aibom_cli._inventory_snapshot_event(
+            snapshot=local, workspace_id="workspace-1", device_id=None, generated_at=generated
+        )

--- a/tests/test_paseo_adapter.py
+++ b/tests/test_paseo_adapter.py
@@ -310,15 +310,16 @@ def test_missing_runtime_cannot_create_an_active_install(
     assert not receipt_path(context).exists()
 
 
-def test_install_failure_removes_old_receipt_but_does_not_uninstall_shared_hooks(
+def test_install_failure_preserves_last_receipt_and_shared_hooks(
     context: HarnessContext, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A failed repair invalidates composite success without rolling back shared protection."""
+    """An unchanged installation remains tracked when a repair fails before writing."""
     configure(context, {"pi": {"enabled": True}})
     adapter = PaseoHarnessAdapter()
     adapter.install(context)
     extension = context.home_dir / ".pi/agent/extensions/hol-guard.ts"
     original = extension.read_bytes()
+    original_receipt = receipt_path(context).read_bytes()
 
     def fail(_context: HarnessContext) -> dict[str, object]:
         """Simulate a native installer failure after an earlier successful installation."""
@@ -327,9 +328,9 @@ def test_install_failure_removes_old_receipt_but_does_not_uninstall_shared_hooks
     monkeypatch.setattr(get_adapter("pi"), "install", fail)
     with pytest.raises(ValueError, match="test installation failure"):
         adapter.install(context)
-    assert not receipt_path(context).exists()
+    assert receipt_path(context).read_bytes() == original_receipt
     assert extension.read_bytes() == original
-    assert adapter.diagnostics(context)["setup_status"] != "active"
+    assert adapter.diagnostics(context)["setup_status"] == "active"
 
 
 def test_public_install_flow_and_dry_run_use_paseo_contract(context: HarnessContext) -> None:
@@ -459,6 +460,8 @@ def test_cloud_sync_preserves_native_inventories_without_sending_local_paseo_con
     def collect(*_args, primary_content_sources, **_kwargs):
         """Provide local and native fixtures while exposing a local-only content candidate."""
         primary_content_sources.append(SimpleNamespace(snapshot_id=local.snapshot_id))
+        if include_native:
+            primary_content_sources.append(SimpleNamespace(snapshot_id=native.snapshot_id))
         return snapshots
 
     def request(_auth, *, data, **_kwargs):
@@ -486,7 +489,9 @@ def test_cloud_sync_preserves_native_inventories_without_sending_local_paseo_con
     assert summary["snapshots"] == int(include_native)
     assert len(sent) == int(include_native)
     assert all(event["payload"]["snapshot"]["agentType"] == "pi" for batch in sent for event in batch["events"])
-    assert all(not sources for sources in uploads)
+    assert [source.snapshot_id for sources in uploads for source in sources] == (
+        [native.snapshot_id] if include_native else []
+    )
     assert serialize_inventory_snapshot(local)["agentType"] == "paseo"
     with pytest.raises(ValueError, match="local-only"):
         aibom_cli._inventory_snapshot_event(

--- a/tests/test_paseo_inherited_profiles.py
+++ b/tests/test_paseo_inherited_profiles.py
@@ -1,0 +1,82 @@
+"""Inherited provider execution and shared-hook disconnect contracts."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.paseo import PaseoHarnessAdapter
+from codex_plugin_scanner.guard.adapters.paseo_config import paseo_providers
+from codex_plugin_scanner.guard.adapters.paseo_install import receipt_path
+from codex_plugin_scanner.guard.cli.install_commands import build_harness_setup_plan
+from tests.test_paseo_adapter import configure, statuses
+from tests.test_paseo_adapter import context as context
+
+
+@pytest.mark.security_critical
+@pytest.mark.parametrize(
+    "inherited",
+    [
+        {"command": ["pi", "--no-extensions"]},
+        {"env": {"PI_CODING_AGENT_DIR": "/elsewhere"}},
+        {"env": {"HOL_GUARD_DISABLED": "1"}},
+        {"env": {"NODE_OPTIONS": "--require=/untrusted.js"}},
+    ],
+)
+def test_inherited_provider_overrides_cannot_claim_native_protection(
+    context: HarnessContext, inherited: dict[str, object]
+) -> None:
+    """A child's harmless environment does not erase unsafe base launch settings."""
+    configure(
+        context,
+        {
+            "pi": {"enabled": False, **inherited},
+            "pi-work": {"extends": "pi", "label": "Work", "env": {"API_KEY": "test-secret"}},
+        },
+    )
+    providers = {item.provider_id: item for item in paseo_providers(context)}
+    assert providers["pi-work"].enabled is True
+    assert providers["pi-work"].unsupported_reason
+    with pytest.raises(ValueError, match="No supported, enabled"):
+        PaseoHarnessAdapter().install(context)
+    assert not receipt_path(context).exists()
+
+
+def test_inherited_credentials_preserve_profile_support_without_entering_receipts(context: HarnessContext) -> None:
+    """Ordinary inherited endpoint and credential settings do not disable native hooks."""
+    configure(
+        context,
+        {
+            "pi": {"enabled": False, "env": {"API_KEY": "private-base-credential"}},
+            "pi-work": {"extends": "pi", "label": "Work", "env": {"API_BASE_URL": "https://models.test"}},
+        },
+    )
+    manifest = PaseoHarnessAdapter().install(context)
+    assert statuses(manifest)["pi-work"] == "native-hooks-installed"
+    assert "private-base-credential" not in json.dumps(manifest)
+
+
+def test_disconnect_plan_warns_that_native_protection_remains(context: HarnessContext) -> None:
+    """Show shared-hook ownership before the operator confirms disconnection."""
+    plan = build_harness_setup_plan("uninstall", "paseo", context, dry_run=True)
+    step = plan["steps"][0]
+    assert "receipt and launcher" in step["body"]
+    assert "native provider protection remains installed" in step["body"]
+    assert step["requires_confirmation"] is True
+
+
+@pytest.mark.parametrize("artifact", ["settings.json", "extensions/hol-guard.ts"])
+def test_reinstall_repairs_deleted_native_artifacts(context: HarnessContext, artifact: str) -> None:
+    """Reinstall rebuilds drifted native settings/extensions and publishes fresh proofs."""
+    configure(context, {"pi": {"enabled": True}})
+    adapter = PaseoHarnessAdapter()
+    adapter.install(context)
+    target = context.home_dir / ".pi/agent" / artifact
+    target.unlink()
+    assert adapter.diagnostics(context)["setup_status"] == "broken"
+    repaired = adapter.install(context)
+    assert target.is_file()
+    assert statuses(repaired)["pi"] == "native-hooks-installed"
+    assert adapter.diagnostics(context)["setup_status"] == "active"

--- a/tests/test_paseo_review_boundaries.py
+++ b/tests/test_paseo_review_boundaries.py
@@ -1,0 +1,93 @@
+"""Regression coverage for Paseo's path, repair, and public coverage boundaries."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.contracts import setup_contract_for
+from codex_plugin_scanner.guard.adapters.paseo import PaseoHarnessAdapter
+from codex_plugin_scanner.guard.adapters.paseo_config import paseo_providers, require_local_path
+from codex_plugin_scanner.guard.adapters.paseo_install import receipt_path
+from tests.test_paseo_adapter import configure
+from tests.test_paseo_adapter import context as context
+
+
+@pytest.mark.parametrize("provider", ["opencode", "copilot"])
+@pytest.mark.parametrize("origin", ["ambient", "provider"])
+@pytest.mark.parametrize("relocated", [False, True])
+def test_xdg_config_home_only_rejects_relocated_roots(
+    context: HarnessContext, monkeypatch: pytest.MonkeyPatch, provider: str, origin: str, relocated: bool
+) -> None:
+    """Linux's ordinary default XDG root does not silently drop native coverage."""
+    value = str(context.home_dir / ("elsewhere" if relocated else ".config"))
+    entry = {"enabled": True}
+    if origin == "ambient":
+        monkeypatch.setenv("XDG_CONFIG_HOME", value)
+    else:
+        entry["env"] = {"XDG_CONFIG_HOME": value}
+    configure(context, {provider: entry})
+    profile = next(item for item in paseo_providers(context) if item.provider_id == provider)
+    assert bool(profile.unsupported_reason) is relocated
+
+
+@pytest.mark.security_critical
+@pytest.mark.parametrize("inside_home", [False, True])
+def test_nonexistent_guard_root_cannot_hide_a_symlinked_ancestor(
+    context: HarnessContext, tmp_path: Path, inside_home: bool
+) -> None:
+    """Reject redirected launcher roots before any shared native installation starts."""
+    outside = tmp_path / "escape"
+    outside.mkdir()
+    ancestor = (context.home_dir if inside_home else tmp_path) / "redirected"
+    ancestor.symlink_to(outside, target_is_directory=True)
+    redirected = replace(context, guard_home=ancestor / "state" / "guard")
+    configure(redirected, {"pi": {"enabled": True}})
+    with pytest.raises(ValueError, match="symlink"):
+        PaseoHarnessAdapter().install(redirected)
+    assert list(outside.iterdir()) == []
+    assert not (context.home_dir / ".pi").exists()
+
+
+def test_symlinked_user_home_remains_an_explicit_path_anchor(tmp_path: Path) -> None:
+    """The user's declared home may be a link, but links inside it remain forbidden."""
+    actual_home = tmp_path / "actual"
+    actual_home.mkdir()
+    home = tmp_path / "home"
+    home.symlink_to(actual_home, target_is_directory=True)
+    root = home / ".local/state/guard"
+    require_local_path(root, root / "bin/guard-paseo", home_dir=home)
+    (actual_home / ".local").symlink_to(tmp_path / "elsewhere", target_is_directory=True)
+    with pytest.raises(ValueError, match="symlink"):
+        require_local_path(root, root / "bin/guard-paseo", home_dir=home)
+
+
+def test_failed_repair_keeps_receipt_but_detects_changed_artifacts(
+    context: HarnessContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Keeping an old receipt cannot hide artifact drift caused by a failed repair."""
+    configure(context, {"pi": {"enabled": True}})
+    adapter = PaseoHarnessAdapter()
+    adapter.install(context)
+    original = receipt_path(context).read_bytes()
+
+    def fail_after_write(*_args: object) -> None:
+        """Simulate a native installer which changes one file and then fails."""
+        (context.home_dir / ".pi/agent/extensions/hol-guard.ts").write_text("changed", encoding="utf-8")
+        raise ValueError("installation failed")
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.paseo.install_native", fail_after_write)
+    with pytest.raises(ValueError, match="installation failed"):
+        adapter.install(context)
+    assert receipt_path(context).read_bytes() == original
+    assert adapter.diagnostics(context)["setup_status"] == "broken"
+
+
+def test_paseo_setup_contract_has_no_composite_browser_fallback() -> None:
+    """Approvals remain native-provider-specific, never a claimed Paseo endpoint."""
+    contract = setup_contract_for("paseo")
+    assert contract is not None
+    assert contract.to_dict()["coverage"]["browser_fallback"] is False


### PR DESCRIPTION
## Why

#2892 was mistakenly merged into the obsolete `release/3.0` branch. This ports the reviewed Paseo integration onto current **main** without bringing unrelated release-branch commits along.

## Changes

Adds Paseo install, dry-run, repair, per-provider diagnostics, shared native-provider hooks, local inventory, and documentation. Native integrations retain their own policy and approval identities. Paseo terminals, daemon operations, custom commands, relocated native homes, and arbitrary ACP/plugin providers are not claimed as protected.

Reviewed fixes cover inherited execution overrides, artifact proofs, safe managed paths, repair receipt preservation, command/path export redaction, cloud content filtering, and bounded daemon health checks. The generated Grok hook is validated against the actual Guard store, home, and workspace rather than merely consistent serialized values.

Inventory types, fingerprints, redaction, metadata, items, MCP data, and scan conversion now live in focused modules. The existing inventory API and import paths remain available. Current main's Cline surfaces, authenticated daemon behavior, inventory trust handling, and Rust ownership gates are preserved. No existing CI/security gate was weakened or disabled.

Paseo's composite inventory and associated content stay local. Shared native provider hooks remain installed after Paseo disconnect. The companion portal catalog/setup update is handled separately, without expanding the cloud agent-type enum.

## Validation

347 focused tests passed on the final patch, covering native installation, inherited profiles, path redirects across Python/frozen/desktop launch forms, repair, inventory contracts, source-of-truth evidence, exports, cloud filtering, and Grok readiness. Full basedpyright, Ruff, formatting, and the unchanged Rust ownership gate also passed.

The native installers run in isolated homes with executable discovery substituted. This does not represent a live authenticated Paseo/model session.

Full normal PR CI and current-head review must pass before merge. Target branch: **main**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Guard support for Paseo and its supported native provider integrations.
  * Added Paseo installation, verification, diagnostics, repair, and uninstall workflows.
  * Added provider coverage and managed-install status reporting.
  * Added structured inventory and protection coverage reporting.

* **Bug Fixes**
  * Improved export privacy by redacting sensitive launch commands, credentials, and local paths.
  * Improved daemon health checks for invalid responses, redirects, oversized payloads, and timeouts.

* **Documentation**
  * Documented Paseo support, setup instructions, supported providers, limitations, and troubleshooting guidance.
  * Clarified that Paseo does not provide browser fallback or resume support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->