### PR TITLE
fix(ci): enforce least-privilege workflow token permissions

### DIFF
--- a/.github/workflows/extension-claim-notice.yml
+++ b/.github/workflows/extension-claim-notice.yml
@@ -19,10 +19,8 @@ on:
         default: false
         type: boolean
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+# New jobs start without a token grant; writers declare only their own scopes.
+permissions: {}
 
 concurrency:
   group: extension-claim-notice-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.run_id }}
@@ -30,6 +28,9 @@ concurrency:
 
 jobs:
   notify:
+    permissions:
+      contents: read
+      pull-requests: write
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/finish-extension-authority-stability.yml
+++ b/.github/workflows/finish-extension-authority-stability.yml
@@ -7,8 +7,8 @@ on:
     paths:
       - .github/workflows/finish-extension-authority-stability.yml
 
-permissions:
-  contents: write
+# New jobs start without a token grant; writers declare only their own scopes.
+permissions: {}
 
 concurrency:
   group: finish-extension-authority-stability
@@ -16,6 +16,8 @@ concurrency:
 
 jobs:
   finish:
+    permissions:
+      contents: write
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:

--- a/.github/workflows/guarded-repository.yml
+++ b/.github/workflows/guarded-repository.yml
@@ -45,15 +45,17 @@ on:
         description: Expiring public badge URL when visibility is public
         value: ${{ jobs.scan.outputs.badge_url }}
 
-permissions:
-  contents: read
-  id-token: write
-  attestations: write
-  artifact-metadata: write
-  security-events: write
+# New jobs start without a token grant; writers declare only their own scopes.
+permissions: {}
 
 jobs:
   scan:
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+      security-events: write
     runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -6,9 +6,8 @@ on:
     types: [completed]
     branches: [main, release/3.0]
 
-permissions:
-  contents: read
-  id-token: write
+# New jobs start without a token grant; writers declare only their own scopes.
+permissions: {}
 
 concurrency:
   group: hol-guard-mcp-registry-${{ github.event.workflow_run.head_branch }}
@@ -16,6 +15,9 @@ concurrency:
 
 jobs:
   publish:
+    permissions:
+      contents: read
+      id-token: write
     name: Publish verified MCP metadata
     if: >-
       vars.RELEASE_PUBLISHING_ENABLED == 'true' &&

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,7 +4,7 @@ on:
     - cron: '0 0 * * 0'
   push:
     branches: [main]
-permissions: read-all
+permissions: {}
 
 jobs:
   scorecard:

--- a/.github/workflows/security-gates.yml
+++ b/.github/workflows/security-gates.yml
@@ -29,7 +29,13 @@ jobs:
           version: "0.9.26"
       - name: Install policy dependencies
         run: uv sync --frozen --extra dev
-      - name: Enforce privileged workflow pins
+      - name: Validate workflow policy code
+        run: |
+          uv run --no-sync ruff check scripts/check_privileged_workflows.py tests/test_privileged_workflow_policy.py tests/test_workflow_token_permissions.py
+          uv run --no-sync ruff format --check scripts/check_privileged_workflows.py tests/test_privileged_workflow_policy.py tests/test_workflow_token_permissions.py
+      - name: Run workflow permission regressions
+        run: uv run --no-sync pytest -q tests/test_privileged_workflow_policy.py tests/test_workflow_token_permissions.py
+      - name: Enforce least-privilege permissions and immutable toolchains
         run: uv run --no-sync python scripts/check_privileged_workflows.py
 
   semgrep:

--- a/docs/development/workflow-permissions.md
+++ b/docs/development/workflow-permissions.md
@@ -1,0 +1,53 @@
+# GitHub Actions token permissions
+
+Workflow defaults must be an explicit map containing only `read` or `none`, or
+`permissions: {}`. A job that needs to publish, attest, upload findings, comment,
+or dispatch another workflow declares its own named scopes. Do not use
+`read-all`, `write-all`, or rely on the repository's default token settings.
+Job-level maps replace the workflow map; they do not add to it.
+
+`Security Gates / Privileged workflow policy` enforces these rules on pull
+requests and merge groups, alongside the existing full action SHA and exact uv
+version requirements for privileged jobs. Test locally with:
+
+```sh
+uv run --no-sync python scripts/check_privileged_workflows.py
+uv run --no-sync pytest tests/test_privileged_workflow_policy.py tests/test_workflow_token_permissions.py
+```
+
+## Permissions that are intentionally retained
+
+| Workflow or job | Write access | Consumer |
+| --- | --- | --- |
+| `dependabot-uv-lock.yml` | `contents` | Commits the regenerated lockfile to the Dependabot branch. |
+| `finish-extension-authority-stability.yml` / `finish` | `contents` | Updates its dedicated repair branch; no other job inherits this grant. |
+| `publish.yml` tag reservation and reservation cleanup jobs | `contents` | Creates or deletes release reservation tags. |
+| `publish.yml` PyPI jobs | `id-token` | Authenticates the existing trusted-publisher uploads. |
+| `publish.yml` release jobs | `contents`, `attestations`, `id-token` | Publishes release assets and their provenance. |
+| `publish.yml` / `publish-container` and `devcontainer-features.yml` / `publish` | `packages` | Publishes images or features to GHCR. |
+| `desktop-core-alpha-feed.yml` / `publish-macos-arm64` | `contents`, `attestations`, `id-token` | Publishes the signed Core sidecar and provenance. |
+| `publish-mcpb.yml` / `publish` | `contents` | Attaches the bundle and checksum to the verified release. |
+| `publish-mcp-registry.yml` / `publish` | `id-token` | Authenticates the MCP Registry publisher. |
+| `codeql.yml`, `fuzz.yml`, and `scorecard.yml` analysis jobs | `security-events` | Uploads code-scanning findings. Scorecard also uses `id-token` to publish its results. |
+| `guarded-repository.yml` / `scan` | `security-events`, `attestations`, `artifact-metadata`, `id-token` | Scans, attests, and registers the caller's repository. The caller must authorize the required scopes. |
+| `extension-claim-notice.yml` / `notify` | `pull-requests` | Comments on verified merged contribution PRs. Separate `issues: write` is unnecessary. |
+| `wake-desktop-core-alpha-feed.yml` / `wake` | `actions` | Dispatches the existing Core feed producer. |
+
+These grants are not exemptions from the policy. They are explicit job-level
+capabilities, with the workflows' existing event, source, and publication checks
+unchanged. Do not remove a required scope merely to silence a scanner warning,
+or replace the workflow token with a broader personal access token.
+
+## Reading Scorecard results
+
+The OpenSSF `Token-Permissions` check penalizes broad workflow-level grants.
+It can still print warnings about sensitive **job-level** permissions while
+awarding full marks when workflow defaults are read-only or empty. The warnings
+above are therefore not a reason to break releases, disable fuzz SARIF, or remove
+provenance. A full score does not prove that every privileged step is safe.
+
+References:
+
+- [OpenSSF Token-Permissions check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions)
+- [GitHub workflow permission syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions)
+- [Comment API permission alternatives](https://docs.github.com/en/rest/issues/comments#create-an-issue-comment)

--- a/scripts/check_privileged_workflows.py
+++ b/scripts/check_privileged_workflows.py
@@ -14,6 +14,30 @@ import yaml
 _FULL_COMMIT_SHA = re.compile(r"^[0-9a-fA-F]{40}$")
 _EXACT_UV_VERSION = re.compile(r"^\d+\.\d+\.\d+$")
 _WORKFLOW_SUFFIXES = frozenset({".yml", ".yaml"})
+# GitHub Actions workflow-syntax permission table, checked 2026-09-12.
+# https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions
+_PERMISSION_LEVELS = {
+    scope: frozenset({"read", "write", "none"})
+    for scope in (
+        "actions",
+        "artifact-metadata",
+        "attestations",
+        "checks",
+        "code-quality",
+        "contents",
+        "deployments",
+        "discussions",
+        "issues",
+        "packages",
+        "pages",
+        "pull-requests",
+        "security-events",
+        "statuses",
+    )
+} | {
+    "id-token": frozenset({"write", "none"}),
+    "vulnerability-alerts": frozenset({"read", "none"}),
+}
 
 
 @dataclass(frozen=True)
@@ -67,16 +91,16 @@ def _validate_permissions(
     for scope, level in permissions.items():
         if (
             not isinstance(scope, str)
-            or not scope.strip()
+            or scope not in _PERMISSION_LEVELS
             or not isinstance(level, str)
-            or level not in {"read", "write", "none"}
+            or level not in _PERMISSION_LEVELS[scope]
         ):
             violations.append(
                 WorkflowPolicyViolation(
                     workflow_path,
                     job_name,
                     "permission-invalid",
-                    f"Invalid permission {scope!r}: {level!r}; use a named scope with read, write, or none.",
+                    f"Invalid permission {scope!r}: {level!r}; use an exact supported scope and access level.",
                 )
             )
         elif level == "write" and not allow_write:

--- a/scripts/check_privileged_workflows.py
+++ b/scripts/check_privileged_workflows.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Enforce immutable toolchain inputs in privileged GitHub Actions jobs."""
+"""Enforce least-privilege token grants and immutable privileged-job toolchains."""
 
 from __future__ import annotations
 
@@ -45,6 +45,50 @@ def _has_write_capability(permissions: object) -> bool:
     if isinstance(permissions, str):
         return permissions.strip().lower() == "write-all"
     return any(str(value).strip().lower() == "write" for value in _mapping(permissions).values())
+
+
+def _validate_permissions(
+    *,
+    workflow_path: Path,
+    job_name: str,
+    permissions: object,
+    allow_write: bool,
+) -> list[WorkflowPolicyViolation]:
+    if not isinstance(permissions, dict):
+        return [
+            WorkflowPolicyViolation(
+                workflow_path,
+                job_name,
+                "permission-map-required",
+                "Declare a permission map ({} for none); inherited defaults and wildcard grants are forbidden.",
+            )
+        ]
+    violations: list[WorkflowPolicyViolation] = []
+    for scope, level in permissions.items():
+        if (
+            not isinstance(scope, str)
+            or not scope.strip()
+            or not isinstance(level, str)
+            or level not in {"read", "write", "none"}
+        ):
+            violations.append(
+                WorkflowPolicyViolation(
+                    workflow_path,
+                    job_name,
+                    "permission-invalid",
+                    f"Invalid permission {scope!r}: {level!r}; use a named scope with read, write, or none.",
+                )
+            )
+        elif level == "write" and not allow_write:
+            violations.append(
+                WorkflowPolicyViolation(
+                    workflow_path,
+                    job_name,
+                    "workflow-write-permission",
+                    f"Move {scope}: write to the job that needs it; workflow defaults must be read-only or empty.",
+                )
+            )
+    return violations
 
 
 def _effective_permissions(workflow: dict[object, object], job: dict[object, object]) -> object:
@@ -136,7 +180,7 @@ def _validate_privileged_job(
 
 
 def validate_privileged_workflows(root: Path) -> tuple[WorkflowPolicyViolation, ...]:
-    """Return policy violations for explicitly write-capable workflow jobs."""
+    """Validate token defaults, job grants, and write-capable job toolchains."""
 
     workflows_dir = root / ".github" / "workflows"
     violations: list[WorkflowPolicyViolation] = []
@@ -155,9 +199,31 @@ def validate_privileged_workflows(root: Path) -> tuple[WorkflowPolicyViolation, 
                 )
             )
             continue
+        if not isinstance(raw_workflow, dict):
+            violations.append(
+                WorkflowPolicyViolation(workflow_path, "<workflow>", "workflow-invalid", "Expected a workflow mapping.")
+            )
+            continue
         workflow = _mapping(raw_workflow)
+        violations.extend(
+            _validate_permissions(
+                workflow_path=workflow_path,
+                job_name="<workflow>",
+                permissions=workflow.get("permissions"),
+                allow_write=False,
+            )
+        )
         for raw_job_name, raw_job in _mapping(workflow.get("jobs")).items():
             job = _mapping(raw_job)
+            if "permissions" in job:
+                violations.extend(
+                    _validate_permissions(
+                        workflow_path=workflow_path,
+                        job_name=str(raw_job_name),
+                        permissions=job["permissions"],
+                        allow_write=True,
+                    )
+                )
             if not job or not _has_write_capability(_effective_permissions(workflow, job)):
                 continue
             violations.extend(

--- a/scripts/check_privileged_workflows.py
+++ b/scripts/check_privileged_workflows.py
@@ -78,6 +78,8 @@ def _validate_permissions(
     permissions: object,
     allow_write: bool,
 ) -> list[WorkflowPolicyViolation]:
+    """Reject implicit grants, unsupported scopes, and workflow-wide write access."""
+
     if not isinstance(permissions, dict):
         return [
             WorkflowPolicyViolation(

--- a/src/codex_plugin_scanner/guard/daemon/hook_process_worker.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_process_worker.py
@@ -107,37 +107,37 @@ def terminate_owned_process_group(process: WorkerProcess, signal_number: int) ->
 def retire_worker_slot(slot: HookWorkerSlot, *, graceful: bool = False) -> bool:
     """Contain one worker tree; callers may run this outside request deadlines."""
 
+    # Retirement is complete only after containment has been proved. Keep the
+    # proof and publication under one lock so close() cannot race the reaper and
+    # mistake a dead guardian for a successfully contained process tree.
     with slot.retire_lock:
         if slot.retired:
             return not slot.process.is_alive()
-        slot.retired = True
-    if graceful and slot.process.is_alive():
-        with slot.handshake_lock:
-            with suppress(BrokenPipeError, OSError):
-                slot.connection.send(("stop", None))
-            slot.process.join(timeout=0.2)
-    if os.name != "nt" and slot.isolation_ready:
-        tree_contained = terminate_owned_process_group(slot.process, getattr(signal, "SIGKILL", 9))
-    elif slot.pre_isolation_contained:
-        if slot.process.is_alive():
+        if graceful and slot.process.is_alive():
+            with slot.handshake_lock:
+                with suppress(BrokenPipeError, OSError):
+                    slot.connection.send(("stop", None))
+                slot.process.join(timeout=0.2)
+        if os.name != "nt" and slot.isolation_ready:
+            tree_contained = terminate_owned_process_group(slot.process, getattr(signal, "SIGKILL", 9))
+        elif slot.pre_isolation_contained:
+            if slot.process.is_alive():
+                with suppress(OSError):
+                    slot.process.kill()
+            tree_contained = True
+        elif slot.process.is_alive():
             with suppress(OSError):
                 slot.process.kill()
-        tree_contained = True
-    elif slot.process.is_alive():
-        with suppress(OSError):
-            slot.process.kill()
-        tree_contained = False
-    else:
-        # A worker that died before the parent sent it a review request never
-        # handled untrusted input. Its dead bootstrap process cannot retain
-        # request-derived descendants, so the supervisor may safely replace it.
-        tree_contained = slot.windows_job_contained or not slot.request_exposed
-    slot.process.join(timeout=_WORKER_RETIRE_JOIN_TIMEOUT_SECONDS)
-    contained = (tree_contained or slot.windows_job_contained) and not slot.process.is_alive()
-    if not contained:
-        with slot.retire_lock:
-            slot.retired = False
-    return contained
+            tree_contained = False
+        else:
+            # A worker that died before the parent sent it a review request never
+            # handled untrusted input. Its dead bootstrap process cannot retain
+            # request-derived descendants, so the supervisor may safely replace it.
+            tree_contained = slot.windows_job_contained or not slot.request_exposed
+        slot.process.join(timeout=_WORKER_RETIRE_JOIN_TIMEOUT_SECONDS)
+        contained = (tree_contained or slot.windows_job_contained) and not slot.process.is_alive()
+        slot.retired = contained
+        return contained
 
 
 def worker_retirement_thread(

--- a/tests/test_guard_extension_claim_notice.py
+++ b/tests/test_guard_extension_claim_notice.py
@@ -296,7 +296,7 @@ def test_workflow_is_merge_only_and_supports_reviewed_rename_backfill() -> None:
     assert "allow_renames:" in text
     assert "contributions/extension-listings/**" in text
     assert "pull-requests: write" in text
-    assert "issues: write" in text
+    assert "issues: write" not in text
     assert "persist-credentials: false" in text
     assert "--allow-renames" in text
     assert "notify_merged_extension_claimants.py" in text

--- a/tests/test_guard_extension_claim_notice.py
+++ b/tests/test_guard_extension_claim_notice.py
@@ -287,6 +287,8 @@ def test_changed_extension_ids_track_renames_and_ignore_removed_files() -> None:
 
 
 def test_workflow_is_merge_only_and_supports_reviewed_rename_backfill() -> None:
+    """Claim notices retain merge checks and PR-comment access without issue-management access."""
+
     text = WORKFLOW.read_text(encoding="utf-8")
     assert "pull_request_target:" in text
     assert "types: [closed]" in text

--- a/tests/test_guard_hook_process_containment.py
+++ b/tests/test_guard_hook_process_containment.py
@@ -101,11 +101,15 @@ def test_concurrent_retirement_waits_for_containment_proof(
     results: dict[str, bool] = {}
 
     def prove_containment(_process: object, _signal: int) -> bool:
+        """Pause the containment result until the competing retirement has started."""
+
         entered.set()
         assert release.wait(timeout=5)
         return tree_contained
 
     def retire_second() -> None:
+        """Attempt shutdown while another caller is still proving containment."""
+
         second_started.set()
         results["second"] = retire_worker_slot(slot)
 

--- a/tests/test_guard_hook_process_containment.py
+++ b/tests/test_guard_hook_process_containment.py
@@ -88,6 +88,48 @@ def test_post_request_unknown_isolation_does_not_signal_group_without_live_guard
     assert not retire_worker_slot(slot)
 
 
+@pytest.mark.parametrize("tree_contained", [False, True])
+def test_concurrent_retirement_waits_for_containment_proof(
+    monkeypatch: pytest.MonkeyPatch, tree_contained: bool
+) -> None:
+    """An in-progress retirement must not let another caller report unproven containment."""
+
+    slot = HookWorkerSlot(process=_DeadGuardian(), connection=_Connection(), isolation_ready=True)
+    entered = threading.Event()
+    release = threading.Event()
+    second_started = threading.Event()
+    results: dict[str, bool] = {}
+
+    def prove_containment(_process: object, _signal: int) -> bool:
+        entered.set()
+        assert release.wait(timeout=5)
+        return tree_contained
+
+    def retire_second() -> None:
+        second_started.set()
+        results["second"] = retire_worker_slot(slot)
+
+    monkeypatch.setattr(hook_worker_module.os, "name", "posix")
+    monkeypatch.setattr(hook_worker_module, "terminate_owned_process_group", prove_containment)
+    first = threading.Thread(target=lambda: results.update(first=retire_worker_slot(slot)))
+    second = threading.Thread(target=retire_second)
+    first.start()
+    try:
+        assert entered.wait(timeout=5)
+        second.start()
+        assert second_started.wait(timeout=5)
+        assert not slot.retired
+    finally:
+        release.set()
+        first.join(timeout=5)
+        if second.ident is not None:
+            second.join(timeout=5)
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert results == {"first": tree_contained, "second": tree_contained}
+    assert slot.retired is tree_contained
+
+
 def test_explicit_pre_isolation_failure_allows_direct_cleanup() -> None:
     slot = HookWorkerSlot(
         process=_DeadGuardian(),

--- a/tests/test_privileged_workflow_policy.py
+++ b/tests/test_privileged_workflow_policy.py
@@ -83,6 +83,8 @@ jobs:
 
 
 def test_job_level_read_permissions_remove_inherited_write_capability(tmp_path: Path) -> None:
+    """A read-only job avoids pin checks but does not excuse an unsafe workflow default."""
+
     _write_workflow(
         tmp_path,
         """
@@ -103,6 +105,8 @@ jobs:
 
 
 def test_privileged_job_accepts_commit_pins_and_exact_uv_version(tmp_path: Path) -> None:
+    """Job-scoped writes remain usable with immutable action and tool versions."""
+
     _write_workflow(
         tmp_path,
         f"""

--- a/tests/test_privileged_workflow_policy.py
+++ b/tests/test_privileged_workflow_policy.py
@@ -97,13 +97,16 @@ jobs:
 """,
     )
 
-    assert validate_privileged_workflows(tmp_path) == ()
+    violations = validate_privileged_workflows(tmp_path)
+    assert [violation.code for violation in violations] == ["workflow-write-permission"]
+    assert violations[0].job == "<workflow>"
 
 
 def test_privileged_job_accepts_commit_pins_and_exact_uv_version(tmp_path: Path) -> None:
     _write_workflow(
         tmp_path,
         f"""
+permissions: {{}}
 jobs:
   release:
     permissions:

--- a/tests/test_workflow_token_permissions.py
+++ b/tests/test_workflow_token_permissions.py
@@ -14,6 +14,8 @@ PINNED_ACTION = "actions/checkout@0123456789abcdef0123456789abcdef01234567"
 
 
 def _write_workflow(root: Path, header: str, job_permissions: str = "") -> Path:
+    """Create a workflow whose root and job permission declarations vary independently."""
+
     path = root / ".github/workflows/fixture.yaml"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
@@ -28,6 +30,8 @@ def _write_workflow(root: Path, header: str, job_permissions: str = "") -> Path:
     ["", "permissions:", "permissions: null", "permissions: []", "permissions: read-all", "permissions: write-all"],
 )
 def test_workflow_requires_explicit_named_permissions(tmp_path: Path, header: str) -> None:
+    """Repository defaults and wildcard declarations cannot silently grant token capabilities."""
+
     _write_workflow(tmp_path, header, "    permissions: {}\n")
     violations = validate_privileged_workflows(tmp_path)
     assert [item.code for item in violations] == ["permission-map-required"]
@@ -49,6 +53,8 @@ def test_workflow_requires_explicit_named_permissions(tmp_path: Path, header: st
     ],
 )
 def test_workflow_write_grants_are_rejected_even_with_read_only_job(tmp_path: Path, scope: str) -> None:
+    """A safe existing job does not make write-capable defaults safe for future jobs."""
+
     _write_workflow(tmp_path, f"permissions:\n  {scope}: write", "    permissions:\n      contents: read\n")
     violations = validate_privileged_workflows(tmp_path)
     assert [item.code for item in violations] == ["workflow-write-permission"]
@@ -57,6 +63,8 @@ def test_workflow_write_grants_are_rejected_even_with_read_only_job(tmp_path: Pa
 
 @pytest.mark.parametrize("value", ["read-all", "write-all", "null", "[]", "true"])
 def test_job_wildcard_and_malformed_grants_are_rejected(tmp_path: Path, value: str) -> None:
+    """Explicit job grants must be named maps rather than wildcard or malformed values."""
+
     _write_workflow(tmp_path, "permissions: {}", f"    permissions: {value}\n")
     violations = validate_privileged_workflows(tmp_path)
     assert [item.code for item in violations] == ["permission-map-required"]
@@ -69,6 +77,8 @@ def test_job_wildcard_and_malformed_grants_are_rejected(tmp_path: Path, value: s
 )
 @pytest.mark.parametrize("job_level", [False, True])
 def test_invalid_scope_values_fail_closed(tmp_path: Path, entry: str, job_level: bool) -> None:
+    """Malformed permission entries fail at both workflow and job scope."""
+
     header = "permissions: {}" if job_level else f"permissions:\n  {entry}"
     job = f"    permissions:\n      {entry}\n" if job_level else ""
     _write_workflow(tmp_path, header, job)
@@ -79,6 +89,8 @@ def test_invalid_scope_values_fail_closed(tmp_path: Path, entry: str, job_level:
     "header", ["permissions: {}", "permissions:\n  contents: read", "permissions:\n  contents: none"]
 )
 def test_read_only_or_empty_defaults_are_allowed(tmp_path: Path, header: str) -> None:
+    """Empty, read-only, and explicitly disabled workflow grants are valid defaults."""
+
     _write_workflow(tmp_path, header)
     assert validate_privileged_workflows(tmp_path) == ()
 
@@ -86,6 +98,8 @@ def test_read_only_or_empty_defaults_are_allowed(tmp_path: Path, header: str) ->
 @pytest.mark.parametrize("scope", ["content", "CONTENTS", " contents", "contents ", "security_events", "unknown", "*"])
 @pytest.mark.parametrize("job_level", [False, True])
 def test_unknown_or_noncanonical_scope_names_are_rejected(tmp_path: Path, scope: str, job_level: bool) -> None:
+    """Misspellings, whitespace, and case variants cannot pass as valid scope names."""
+
     entry = f'"{scope}": read'
     header = "permissions: {}" if job_level else f"permissions:\n  {entry}"
     job = f"    permissions:\n      {entry}\n" if job_level else ""
@@ -98,6 +112,8 @@ def test_unknown_or_noncanonical_scope_names_are_rejected(tmp_path: Path, scope:
 def test_scope_specific_invalid_access_levels_are_rejected(
     tmp_path: Path, scope: str, level: str, job_level: bool
 ) -> None:
+    """OIDC and vulnerability alerts reject access levels their APIs do not support."""
+
     entry = f"{scope}: {level}"
     header = "permissions: {}" if job_level else f"permissions:\n  {entry}"
     job = f"    permissions:\n      {entry}\n" if job_level else ""
@@ -127,6 +143,8 @@ def test_scope_specific_invalid_access_levels_are_rejected(
     ],
 )
 def test_documented_scope_levels_are_accepted(tmp_path: Path, scope: str, levels: tuple[str, ...]) -> None:
+    """Every documented scope retains its valid job grants and non-write workflow grants."""
+
     for level in levels:
         _write_workflow(tmp_path, "permissions: {}", f"    permissions:\n      {scope}: {level}\n")
         assert validate_privileged_workflows(tmp_path) == ()
@@ -136,12 +154,16 @@ def test_documented_scope_levels_are_accepted(tmp_path: Path, scope: str, levels
 
 
 def test_explicit_job_grants_do_not_inherit_root_scopes(tmp_path: Path) -> None:
+    """An explicit empty job map replaces rather than extends workflow permissions."""
+
     path = _write_workflow(tmp_path, "permissions:\n  contents: read", "    permissions: {}\n")
     path.write_text(path.read_text().replace(PINNED_ACTION, "actions/checkout@v4"))
     assert validate_privileged_workflows(tmp_path) == ()
 
 
 def test_job_write_grants_still_enforce_action_pins(tmp_path: Path) -> None:
+    """Narrow token grants do not relax the immutable-action requirement for writers."""
+
     path = _write_workflow(tmp_path, "permissions: {}", "    permissions:\n      contents: write\n")
     path.write_text(path.read_text().replace(PINNED_ACTION, "actions/checkout@v4"))
     assert [item.code for item in validate_privileged_workflows(tmp_path)] == ["action-not-commit-pinned"]
@@ -149,6 +171,8 @@ def test_job_write_grants_still_enforce_action_pins(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("text", ["", "null", "[]", "workflow", "[broken"])
 def test_non_mapping_or_unreadable_workflow_fails_closed(tmp_path: Path, text: str) -> None:
+    """Invalid workflow documents produce a policy failure instead of being ignored."""
+
     path = _write_workflow(tmp_path, "permissions: {}")
     path.write_text(text, encoding="utf-8")
     violations = validate_privileged_workflows(tmp_path)
@@ -183,12 +207,16 @@ def test_non_mapping_or_unreadable_workflow_fails_closed(tmp_path: Path, text: s
 def test_writer_workflows_start_empty_and_preserve_needed_job_grants(
     filename: str, job: str, permissions: dict[str, str]
 ) -> None:
+    """Release, scan, and notification jobs retain exactly their required capabilities."""
+
     workflow = yaml.safe_load((ROOT / ".github/workflows" / filename).read_text(encoding="utf-8"))
     assert workflow["permissions"] == {}
     assert workflow["jobs"][job]["permissions"] == permissions
 
 
 def test_security_gate_runs_permission_policy_on_pull_requests() -> None:
+    """Pull-request validation invokes the same permission policy checked by these tests."""
+
     workflow = yaml.safe_load((ROOT / ".github/workflows/security-gates.yml").read_text(encoding="utf-8"))
     # PyYAML's YAML 1.1 loader represents the GitHub Actions `on` key as True.
     assert "pull_request" in workflow[True]

--- a/tests/test_workflow_token_permissions.py
+++ b/tests/test_workflow_token_permissions.py
@@ -83,6 +83,58 @@ def test_read_only_or_empty_defaults_are_allowed(tmp_path: Path, header: str) ->
     assert validate_privileged_workflows(tmp_path) == ()
 
 
+@pytest.mark.parametrize("scope", ["content", "CONTENTS", " contents", "contents ", "security_events", "unknown", "*"])
+@pytest.mark.parametrize("job_level", [False, True])
+def test_unknown_or_noncanonical_scope_names_are_rejected(tmp_path: Path, scope: str, job_level: bool) -> None:
+    entry = f'"{scope}": read'
+    header = "permissions: {}" if job_level else f"permissions:\n  {entry}"
+    job = f"    permissions:\n      {entry}\n" if job_level else ""
+    _write_workflow(tmp_path, header, job)
+    assert [item.code for item in validate_privileged_workflows(tmp_path)] == ["permission-invalid"]
+
+
+@pytest.mark.parametrize("scope,level", [("id-token", "read"), ("vulnerability-alerts", "write")])
+@pytest.mark.parametrize("job_level", [False, True])
+def test_scope_specific_invalid_access_levels_are_rejected(
+    tmp_path: Path, scope: str, level: str, job_level: bool
+) -> None:
+    entry = f"{scope}: {level}"
+    header = "permissions: {}" if job_level else f"permissions:\n  {entry}"
+    job = f"    permissions:\n      {entry}\n" if job_level else ""
+    _write_workflow(tmp_path, header, job)
+    assert [item.code for item in validate_privileged_workflows(tmp_path)] == ["permission-invalid"]
+
+
+@pytest.mark.parametrize(
+    "scope,levels",
+    [
+        ("actions", ("read", "write", "none")),
+        ("artifact-metadata", ("read", "write", "none")),
+        ("attestations", ("read", "write", "none")),
+        ("checks", ("read", "write", "none")),
+        ("code-quality", ("read", "write", "none")),
+        ("contents", ("read", "write", "none")),
+        ("deployments", ("read", "write", "none")),
+        ("discussions", ("read", "write", "none")),
+        ("id-token", ("write", "none")),
+        ("issues", ("read", "write", "none")),
+        ("packages", ("read", "write", "none")),
+        ("pages", ("read", "write", "none")),
+        ("pull-requests", ("read", "write", "none")),
+        ("security-events", ("read", "write", "none")),
+        ("statuses", ("read", "write", "none")),
+        ("vulnerability-alerts", ("read", "none")),
+    ],
+)
+def test_documented_scope_levels_are_accepted(tmp_path: Path, scope: str, levels: tuple[str, ...]) -> None:
+    for level in levels:
+        _write_workflow(tmp_path, "permissions: {}", f"    permissions:\n      {scope}: {level}\n")
+        assert validate_privileged_workflows(tmp_path) == ()
+        if level != "write":
+            _write_workflow(tmp_path, f"permissions:\n  {scope}: {level}")
+            assert validate_privileged_workflows(tmp_path) == ()
+
+
 def test_explicit_job_grants_do_not_inherit_root_scopes(tmp_path: Path) -> None:
     path = _write_workflow(tmp_path, "permissions:\n  contents: read", "    permissions: {}\n")
     path.write_text(path.read_text().replace(PINNED_ACTION, "actions/checkout@v4"))

--- a/tests/test_workflow_token_permissions.py
+++ b/tests/test_workflow_token_permissions.py
@@ -1,0 +1,144 @@
+"""Token grants stay explicit and local to the jobs that consume them."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.check_privileged_workflows import validate_privileged_workflows
+
+ROOT = Path(__file__).resolve().parents[1]
+PINNED_ACTION = "actions/checkout@0123456789abcdef0123456789abcdef01234567"
+
+
+def _write_workflow(root: Path, header: str, job_permissions: str = "") -> Path:
+    path = root / ".github/workflows/fixture.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"{header}\njobs:\n  test:\n{job_permissions}    steps:\n      - uses: {PINNED_ACTION}\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+@pytest.mark.parametrize(
+    "header",
+    ["", "permissions:", "permissions: null", "permissions: []", "permissions: read-all", "permissions: write-all"],
+)
+def test_workflow_requires_explicit_named_permissions(tmp_path: Path, header: str) -> None:
+    _write_workflow(tmp_path, header, "    permissions: {}\n")
+    violations = validate_privileged_workflows(tmp_path)
+    assert [item.code for item in violations] == ["permission-map-required"]
+    assert violations[0].job == "<workflow>"
+
+
+@pytest.mark.parametrize(
+    "scope",
+    [
+        "contents",
+        "packages",
+        "actions",
+        "security-events",
+        "id-token",
+        "attestations",
+        "artifact-metadata",
+        "pull-requests",
+        "issues",
+    ],
+)
+def test_workflow_write_grants_are_rejected_even_with_read_only_job(tmp_path: Path, scope: str) -> None:
+    _write_workflow(tmp_path, f"permissions:\n  {scope}: write", "    permissions:\n      contents: read\n")
+    violations = validate_privileged_workflows(tmp_path)
+    assert [item.code for item in violations] == ["workflow-write-permission"]
+    assert scope in violations[0].message
+
+
+@pytest.mark.parametrize("value", ["read-all", "write-all", "null", "[]", "true"])
+def test_job_wildcard_and_malformed_grants_are_rejected(tmp_path: Path, value: str) -> None:
+    _write_workflow(tmp_path, "permissions: {}", f"    permissions: {value}\n")
+    violations = validate_privileged_workflows(tmp_path)
+    assert [item.code for item in violations] == ["permission-map-required"]
+    assert violations[0].job == "test"
+
+
+@pytest.mark.parametrize(
+    "entry",
+    ["contents: true", "contents: null", "contents: [read]", "contents: admin", '"": read', "123: read"],
+)
+@pytest.mark.parametrize("job_level", [False, True])
+def test_invalid_scope_values_fail_closed(tmp_path: Path, entry: str, job_level: bool) -> None:
+    header = "permissions: {}" if job_level else f"permissions:\n  {entry}"
+    job = f"    permissions:\n      {entry}\n" if job_level else ""
+    _write_workflow(tmp_path, header, job)
+    assert [item.code for item in validate_privileged_workflows(tmp_path)] == ["permission-invalid"]
+
+
+@pytest.mark.parametrize(
+    "header", ["permissions: {}", "permissions:\n  contents: read", "permissions:\n  contents: none"]
+)
+def test_read_only_or_empty_defaults_are_allowed(tmp_path: Path, header: str) -> None:
+    _write_workflow(tmp_path, header)
+    assert validate_privileged_workflows(tmp_path) == ()
+
+
+def test_explicit_job_grants_do_not_inherit_root_scopes(tmp_path: Path) -> None:
+    path = _write_workflow(tmp_path, "permissions:\n  contents: read", "    permissions: {}\n")
+    path.write_text(path.read_text().replace(PINNED_ACTION, "actions/checkout@v4"))
+    assert validate_privileged_workflows(tmp_path) == ()
+
+
+def test_job_write_grants_still_enforce_action_pins(tmp_path: Path) -> None:
+    path = _write_workflow(tmp_path, "permissions: {}", "    permissions:\n      contents: write\n")
+    path.write_text(path.read_text().replace(PINNED_ACTION, "actions/checkout@v4"))
+    assert [item.code for item in validate_privileged_workflows(tmp_path)] == ["action-not-commit-pinned"]
+
+
+@pytest.mark.parametrize("text", ["", "null", "[]", "workflow", "[broken"])
+def test_non_mapping_or_unreadable_workflow_fails_closed(tmp_path: Path, text: str) -> None:
+    path = _write_workflow(tmp_path, "permissions: {}")
+    path.write_text(text, encoding="utf-8")
+    violations = validate_privileged_workflows(tmp_path)
+    assert len(violations) == 1
+    assert violations[0].code in {"workflow-invalid", "workflow-unreadable"}
+
+
+@pytest.mark.parametrize(
+    ("filename", "job", "permissions"),
+    [
+        ("finish-extension-authority-stability.yml", "finish", {"contents": "write"}),
+        (
+            "guarded-repository.yml",
+            "scan",
+            {
+                "contents": "read",
+                "id-token": "write",
+                "attestations": "write",
+                "artifact-metadata": "write",
+                "security-events": "write",
+            },
+        ),
+        ("extension-claim-notice.yml", "notify", {"contents": "read", "pull-requests": "write"}),
+        ("publish-mcp-registry.yml", "publish", {"contents": "read", "id-token": "write"}),
+        (
+            "scorecard.yml",
+            "scorecard",
+            {"actions": "read", "contents": "read", "id-token": "write", "security-events": "write"},
+        ),
+    ],
+)
+def test_writer_workflows_start_empty_and_preserve_needed_job_grants(
+    filename: str, job: str, permissions: dict[str, str]
+) -> None:
+    workflow = yaml.safe_load((ROOT / ".github/workflows" / filename).read_text(encoding="utf-8"))
+    assert workflow["permissions"] == {}
+    assert workflow["jobs"][job]["permissions"] == permissions
+
+
+def test_security_gate_runs_permission_policy_on_pull_requests() -> None:
+    workflow = yaml.safe_load((ROOT / ".github/workflows/security-gates.yml").read_text(encoding="utf-8"))
+    # PyYAML's YAML 1.1 loader represents the GitHub Actions `on` key as True.
+    assert "pull_request" in workflow[True]
+    steps = workflow["jobs"]["privileged-workflow-policy"]["steps"]
+    assert any(step.get("run") == "uv run --no-sync python scripts/check_privileged_workflows.py" for step in steps)


### PR DESCRIPTION
## What changed

Move workflow-wide write grants into the jobs that use them, and replace Scorecard's `read-all` default with an empty permission map. Extension claim notices retain `pull-requests: write` without the redundant `issues: write` grant.

The existing privileged-workflow CI gate now rejects missing or malformed permission maps, wildcard grants, workflow-level write scopes, unsupported scope names, and invalid scope-specific access levels. The action SHA and uv pin checks remain in place. The gate also runs the policy's regression tests and Ruff checks.

Release tags, package uploads, attestations, SARIF uploads, and workflow dispatch keep their required job-level permissions. No release checks or publication guards are removed. The retained grants are documented in `docs/development/workflow-permissions.md`.

## CI failure fixed

The full CI run exposed a real race in worker retirement: the async reaper set `slot.retired` before proving process-tree containment, so concurrent shutdown could incorrectly report success for a dead guardian. Retirement now holds its lock through the containment check and only marks the slot retired after that check succeeds. Added deterministic concurrent tests for both successful and failed containment; both failed before the fix and pass afterward. The existing guardian-loss integration test is unchanged.

## Verification

- OpenSSF Scorecard v5.5.0, `--local --checks=Token-Permissions --show-details --format=json`: **0/10 before, 10/10 after**, also confirmed after the permission review fix.
- Focused permission, containment, reusable-workflow, claim-notice, release-train, canary, and action-bundle regressions: **142 passed with branch coverage enabled**.
- Ruff lint and format checks passed for all changed Python files.
- Fixed Qodo's scope-name validation finding with root/job cases for typos, whitespace, case variants, and invalid access levels.
- Added docstrings explaining the changed policy and regression contracts.

Sensitive job-level permissions can still appear as warnings in Scorecard's details. OpenSSF explicitly permits required job-level writes with read-only or empty workflow defaults; replacing them with broader credentials or breaking publishing to hide warnings would not improve security.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Strengthened automation security with least-privilege access by default.
  - Restricted elevated permissions to only the jobs that require them.
  - Removed unnecessary issue-writing access from extension claim notifications.
  - Improved safeguards for privileged automation and toolchains.

- **Documentation**
  - Added guidance on workflow token permissions, explicit access grants, and security scan results.

- **Quality Improvements**
  - Expanded validation for missing, broad, malformed, or unsafe workflow permissions.
  - Added automated coverage for secure permission settings and pull-request checks.
  - Improved reliability when stopping concurrent background processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->